### PR TITLE
MINOR: Enable GitHub CI flows for main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ on:
   push:
     branches:
       - 'trunk'
+      - 'main'
 
   schedule:
     - cron: '0 0 * * 6,0'    # Run on Saturday and Sunday at midnight UTC
@@ -27,17 +28,18 @@ on:
     types: [ opened, synchronize, ready_for_review, reopened ]
     branches:
       - 'trunk'
+      - 'main'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/trunk' }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   build:
     uses: ./.github/workflows/build.yml
     with:
-      gradle-cache-read-only: ${{ github.ref != 'refs/heads/trunk' }}
-      gradle-cache-write-only: ${{ github.ref == 'refs/heads/trunk' }}
+      gradle-cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+      gradle-cache-write-only: ${{ github.ref == 'refs/heads/main' }}
       is-public-fork: ${{ github.event.pull_request.head.repo.fork || false }}
     secrets:
       inherit


### PR DESCRIPTION
Make GitHub workflows recognize the main branch for CI purposes.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
