### PR TITLE
Add FetchInterceptor

### DIFF
--- a/storage/inkless/src/main/java/io/aiven/inkless/consume/FetchInterceptor.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/consume/FetchInterceptor.java
@@ -1,0 +1,76 @@
+// Copyright (c) 2024 Aiven, Helsinki, Finland. https://aiven.io/
+package io.aiven.inkless.consume;
+
+import io.aiven.inkless.control_plane.MetadataView;
+import org.apache.kafka.common.TopicIdPartition;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.requests.FetchRequest;
+import org.apache.kafka.server.storage.log.FetchParams;
+import org.apache.kafka.server.storage.log.FetchPartitionData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+public class FetchInterceptor {
+    private static final Logger LOGGER = LoggerFactory.getLogger(FetchInterceptor.class);
+
+    private final MetadataView metadataView;
+
+    public FetchInterceptor(final MetadataView metadataView) {
+        this.metadataView = metadataView;
+    }
+
+    public boolean intercept(final FetchParams params,
+                             final Map<TopicIdPartition, FetchRequest.PartitionData> fetchInfos,
+                             final Consumer<Map<TopicIdPartition, FetchPartitionData>> responseCallback) {
+
+        final EntrySeparationResult entrySeparationResult = separateEntries(fetchInfos);
+        if (entrySeparationResult.bothTypesPresent()) {
+            LOGGER.warn("Producing to Inkless and class topic in same request isn't supported");
+            final var response = fetchInfos.entrySet().stream()
+                    .collect(Collectors.toMap(
+                            Map.Entry::getKey,
+                            ignored -> new FetchPartitionData(Errors.INVALID_REQUEST, -1, -1,
+                                    null, Optional.empty(), OptionalLong.empty(),
+                                    Optional.empty(), OptionalInt.empty(), false)));
+
+            responseCallback.accept(response);
+            return true;
+        }
+
+        // This request produces only to classic topics, don't intercept.
+        if (!entrySeparationResult.entitiesForNonInklessTopics.isEmpty()) {
+            return false;
+        }
+
+        return true;
+    }
+
+
+    private EntrySeparationResult separateEntries(final Map<TopicIdPartition, FetchRequest.PartitionData> entriesPerPartition) {
+        final Map<TopicIdPartition, FetchRequest.PartitionData> entitiesForInklessTopics = new HashMap<>();
+        final Map<TopicIdPartition, FetchRequest.PartitionData> entitiesForNonInklessTopics = new HashMap<>();
+        for (final var entry : entriesPerPartition.entrySet()) {
+            if (metadataView.isInklessTopic(entry.getKey().topic())) {
+                entitiesForInklessTopics.put(entry.getKey(), entry.getValue());
+            } else {
+                entitiesForNonInklessTopics.put(entry.getKey(), entry.getValue());
+            }
+        }
+        return new EntrySeparationResult(entitiesForInklessTopics, entitiesForNonInklessTopics);
+    }
+
+    private record EntrySeparationResult(Map<TopicIdPartition, FetchRequest.PartitionData> entitiesForInklessTopics,
+                                         Map<TopicIdPartition, FetchRequest.PartitionData> entitiesForNonInklessTopics) {
+        boolean bothTypesPresent() {
+            return !entitiesForInklessTopics.isEmpty() && !entitiesForNonInklessTopics.isEmpty();
+        }
+    }
+}

--- a/storage/inkless/src/test/java/io/aiven/inkless/consume/FetchInterceptorTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/consume/FetchInterceptorTest.java
@@ -1,0 +1,105 @@
+// Copyright (c) 2024 Aiven, Helsinki, Finland. https://aiven.io/
+package io.aiven.inkless.consume;
+
+import io.aiven.inkless.control_plane.MetadataView;
+import org.apache.kafka.common.TopicIdPartition;
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.message.ApiMessageType;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.requests.FetchRequest;
+import org.apache.kafka.server.storage.log.FetchIsolation;
+import org.apache.kafka.server.storage.log.FetchParams;
+import org.apache.kafka.server.storage.log.FetchPartitionData;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.STRICT_STUBS)
+public class FetchInterceptorTest {
+    @Mock
+    MetadataView metadataView;
+    @Mock
+    Consumer<Map<TopicIdPartition, FetchPartitionData>> responseCallback;
+
+    @Captor
+    ArgumentCaptor<Map<TopicIdPartition, FetchPartitionData>> resultCaptor;
+
+    private final short fetchVersion = ApiMessageType.FETCH.highestSupportedVersion(true);
+    private final Uuid inklessUuid = Uuid.randomUuid();
+    private final Uuid inklessOtherUuid = Uuid.randomUuid();
+    private final Uuid classicUuid = Uuid.randomUuid();
+
+    @Test
+    public void mixingInklessAndClassicTopicsIsNotAllowed() {
+        when(metadataView.isInklessTopic(eq("inkless"))).thenReturn(true);
+        when(metadataView.isInklessTopic(eq("non_inkless"))).thenReturn(false);
+        final FetchInterceptor interceptor = new FetchInterceptor(metadataView);
+
+        final FetchParams params = new FetchParams(fetchVersion,
+                -1, -1, -1, -1, -1,
+                FetchIsolation.LOG_END, Optional.empty());
+
+        final Map<TopicIdPartition, FetchRequest.PartitionData> fetchInfos = Map.of(
+                new TopicIdPartition(inklessUuid, 0, "inkless"),
+                new FetchRequest.PartitionData(inklessUuid, 0, 0, 1024, Optional.empty()),
+                new TopicIdPartition(classicUuid, 0, "non_inkless"),
+                new FetchRequest.PartitionData(classicUuid, 0, 0, 1024, Optional.empty())
+        );
+
+        final boolean result = interceptor.intercept(params, fetchInfos, responseCallback);
+        assertThat(result).isTrue();
+
+        FetchPartitionData error = new FetchPartitionData(Errors.INVALID_REQUEST, -1, -1,
+                null, Optional.empty(), OptionalLong.empty(),
+                Optional.empty(), OptionalInt.empty(), false);
+
+        verify(responseCallback).accept(resultCaptor.capture());
+        assertThat(resultCaptor.getValue())
+                .isNotNull()
+                .containsKeys(
+                        new TopicIdPartition(inklessUuid, 0, "inkless"),
+                        new TopicIdPartition(classicUuid, 0, "non_inkless")
+                )
+                .values()
+                .allMatch(fetchPartitionData -> fetchPartitionData.error == Errors.INVALID_REQUEST);
+    }
+
+    @Test
+    public void notInterceptProducingToClassicTopics() {
+        when(metadataView.isInklessTopic(eq("non_inkless"))).thenReturn(false);
+        final FetchInterceptor interceptor = new FetchInterceptor(metadataView);
+
+        final FetchParams params = new FetchParams(fetchVersion,
+                -1, -1, -1, -1, -1,
+                FetchIsolation.LOG_END, Optional.empty());
+
+        final Map<TopicIdPartition, FetchRequest.PartitionData> fetchInfos = Map.of(
+                new TopicIdPartition(classicUuid, 0, "non_inkless"),
+                new FetchRequest.PartitionData(classicUuid, 0, 0, 1024, Optional.empty())
+        );
+
+        final boolean result = interceptor.intercept(params, fetchInfos, responseCallback);
+        assertThat(result).isFalse();
+        verify(responseCallback, never()).accept(any());
+    }
+
+}


### PR DESCRIPTION
Modelled after the AppendInterceptor, but the types are different enough that I copied the implementation rather than finding an abstract parent. Maybe if/when the Produce infrastructure is refactored to pass through TopicIdPartition it will be easier to find a common abstraction.

The tests are also slightly different, because FetchPartitionData doesn't have an equals() method.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
