### PR TITLE
Reject Produce requests to Inkless topics with version < 3

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -751,7 +751,8 @@ class KafkaApis(val requestChannel: RequestChannel,
         responseCallback = sendResponseCallback,
         recordValidationStatsCallback = processingStatsCallback,
         requestLocal = requestLocal,
-        transactionSupportedOperation = transactionSupportedOperation)
+        transactionSupportedOperation = transactionSupportedOperation,
+        requestVersion = produceRequest.version())
 
       // if the request is put into the purgatory, it will have a held reference and hence cannot be garbage collected;
       // hence we clear its data here in order to let GC reclaim its memory since it is already appended to log

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -817,13 +817,14 @@ class ReplicaManager(val config: KafkaConfig,
                     recordValidationStatsCallback: Map[TopicPartition, RecordValidationStats] => Unit = _ => (),
                     requestLocal: RequestLocal = RequestLocal.noCaching,
                     actionQueue: ActionQueue = this.defaultActionQueue,
-                    verificationGuards: Map[TopicPartition, VerificationGuard] = Map.empty): Unit = {
+                    verificationGuards: Map[TopicPartition, VerificationGuard] = Map.empty,
+                    requestVersion: Short = 0): Unit = {
     if (!isValidRequiredAcks(requiredAcks)) {
       sendInvalidRequiredAcksResponse(entriesPerPartition, responseCallback)
       return
     }
 
-    if (inklessAppendInterceptor.intercept(entriesPerPartition.asJava, r => responseCallback(r.asScala))) {
+    if (inklessAppendInterceptor.intercept(requestVersion, entriesPerPartition.asJava, r => responseCallback(r.asScala))) {
       return
     }
 
@@ -879,7 +880,8 @@ class ReplicaManager(val config: KafkaConfig,
                           recordValidationStatsCallback: Map[TopicPartition, RecordValidationStats] => Unit = _ => (),
                           requestLocal: RequestLocal = RequestLocal.noCaching,
                           actionQueue: ActionQueue = this.defaultActionQueue,
-                          transactionSupportedOperation: TransactionSupportedOperation): Unit = {
+                          transactionSupportedOperation: TransactionSupportedOperation,
+                          requestVersion: Short = 0): Unit = {
 
     val transactionalProducerInfo = mutable.HashSet[(Long, Short)]()
     val topicPartitionBatchInfo = mutable.Map[TopicPartition, Int]()
@@ -938,7 +940,8 @@ class ReplicaManager(val config: KafkaConfig,
         recordValidationStatsCallback = recordValidationStatsCallback,
         requestLocal = newRequestLocal,
         actionQueue = actionQueue,
-        verificationGuards = verificationGuards
+        verificationGuards = verificationGuards,
+        requestVersion = requestVersion
       )
     }
 

--- a/storage/inkless/src/test/java/io/aiven/inkless/produce/AppendInterceptorTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/produce/AppendInterceptorTest.java
@@ -1,8 +1,8 @@
 // Copyright (c) 2024 Aiven, Helsinki, Finland. https://aiven.io/
 package io.aiven.inkless.produce;
 
-import java.time.Duration;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
 import io.aiven.inkless.common.SharedState;
@@ -21,7 +21,6 @@ import io.aiven.inkless.config.InklessConfig;
 import io.aiven.inkless.control_plane.MetadataView;
 import io.aiven.inkless.storage_backend.common.StorageBackend;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -34,7 +33,6 @@ import org.mockito.quality.Strictness;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -53,17 +51,11 @@ public class AppendInterceptorTest {
     StorageBackend storageBackend;
     @Mock
     Consumer<Map<TopicPartition, PartitionResponse>> responseCallback;
+    @Mock
+    Writer writer;
 
     @Captor
     ArgumentCaptor<Map<TopicPartition, PartitionResponse>> resultCaptor;
-
-    @BeforeEach
-    void setup() {
-        when(inklessConfig.commitInterval()).thenReturn(Duration.ofMillis(1));
-        when(inklessConfig.produceBufferMaxBytes()).thenReturn(1);
-        when(inklessConfig.produceMaxUploadAttempts()).thenReturn(1);
-        when(inklessConfig.produceUploadBackoff()).thenReturn(Duration.ofMillis(1));
-    }
 
     private static final MemoryRecords RECORDS_WITH_PRODUCER_ID = MemoryRecords.withRecords(
         (byte) 2,
@@ -82,7 +74,7 @@ public class AppendInterceptorTest {
         0L,
         Compression.NONE,
         TimestampType.CREATE_TIME,
-        123L,
+        -1L,
         (short) 0,
         0,
         0,
@@ -94,7 +86,8 @@ public class AppendInterceptorTest {
     public void mixingInklessAndClassicTopicsIsNotAllowed() {
         when(metadataView.isInklessTopic(eq("inkless"))).thenReturn(true);
         when(metadataView.isInklessTopic(eq("non_inkless"))).thenReturn(false);
-        final AppendInterceptor interceptor = new AppendInterceptor(new SharedState(time, inklessConfig, metadataView, controlPlane, storageBackend));
+        final AppendInterceptor interceptor = new AppendInterceptor(
+            new SharedState(time, inklessConfig, metadataView, controlPlane, storageBackend), writer);
 
         final Map<TopicPartition, MemoryRecords> entriesPerPartition = Map.of(
             new TopicPartition("inkless", 0),
@@ -103,7 +96,7 @@ public class AppendInterceptorTest {
             MemoryRecords.withRecords(Compression.NONE, new SimpleRecord("first message".getBytes()))
         );
 
-        final boolean result = interceptor.intercept(entriesPerPartition, responseCallback);
+        final boolean result = interceptor.intercept((short) 10, entriesPerPartition, responseCallback);
         assertThat(result).isTrue();
 
         verify(responseCallback).accept(resultCaptor.capture());
@@ -113,28 +106,32 @@ public class AppendInterceptorTest {
             new TopicPartition("non_inkless", 0),
             new PartitionResponse(Errors.INVALID_REQUEST)
         ));
+        verify(writer, never()).write(any());
     }
 
     @Test
     public void notInterceptProducingToClassicTopics() {
         when(metadataView.isInklessTopic(eq("non_inkless"))).thenReturn(false);
-        final AppendInterceptor interceptor = new AppendInterceptor(new SharedState(time, inklessConfig, metadataView, controlPlane, storageBackend));
+        final AppendInterceptor interceptor = new AppendInterceptor(
+            new SharedState(time, inklessConfig, metadataView, controlPlane, storageBackend), writer);
 
         final Map<TopicPartition, MemoryRecords> entriesPerPartition = Map.of(
             new TopicPartition("non_inkless", 0),
             MemoryRecords.withRecords(Compression.NONE, new SimpleRecord("first message".getBytes()))
         );
 
-        final boolean result = interceptor.intercept(entriesPerPartition, responseCallback);
+        final boolean result = interceptor.intercept((short) 10, entriesPerPartition, responseCallback);
         assertThat(result).isFalse();
         verify(responseCallback, never()).accept(any());
+        verify(writer, never()).write(any());
     }
 
     @Test
     public void rejectIdempotentProduceForInklessTopics() {
         when(metadataView.isInklessTopic(eq("inkless1"))).thenReturn(true);
         when(metadataView.isInklessTopic(eq("inkless2"))).thenReturn(true);
-        final AppendInterceptor interceptor = new AppendInterceptor(new SharedState(time, inklessConfig, metadataView, controlPlane, storageBackend));
+        final AppendInterceptor interceptor = new AppendInterceptor(
+            new SharedState(time, inklessConfig, metadataView, controlPlane, storageBackend), writer);
 
         final Map<TopicPartition, MemoryRecords> entriesPerPartition = Map.of(
             new TopicPartition("inkless1", 0),
@@ -143,7 +140,7 @@ public class AppendInterceptorTest {
             RECORDS_WITH_PRODUCER_ID
         );
 
-        final boolean result = interceptor.intercept(entriesPerPartition, responseCallback);
+        final boolean result = interceptor.intercept((short) 10, entriesPerPartition, responseCallback);
         assertThat(result).isTrue();
 
         verify(responseCallback).accept(resultCaptor.capture());
@@ -153,21 +150,65 @@ public class AppendInterceptorTest {
             new TopicPartition("inkless2", 0),
             new PartitionResponse(Errors.INVALID_REQUEST)
         ));
+        verify(writer, never()).write(any());
     }
 
     @Test
     public void acceptIdempotentProduceForNonInklessTopics() {
         when(metadataView.isInklessTopic(eq("non_inkless"))).thenReturn(false);
-        final AppendInterceptor interceptor = new AppendInterceptor(new SharedState(time, inklessConfig, metadataView, controlPlane, storageBackend));
+        final AppendInterceptor interceptor = new AppendInterceptor(
+            new SharedState(time, inklessConfig, metadataView, controlPlane, storageBackend), writer);
 
         final Map<TopicPartition, MemoryRecords> entriesPerPartition = Map.of(
             new TopicPartition("non_inkless", 0),
             RECORDS_WITH_PRODUCER_ID
         );
 
-        final boolean result = interceptor.intercept(entriesPerPartition, responseCallback);
+        final boolean result = interceptor.intercept((short) 10, entriesPerPartition, responseCallback);
         assertThat(result).isFalse();
 
         verify(responseCallback, never()).accept(any());
+        verify(writer, never()).write(any());
+    }
+
+    @Test
+    void rejectRequestsWithVersionBelow3() {
+        when(metadataView.isInklessTopic(eq("inkless"))).thenReturn(true);
+        final AppendInterceptor interceptor = new AppendInterceptor(
+            new SharedState(time, inklessConfig, metadataView, controlPlane, storageBackend), writer);
+
+        final Map<TopicPartition, MemoryRecords> entriesPerPartition = Map.of(
+            new TopicPartition("inkless", 0),
+            RECORDS_WITHOUT_PRODUCER_ID
+        );
+
+        final boolean result = interceptor.intercept((short) 2, entriesPerPartition, responseCallback);
+        assertThat(result).isTrue();
+
+        verify(responseCallback).accept(resultCaptor.capture());
+        assertThat(resultCaptor.getValue()).isEqualTo(Map.of(
+            new TopicPartition("inkless", 0),
+            new PartitionResponse(Errors.INVALID_REQUEST)
+        ));
+        verify(writer, never()).write(any());
+    }
+
+    @Test
+    void acceptRequestsWithVersionAboveOrEqual3() {
+        when(writer.write(any())).thenReturn(new CompletableFuture<>());
+        when(metadataView.isInklessTopic(eq("inkless"))).thenReturn(true);
+        final AppendInterceptor interceptor = new AppendInterceptor(
+            new SharedState(time, inklessConfig, metadataView, controlPlane, storageBackend), writer);
+
+        final Map<TopicPartition, MemoryRecords> entriesPerPartition = Map.of(
+            new TopicPartition("inkless", 0),
+            RECORDS_WITHOUT_PRODUCER_ID
+        );
+
+        final boolean result = interceptor.intercept((short) 3, entriesPerPartition, responseCallback);
+        assertThat(result).isTrue();
+
+        verify(responseCallback, never()).accept(any());
+        verify(writer).write(any());
     }
 }


### PR DESCRIPTION
We do this to ensure each topic-partition has exactly one batch in the request. The check itself is done in KafkaApis.handleProduceRequest, but it's performed only for version >= 3. If we enforce the version here, we piggyback on the original Kafka check.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
