### PR TITLE
fix(inkless:consume): return empty batch when requesting hwm offset

### DIFF
--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/InMemoryControlPlane.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/InMemoryControlPlane.java
@@ -160,7 +160,7 @@ public class InMemoryControlPlane implements ControlPlane {
                                                               final boolean minOneMessage,
                                                               final int fetchMaxBytes) {
         final LogInfo logInfo = logs.get(request.topicIdPartition());
-        final TreeMap<Long, BatchInfo> coordinates = this.batches.get(request.topicIdPartition());
+        final TreeMap<Long, BatchInfo> coordinates = batches.get(request.topicIdPartition());
         if (logInfo == null || coordinates == null) {
             return FindBatchResponse.unknownTopicOrPartition();
         }
@@ -170,7 +170,9 @@ public class InMemoryControlPlane implements ControlPlane {
             return FindBatchResponse.offsetOutOfRange(logInfo.logStartOffset, logInfo.highWatermark);
         }
 
-        if (request.offset() >= logInfo.highWatermark) {
+        // if offset requests is > end offset return out-of-range exception, otherwise return empty batch.
+        // Similar to {@link LocalLog#read() L490}
+        if (request.offset() > logInfo.highWatermark) {
             return FindBatchResponse.offsetOutOfRange(logInfo.logStartOffset, logInfo.highWatermark);
         }
 

--- a/storage/inkless/src/test/java/io/aiven/inkless/control_plane/AbstractControlPlaneTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/control_plane/AbstractControlPlaneTest.java
@@ -208,7 +208,7 @@ abstract class AbstractControlPlaneTest {
     }
 
     @Test
-    void findOffsetOutOfRange() {
+    void findEmptyBatchOnLastOffset() {
         final String objectKey = "a";
 
         controlPlane.commitFile(
@@ -220,6 +220,26 @@ abstract class AbstractControlPlaneTest {
 
         final List<FindBatchResponse> findResponse = controlPlane.findBatches(
             List.of(new FindBatchRequest(EXISTING_TOPIC_ID_PARTITION, 10, Integer.MAX_VALUE)),
+            true,
+            Integer.MAX_VALUE);
+        assertThat(findResponse).containsExactly(
+            new FindBatchResponse(Errors.NONE, List.of(), 0, 10)
+        );
+    }
+
+    @Test
+    void findOffsetOutOfRange() {
+        final String objectKey = "a";
+
+        controlPlane.commitFile(
+            objectKey,
+            List.of(
+                new CommitBatchRequest(new TopicPartition(EXISTING_TOPIC, 0), 11, 10, 10)
+            )
+        );
+
+        final List<FindBatchResponse> findResponse = controlPlane.findBatches(
+            List.of(new FindBatchRequest(EXISTING_TOPIC_ID_PARTITION, 11, Integer.MAX_VALUE)),
             true,
             Integer.MAX_VALUE);
         assertThat(findResponse).containsExactly(


### PR DESCRIPTION
*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
