### PR TITLE
Lock log rows for update when committing [INK-39]

### DIFF
--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/LogEntity.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/LogEntity.java
@@ -1,0 +1,30 @@
+package io.aiven.inkless.control_plane.postgres;
+
+import org.apache.kafka.common.TopicIdPartition;
+import org.apache.kafka.common.Uuid;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.UUID;
+
+import io.aiven.inkless.common.UuidUtil;
+
+record LogEntity(Uuid topicId,
+                 int partition,
+                 String topicName,
+                 long logStartOffset,
+                 long highWatermark) {
+    static LogEntity fromResultSet(final ResultSet resultSet) throws SQLException {
+        return new LogEntity(
+            UuidUtil.fromJava(resultSet.getObject("topic_id", UUID.class)),
+            resultSet.getInt("partition"),
+            resultSet.getString("topic_name"),
+            resultSet.getLong("log_start_offset"),
+            resultSet.getLong("high_watermark")
+        );
+    }
+
+    TopicIdPartition topicIdPartition() {
+        return new TopicIdPartition(this.topicId(), this.partition(), this.topicName());
+    }
+}

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/LogSelectQuery.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/LogSelectQuery.java
@@ -1,0 +1,61 @@
+// Copyright (c) 2024 Aiven, Helsinki, Finland. https://aiven.io/
+package io.aiven.inkless.control_plane.postgres;
+
+import org.apache.kafka.common.TopicIdPartition;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import io.aiven.inkless.common.UuidUtil;
+
+class LogSelectQuery {
+    private static final MessageFormat SELECT_LOGS_QUERY_TEMPLATE = new MessageFormat("""
+        SELECT topic_id, partition, topic_name, log_start_offset, high_watermark
+        FROM logs
+        WHERE {0}
+        {1}
+        """);
+
+    static List<LogEntity> execute(
+        final Connection connection,
+        final Collection<TopicIdPartition> topicIdAndPartitions,
+        final boolean forUpdate
+    ) throws SQLException {
+        Objects.requireNonNull(connection, "connection cannot be null");
+        Objects.requireNonNull(topicIdAndPartitions, "topicIdAndPartitions cannot be null");
+        if (topicIdAndPartitions.isEmpty()) {
+            throw new IllegalArgumentException("topicIdAndPartitions cannot be empty");
+        }
+
+        final String wherePlaceholders = topicIdAndPartitions.stream()
+            .map(r -> "(topic_id = ? AND partition = ?)")
+            .collect(Collectors.joining(" OR "));
+
+        final String forUpdateStr = forUpdate ? "FOR UPDATE" : "";
+        final String query = SELECT_LOGS_QUERY_TEMPLATE.format(new String[]{wherePlaceholders, forUpdateStr});
+
+        final List<LogEntity> result = new ArrayList<>();
+        try (final PreparedStatement preparedStatement = connection.prepareStatement(query)) {
+            int placeholderI = 1;
+            for (final TopicIdPartition request : topicIdAndPartitions) {
+                preparedStatement.setObject(placeholderI++, UuidUtil.toJava(request.topicId()));
+                preparedStatement.setInt(placeholderI++, request.partition());
+            }
+
+            try (final ResultSet resultSet = preparedStatement.executeQuery()) {
+                while (resultSet.next()) {
+                    result.add(LogEntity.fromResultSet(resultSet));
+                }
+            }
+        }
+        return result;
+    }
+}

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/PostgresControlPlane.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/PostgresControlPlane.java
@@ -61,8 +61,7 @@ public class PostgresControlPlane extends AbstractControlPlane {
         config.setUsername(controlPlaneConfig.username());
         config.setPassword(controlPlaneConfig.password());
 
-        // TODO consider relaxing
-        config.setTransactionIsolation(IsolationLevel.TRANSACTION_REPEATABLE_READ.name());
+        config.setTransactionIsolation(IsolationLevel.TRANSACTION_READ_COMMITTED.name());
 
         // We're doing interactive transactions.
         config.setAutoCommit(false);

--- a/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/LogSelectQueryTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/LogSelectQueryTest.java
@@ -1,0 +1,178 @@
+// Copyright (c) 2024 Aiven, Helsinki, Finland. https://aiven.io/
+package io.aiven.inkless.control_plane.postgres;
+
+import org.apache.kafka.common.TopicIdPartition;
+import org.apache.kafka.common.Uuid;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import io.aiven.inkless.common.UuidUtil;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.STRICT_STUBS)
+class LogSelectQueryTest {
+    @Mock
+    Connection connection;
+    @Mock
+    PreparedStatement preparedStatement;
+    @Mock
+    ResultSet resultSet;
+
+    @Captor
+    ArgumentCaptor<String> queryCaptor;
+
+    static final TopicIdPartition T0P0 = new TopicIdPartition(Uuid.ZERO_UUID, 0, "t0");
+    static final TopicIdPartition T0P1 = new TopicIdPartition(Uuid.ZERO_UUID, 1, "t0");
+    static final TopicIdPartition T1P0 = new TopicIdPartition(Uuid.ONE_UUID, 0, "t1");
+    static final TopicIdPartition T1P1 = new TopicIdPartition(Uuid.ONE_UUID, 1, "t1");
+
+    @Test
+    void testNulls() {
+        assertThatThrownBy(() -> LogSelectQuery.execute(null, List.of(T0P0), false))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessage("connection cannot be null");
+        assertThatThrownBy(() -> LogSelectQuery.execute(connection, null, false))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessage("topicIdAndPartitions cannot be null");
+    }
+
+    @Test
+    void testEmpty() {
+        assertThatThrownBy(() -> LogSelectQuery.execute(connection, List.of(), false))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("topicIdAndPartitions cannot be empty");
+    }
+
+    @ParameterizedTest
+    @MethodSource("testSingleTopicPartitionProvider")
+    void testSingleTopicPartition(final boolean forUpdate, final String expectedQuery) throws SQLException {
+        final long logStartOffset = 1L;
+        final long highWatermark = 2L;
+
+        when(connection.prepareStatement(anyString())).thenReturn(preparedStatement);
+        when(preparedStatement.executeQuery()).thenReturn(resultSet);
+
+        when(resultSet.next()).thenReturn(true, false);
+
+        when(resultSet.getObject(eq("topic_id"), eq(UUID.class)))
+            .thenReturn(UuidUtil.toJava(T0P1.topicId()));
+        when(resultSet.getInt(eq("partition")))
+            .thenReturn(T0P1.partition());
+        when(resultSet.getString(eq("topic_name")))
+            .thenReturn(T0P1.topic());
+        when(resultSet.getLong(eq("log_start_offset")))
+            .thenReturn(logStartOffset);
+        when(resultSet.getLong(eq("high_watermark")))
+            .thenReturn(highWatermark);
+
+        final List<LogEntity> result = LogSelectQuery.execute(connection, List.of(T0P1), forUpdate);
+        assertThat(result).containsExactlyInAnyOrder(
+            new LogEntity(T0P1.topicId(), T0P1.partition(), T0P1.topic(), logStartOffset, highWatermark));
+
+        verify(connection).prepareStatement(queryCaptor.capture());
+        assertThat(queryCaptor.getValue().trim()).isEqualTo(expectedQuery.trim());
+
+        verify(preparedStatement).setObject(eq(1), eq(UuidUtil.toJava(T0P1.topicId())));
+        verify(preparedStatement).setInt(eq(2), eq(T0P1.partition()));
+    }
+
+    static Stream<Arguments> testSingleTopicPartitionProvider() {
+        final String queryNotForUpdate = """
+        SELECT topic_id, partition, topic_name, log_start_offset, high_watermark
+        FROM logs
+        WHERE (topic_id = ? AND partition = ?)
+        """;
+        final String queryForUpdate = """
+        SELECT topic_id, partition, topic_name, log_start_offset, high_watermark
+        FROM logs
+        WHERE (topic_id = ? AND partition = ?)
+        FOR UPDATE
+        """;
+        return Stream.of(
+            Arguments.of(false, queryNotForUpdate),
+            Arguments.of(true, queryForUpdate)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("testMultipleTopicPartitionsProvider")
+    void testMultipleTopicPartitions(final boolean forUpdate, final String expectedQuery) throws SQLException {
+        final long logStartOffset1 = 1L;
+        final long highWatermark1 = 2L;
+        final long logStartOffset2 = 10L;
+        final long highWatermark2 = 20L;
+
+        when(connection.prepareStatement(anyString())).thenReturn(preparedStatement);
+        when(preparedStatement.executeQuery()).thenReturn(resultSet);
+
+        when(resultSet.next()).thenReturn(true, true, false);
+
+        when(resultSet.getObject(eq("topic_id"), eq(UUID.class)))
+            .thenReturn(UuidUtil.toJava(T0P1.topicId()), UuidUtil.toJava(T1P0.topicId()));
+        when(resultSet.getInt(eq("partition")))
+            .thenReturn(T0P1.partition(), T1P0.partition());
+        when(resultSet.getString(eq("topic_name")))
+            .thenReturn(T0P1.topic(), T1P0.topic());
+        when(resultSet.getLong(eq("log_start_offset")))
+            .thenReturn(logStartOffset1, logStartOffset2);
+        when(resultSet.getLong(eq("high_watermark")))
+            .thenReturn(highWatermark1, highWatermark2);
+
+        final List<LogEntity> result = LogSelectQuery.execute(connection, List.of(T0P1, T1P0), forUpdate);
+        assertThat(result).containsExactlyInAnyOrder(
+            new LogEntity(T0P1.topicId(), T0P1.partition(), T0P1.topic(), logStartOffset1, highWatermark1),
+            new LogEntity(T1P0.topicId(), T1P0.partition(), T1P0.topic(), logStartOffset2, highWatermark2)
+        );
+
+        verify(connection).prepareStatement(queryCaptor.capture());
+        assertThat(queryCaptor.getValue().trim()).isEqualTo(expectedQuery.trim());
+
+        verify(preparedStatement).setObject(eq(1), eq(UuidUtil.toJava(T0P1.topicId())));
+        verify(preparedStatement).setInt(eq(2), eq(T0P1.partition()));
+        verify(preparedStatement).setObject(eq(3), eq(UuidUtil.toJava(T1P0.topicId())));
+        verify(preparedStatement).setInt(eq(4), eq(T1P0.partition()));
+    }
+
+    static Stream<Arguments> testMultipleTopicPartitionsProvider() {
+        final String queryNotForUpdate = """
+        SELECT topic_id, partition, topic_name, log_start_offset, high_watermark
+        FROM logs
+        WHERE (topic_id = ? AND partition = ?) OR (topic_id = ? AND partition = ?)
+        """;
+        final String queryForUpdate = """
+        SELECT topic_id, partition, topic_name, log_start_offset, high_watermark
+        FROM logs
+        WHERE (topic_id = ? AND partition = ?) OR (topic_id = ? AND partition = ?)
+        FOR UPDATE
+        """;
+        return Stream.of(
+            Arguments.of(false, queryNotForUpdate),
+            Arguments.of(true, queryForUpdate)
+        );
+    }
+}


### PR DESCRIPTION
This allows to avoid `org.postgresql.util.PSQLException: ERROR: could not serialize access due to concurrent update` and doing expensive retries of interactive transactions. This also allows relaxing the transaction isolation level to `READ COMMITTED`, which should also improve the overall concurrency landscape.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
