### PR TITLE
Make ControlPlane closeable [INK-42]

### DIFF
--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/ControlPlane.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/ControlPlane.java
@@ -4,13 +4,14 @@ package io.aiven.inkless.control_plane;
 import org.apache.kafka.common.Configurable;
 import org.apache.kafka.common.utils.Time;
 
+import java.io.Closeable;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 
 import io.aiven.inkless.config.InklessConfig;
 
-public interface ControlPlane extends Configurable, TopicMetadataChangesSubscriber {
+public interface ControlPlane extends Closeable, Configurable, TopicMetadataChangesSubscriber {
     List<CommitBatchResponse> commitFile(String objectKey,
                                          int uploaderBrokerId,
                                          long fileSize,

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/InMemoryControlPlane.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/InMemoryControlPlane.java
@@ -11,6 +11,7 @@ import com.groupcdg.pitest.annotations.DoNotMutate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -159,6 +160,11 @@ public class InMemoryControlPlane extends AbstractControlPlane {
             }
         }
         return FindBatchResponse.success(batches, logInfo.logStartOffset, logInfo.highWatermark);
+    }
+
+    @Override
+    public void close() throws IOException {
+        // Do nothing.
     }
 
     private static class LogInfo {

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/PostgresControlPlane.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/PostgresControlPlane.java
@@ -8,6 +8,7 @@ import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import com.zaxxer.hikari.util.IsolationLevel;
 
+import java.io.IOException;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
@@ -100,5 +101,10 @@ public class PostgresControlPlane extends AbstractControlPlane {
             requests.toList(), minOneMessage, fetchMaxBytes,
             metrics::onFindBatchesCompleted, metrics::onGetLogsCompleted);
         return job.call().iterator();
+    }
+
+    @Override
+    public void close() throws IOException {
+        hikariDataSource.close();
     }
 }


### PR DESCRIPTION
For testing, Pg control plane needs to close Datasource to close connection. If it doesn't, it reaches the maximum number of clients.

```
FATAL: sorry, too many clients already
```

[INK-42]

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)


[INK-42]: https://aiven.atlassian.net/browse/INK-42?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ