### PR TITLE
Correctly commit batch timestamp [INK-64]

### DIFF
--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/CommitBatchRequest.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/CommitBatchRequest.java
@@ -6,5 +6,6 @@ import org.apache.kafka.common.TopicPartition;
 public record CommitBatchRequest(TopicPartition topicPartition,
                                  int byteOffset,
                                  int size,
-                                 long numberOfRecords) {
+                                 long numberOfRecords,
+                                 long maxTimestamp) {
 }

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/CommitBatchResponse.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/CommitBatchResponse.java
@@ -5,8 +5,8 @@ import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.record.RecordBatch;
 
 public record CommitBatchResponse(Errors errors, long assignedOffset, long logAppendTime, long logStartOffset) {
-    public static CommitBatchResponse success(final long assignedOffset, final long timestamp, final long logStartOffset) {
-        return new CommitBatchResponse(Errors.NONE, assignedOffset, timestamp, logStartOffset);
+    public static CommitBatchResponse success(final long assignedOffset, final long logAppendTime, final long logStartOffset) {
+        return new CommitBatchResponse(Errors.NONE, assignedOffset, logAppendTime, logStartOffset);
     }
     public static CommitBatchResponse unknownTopicOrPartition() {
         return new CommitBatchResponse(Errors.UNKNOWN_TOPIC_OR_PARTITION, -1, RecordBatch.NO_TIMESTAMP, -1);

--- a/storage/inkless/src/main/java/io/aiven/inkless/produce/BatchBuffer.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/produce/BatchBuffer.java
@@ -52,7 +52,8 @@ class BatchBuffer {
                     batchHolder.topicPartition(),
                     byteOffset,
                     batchHolder.batch.sizeInBytes(),
-                    batchHolder.numberOfRecords()
+                    batchHolder.numberOfRecords(),
+                    batchHolder.batch.maxTimestamp()
                 )
             );
             requestIds.add(batchHolder.requestId);

--- a/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/CommitFileJobTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/CommitFileJobTest.java
@@ -67,13 +67,13 @@ class CommitFileJobTest extends SharedPostgreSQLTest {
         when(time.milliseconds()).thenReturn(123456L);
 
         final CommitFileJob job = new CommitFileJob(time, hikariDataSource, objectKey, List.of(
-            new CommitFileJob.CommitBatchRequestExtra(new CommitBatchRequest(T0P1, 0, 100, 15), TOPIC_ID_0, TimestampType.CREATE_TIME),
-            new CommitFileJob.CommitBatchRequestExtra(new CommitBatchRequest(T1P0, 100, 50, 27), TOPIC_ID_1, TimestampType.LOG_APPEND_TIME)
+            new CommitFileJob.CommitBatchRequestExtra(new CommitBatchRequest(T0P1, 0, 100, 15, 1000L), TOPIC_ID_0, TimestampType.CREATE_TIME),
+            new CommitFileJob.CommitBatchRequestExtra(new CommitBatchRequest(T1P0, 100, 50, 27, 1001L), TOPIC_ID_1, TimestampType.LOG_APPEND_TIME)
         ));
         final List<CommitBatchResponse> result = job.call();
 
         assertThat(result).containsExactlyInAnyOrder(
-            new CommitBatchResponse(Errors.NONE, 0, 123456L, 0),
+            new CommitBatchResponse(Errors.NONE, 0, 1000L, 0),
             new CommitBatchResponse(Errors.NONE, 0, 123456L, 0)
         );
 
@@ -96,30 +96,30 @@ class CommitFileJobTest extends SharedPostgreSQLTest {
         final String objectKey1 = "obj1";
         final String objectKey2 = "obj2";
 
-        when(time.milliseconds()).thenReturn(1000L);
+        when(time.milliseconds()).thenReturn(123456L);
 
         final CommitFileJob job1 = new CommitFileJob(time, hikariDataSource, objectKey1, List.of(
-            new CommitFileJob.CommitBatchRequestExtra(new CommitBatchRequest(T0P1, 0, 100, 15), TOPIC_ID_0, TimestampType.CREATE_TIME),
-            new CommitFileJob.CommitBatchRequestExtra(new CommitBatchRequest(T1P0, 100, 50, 27), TOPIC_ID_1, TimestampType.LOG_APPEND_TIME)
+            new CommitFileJob.CommitBatchRequestExtra(new CommitBatchRequest(T0P1, 0, 100, 15, 1000L), TOPIC_ID_0, TimestampType.CREATE_TIME),
+            new CommitFileJob.CommitBatchRequestExtra(new CommitBatchRequest(T1P0, 100, 50, 27, 1001L), TOPIC_ID_1, TimestampType.LOG_APPEND_TIME)
         ));
         final List<CommitBatchResponse> result1 = job1.call();
 
         assertThat(result1).containsExactlyInAnyOrder(
             new CommitBatchResponse(Errors.NONE, 0, 1000L, 0),
-            new CommitBatchResponse(Errors.NONE, 0, 1000L, 0)
+            new CommitBatchResponse(Errors.NONE, 0, 123456L, 0)
         );
 
-        when(time.milliseconds()).thenReturn(2000L);
+        when(time.milliseconds()).thenReturn(7891011L);
 
         final CommitFileJob job2 = new CommitFileJob(time, hikariDataSource, objectKey2, List.of(
-            new CommitFileJob.CommitBatchRequestExtra(new CommitBatchRequest(T0P0, 0, 111, 159), TOPIC_ID_0, TimestampType.CREATE_TIME),
-            new CommitFileJob.CommitBatchRequestExtra(new CommitBatchRequest(T0P1, 111, 222, 245), TOPIC_ID_0, TimestampType.CREATE_TIME)
+            new CommitFileJob.CommitBatchRequestExtra(new CommitBatchRequest(T0P0, 0, 111, 159, 2000L), TOPIC_ID_0, TimestampType.CREATE_TIME),
+            new CommitFileJob.CommitBatchRequestExtra(new CommitBatchRequest(T0P1, 111, 222, 245, 2001L), TOPIC_ID_0, TimestampType.CREATE_TIME)
         ));
         final List<CommitBatchResponse> result2 = job2.call();
 
         assertThat(result2).containsExactlyInAnyOrder(
             new CommitBatchResponse(Errors.NONE, 0, 2000L, 0),
-            new CommitBatchResponse(Errors.NONE, 15, 2000L, 0)
+            new CommitBatchResponse(Errors.NONE, 15, 2001L, 0)
         );
 
         assertThat(DBUtils.getAllLogs(hikariDataSource))
@@ -148,15 +148,15 @@ class CommitFileJobTest extends SharedPostgreSQLTest {
         // Non-existent partition.
         final var t1p1 = new TopicPartition(TOPIC_1, 10);
         final CommitFileJob job = new CommitFileJob(time, hikariDataSource, objectKey, List.of(
-            new CommitFileJob.CommitBatchRequestExtra(new CommitBatchRequest(T0P1, 0, 100, 15), TOPIC_ID_0, TimestampType.CREATE_TIME),
-            new CommitFileJob.CommitBatchRequestExtra(new CommitBatchRequest(T1P0, 100, 50, 27), TOPIC_ID_1, TimestampType.LOG_APPEND_TIME),
-            new CommitFileJob.CommitBatchRequestExtra(new CommitBatchRequest(t1p1, 150, 1243, 82), TOPIC_ID_1, TimestampType.LOG_APPEND_TIME)
+            new CommitFileJob.CommitBatchRequestExtra(new CommitBatchRequest(T0P1, 0, 100, 15, 1000L), TOPIC_ID_0, TimestampType.CREATE_TIME),
+            new CommitFileJob.CommitBatchRequestExtra(new CommitBatchRequest(T1P0, 100, 50, 27, 1001L), TOPIC_ID_1, TimestampType.LOG_APPEND_TIME),
+            new CommitFileJob.CommitBatchRequestExtra(new CommitBatchRequest(t1p1, 150, 1243, 82, 1002L), TOPIC_ID_1, TimestampType.LOG_APPEND_TIME)
         ));
 
         final List<CommitBatchResponse> result = job.call();
 
         assertThat(result).containsExactlyInAnyOrder(
-            new CommitBatchResponse(Errors.NONE, 0, 123456L, 0),
+            new CommitBatchResponse(Errors.NONE, 0, 1000L, 0),
             new CommitBatchResponse(Errors.NONE, 0, 123456L, 0),
             new CommitBatchResponse(Errors.UNKNOWN_TOPIC_OR_PARTITION, -1, -1, -1)
         );

--- a/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/FindBatchesJobTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/FindBatchesJobTest.java
@@ -67,12 +67,10 @@ class FindBatchesJobTest extends SharedPostgreSQLTest {
     void simpleFind() {
         final String objectKey1 = "obj1";
 
-        when(time.milliseconds()).thenReturn(123456L);
-
         final CommitFileJob commitJob = new CommitFileJob(
             time, hikariDataSource, objectKey1,
             List.of(
-                new CommitFileJob.CommitBatchRequestExtra(new CommitBatchRequest(T0P0, 0, 1234, 12), TOPIC_ID_0, TimestampType.CREATE_TIME)
+                new CommitFileJob.CommitBatchRequestExtra(new CommitBatchRequest(T0P0, 0, 1234, 12, 123456L), TOPIC_ID_0, TimestampType.CREATE_TIME)
             )
         );
         assertThat(commitJob.call()).isNotEmpty();

--- a/storage/inkless/src/test/java/io/aiven/inkless/produce/ActiveFileTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/produce/ActiveFileTest.java
@@ -86,13 +86,13 @@ class ActiveFileTest {
         final Instant start = Instant.ofEpochMilli(10);
         final ActiveFile file = new ActiveFile(Time.SYSTEM, start);
         final Map<TopicPartition, MemoryRecords> request1 = Map.of(
-            T0P0, MemoryRecords.withRecords(Compression.NONE, new SimpleRecord(new byte[10])),
-            T0P1, MemoryRecords.withRecords(Compression.NONE, new SimpleRecord(new byte[10]))
+            T0P0, MemoryRecords.withRecords(Compression.NONE, new SimpleRecord(1000L, new byte[10])),
+            T0P1, MemoryRecords.withRecords(Compression.NONE, new SimpleRecord(1001L, new byte[10]))
         );
         file.add(request1);
         final Map<TopicPartition, MemoryRecords> request2 = Map.of(
-            T0P1, MemoryRecords.withRecords(Compression.NONE, new SimpleRecord(new byte[10])),
-            T1P0, MemoryRecords.withRecords(Compression.NONE, new SimpleRecord(new byte[10]))
+            T0P1, MemoryRecords.withRecords(Compression.NONE, new SimpleRecord(1002L, new byte[10])),
+            T1P0, MemoryRecords.withRecords(Compression.NONE, new SimpleRecord(1003L, new byte[10]))
         );
         file.add(request2);
 
@@ -106,10 +106,10 @@ class ActiveFileTest {
         assertThat(result.awaitingFuturesByRequest().get(0)).isNotCompleted();
         assertThat(result.awaitingFuturesByRequest().get(1)).isNotCompleted();
         assertThat(result.commitBatchRequests()).containsExactly(
-            new CommitBatchRequest(T0P0, 0, 78, 1),
-            new CommitBatchRequest(T0P1, 78, 78, 1),
-            new CommitBatchRequest(T0P1, 156, 78, 1),
-            new CommitBatchRequest(T1P0, 234, 78, 1)
+            new CommitBatchRequest(T0P0, 0, 78, 1, 1000L),
+            new CommitBatchRequest(T0P1, 78, 78, 1, 1001L),
+            new CommitBatchRequest(T0P1, 156, 78, 1, 1002L),
+            new CommitBatchRequest(T1P0, 234, 78, 1, 1003L)
         );
         assertThat(result.requestIds()).containsExactly(0, 0, 1, 1);
         assertThat(result.data()).hasSize(312);

--- a/storage/inkless/src/test/java/io/aiven/inkless/produce/BatchBufferTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/produce/BatchBufferTest.java
@@ -71,7 +71,7 @@ class BatchBufferTest {
 
         final BatchBuffer.CloseResult result = buffer.close();
         assertThat(result.commitBatchRequests()).containsExactly(
-            new CommitBatchRequest(T0P0, 0, batch.sizeInBytes(), 3)
+            new CommitBatchRequest(T0P0, 0, batch.sizeInBytes(), 3, time.milliseconds())
         );
         assertThat(result.requestIds()).containsExactly(0);
         assertThat(result.data()).containsExactly(batchToBytes(batch));
@@ -80,7 +80,8 @@ class BatchBufferTest {
 
     @Test
     void multipleTopicPartitions() {
-        final Time time = Time.SYSTEM;
+        final Time time = new MockTime();
+
         final BatchBuffer buffer = new BatchBuffer();
 
         final MutableRecordBatch t0p0b0 = createBatch(time, T0P0 + "-0");
@@ -110,16 +111,17 @@ class BatchBufferTest {
 
         // Here batches are sorted.
         final BatchBuffer.CloseResult result = buffer.close();
+        final long expectedTimestamp = time.milliseconds();
         assertThat(result.commitBatchRequests()).containsExactly(
-            new CommitBatchRequest(T0P0, 0, batchSize, 1),
-            new CommitBatchRequest(T0P0, batchSize, batchSize, 1),
-            new CommitBatchRequest(T0P0, batchSize*2, batchSize, 1),
-            new CommitBatchRequest(T0P1, batchSize*3, batchSize, 1),
-            new CommitBatchRequest(T0P1, batchSize*4, batchSize, 1),
-            new CommitBatchRequest(T0P1, batchSize*5, batchSize, 1),
-            new CommitBatchRequest(T1P0, batchSize*6, batchSize, 1),
-            new CommitBatchRequest(T1P0, batchSize*7, batchSize, 1),
-            new CommitBatchRequest(T1P0, batchSize*8, batchSize, 1)
+            new CommitBatchRequest(T0P0, 0, batchSize, 1, expectedTimestamp),
+            new CommitBatchRequest(T0P0, batchSize, batchSize, 1, expectedTimestamp),
+            new CommitBatchRequest(T0P0, batchSize*2, batchSize, 1, expectedTimestamp),
+            new CommitBatchRequest(T0P1, batchSize*3, batchSize, 1, expectedTimestamp),
+            new CommitBatchRequest(T0P1, batchSize*4, batchSize, 1, expectedTimestamp),
+            new CommitBatchRequest(T0P1, batchSize*5, batchSize, 1, expectedTimestamp),
+            new CommitBatchRequest(T1P0, batchSize*6, batchSize, 1, expectedTimestamp),
+            new CommitBatchRequest(T1P0, batchSize*7, batchSize, 1, expectedTimestamp),
+            new CommitBatchRequest(T1P0, batchSize*8, batchSize, 1, expectedTimestamp)
         );
         assertThat(result.requestIds()).containsExactly(
             0, 0, 1,
@@ -147,14 +149,15 @@ class BatchBufferTest {
 
     @Test
     void notWorksAfterClosing() {
-        final Time time = Time.SYSTEM;
+        final Time time = new MockTime();
+
         final BatchBuffer buffer = new BatchBuffer();
 
         final MutableRecordBatch batch1 = createBatch(time, T0P0 + "-0");
         buffer.addBatch(T0P0, batch1, 0);
         final BatchBuffer.CloseResult result1 = buffer.close();
         assertThat(result1.commitBatchRequests()).containsExactly(
-            new CommitBatchRequest(T0P0, 0, batch1.sizeInBytes(), 1)
+            new CommitBatchRequest(T0P0, 0, batch1.sizeInBytes(), 1, time.milliseconds())
         );
         assertThat(result1.data()).containsExactly(batchToBytes(batch1));
         assertThat(result1.requestIds()).containsExactly(0);

--- a/storage/inkless/src/test/java/io/aiven/inkless/produce/ClosedFileTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/produce/ClosedFileTest.java
@@ -60,7 +60,7 @@ class ClosedFileTest {
         assertThatThrownBy(() -> new ClosedFile(
             Instant.EPOCH,
             Map.of(), Map.of(),
-            List.of(new CommitBatchRequest(null, 0, 0, 0)),
+            List.of(new CommitBatchRequest(null, 0, 0, 0, 1000L)),
             List.of(),
             new byte[1]))
             .isInstanceOf(IllegalArgumentException.class)

--- a/storage/inkless/src/test/java/io/aiven/inkless/produce/FileCommitJobTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/produce/FileCommitJobTest.java
@@ -54,10 +54,10 @@ class FileCommitJobTest {
         1, REQUEST_1
     );
     static final List<CommitBatchRequest> COMMIT_BATCH_REQUESTS = List.of(
-        new CommitBatchRequest(T0P0, 0, 100, 10),
-        new CommitBatchRequest(T0P1, 100, 100, 10),
-        new CommitBatchRequest(T0P1, 200, 100, 10),
-        new CommitBatchRequest(T1P0, 300, 100, 10)
+        new CommitBatchRequest(T0P0, 0, 100, 10, 1000L),
+        new CommitBatchRequest(T0P1, 100, 100, 10, 1001L),
+        new CommitBatchRequest(T0P1, 200, 100, 10, 1002L),
+        new CommitBatchRequest(T1P0, 300, 100, 10, 1003L)
     );
     static final List<Integer> REQUEST_IDS = List.of(0, 0, 1, 1);
 

--- a/storage/inkless/src/test/java/io/aiven/inkless/produce/WriterPropertyTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/produce/WriterPropertyTest.java
@@ -9,6 +9,7 @@ import org.apache.kafka.common.metadata.PartitionRecord;
 import org.apache.kafka.common.metadata.TopicRecord;
 import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.record.SimpleRecord;
+import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.common.requests.ProduceResponse;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
@@ -35,7 +36,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
@@ -101,7 +101,7 @@ class WriterPropertyTest {
 
         @Override
         public LogConfig getTopicConfig(final String topicName) {
-            return LogConfig.fromProps(Map.of(), new Properties());
+            return new LogConfig(Map.of("message.timestamp.type", TimestampType.LOG_APPEND_TIME.name));
         }
 
         @Override


### PR DESCRIPTION
Currently, the control plane commits the append time as the timestamp for batches regardless of the topic config. This change makes it commit `CreateTime` timestamp commit if the topic is configured so.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
