### PR TITLE
Don't commit by time when not needed [INK-67]

### DIFF
--- a/storage/inkless/src/test/java/io/aiven/inkless/produce/WriterMockedTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/produce/WriterMockedTest.java
@@ -69,12 +69,23 @@ class WriterMockedTest {
         final Writer writer = new Writer(
             time, Duration.ofMillis(1), 8 * 1024, commitTickScheduler, fileCommitter, writerMetrics, brokerTopicMetricMarks);
 
-        verify(commitTickScheduler).scheduleAtFixedRate(any(), eq(1L), eq(1L), eq(TimeUnit.MILLISECONDS));
-
         writer.tick();
 
         // Tick must be ignored in as the active file is empty.
         verify(fileCommitter, never()).commit(any());
+    }
+
+    @Test
+    void tickIsScheduledWhenFileIsWrittenTo() {
+        final Writer writer = new Writer(
+            time, Duration.ofMillis(1), 8 * 1024, commitTickScheduler, fileCommitter, writerMetrics, brokerTopicMetricMarks);
+
+        final Map<TopicPartition, MemoryRecords> writeRequest = Map.of(
+            T0P0, recordCreator.create(T0P0, 100)
+        );
+        writer.write(writeRequest);
+
+        verify(commitTickScheduler).schedule(any(Runnable.class), eq(1L), eq(TimeUnit.MILLISECONDS));
     }
 
     @Test


### PR DESCRIPTION
There may be a situation where under high traffic files are mostly committed due to size. However, the commit-by-time ticks are still running and sometimes commit small files. There’s a condition for not committing empty files, but committing files with one request in them is possible, while more requests are waiting in the queue.

This change makes scheduled tick more controlled: they are scheduled only when the current file is written to for the first time and are cancelled when it's committed due to size. There's still room for accidental commit of a small file due to time, but the probability doesn't seem to be high + no serious consequences. Because of this, it was decided to not do even more strict control (like check what file was supposed to be committed when the time comes) to not complicate tests.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
