### PR TITLE
In ControlPlane, process non-existent partitions separately

### DIFF
--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/SplitMapper.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/SplitMapper.java
@@ -1,0 +1,102 @@
+// Copyright (c) 2024 Aiven, Helsinki, Finland. https://aiven.io/
+package io.aiven.inkless.control_plane;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Predicate;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+/**
+ * The class to split the list by a predicate, transform independently, and merge back preserving the order.
+ *
+ * <pre>
+ *     +---+              +----+              +----+
+ *     | 0 |              | t0 |              | t0 |
+ *     +---+              +----+              +----+
+ *     | 1 |              | t1 |              | t1 |
+ *     +---+    ===>      +----+    ===>      +----+
+ *     | 2 |              | t3 |              | f2 |
+ *     +---+              +----+              +----+
+ *     | 3 |                                  | t3 |
+ *     +---+                                  +----+
+ *                        +----+
+ *                        | f2 |
+ *                        +----+
+ * </pre>
+ *
+ * @param <TIn> The type of input objects.
+ * @param <TOut> The type of output objects.
+ */
+public class SplitMapper<TIn, TOut> {
+    private final List<TIn> in;
+    private final List<Boolean> marks;
+    private Iterator<TOut> trueOut;
+    private Iterator<TOut> falseOut;
+
+    public SplitMapper(final List<TIn> in, final Predicate<TIn> predicate) {
+        Objects.requireNonNull(in, "in cannot be null");
+        Objects.requireNonNull(predicate, "predicate cannot be null");
+        this.in = new ArrayList<>(in.size());
+        this.marks = new ArrayList<>(in.size());
+        for (final TIn el : in) {
+            this.in.add(el);
+            this.marks.add(predicate.test(el));
+        }
+    }
+
+    public Stream<TIn> getTrueIn() {
+        return getGetStream(true);
+    }
+
+    public Stream<TIn> getFalseIn() {
+        return getGetStream(false);
+    }
+
+    private Stream<TIn> getGetStream(final boolean which) {
+        return IntStream.range(0, in.size())
+            .filter(i -> marks.get(i) == which)
+            .mapToObj(in::get);
+    }
+
+    public void setTrueOut(final Iterator<TOut> trueOut) {
+        this.trueOut = Objects.requireNonNull(trueOut, "trueOut cannot be null");
+    }
+
+    public void setFalseOut(final Iterator<TOut> falseOut) {
+        this.falseOut = Objects.requireNonNull(falseOut, "falseOut cannot be null");
+    }
+
+    public List<TOut> getOut() {
+        if (this.trueOut == null) {
+            throw new IllegalStateException("True out is not set");
+        }
+        if (this.falseOut == null) {
+            throw new IllegalStateException("False out is not set");
+        }
+
+        final List<TOut> result = new ArrayList<>(in.size());
+        for (final Boolean mark : marks) {
+            try {
+                final Iterator<TOut> iter = mark ? trueOut : falseOut;
+                result.add(iter.next());
+            } catch (final Exception e) {
+                final String iterName = mark ? "True out" : "False out";
+                throw new IllegalStateException(iterName + " is exhausted");
+            }
+        }
+
+        if (trueOut.hasNext()) {
+            throw new IllegalStateException("True out is not exhausted");
+        }
+        if (falseOut.hasNext()) {
+            throw new IllegalStateException("False out is not exhausted");
+        }
+        // Did we miss some check above? We'll see in test.
+        assert result.size() == in.size();
+
+        return result;
+    }
+}

--- a/storage/inkless/src/test/java/io/aiven/inkless/control_plane/SplitMapperTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/control_plane/SplitMapperTest.java
@@ -1,0 +1,137 @@
+// Copyright (c) 2024 Aiven, Helsinki, Finland. https://aiven.io/
+package io.aiven.inkless.control_plane;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class SplitMapperTest {
+    @Test
+    void empty() {
+        final SplitMapper<String, String> mapper = new SplitMapper<>(List.of(), e -> true);
+        mapper.setFalseOut(Collections.emptyIterator());
+        mapper.setTrueOut(Collections.emptyIterator());
+        assertThat(mapper.getOut()).isEmpty();
+    }
+
+    @Test
+    void allTrue() {
+        final SplitMapper<Integer, String> mapper = new SplitMapper<>(List.of(1, 2, 3, 4, 5, 6), e -> true);
+        mapper.setFalseOut(Collections.emptyIterator());
+        mapper.setTrueOut(mapper.getTrueIn().map(i -> Integer.toString(i)).iterator());
+
+        assertThat(mapper.getOut()).containsExactly("1", "2", "3", "4", "5", "6");
+    }
+
+    @Test
+    void allFalse() {
+        final SplitMapper<Integer, String> mapper = new SplitMapper<>(List.of(1, 2, 3, 4, 5, 6), e -> false);
+        mapper.setTrueOut(Collections.emptyIterator());
+        mapper.setFalseOut(mapper.getFalseIn().map(i -> Integer.toString(i)).iterator());
+
+        assertThat(mapper.getOut()).containsExactly("1", "2", "3", "4", "5", "6");
+    }
+
+    @Test
+    void mixed() {
+        final SplitMapper<Integer, String> mapper = new SplitMapper<>(List.of(0, 2, 3, 5, 6, 7, 8, 9, 10, 12), e -> e % 2 == 0);
+        mapper.setTrueOut(mapper.getTrueIn().map(i -> "Even: " + i).iterator());
+        mapper.setFalseOut(mapper.getFalseIn().map(i -> "Odd: " + i).iterator());
+
+        assertThat(mapper.getOut()).containsExactly(
+            "Even: 0",
+            "Even: 2",
+            "Odd: 3",
+            "Odd: 5",
+            "Even: 6",
+            "Odd: 7",
+            "Even: 8",
+            "Odd: 9",
+            "Even: 10",
+            "Even: 12"
+        );
+    }
+
+    @Test
+    void constructorNulls() {
+        assertThatThrownBy(() -> new SplitMapper<>(null, e -> true))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessage("in cannot be null");
+        assertThatThrownBy(() -> new SplitMapper<>(List.of(), null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessage("predicate cannot be null");
+    }
+
+    @Test
+    void setOutNulls() {
+        final SplitMapper<Object, Object> mapper = new SplitMapper<>(List.of(), e -> true);
+        assertThatThrownBy(() -> mapper.setTrueOut(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessage("trueOut cannot be null");
+        assertThatThrownBy(() -> mapper.setFalseOut(null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessage("falseOut cannot be null");
+    }
+
+    @Test
+    void trueOutNotSet() {
+        final SplitMapper<String, String> mapper = new SplitMapper<>(List.of(), e -> true);
+        mapper.setFalseOut(Collections.emptyIterator());
+        assertThatThrownBy(mapper::getOut)
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("True out is not set");
+    }
+
+    @Test
+    void falseOutNotSet() {
+        final SplitMapper<String, String> mapper = new SplitMapper<>(List.of(), e -> true);
+        mapper.setTrueOut(Collections.emptyIterator());
+        assertThatThrownBy(mapper::getOut)
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("False out is not set");
+    }
+
+    @Test
+    void trueOutIsTooShort() {
+        final SplitMapper<Integer, Integer> mapper = new SplitMapper<>(List.of(1), e -> true);
+        mapper.setFalseOut(Collections.emptyIterator());
+        mapper.setTrueOut(Collections.emptyIterator());
+        assertThatThrownBy(mapper::getOut)
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("True out is exhausted");
+    }
+
+    @Test
+    void trueOutIsTooLong() {
+        final SplitMapper<Integer, Integer> mapper = new SplitMapper<>(List.of(), e -> true);
+        mapper.setFalseOut(Collections.emptyIterator());
+        mapper.setTrueOut(List.of(1).iterator());
+        assertThatThrownBy(mapper::getOut)
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("True out is not exhausted");
+    }
+
+    @Test
+    void falseOutIsTooShort() {
+        final SplitMapper<Integer, Integer> mapper = new SplitMapper<>(List.of(1), e -> false);
+        mapper.setFalseOut(Collections.emptyIterator());
+        mapper.setTrueOut(Collections.emptyIterator());
+        assertThatThrownBy(mapper::getOut)
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("False out is exhausted");
+    }
+
+    @Test
+    void falseOutIsTooLong() {
+        final SplitMapper<Integer, Integer> mapper = new SplitMapper<>(List.of(), e -> false);
+        mapper.setFalseOut(List.of(1).iterator());
+        mapper.setTrueOut(Collections.emptyIterator());
+        assertThatThrownBy(mapper::getOut)
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("False out is not exhausted");
+    }
+}


### PR DESCRIPTION
While this doesn't make much difference in case of `InMemoryControlPlane`, any DB-based control plane would benefit from batching. For batching, separating of entities that are handled locally (i.e. without a query to the DB) is essential.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
