### PR TITLE
Remove ObjectKey concept from ControlPlane

### DIFF
--- a/storage/inkless/src/main/java/io/aiven/inkless/common/ObjectKey.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/common/ObjectKey.java
@@ -3,4 +3,8 @@ package io.aiven.inkless.common;
 
 public interface ObjectKey {
     String value();
+
+    default String storedPart() {
+        return value();
+    }
 }

--- a/storage/inkless/src/main/java/io/aiven/inkless/common/PlainObjectKey.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/common/PlainObjectKey.java
@@ -15,7 +15,16 @@ public record PlainObjectKey(String prefix, String mainPath) implements ObjectKe
     }
 
     @Override
+    public String storedPart() {
+        return mainPath;
+    }
+
+    @Override
     public String toString() {
         return value();
+    }
+
+    public static ObjectKeyCreator creator(final String prefix) {
+        return (s) -> new PlainObjectKey(prefix, s);
     }
 }

--- a/storage/inkless/src/main/java/io/aiven/inkless/common/SharedState.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/common/SharedState.java
@@ -15,6 +15,7 @@ public record SharedState(
         MetadataView metadata,
         ControlPlane controlPlane,
         StorageBackend storage,
+        ObjectKeyCreator objectKeyCreator,
         BrokerTopicStats brokerTopicStats
 ) {
 
@@ -30,6 +31,7 @@ public record SharedState(
             metadata,
             ControlPlane.create(config, time, metadata),
             config.storage(),
+            PlainObjectKey.creator(config.objectKeyPrefix()),
             brokerTopicStats
         );
     }

--- a/storage/inkless/src/main/java/io/aiven/inkless/consume/FetchInterceptor.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/consume/FetchInterceptor.java
@@ -29,7 +29,7 @@ public class FetchInterceptor implements Closeable {
     private final Reader reader;
 
     public FetchInterceptor(final SharedState state) {
-        this(state, new Reader(state.time(), state.controlPlane(), state.storage()));
+        this(state, new Reader(state.time(), state.objectKeyCreator(), state.controlPlane(), state.storage()));
     }
 
     public FetchInterceptor(final SharedState state, final Reader reader) {

--- a/storage/inkless/src/main/java/io/aiven/inkless/consume/FetchPlannerJob.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/consume/FetchPlannerJob.java
@@ -15,6 +15,7 @@ import java.util.stream.Collectors;
 
 import io.aiven.inkless.TimeUtils;
 import io.aiven.inkless.common.ByteRange;
+import io.aiven.inkless.common.ObjectKeyCreator;
 import io.aiven.inkless.control_plane.BatchInfo;
 import io.aiven.inkless.control_plane.FindBatchResponse;
 import io.aiven.inkless.storage_backend.common.ObjectFetcher;
@@ -22,6 +23,7 @@ import io.aiven.inkless.storage_backend.common.ObjectFetcher;
 public class FetchPlannerJob implements Callable<List<Future<FetchedFile>>> {
 
     private final Time time;
+    private final ObjectKeyCreator objectKeyCreator;
     private final ObjectFetcher objectFetcher;
     private final ExecutorService dataExecutor;
     private final Future<Map<TopicIdPartition, FindBatchResponse>> batchCoordinatesFuture;
@@ -29,12 +31,14 @@ public class FetchPlannerJob implements Callable<List<Future<FetchedFile>>> {
     private final Consumer<Long> fileFetchDurationCallback;
 
     public FetchPlannerJob(Time time,
+                           ObjectKeyCreator objectKeyCreator,
                            ObjectFetcher objectFetcher,
                            ExecutorService dataExecutor,
                            Future<Map<TopicIdPartition, FindBatchResponse>> batchCoordinatesFuture,
                            Consumer<Long> durationCallback,
                            Consumer<Long> fileFetchDurationCallback) {
         this.time = time;
+        this.objectKeyCreator = objectKeyCreator;
         this.objectFetcher = objectFetcher;
         this.dataExecutor = dataExecutor;
         this.batchCoordinatesFuture = batchCoordinatesFuture;
@@ -62,7 +66,7 @@ public class FetchPlannerJob implements Callable<List<Future<FetchedFile>>> {
                 .entrySet()
                 .stream()
                 .map(e ->
-                    new FileFetchJob(time, objectFetcher, e.getKey(), e.getValue(), fileFetchDurationCallback))
+                    new FileFetchJob(time, objectFetcher, objectKeyCreator.create(e.getKey()), e.getValue(), fileFetchDurationCallback))
                 .collect(Collectors.toList());
     }
 

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/BatchInfo.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/BatchInfo.java
@@ -4,10 +4,9 @@ package io.aiven.inkless.control_plane;
 import org.apache.kafka.common.record.TimestampType;
 
 import io.aiven.inkless.common.ByteRange;
-import io.aiven.inkless.common.ObjectKey;
 
 public record BatchInfo(
-    ObjectKey objectKey,
+    String objectKey,
     long byteOffset,
     long size,
     long recordOffset,

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/ControlPlane.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/ControlPlane.java
@@ -8,11 +8,10 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 
-import io.aiven.inkless.common.ObjectKey;
 import io.aiven.inkless.config.InklessConfig;
 
 public interface ControlPlane extends Configurable, TopicMetadataChangesSubscriber {
-    List<CommitBatchResponse> commitFile(ObjectKey objectKey,
+    List<CommitBatchResponse> commitFile(String objectKey,
                                          List<CommitBatchRequest> batches);
 
     List<FindBatchResponse> findBatches(List<FindBatchRequest> findBatchRequests,

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/InMemoryControlPlane.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/InMemoryControlPlane.java
@@ -20,7 +20,6 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 
-import io.aiven.inkless.common.ObjectKey;
 
 public class InMemoryControlPlane implements ControlPlane {
     private static final Logger logger = LoggerFactory.getLogger(InMemoryControlPlane.class);
@@ -69,7 +68,7 @@ public class InMemoryControlPlane implements ControlPlane {
     }
 
     @Override
-    public synchronized List<CommitBatchResponse> commitFile(final ObjectKey objectKey,
+    public synchronized List<CommitBatchResponse> commitFile(final String objectKey,
                                                              final List<CommitBatchRequest> batches) {
         // Real-life batches cannot be empty, even if they have 0 records
         // Checking this just as an assertion.
@@ -107,7 +106,7 @@ public class InMemoryControlPlane implements ControlPlane {
     }
 
     private CommitBatchResponse commitFileForExistingPartition(final long now,
-                                                               final ObjectKey objectKey,
+                                                               final String objectKey,
                                                                final CommitBatchRequest request) {
         final String topicName = request.topicPartition().topic();
         final Uuid topicId = metadataView.getTopicId(topicName);

--- a/storage/inkless/src/main/java/io/aiven/inkless/produce/AppendInterceptor.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/produce/AppendInterceptor.java
@@ -18,7 +18,6 @@ import java.util.Map;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
-import io.aiven.inkless.common.PlainObjectKey;
 import io.aiven.inkless.common.SharedState;
 
 public class AppendInterceptor implements Closeable {
@@ -34,7 +33,7 @@ public class AppendInterceptor implements Closeable {
             state,
             new Writer(
                 state.time(),
-                (s) -> new PlainObjectKey(state.config().objectKeyPrefix(), s),
+                state.objectKeyCreator(),
                 state.storage(),
                 state.controlPlane(),
                 state.config().commitInterval(),

--- a/storage/inkless/src/main/java/io/aiven/inkless/produce/FileCommitJob.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/produce/FileCommitJob.java
@@ -76,7 +76,7 @@ class FileCommitJob implements Runnable {
     }
 
     private void finishCommitSuccessfully(final ObjectKey objectKey) {
-        final var commitBatchResponses = controlPlane.commitFile(objectKey, file.commitBatchRequests());
+        final var commitBatchResponses = controlPlane.commitFile(objectKey.storedPart(), file.commitBatchRequests());
         LOGGER.debug("Committed successfully");
 
         // Each request must have a response.

--- a/storage/inkless/src/test/java/io/aiven/inkless/consume/FetchCompleterJobTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/consume/FetchCompleterJobTest.java
@@ -29,6 +29,7 @@ import java.util.stream.Stream;
 
 import io.aiven.inkless.common.ByteRange;
 import io.aiven.inkless.common.ObjectKey;
+import io.aiven.inkless.common.ObjectKeyCreator;
 import io.aiven.inkless.common.PlainObjectKey;
 import io.aiven.inkless.control_plane.BatchInfo;
 import io.aiven.inkless.control_plane.FindBatchResponse;
@@ -39,16 +40,21 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.STRICT_STUBS)
 public class FetchCompleterJobTest {
+    static final String OBJECT_KEY_PREFIX = "prefix/";
+    static final ObjectKeyCreator OBJECT_KEY_CREATOR = PlainObjectKey.creator(OBJECT_KEY_PREFIX);
+    static final String OBJECT_KEY_A_MAIN_PART = "a";
+    static final String OBJECT_KEY_B_MAIN_PART = "b";
+    static final ObjectKey OBJECT_KEY_A = new PlainObjectKey(OBJECT_KEY_PREFIX, OBJECT_KEY_A_MAIN_PART);
+    static final ObjectKey OBJECT_KEY_B = new PlainObjectKey(OBJECT_KEY_PREFIX, OBJECT_KEY_B_MAIN_PART);
 
     Uuid topicId = Uuid.randomUuid();
-    ObjectKey objectA = new PlainObjectKey("a", "a");
-    ObjectKey objectB = new PlainObjectKey("b", "b");
     TopicIdPartition partition0 = new TopicIdPartition(topicId, 0, "inkless-topic");
 
     @Test
     public void testEmptyFetch() {
         FetchCompleterJob job = new FetchCompleterJob(
             new MockTime(),
+            OBJECT_KEY_CREATOR,
             Collections.emptyMap(),
             CompletableFuture.completedFuture(Collections.emptyMap()),
             CompletableFuture.completedFuture(Collections.emptyList()),
@@ -65,6 +71,7 @@ public class FetchCompleterJobTest {
         );
         FetchCompleterJob job = new FetchCompleterJob(
             new MockTime(),
+            OBJECT_KEY_CREATOR,
             fetchInfos,
             CompletableFuture.completedFuture(Collections.emptyMap()),
             CompletableFuture.completedFuture(Collections.emptyList()),
@@ -87,6 +94,7 @@ public class FetchCompleterJobTest {
         );
         FetchCompleterJob job = new FetchCompleterJob(
             new MockTime(),
+            OBJECT_KEY_CREATOR,
             fetchInfos,
             CompletableFuture.completedFuture(coordinates),
             CompletableFuture.completedFuture(Collections.emptyList()),
@@ -110,11 +118,12 @@ public class FetchCompleterJobTest {
         int highWatermark = 1;
         Map<TopicIdPartition, FindBatchResponse> coordinates = Map.of(
                 partition0, FindBatchResponse.success(List.of(
-                        new BatchInfo(objectA, 0, 10, 0, 1, TimestampType.CREATE_TIME, logAppendTime)
+                        new BatchInfo(OBJECT_KEY_A_MAIN_PART, 0, 10, 0, 1, TimestampType.CREATE_TIME, logAppendTime)
                 ), logStartOffset, highWatermark)
         );
         FetchCompleterJob job = new FetchCompleterJob(
             new MockTime(),
+            OBJECT_KEY_CREATOR,
             fetchInfos,
             CompletableFuture.completedFuture(coordinates),
             CompletableFuture.completedFuture(Collections.emptyList()),
@@ -137,17 +146,18 @@ public class FetchCompleterJobTest {
         int highWatermark = 1;
         Map<TopicIdPartition, FindBatchResponse> coordinates = Map.of(
                 partition0, FindBatchResponse.success(List.of(
-                        new BatchInfo(objectA, 0, records.sizeInBytes(), 0, 1, TimestampType.CREATE_TIME, logAppendTime),
-                        new BatchInfo(objectB, 0, records.sizeInBytes(), 0, 1, TimestampType.CREATE_TIME, logAppendTime)
+                        new BatchInfo(OBJECT_KEY_A_MAIN_PART, 0, records.sizeInBytes(), 0, 1, TimestampType.CREATE_TIME, logAppendTime),
+                        new BatchInfo(OBJECT_KEY_B_MAIN_PART, 0, records.sizeInBytes(), 0, 1, TimestampType.CREATE_TIME, logAppendTime)
                 ), logStartOffset, highWatermark)
         );
 
         List<Future<FetchedFile>> files = Stream.of(
-                new FetchedFile(objectA, new ByteRange(0, records.sizeInBytes()), records.buffer()),
-                new FetchedFile(objectB, new ByteRange(0, records.sizeInBytes()), records.buffer())
+                new FetchedFile(OBJECT_KEY_A, new ByteRange(0, records.sizeInBytes()), records.buffer()),
+                new FetchedFile(OBJECT_KEY_B, new ByteRange(0, records.sizeInBytes()), records.buffer())
         ).map(CompletableFuture::completedFuture).collect(Collectors.toList());
         FetchCompleterJob job = new FetchCompleterJob(
             new MockTime(),
+            OBJECT_KEY_CREATOR,
             fetchInfos,
             CompletableFuture.completedFuture(coordinates),
             CompletableFuture.completedFuture(files),
@@ -173,15 +183,16 @@ public class FetchCompleterJobTest {
         int highWatermark = 1;
         Map<TopicIdPartition, FindBatchResponse> coordinates = Map.of(
                 partition0, FindBatchResponse.success(List.of(
-                        new BatchInfo(objectA, 0, records.sizeInBytes(), 0, 1, TimestampType.CREATE_TIME, logAppendTime)
+                        new BatchInfo(OBJECT_KEY_A_MAIN_PART, 0, records.sizeInBytes(), 0, 1, TimestampType.CREATE_TIME, logAppendTime)
                 ), logStartOffset, highWatermark)
         );
 
         List<Future<FetchedFile>> files = Stream.of(
-                new FetchedFile(objectA, new ByteRange(0, records.sizeInBytes()), records.buffer())
+                new FetchedFile(OBJECT_KEY_A, new ByteRange(0, records.sizeInBytes()), records.buffer())
         ).map(CompletableFuture::completedFuture).collect(Collectors.toList());
         FetchCompleterJob job = new FetchCompleterJob(
             new MockTime(),
+            OBJECT_KEY_CREATOR,
             fetchInfos,
             CompletableFuture.completedFuture(coordinates),
             CompletableFuture.completedFuture(files),

--- a/storage/inkless/src/test/java/io/aiven/inkless/consume/FetchInterceptorTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/consume/FetchInterceptorTest.java
@@ -31,6 +31,8 @@ import java.util.OptionalLong;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
+import io.aiven.inkless.common.ObjectKeyCreator;
+import io.aiven.inkless.common.PlainObjectKey;
 import io.aiven.inkless.common.SharedState;
 import io.aiven.inkless.config.InklessConfig;
 import io.aiven.inkless.control_plane.ControlPlane;
@@ -47,6 +49,8 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.STRICT_STUBS)
 public class FetchInterceptorTest {
+    static final ObjectKeyCreator OBJECT_KEY_CREATOR = PlainObjectKey.creator("");
+
     Time time = new MockTime();
     @Mock
     InklessConfig inklessConfig;
@@ -73,7 +77,7 @@ public class FetchInterceptorTest {
 
     @BeforeEach
     public void setup() {
-        sharedState = new SharedState(time, inklessConfig, metadataView, controlPlane, storageBackend, brokerTopicStats);
+        sharedState = new SharedState(time, inklessConfig, metadataView, controlPlane, storageBackend, OBJECT_KEY_CREATOR, brokerTopicStats);
     }
 
     @Test

--- a/storage/inkless/src/test/java/io/aiven/inkless/consume/FindBatchesJobTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/consume/FindBatchesJobTest.java
@@ -22,8 +22,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import io.aiven.inkless.common.ObjectKey;
-import io.aiven.inkless.common.PlainObjectKey;
 import io.aiven.inkless.control_plane.BatchInfo;
 import io.aiven.inkless.control_plane.ControlPlane;
 import io.aiven.inkless.control_plane.FindBatchRequest;
@@ -51,7 +49,7 @@ public class FindBatchesJobTest {
     ArgumentCaptor<List<FindBatchRequest>> requestCaptor;
 
     Uuid topicId = Uuid.randomUuid();
-    ObjectKey objectA = new PlainObjectKey("a", "a");
+    static final String OBJECT_KEY_MAIN_PART = "a";
     TopicIdPartition partition0 = new TopicIdPartition(topicId, 0, "inkless-topic");
 
     @Test
@@ -64,7 +62,7 @@ public class FindBatchesJobTest {
         int highWatermark = 1;
         Map<TopicIdPartition, FindBatchResponse> coordinates = Map.of(
                 partition0, FindBatchResponse.success(List.of(
-                        new BatchInfo(objectA, 0, 10, 0, 1, TimestampType.CREATE_TIME, logAppendTime)
+                        new BatchInfo(OBJECT_KEY_MAIN_PART, 0, 10, 0, 1, TimestampType.CREATE_TIME, logAppendTime)
                 ), logStartOffset, highWatermark)
         );
         FindBatchesJob job = new FindBatchesJob(time, controlPlane, params, fetchInfos, durationMs -> { });

--- a/storage/inkless/src/test/java/io/aiven/inkless/consume/ReaderTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/consume/ReaderTest.java
@@ -32,6 +32,8 @@ import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 
+import io.aiven.inkless.common.ObjectKeyCreator;
+import io.aiven.inkless.common.PlainObjectKey;
 import io.aiven.inkless.control_plane.ControlPlane;
 import io.aiven.inkless.storage_backend.common.ObjectFetcher;
 
@@ -45,7 +47,7 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.STRICT_STUBS)
 public class ReaderTest {
-
+    static final ObjectKeyCreator OBJECT_KEY_CREATOR = PlainObjectKey.creator("");
     @Mock
     private ControlPlane controlPlane;
     @Mock
@@ -66,7 +68,7 @@ public class ReaderTest {
 
     @BeforeEach
     public void setup() {
-        reader = new Reader(time, controlPlane, objectFetcher, metadataExecutor, fetchPlannerExecutor, dataExecutor, fetchCompleterExecutor);
+        reader = new Reader(time, OBJECT_KEY_CREATOR, controlPlane, objectFetcher, metadataExecutor, fetchPlannerExecutor, dataExecutor, fetchCompleterExecutor);
     }
 
     @Test

--- a/storage/inkless/src/test/java/io/aiven/inkless/control_plane/AbstractControlPlaneTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/control_plane/AbstractControlPlaneTest.java
@@ -25,8 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import io.aiven.inkless.common.PlainObjectKey;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.eq;
@@ -82,7 +80,7 @@ abstract class AbstractControlPlaneTest {
     @Test
     void emptyCommit() {
         final List<CommitBatchResponse> commitBatchResponse = controlPlane.commitFile(
-            new PlainObjectKey("a", "a"),
+            "a",
             List.of()
         );
         assertThat(commitBatchResponse).isEmpty();
@@ -90,7 +88,9 @@ abstract class AbstractControlPlaneTest {
 
     @Test
     void successfulCommitToExistingPartitions() {
-        final PlainObjectKey objectKey1 = new PlainObjectKey("a", "a1");
+        final String objectKey1 = "a1";
+        final String objectKey2 = "a2";
+
         final List<CommitBatchResponse> commitResponse1 = controlPlane.commitFile(
             objectKey1,
             List.of(
@@ -105,7 +105,6 @@ abstract class AbstractControlPlaneTest {
             new CommitBatchResponse(Errors.UNKNOWN_TOPIC_OR_PARTITION, -1, -1, -1)
         );
 
-        final PlainObjectKey objectKey2 = new PlainObjectKey("a", "a2");
         final List<CommitBatchResponse> commitResponse2 = controlPlane.commitFile(
             objectKey2,
             List.of(
@@ -138,8 +137,8 @@ abstract class AbstractControlPlaneTest {
 
     @Test
     void fullSpectrumFind() {
-        final PlainObjectKey objectKey1 = new PlainObjectKey("a", "a1");
-        final PlainObjectKey objectKey2 = new PlainObjectKey("a", "a2");
+        final String objectKey1 = "a1";
+        final String objectKey2 = "a2";
         final int numberOfRecordsInBatch1 = 3;
         final int numberOfRecordsInBatch2 = 2;
         controlPlane.commitFile(objectKey1,
@@ -174,7 +173,8 @@ abstract class AbstractControlPlaneTest {
 
     @Test
     void topicDisappear() {
-        final PlainObjectKey objectKey = new PlainObjectKey("a", "a");
+        final String objectKey = "a";
+
         controlPlane.commitFile(
             objectKey,
             List.of(
@@ -209,7 +209,8 @@ abstract class AbstractControlPlaneTest {
 
     @Test
     void findOffsetOutOfRange() {
-        final PlainObjectKey objectKey = new PlainObjectKey("a", "a");
+        final String objectKey = "a";
+
         controlPlane.commitFile(
             objectKey,
             List.of(
@@ -228,7 +229,8 @@ abstract class AbstractControlPlaneTest {
 
     @Test
     void findNegativeOffset() {
-        final PlainObjectKey objectKey = new PlainObjectKey("a", "a");
+        final String objectKey = "a";
+
         controlPlane.commitFile(
             objectKey,
             List.of(
@@ -258,7 +260,8 @@ abstract class AbstractControlPlaneTest {
 
     @Test
     void commitEmptyBatches() {
-        final PlainObjectKey objectKey = new PlainObjectKey("a", "a1");
+        final String objectKey = "a";
+
         assertThatThrownBy(() -> controlPlane.commitFile(objectKey,
             List.of(
                 new CommitBatchRequest(new TopicPartition(EXISTING_TOPIC, 0), 1, 10, 10),

--- a/storage/inkless/src/test/java/io/aiven/inkless/produce/AppendInterceptorTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/produce/AppendInterceptorTest.java
@@ -26,6 +26,8 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
+import io.aiven.inkless.common.ObjectKeyCreator;
+import io.aiven.inkless.common.PlainObjectKey;
 import io.aiven.inkless.common.SharedState;
 import io.aiven.inkless.config.InklessConfig;
 import io.aiven.inkless.control_plane.ControlPlane;
@@ -42,6 +44,8 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.STRICT_STUBS)
 public class AppendInterceptorTest {
+    static final ObjectKeyCreator OBJECT_KEY_CREATOR = PlainObjectKey.creator("");
+
     Time time = new MockTime();
     @Mock
     InklessConfig inklessConfig;
@@ -98,7 +102,7 @@ public class AppendInterceptorTest {
         when(metadataView.isInklessTopic(eq("inkless"))).thenReturn(true);
         when(metadataView.isInklessTopic(eq("non_inkless"))).thenReturn(false);
         final AppendInterceptor interceptor = new AppendInterceptor(
-            new SharedState(time, inklessConfig, metadataView, controlPlane, storageBackend, brokerTopicStats), writer);
+            new SharedState(time, inklessConfig, metadataView, controlPlane, storageBackend, OBJECT_KEY_CREATOR, brokerTopicStats), writer);
 
         final Map<TopicPartition, MemoryRecords> entriesPerPartition = Map.of(
             new TopicPartition("inkless", 0),
@@ -124,7 +128,7 @@ public class AppendInterceptorTest {
     public void notInterceptProducingToClassicTopics() {
         when(metadataView.isInklessTopic(eq("non_inkless"))).thenReturn(false);
         final AppendInterceptor interceptor = new AppendInterceptor(
-            new SharedState(time, inklessConfig, metadataView, controlPlane, storageBackend, brokerTopicStats), writer);
+            new SharedState(time, inklessConfig, metadataView, controlPlane, storageBackend, OBJECT_KEY_CREATOR, brokerTopicStats), writer);
 
         final Map<TopicPartition, MemoryRecords> entriesPerPartition = Map.of(
             new TopicPartition("non_inkless", 0),
@@ -142,7 +146,7 @@ public class AppendInterceptorTest {
         when(metadataView.isInklessTopic(eq("inkless1"))).thenReturn(true);
         when(metadataView.isInklessTopic(eq("inkless2"))).thenReturn(true);
         final AppendInterceptor interceptor = new AppendInterceptor(
-            new SharedState(time, inklessConfig, metadataView, controlPlane, storageBackend, brokerTopicStats), writer);
+            new SharedState(time, inklessConfig, metadataView, controlPlane, storageBackend, OBJECT_KEY_CREATOR, brokerTopicStats), writer);
 
         final Map<TopicPartition, MemoryRecords> entriesPerPartition = Map.of(
             new TopicPartition("inkless1", 0),
@@ -168,7 +172,7 @@ public class AppendInterceptorTest {
     public void acceptIdempotentProduceForNonInklessTopics() {
         when(metadataView.isInklessTopic(eq("non_inkless"))).thenReturn(false);
         final AppendInterceptor interceptor = new AppendInterceptor(
-            new SharedState(time, inklessConfig, metadataView, controlPlane, storageBackend, brokerTopicStats), writer);
+            new SharedState(time, inklessConfig, metadataView, controlPlane, storageBackend, OBJECT_KEY_CREATOR, brokerTopicStats), writer);
 
         final Map<TopicPartition, MemoryRecords> entriesPerPartition = Map.of(
             new TopicPartition("non_inkless", 0),
@@ -187,7 +191,7 @@ public class AppendInterceptorTest {
         when(metadataView.isInklessTopic(eq("inkless1"))).thenReturn(true);
         when(metadataView.isInklessTopic(eq("inkless2"))).thenReturn(true);
         final AppendInterceptor interceptor = new AppendInterceptor(
-            new SharedState(time, inklessConfig, metadataView, controlPlane, storageBackend, brokerTopicStats), writer);
+            new SharedState(time, inklessConfig, metadataView, controlPlane, storageBackend, OBJECT_KEY_CREATOR, brokerTopicStats), writer);
 
         final Map<TopicPartition, MemoryRecords> entriesPerPartition = Map.of(
             new TopicPartition("inkless1", 0),
@@ -213,7 +217,7 @@ public class AppendInterceptorTest {
     public void acceptTransactionalProduceForNonInklessTopics() {
         when(metadataView.isInklessTopic(eq("non_inkless"))).thenReturn(false);
         final AppendInterceptor interceptor = new AppendInterceptor(
-            new SharedState(time, inklessConfig, metadataView, controlPlane, storageBackend, brokerTopicStats), writer);
+            new SharedState(time, inklessConfig, metadataView, controlPlane, storageBackend, OBJECT_KEY_CREATOR, brokerTopicStats), writer);
 
         final Map<TopicPartition, MemoryRecords> entriesPerPartition = Map.of(
             new TopicPartition("non_inkless", 0),
@@ -243,7 +247,7 @@ public class AppendInterceptorTest {
 
         when(metadataView.isInklessTopic(eq("inkless"))).thenReturn(true);
         final AppendInterceptor interceptor = new AppendInterceptor(
-            new SharedState(time, inklessConfig, metadataView, controlPlane, storageBackend, brokerTopicStats), writer);
+            new SharedState(time, inklessConfig, metadataView, controlPlane, storageBackend, OBJECT_KEY_CREATOR, brokerTopicStats), writer);
 
         final boolean result = interceptor.intercept(entriesPerPartition, responseCallback);
         assertThat(result).isTrue();
@@ -265,7 +269,7 @@ public class AppendInterceptorTest {
 
         when(metadataView.isInklessTopic(eq("inkless"))).thenReturn(true);
         final AppendInterceptor interceptor = new AppendInterceptor(
-            new SharedState(time, inklessConfig, metadataView, controlPlane, storageBackend, brokerTopicStats), writer);
+            new SharedState(time, inklessConfig, metadataView, controlPlane, storageBackend, OBJECT_KEY_CREATOR, brokerTopicStats), writer);
 
         final boolean result = interceptor.intercept(entriesPerPartition, responseCallback);
         assertThat(result).isTrue();
@@ -279,7 +283,7 @@ public class AppendInterceptorTest {
     @Test
     public void close() throws IOException {
         final AppendInterceptor interceptor = new AppendInterceptor(
-            new SharedState(time, inklessConfig, metadataView, controlPlane, storageBackend, brokerTopicStats), writer);
+            new SharedState(time, inklessConfig, metadataView, controlPlane, storageBackend, OBJECT_KEY_CREATOR, brokerTopicStats), writer);
 
         interceptor.close();
 

--- a/storage/inkless/src/test/java/io/aiven/inkless/produce/FileCommitJobTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/produce/FileCommitJobTest.java
@@ -62,7 +62,8 @@ class FileCommitJobTest {
     static final List<Integer> REQUEST_IDS = List.of(0, 0, 1, 1);
 
     static final byte[] DATA = new byte[10];
-    static final ObjectKey OBJECT_KEY = new PlainObjectKey("", "s");
+    static final String OBJECT_KEY_MAIN_PART = "obj";
+    static final ObjectKey OBJECT_KEY = new PlainObjectKey("", OBJECT_KEY_MAIN_PART);
 
     @Mock
     Time time;
@@ -85,7 +86,7 @@ class FileCommitJobTest {
             new CommitBatchResponse(Errors.NONE, 30, 10, 0)
         );
 
-        when(controlPlane.commitFile(eq(OBJECT_KEY), eq(COMMIT_BATCH_REQUESTS)))
+        when(controlPlane.commitFile(eq(OBJECT_KEY_MAIN_PART), eq(COMMIT_BATCH_REQUESTS)))
             .thenReturn(commitBatchResponses);
         when(time.nanoseconds()).thenReturn(10_000_000L, 20_000_000L);
 
@@ -117,7 +118,7 @@ class FileCommitJobTest {
 
         final List<CommitBatchResponse> commitBatchResponses = List.of();
 
-        when(controlPlane.commitFile(eq(OBJECT_KEY), eq(COMMIT_BATCH_REQUESTS)))
+        when(controlPlane.commitFile(eq(OBJECT_KEY_MAIN_PART), eq(COMMIT_BATCH_REQUESTS)))
             .thenReturn(commitBatchResponses);
         when(time.nanoseconds()).thenReturn(10_000_000L, 20_000_000L);
 

--- a/storage/inkless/src/test/java/io/aiven/inkless/produce/WriterIntegrationTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/produce/WriterIntegrationTest.java
@@ -145,7 +145,7 @@ class WriterIntegrationTest {
 
         try (
             final Writer writer = new Writer(
-                time, (String s) -> new PlainObjectKey("", s), storage, controlPlane, Duration.ofMillis(10),
+                time, PlainObjectKey.creator(""), storage, controlPlane, Duration.ofMillis(10),
                 10 * 1024,
                 1,
                 Duration.ofMillis(10),

--- a/storage/inkless/src/test/java/io/aiven/inkless/produce/WriterPropertyTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/produce/WriterPropertyTest.java
@@ -153,7 +153,7 @@ class WriterPropertyTest {
         );
         final FileCommitter fileCommitter = new FileCommitter(
             controlPlane,
-            (String s) -> new PlainObjectKey("", s),
+            PlainObjectKey.creator(""),
             objectUploader,
             time,
             1,


### PR DESCRIPTION
`ObjectKey` abstracts the value logic from printing (e.g. in logs). Particularly, by hiding the prefix if necessary. The knowledge about this is not needed on the control plane level. Moreover, it's better to not have it there for the following reasons:
1. If we operate with two-part keys, the control plane needs to be aware of this and be able to split and recombine these keys for storage. This exposes it to unnecessary implementation details.
2. In the typical Aiven setup, the prefix is very service-dependent and contains e.g. project ID. If the control plane is multi-tenant, we don't want this prefixes there as they're a part of secrecy in shared buckets.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
