### PR TITLE
Notify control plane about topic/partition creation/deletion

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2369,6 +2369,7 @@ project(':storage:inkless') {
     api project(':clients')
     implementation project(':server-common')
     implementation project(':storage')
+    implementation project(':metadata')
 
     api libs.pitestAnnotations
 

--- a/core/src/main/java/kafka/server/builders/ReplicaManagerBuilder.java
+++ b/core/src/main/java/kafka/server/builders/ReplicaManagerBuilder.java
@@ -222,6 +222,7 @@ public class ReplicaManagerBuilder {
                              () -> brokerEpoch,
                              OptionConverters.toScala(addPartitionsToTxnManager),
                              directoryEventHandler,
-                             new DelayedActionQueue());
+                             new DelayedActionQueue(),
+                             OptionConverters.toScala(Optional.empty()));
     }
 }

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -17,6 +17,7 @@
 
 package kafka.server
 
+import io.aiven.inkless.common.SharedState
 import kafka.coordinator.group.{CoordinatorLoaderImpl, CoordinatorPartitionWriter, GroupCoordinatorAdapter}
 import kafka.coordinator.transaction.TransactionCoordinator
 import kafka.log.LogManager
@@ -334,6 +335,9 @@ class BrokerServer(
        */
       val defaultActionQueue = new DelayedActionQueue
 
+      val inklessMetadataView = new InklessMetadataView(metadataCache, () => logManager.currentDefaultConfig)
+      val inklessSharedState = SharedState.initialize(time, config.inklessConfig, inklessMetadataView, brokerTopicStats)
+
       this._replicaManager = new ReplicaManager(
         config = config,
         metrics = metrics,
@@ -353,7 +357,8 @@ class BrokerServer(
         brokerEpochSupplier = () => lifecycleManager.brokerEpoch,
         addPartitionsToTxnManager = Some(addPartitionsToTxnManager),
         directoryEventHandler = directoryEventHandler,
-        defaultActionQueue = defaultActionQueue
+        defaultActionQueue = defaultActionQueue,
+        inklessSharedState = Some(inklessSharedState)
       )
 
       /* start token manager */
@@ -529,6 +534,7 @@ class BrokerServer(
           "broker",
           authorizer
         ),
+        new InklessMetadataPublisher(inklessMetadataView),
         sharedServer.initialBrokerMetadataLoadFaultHandler,
         sharedServer.metadataPublishingFaultHandler
       )

--- a/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
+++ b/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
@@ -74,6 +74,7 @@ class BrokerMetadataPublisher(
   scramPublisher: ScramPublisher,
   delegationTokenPublisher: DelegationTokenPublisher,
   aclPublisher: AclPublisher,
+  inklessPublisher: InklessMetadataPublisher,
   fatalFaultHandler: FaultHandler,
   metadataPublishingFaultHandler: FaultHandler,
 ) extends MetadataPublisher with Logging {
@@ -207,6 +208,9 @@ class BrokerMetadataPublisher(
 
       // Apply ACL delta.
       aclPublisher.onMetadataUpdate(delta, newImage, manifest)
+
+      // Apply Inkless delta.
+      inklessPublisher.onMetadataUpdate(delta, newImage, manifest)
 
       try {
         // Propagate the new image to the group coordinator.

--- a/core/src/main/scala/kafka/server/metadata/InklessMetadataPublisher.scala
+++ b/core/src/main/scala/kafka/server/metadata/InklessMetadataPublisher.scala
@@ -1,0 +1,23 @@
+// Copyright (c) 2024 Aiven, Helsinki, Finland. https://aiven.io/
+package kafka.server.metadata
+
+import kafka.utils.Logging
+import org.apache.kafka.image.loader.LoaderManifest
+import org.apache.kafka.image.{MetadataDelta, MetadataImage}
+import org.apache.kafka.image.publisher.MetadataPublisher
+
+/**
+ * This publisher is basically a bridge to notify [[InklessMetadataView]] about change in topics and partitions.
+ */
+class InklessMetadataPublisher(metadataView: InklessMetadataView) extends MetadataPublisher with Logging {
+  override def name(): String = s"InklessPublisher"
+
+  override def onMetadataUpdate(delta: MetadataDelta,
+                                newImage: MetadataImage,
+                                manifest: LoaderManifest): Unit = {
+    val topicsDelta = delta.topicsDelta()
+    if (topicsDelta != null) {
+      metadataView.onTopicMetadataUpdate(topicsDelta)
+    }
+  }
+}

--- a/core/src/main/scala/kafka/server/metadata/InklessMetadataView.scala
+++ b/core/src/main/scala/kafka/server/metadata/InklessMetadataView.scala
@@ -1,15 +1,19 @@
 // Copyright (c) 2024 Aiven, Helsinki, Finland. https://aiven.io/
 package kafka.server.metadata
 
-import io.aiven.inkless.control_plane.MetadataView
+import io.aiven.inkless.control_plane.{MetadataView, TopicMetadataChangesSubscriber}
 import org.apache.kafka.common.config.ConfigResource
 import org.apache.kafka.common.{TopicPartition, Uuid}
+import org.apache.kafka.image.TopicsDelta
 import org.apache.kafka.storage.internals.log.LogConfig
 
 import java.util
+import java.util.concurrent.atomic.AtomicReference
 import scala.jdk.CollectionConverters.SetHasAsJava
 
 class InklessMetadataView(val metadataCache: KRaftMetadataCache, val defaultTopicConfigs: () => LogConfig) extends MetadataView {
+  private val topicMetadataChangesSubscribers = new AtomicReference[List[TopicMetadataChangesSubscriber]](Nil)
+
   override def getTopicPartitions(topicName: String): util.Set[TopicPartition] = {
     metadataCache.getTopicPartitions(topicName).asJava
   }
@@ -30,5 +34,13 @@ class InklessMetadataView(val metadataCache: KRaftMetadataCache, val defaultTopi
     }
 
     LogConfig.fromProps(defaultTopicConfigs().originals(), overrides)
+  }
+
+  override def subscribeToTopicMetadataChanges(subscriber: TopicMetadataChangesSubscriber): Unit = {
+    topicMetadataChangesSubscribers.updateAndGet(list => list :+ subscriber)
+  }
+
+  def onTopicMetadataUpdate(topicsDelta: TopicsDelta): Unit = {
+    topicMetadataChangesSubscribers.get().foreach(_.onTopicMetadataChanges(topicsDelta))
   }
 }

--- a/core/src/test/scala/kafka/server/metadata/InklessMetadataPublisherTest.scala
+++ b/core/src/test/scala/kafka/server/metadata/InklessMetadataPublisherTest.scala
@@ -1,0 +1,45 @@
+// Copyright (c) 2024 Aiven, Helsinki, Finland. https://aiven.io/
+package kafka.server.metadata
+
+import org.apache.kafka.common.Uuid
+import org.apache.kafka.common.metadata.{PartitionRecord, TopicRecord}
+import org.apache.kafka.image.loader.LoaderManifest
+import org.apache.kafka.image.{MetadataDelta, MetadataImage, MetadataProvenance}
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mockito.verify
+import org.mockito.junit.jupiter.{MockitoExtension, MockitoSettings}
+import org.mockito.quality.Strictness
+import org.mockito.{ArgumentMatchers, Mock}
+
+@ExtendWith(Array(classOf[MockitoExtension]))
+@MockitoSettings(strictness = Strictness.STRICT_STUBS)
+class InklessMetadataPublisherTest {
+  val TOPIC_1 = "topic1"
+  val TOPIC_ID_1 = new Uuid(1, 1)
+  val TOPIC_2 = "topic2"
+  val TOPIC_ID_2 = new Uuid(2, 2)
+
+  @Mock
+  val metadataView: InklessMetadataView = null
+  @Mock
+  val loaderManifest: LoaderManifest = null
+
+  @Test
+  def topicUpdatesArePropagated(): Unit = {
+    val publisher = new InklessMetadataPublisher(metadataView)
+
+    val oldImage = MetadataImage.EMPTY
+    val delta = new MetadataDelta.Builder().setImage(oldImage).build
+    delta.replay(new TopicRecord().setName(TOPIC_1).setTopicId(TOPIC_ID_1))
+    delta.replay(new PartitionRecord().setTopicId(TOPIC_ID_1).setPartitionId(0))
+    delta.replay(new PartitionRecord().setTopicId(TOPIC_ID_1).setPartitionId(1))
+    delta.replay(new TopicRecord().setName(TOPIC_2).setTopicId(TOPIC_ID_2))
+    delta.replay(new PartitionRecord().setTopicId(TOPIC_ID_2).setPartitionId(0))
+    val newImage = delta.apply(MetadataProvenance.EMPTY)
+
+    publisher.onMetadataUpdate(delta, newImage, loaderManifest)
+
+    verify(metadataView).onTopicMetadataUpdate(ArgumentMatchers.eq(delta.topicsDelta()))
+  }
+}

--- a/core/src/test/scala/kafka/server/metadata/InklessMetadataViewTest.scala
+++ b/core/src/test/scala/kafka/server/metadata/InklessMetadataViewTest.scala
@@ -1,0 +1,35 @@
+// Copyright (c) 2024 Aiven, Helsinki, Finland. https://aiven.io/
+package kafka.server.metadata
+
+import io.aiven.inkless.control_plane.TopicMetadataChangesSubscriber
+import org.apache.kafka.image.TopicsDelta
+import org.apache.kafka.storage.internals.log.LogConfig
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers.same
+import org.mockito.Mockito.{mock, reset, verify}
+
+class InklessMetadataViewTest {
+  @Test
+  def topicMetadataChangesSubscriptionEmpty(): Unit = {
+    val metadataView = new InklessMetadataView(mock(classOf[KRaftMetadataCache]), mock(classOf[() => LogConfig]))
+    val delta = mock(classOf[TopicsDelta])
+
+    // No exception, all good.
+    metadataView.onTopicMetadataUpdate(delta)
+
+    val subscriber1 = mock(classOf[TopicMetadataChangesSubscriber])
+    metadataView.subscribeToTopicMetadataChanges(subscriber1)
+
+    metadataView.onTopicMetadataUpdate(delta)
+    verify(subscriber1).onTopicMetadataChanges(same(delta))
+
+    reset(subscriber1)
+
+    val subscriber2 = mock(classOf[TopicMetadataChangesSubscriber])
+    metadataView.subscribeToTopicMetadataChanges(subscriber2)
+
+    metadataView.onTopicMetadataUpdate(delta)
+    verify(subscriber1).onTopicMetadataChanges(same(delta))
+    verify(subscriber2).onTopicMetadataChanges(same(delta))
+  }
+}

--- a/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataPublisherTest.scala
+++ b/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataPublisherTest.scala
@@ -201,6 +201,7 @@ class BrokerMetadataPublisherTest {
       mock(classOf[ScramPublisher]),
       mock(classOf[DelegationTokenPublisher]),
       mock(classOf[AclPublisher]),
+      mock(classOf[InklessMetadataPublisher]),
       faultHandler,
       faultHandler
     )

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/ControlPlane.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/ControlPlane.java
@@ -11,7 +11,7 @@ import java.util.List;
 import io.aiven.inkless.common.ObjectKey;
 import io.aiven.inkless.config.InklessConfig;
 
-public interface ControlPlane extends Configurable {
+public interface ControlPlane extends Configurable, TopicMetadataChangesSubscriber {
     List<CommitBatchResponse> commitFile(ObjectKey objectKey,
                                          List<CommitBatchRequest> batches);
 

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/MetadataView.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/MetadataView.java
@@ -15,4 +15,6 @@ public interface MetadataView {
     boolean isInklessTopic(String topicName);
 
     LogConfig getTopicConfig(String topicName);
+
+    void subscribeToTopicMetadataChanges(TopicMetadataChangesSubscriber subscriber);
 }

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/TopicMetadataChangesSubscriber.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/TopicMetadataChangesSubscriber.java
@@ -1,0 +1,9 @@
+// Copyright (c) 2024 Aiven, Helsinki, Finland. https://aiven.io/
+package io.aiven.inkless.control_plane;
+
+import org.apache.kafka.image.TopicsDelta;
+
+@FunctionalInterface
+public interface TopicMetadataChangesSubscriber {
+    void onTopicMetadataChanges(TopicsDelta topicsDelta);
+}

--- a/storage/inkless/src/test/java/io/aiven/inkless/control_plane/InMemoryControlPlaneTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/control_plane/InMemoryControlPlaneTest.java
@@ -1,11 +1,9 @@
 // Copyright (c) 2024 Aiven, Helsinki, Finland. https://aiven.io/
 package io.aiven.inkless.control_plane;
 
-import org.junit.jupiter.api.BeforeEach;
-
 class InMemoryControlPlaneTest extends AbstractControlPlaneTest {
-    @BeforeEach
-    void createControlPlane() {
-        controlPlane = new InMemoryControlPlane(time, metadataView);
+    @Override
+    protected ControlPlane createControlPlane() {
+        return new InMemoryControlPlane(time, metadataView);
     }
 }

--- a/storage/inkless/src/test/java/io/aiven/inkless/produce/WriterIntegrationTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/produce/WriterIntegrationTest.java
@@ -30,6 +30,7 @@ import java.util.concurrent.TimeoutException;
 import io.aiven.inkless.common.PlainObjectKey;
 import io.aiven.inkless.control_plane.InMemoryControlPlane;
 import io.aiven.inkless.control_plane.MetadataView;
+import io.aiven.inkless.control_plane.TopicMetadataChangesSubscriber;
 import io.aiven.inkless.storage_backend.s3.S3Storage;
 import io.aiven.inkless.test_utils.S3TestContainer;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
@@ -77,6 +78,11 @@ class WriterIntegrationTest {
         @Override
         public LogConfig getTopicConfig(final String topicName) {
             return LogConfig.fromProps(Map.of(), new Properties());
+        }
+
+        @Override
+        public void subscribeToTopicMetadataChanges(final TopicMetadataChangesSubscriber subscriber) {
+            // We don't create/delete topics/partitions, so this is no-op.
         }
     };
 

--- a/storage/inkless/src/test/java/io/aiven/inkless/produce/WriterPropertyTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/produce/WriterPropertyTest.java
@@ -47,6 +47,7 @@ import io.aiven.inkless.common.PlainObjectKey;
 import io.aiven.inkless.control_plane.ControlPlane;
 import io.aiven.inkless.control_plane.InMemoryControlPlane;
 import io.aiven.inkless.control_plane.MetadataView;
+import io.aiven.inkless.control_plane.TopicMetadataChangesSubscriber;
 import io.aiven.inkless.storage_backend.common.ObjectUploader;
 import io.aiven.inkless.storage_backend.common.StorageBackendException;
 
@@ -90,6 +91,11 @@ class WriterPropertyTest {
         @Override
         public LogConfig getTopicConfig(final String topicName) {
             return LogConfig.fromProps(Map.of(), new Properties());
+        }
+
+        @Override
+        public void subscribeToTopicMetadataChanges(final TopicMetadataChangesSubscriber subscriber) {
+            // We don't create/delete topics/partitions, so this is no-op.
         }
     };
 


### PR DESCRIPTION
This commit make it so that `ControlPlane` knows when a topic created or deleted or when a partition is created (including initial loading of these metadata). Some necessary refactoring made.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
