### PR TITLE
Exclude default topic config from control plane [INK-71]

### DIFF
--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -335,8 +335,9 @@ class BrokerServer(
        */
       val defaultActionQueue = new DelayedActionQueue
 
-      val inklessMetadataView = new InklessMetadataView(metadataCache, () => logManager.currentDefaultConfig)
-      val inklessSharedState = SharedState.initialize(time, config.brokerId, config.inklessConfig, inklessMetadataView, brokerTopicStats)
+      val inklessMetadataView = new InklessMetadataView(metadataCache)
+      val inklessSharedState = SharedState.initialize(time, config.brokerId, config.inklessConfig, inklessMetadataView, brokerTopicStats,
+        () => logManager.currentDefaultConfig)
 
       this._replicaManager = new ReplicaManager(
         config = config,

--- a/core/src/test/scala/kafka/server/metadata/InklessMetadataViewTest.scala
+++ b/core/src/test/scala/kafka/server/metadata/InklessMetadataViewTest.scala
@@ -3,7 +3,6 @@ package kafka.server.metadata
 
 import io.aiven.inkless.control_plane.TopicMetadataChangesSubscriber
 import org.apache.kafka.image.TopicsDelta
-import org.apache.kafka.storage.internals.log.LogConfig
 import org.junit.jupiter.api.Test
 import org.mockito.ArgumentMatchers.same
 import org.mockito.Mockito.{mock, reset, verify}
@@ -11,7 +10,7 @@ import org.mockito.Mockito.{mock, reset, verify}
 class InklessMetadataViewTest {
   @Test
   def topicMetadataChangesSubscriptionEmpty(): Unit = {
-    val metadataView = new InklessMetadataView(mock(classOf[KRaftMetadataCache]), mock(classOf[() => LogConfig]))
+    val metadataView = new InklessMetadataView(mock(classOf[KRaftMetadataCache]))
     val delta = mock(classOf[TopicsDelta])
 
     // No exception, all good.

--- a/storage/inkless/src/main/java/io/aiven/inkless/common/SharedState.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/common/SharedState.java
@@ -2,7 +2,10 @@
 package io.aiven.inkless.common;
 
 import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.storage.internals.log.LogConfig;
 import org.apache.kafka.storage.log.metrics.BrokerTopicStats;
+
+import java.util.function.Supplier;
 
 import io.aiven.inkless.cache.FixedBlockAlignment;
 import io.aiven.inkless.cache.KeyAlignmentStrategy;
@@ -23,7 +26,8 @@ public record SharedState(
         ObjectKeyCreator objectKeyCreator,
         KeyAlignmentStrategy keyAlignmentStrategy,
         ObjectCache cache,
-        BrokerTopicStats brokerTopicStats
+        BrokerTopicStats brokerTopicStats,
+        Supplier<LogConfig> defaultTopicConfigs
 ) {
 
     public static SharedState initialize(
@@ -31,7 +35,8 @@ public record SharedState(
         int brokerId,
         InklessConfig config,
         MetadataView metadata,
-        BrokerTopicStats brokerTopicStats
+        BrokerTopicStats brokerTopicStats,
+        Supplier<LogConfig> defaultTopicConfigs
     ) {
         return new SharedState(
             time,
@@ -43,7 +48,8 @@ public record SharedState(
             ObjectKey.create(config.objectKeyPrefix(), config.objectKeyLogPrefixMasked()),
             new FixedBlockAlignment(config.fetchCacheBlockBytes()),
             new MemoryCache(),
-            brokerTopicStats
+            brokerTopicStats,
+            defaultTopicConfigs
         );
     }
 }

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/CommitBatchRequest.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/CommitBatchRequest.java
@@ -2,10 +2,12 @@
 package io.aiven.inkless.control_plane;
 
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.record.TimestampType;
 
 public record CommitBatchRequest(TopicPartition topicPartition,
                                  int byteOffset,
                                  int size,
                                  long numberOfRecords,
-                                 long batchMaxTimestamp) {
+                                 long batchMaxTimestamp,
+                                 TimestampType messageTimestampType) {
 }

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/InMemoryControlPlane.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/InMemoryControlPlane.java
@@ -110,7 +110,7 @@ public class InMemoryControlPlane extends AbstractControlPlane {
             request.size(),
             firstOffset,
             request.numberOfRecords(),
-            metadataView.getTopicConfig(topicName).messageTimestampType,
+            request.messageTimestampType(),
             now,
             request.batchMaxTimestamp()
         );

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/MetadataView.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/MetadataView.java
@@ -4,8 +4,8 @@ package io.aiven.inkless.control_plane;
 import org.apache.kafka.admin.BrokerMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
-import org.apache.kafka.storage.internals.log.LogConfig;
 
+import java.util.Properties;
 import java.util.Set;
 
 public interface MetadataView {
@@ -17,7 +17,7 @@ public interface MetadataView {
 
     boolean isInklessTopic(String topicName);
 
-    LogConfig getTopicConfig(String topicName);
+    Properties getTopicConfig(String topicName);
 
     void subscribeToTopicMetadataChanges(TopicMetadataChangesSubscriber subscriber);
 }

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/CommitFileJob.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/CommitFileJob.java
@@ -2,7 +2,6 @@
 package io.aiven.inkless.control_plane.postgres;
 
 import org.apache.kafka.common.Uuid;
-import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.common.utils.Time;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -163,8 +162,7 @@ class CommitFileJob implements Callable<List<CommitBatchResponse>> {
     }
 
     record CommitBatchRequestExtra(CommitBatchRequest request,
-                                   Uuid topicId,
-                                   TimestampType timestampType) {
+                                   Uuid topicId) {
 
         @JsonProperty("topic_id")
         UUID topicIdJson() {
@@ -193,7 +191,7 @@ class CommitFileJob implements Callable<List<CommitBatchResponse>> {
 
         @JsonProperty("timestamp_type")
         short timestampTypeJson() {
-            return (short) timestampType.id;
+            return (short) request().messageTimestampType().id;
         }
 
         @JsonProperty("batch_max_timestamp")

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/PostgresControlPlane.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/PostgresControlPlane.java
@@ -82,8 +82,7 @@ public class PostgresControlPlane extends AbstractControlPlane {
         final Stream<CommitBatchRequest> requests) {
         final var requestExtras = requests.map(r -> new CommitFileJob.CommitBatchRequestExtra(
             r,
-            metadataView.getTopicId(r.topicPartition().topic()),
-            metadataView.getTopicConfig(r.topicPartition().topic()).messageTimestampType
+            metadataView.getTopicId(r.topicPartition().topic())
         )).toList();
         final CommitFileJob job = new CommitFileJob(
             time, hikariDataSource,

--- a/storage/inkless/src/test/java/io/aiven/inkless/consume/FetchInterceptorTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/consume/FetchInterceptorTest.java
@@ -12,6 +12,7 @@ import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.server.storage.log.FetchIsolation;
 import org.apache.kafka.server.storage.log.FetchParams;
 import org.apache.kafka.server.storage.log.FetchPartitionData;
+import org.apache.kafka.storage.internals.log.LogConfig;
 import org.apache.kafka.storage.log.metrics.BrokerTopicStats;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -30,6 +31,7 @@ import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 import io.aiven.inkless.cache.FixedBlockAlignment;
 import io.aiven.inkless.cache.KeyAlignmentStrategy;
@@ -73,6 +75,8 @@ public class FetchInterceptorTest {
     BrokerTopicStats brokerTopicStats;
     @Mock
     Reader reader;
+    @Mock
+    Supplier<LogConfig> defaultTopicConfigs;
 
     @Captor
     ArgumentCaptor<Map<TopicIdPartition, FetchPartitionData>> resultCaptor;
@@ -84,7 +88,8 @@ public class FetchInterceptorTest {
 
     @BeforeEach
     public void setup() {
-        sharedState = new SharedState(time, BROKER_ID, inklessConfig, metadataView, controlPlane, storageBackend, OBJECT_KEY_CREATOR, KEY_ALIGNMENT_STRATEGY, OBJECT_CACHE, brokerTopicStats);
+        sharedState = new SharedState(time, BROKER_ID, inklessConfig, metadataView, controlPlane, storageBackend,
+            OBJECT_KEY_CREATOR, KEY_ALIGNMENT_STRATEGY, OBJECT_CACHE, brokerTopicStats, defaultTopicConfigs);
     }
 
     @Test

--- a/storage/inkless/src/test/java/io/aiven/inkless/control_plane/AbstractControlPlaneTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/control_plane/AbstractControlPlaneTest.java
@@ -11,7 +11,6 @@ import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.image.MetadataDelta;
 import org.apache.kafka.image.MetadataImage;
-import org.apache.kafka.storage.internals.log.LogConfig;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -23,7 +22,7 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
 import java.util.List;
-import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -63,7 +62,7 @@ public abstract class AbstractControlPlaneTest {
         when(metadataView.getTopicId(NONEXISTENT_TOPIC))
             .thenReturn(Uuid.ZERO_UUID);
         when(metadataView.getTopicConfig(EXISTING_TOPIC))
-            .thenReturn(new LogConfig(Map.of()));
+            .thenReturn(new Properties());
         when(metadataView.isInklessTopic(anyString()))
             .thenReturn(true);
     }
@@ -101,9 +100,9 @@ public abstract class AbstractControlPlaneTest {
             objectKey1, BROKER_ID,
             FILE_SIZE,
             List.of(
-                new CommitBatchRequest(new TopicPartition(EXISTING_TOPIC, 0), 1, 10, 10, 1000),
-                new CommitBatchRequest(new TopicPartition(EXISTING_TOPIC, 1), 2, 10, 10, 1000),
-                new CommitBatchRequest(new TopicPartition(NONEXISTENT_TOPIC, 0), 3, 10, 10, 1000)
+                new CommitBatchRequest(new TopicPartition(EXISTING_TOPIC, 0), 1, 10, 10, 1000, TimestampType.CREATE_TIME),
+                new CommitBatchRequest(new TopicPartition(EXISTING_TOPIC, 1), 2, 10, 10, 1000, TimestampType.CREATE_TIME),
+                new CommitBatchRequest(new TopicPartition(NONEXISTENT_TOPIC, 0), 3, 10, 10, 1000, TimestampType.CREATE_TIME)
             )
         );
         assertThat(commitResponse1).containsExactly(
@@ -116,9 +115,9 @@ public abstract class AbstractControlPlaneTest {
             objectKey2, BROKER_ID,
             FILE_SIZE,
             List.of(
-                new CommitBatchRequest(new TopicPartition(EXISTING_TOPIC, 0), 100, 10, 10, 1000),
-                new CommitBatchRequest(new TopicPartition(EXISTING_TOPIC, 1), 200, 10, 10, 2000),
-                new CommitBatchRequest(new TopicPartition(NONEXISTENT_TOPIC, 0), 300, 10, 10, 3000)
+                new CommitBatchRequest(new TopicPartition(EXISTING_TOPIC, 0), 100, 10, 10, 1000, TimestampType.CREATE_TIME),
+                new CommitBatchRequest(new TopicPartition(EXISTING_TOPIC, 1), 200, 10, 10, 2000, TimestampType.CREATE_TIME),
+                new CommitBatchRequest(new TopicPartition(NONEXISTENT_TOPIC, 0), 300, 10, 10, 3000, TimestampType.CREATE_TIME)
             )
         );
         assertThat(commitResponse2).containsExactly(
@@ -150,9 +149,9 @@ public abstract class AbstractControlPlaneTest {
         final int numberOfRecordsInBatch1 = 3;
         final int numberOfRecordsInBatch2 = 2;
         controlPlane.commitFile(objectKey1, BROKER_ID, FILE_SIZE,
-            List.of(new CommitBatchRequest(new TopicPartition(EXISTING_TOPIC, 0), 1, 10, numberOfRecordsInBatch1, 1000)));
+            List.of(new CommitBatchRequest(new TopicPartition(EXISTING_TOPIC, 0), 1, 10, numberOfRecordsInBatch1, 1000, TimestampType.CREATE_TIME)));
         controlPlane.commitFile(objectKey2, BROKER_ID, FILE_SIZE,
-            List.of(new CommitBatchRequest(new TopicPartition(EXISTING_TOPIC, 0), 100, 10, numberOfRecordsInBatch2, 2000)));
+            List.of(new CommitBatchRequest(new TopicPartition(EXISTING_TOPIC, 0), 100, 10, numberOfRecordsInBatch2, 2000, TimestampType.CREATE_TIME)));
 
         final long expectedLogStartOffset = 0;
         final long expectedHighWatermark = numberOfRecordsInBatch1 + numberOfRecordsInBatch2;
@@ -186,7 +185,7 @@ public abstract class AbstractControlPlaneTest {
         controlPlane.commitFile(
             objectKey, BROKER_ID, FILE_SIZE,
             List.of(
-                new CommitBatchRequest(new TopicPartition(EXISTING_TOPIC, 0), 11, 10, 10, 1000)
+                new CommitBatchRequest(new TopicPartition(EXISTING_TOPIC, 0), 11, 10, 10, 1000, TimestampType.CREATE_TIME)
             )
         );
 
@@ -222,7 +221,7 @@ public abstract class AbstractControlPlaneTest {
         controlPlane.commitFile(
             objectKey, BROKER_ID, FILE_SIZE,
             List.of(
-                new CommitBatchRequest(new TopicPartition(EXISTING_TOPIC, 0), 11, 10, 10, 1000)
+                new CommitBatchRequest(new TopicPartition(EXISTING_TOPIC, 0), 11, 10, 10, 1000, TimestampType.CREATE_TIME)
             )
         );
 
@@ -242,7 +241,7 @@ public abstract class AbstractControlPlaneTest {
         controlPlane.commitFile(
             objectKey, BROKER_ID, FILE_SIZE,
             List.of(
-                new CommitBatchRequest(new TopicPartition(EXISTING_TOPIC, 0), 11, 10, 10, 1000)
+                new CommitBatchRequest(new TopicPartition(EXISTING_TOPIC, 0), 11, 10, 10, 1000, TimestampType.CREATE_TIME)
             )
         );
 
@@ -262,7 +261,7 @@ public abstract class AbstractControlPlaneTest {
         controlPlane.commitFile(
             objectKey, BROKER_ID, FILE_SIZE,
             List.of(
-                new CommitBatchRequest(new TopicPartition(EXISTING_TOPIC, 0), 11, 10, 10, 1000)
+                new CommitBatchRequest(new TopicPartition(EXISTING_TOPIC, 0), 11, 10, 10, 1000, TimestampType.CREATE_TIME)
             )
         );
 
@@ -292,8 +291,8 @@ public abstract class AbstractControlPlaneTest {
 
         assertThatThrownBy(() -> controlPlane.commitFile(objectKey, BROKER_ID, FILE_SIZE,
             List.of(
-                new CommitBatchRequest(new TopicPartition(EXISTING_TOPIC, 0), 1, 10, 10, 1000),
-                new CommitBatchRequest(new TopicPartition(EXISTING_TOPIC, 1), 2, 0, 10, 1000)
+                new CommitBatchRequest(new TopicPartition(EXISTING_TOPIC, 0), 1, 10, 10, 1000, TimestampType.CREATE_TIME),
+                new CommitBatchRequest(new TopicPartition(EXISTING_TOPIC, 1), 2, 0, 10, 1000, TimestampType.CREATE_TIME)
             )
         ))
             .isInstanceOf(IllegalArgumentException.class)

--- a/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/CommitFileJobTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/CommitFileJobTest.java
@@ -76,8 +76,8 @@ class CommitFileJobTest extends SharedPostgreSQLTest {
         when(time.milliseconds()).thenReturn(123456L);
 
         final CommitFileJob job = new CommitFileJob(time, hikariDataSource, objectKey, BROKER_ID, FILE_SIZE, List.of(
-            new CommitFileJob.CommitBatchRequestExtra(new CommitBatchRequest(T0P1, 0, 100, 15, 1000), TOPIC_ID_0, TimestampType.CREATE_TIME),
-            new CommitFileJob.CommitBatchRequestExtra(new CommitBatchRequest(T1P0, 100, 50, 27, 2000), TOPIC_ID_1, TimestampType.LOG_APPEND_TIME)
+            new CommitFileJob.CommitBatchRequestExtra(new CommitBatchRequest(T0P1, 0, 100, 15, 1000, TimestampType.CREATE_TIME), TOPIC_ID_0),
+            new CommitFileJob.CommitBatchRequestExtra(new CommitBatchRequest(T1P0, 100, 50, 27, 2000, TimestampType.LOG_APPEND_TIME), TOPIC_ID_1)
         ), duration -> {});
         final List<CommitBatchResponse> result = job.call();
 
@@ -113,8 +113,8 @@ class CommitFileJobTest extends SharedPostgreSQLTest {
         when(time.milliseconds()).thenReturn(1000L);
 
         final CommitFileJob job1 = new CommitFileJob(time, hikariDataSource, objectKey1, BROKER_ID, FILE_SIZE, List.of(
-            new CommitFileJob.CommitBatchRequestExtra(new CommitBatchRequest(T0P1, 0, 100, 15, 1000), TOPIC_ID_0, TimestampType.CREATE_TIME),
-            new CommitFileJob.CommitBatchRequestExtra(new CommitBatchRequest(T1P0, 100, 50, 27, 2000), TOPIC_ID_1, TimestampType.LOG_APPEND_TIME)
+            new CommitFileJob.CommitBatchRequestExtra(new CommitBatchRequest(T0P1, 0, 100, 15, 1000, TimestampType.CREATE_TIME), TOPIC_ID_0),
+            new CommitFileJob.CommitBatchRequestExtra(new CommitBatchRequest(T1P0, 100, 50, 27, 2000, TimestampType.LOG_APPEND_TIME), TOPIC_ID_1)
         ), duration -> {});
         final List<CommitBatchResponse> result1 = job1.call();
 
@@ -126,8 +126,8 @@ class CommitFileJobTest extends SharedPostgreSQLTest {
         when(time.milliseconds()).thenReturn(2000L);
 
         final CommitFileJob job2 = new CommitFileJob(time, hikariDataSource, objectKey2, BROKER_ID, FILE_SIZE, List.of(
-            new CommitFileJob.CommitBatchRequestExtra(new CommitBatchRequest(T0P0, 0, 111, 159, 3000), TOPIC_ID_0, TimestampType.CREATE_TIME),
-            new CommitFileJob.CommitBatchRequestExtra(new CommitBatchRequest(T0P1, 111, 222, 245, 4000), TOPIC_ID_0, TimestampType.CREATE_TIME)
+            new CommitFileJob.CommitBatchRequestExtra(new CommitBatchRequest(T0P0, 0, 111, 159, 3000, TimestampType.CREATE_TIME), TOPIC_ID_0),
+            new CommitFileJob.CommitBatchRequestExtra(new CommitBatchRequest(T0P1, 111, 222, 245, 4000, TimestampType.CREATE_TIME), TOPIC_ID_0)
         ), duration -> {});
         final List<CommitBatchResponse> result2 = job2.call();
 
@@ -168,9 +168,9 @@ class CommitFileJobTest extends SharedPostgreSQLTest {
         // Non-existent partition.
         final var t1p1 = new TopicPartition(TOPIC_1, 10);
         final CommitFileJob job = new CommitFileJob(time, hikariDataSource, objectKey, BROKER_ID, FILE_SIZE, List.of(
-            new CommitFileJob.CommitBatchRequestExtra(new CommitBatchRequest(T0P1, 0, 100, 15, 1000), TOPIC_ID_0, TimestampType.CREATE_TIME),
-            new CommitFileJob.CommitBatchRequestExtra(new CommitBatchRequest(T1P0, 100, 50, 27, 2000), TOPIC_ID_1, TimestampType.LOG_APPEND_TIME),
-            new CommitFileJob.CommitBatchRequestExtra(new CommitBatchRequest(t1p1, 150, 1243, 82, 3000), TOPIC_ID_1, TimestampType.LOG_APPEND_TIME)
+            new CommitFileJob.CommitBatchRequestExtra(new CommitBatchRequest(T0P1, 0, 100, 15, 1000, TimestampType.CREATE_TIME), TOPIC_ID_0),
+            new CommitFileJob.CommitBatchRequestExtra(new CommitBatchRequest(T1P0, 100, 50, 27, 2000, TimestampType.LOG_APPEND_TIME), TOPIC_ID_1),
+            new CommitFileJob.CommitBatchRequestExtra(new CommitBatchRequest(t1p1, 150, 1243, 82, 3000, TimestampType.LOG_APPEND_TIME), TOPIC_ID_1)
         ), duration -> {});
 
         final List<CommitBatchResponse> result = job.call();

--- a/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/FindBatchesJobTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/FindBatchesJobTest.java
@@ -74,7 +74,7 @@ class FindBatchesJobTest extends SharedPostgreSQLTest {
         final CommitFileJob commitJob = new CommitFileJob(
             time, hikariDataSource, objectKey1, BROKER_ID, FILE_SIZE,
             List.of(
-                new CommitFileJob.CommitBatchRequestExtra(new CommitBatchRequest(T0P0, 0, 1234, 12, 1000), TOPIC_ID_0, TimestampType.CREATE_TIME)
+                new CommitFileJob.CommitBatchRequestExtra(new CommitBatchRequest(T0P0, 0, 1234, 12, 1000, TimestampType.CREATE_TIME), TOPIC_ID_0)
             ),
             duration -> {}
         );

--- a/storage/inkless/src/test/java/io/aiven/inkless/produce/ClosedFileTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/produce/ClosedFileTest.java
@@ -1,6 +1,8 @@
 // Copyright (c) 2024 Aiven, Helsinki, Finland. https://aiven.io/
 package io.aiven.inkless.produce;
 
+import org.apache.kafka.common.record.TimestampType;
+
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
@@ -60,7 +62,7 @@ class ClosedFileTest {
         assertThatThrownBy(() -> new ClosedFile(
             Instant.EPOCH,
             Map.of(), Map.of(),
-            List.of(new CommitBatchRequest(null, 0, 0, 0, 0)),
+            List.of(new CommitBatchRequest(null, 0, 0, 0, 0, TimestampType.CREATE_TIME)),
             List.of(),
             new byte[1]))
             .isInstanceOf(IllegalArgumentException.class)

--- a/storage/inkless/src/test/java/io/aiven/inkless/produce/FileCommitJobTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/produce/FileCommitJobTest.java
@@ -6,6 +6,7 @@ import org.apache.kafka.common.compress.Compression;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.record.SimpleRecord;
+import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.common.requests.ProduceResponse.PartitionResponse;
 import org.apache.kafka.common.utils.Time;
 
@@ -56,10 +57,10 @@ class FileCommitJobTest {
         1, REQUEST_1
     );
     static final List<CommitBatchRequest> COMMIT_BATCH_REQUESTS = List.of(
-        new CommitBatchRequest(T0P0, 0, 100, 10, 1000),
-        new CommitBatchRequest(T0P1, 100, 100, 10, 1000),
-        new CommitBatchRequest(T0P1, 200, 100, 10, 1000),
-        new CommitBatchRequest(T1P0, 300, 100, 10, 1000)
+        new CommitBatchRequest(T0P0, 0, 100, 10, 1000, TimestampType.CREATE_TIME),
+        new CommitBatchRequest(T0P1, 100, 100, 10, 1000, TimestampType.CREATE_TIME),
+        new CommitBatchRequest(T0P1, 200, 100, 10, 1000, TimestampType.CREATE_TIME),
+        new CommitBatchRequest(T1P0, 300, 100, 10, 1000, TimestampType.LOG_APPEND_TIME)
     );
     static final List<Integer> REQUEST_IDS = List.of(0, 0, 1, 1);
 


### PR DESCRIPTION
This doesn't matter in the present state, but there's an upcoming PR that make Controller use the Control plane, and duplicating merging default and override topic config there is cumbersome. With this change, the resolution happens earlier, in `AppendInterceptor`.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
