### PR TITLE
refactor(inkless:controlplane): return future on topic metadata changes [INK-42]

### DIFF
--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/InMemoryControlPlane.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/InMemoryControlPlane.java
@@ -20,6 +20,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
 import java.util.stream.Stream;
 
 import io.aiven.inkless.TimeUtils;
@@ -44,7 +46,7 @@ public class InMemoryControlPlane extends AbstractControlPlane {
 
     @Override
     @DoNotMutate
-    public synchronized void onTopicMetadataChanges(final TopicsDelta topicsDelta) {
+    public synchronized Future<?> onTopicMetadataChanges(final TopicsDelta topicsDelta) {
         // Create.
         for (final var changedTopic : topicsDelta.changedTopics().entrySet()) {
             final String topicName = changedTopic.getValue().name();
@@ -62,6 +64,7 @@ public class InMemoryControlPlane extends AbstractControlPlane {
                 batches.put(topicIdPartition, new TreeMap<>());
             }
         }
+        return CompletableFuture.completedFuture(null);
     }
 
     @Override

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/TopicMetadataChangesSubscriber.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/TopicMetadataChangesSubscriber.java
@@ -3,7 +3,9 @@ package io.aiven.inkless.control_plane;
 
 import org.apache.kafka.image.TopicsDelta;
 
+import java.util.concurrent.Future;
+
 @FunctionalInterface
 public interface TopicMetadataChangesSubscriber {
-    void onTopicMetadataChanges(TopicsDelta topicsDelta);
+    Future<?> onTopicMetadataChanges(TopicsDelta topicsDelta);
 }

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/PostgresControlPlane.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/PostgresControlPlane.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.stream.Stream;
 
 import io.aiven.inkless.control_plane.AbstractControlPlane;
@@ -47,9 +48,9 @@ public class PostgresControlPlane extends AbstractControlPlane {
         this.metrics = new PostgresControlPlaneMetrics(time);
     }
 
-    public void onTopicMetadataChanges(final TopicsDelta topicsDelta) {
+    public Future<?> onTopicMetadataChanges(final TopicsDelta topicsDelta) {
         // Create.
-        executor.submit(new TopicsCreateJob(
+        return executor.submit(new TopicsCreateJob(
             time, metadataView, hikariDataSource,
             topicsDelta.changedTopics(),
             metrics::onTopicCreateCompleted));

--- a/storage/inkless/src/test/java/io/aiven/inkless/control_plane/AbstractControlPlaneTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/control_plane/AbstractControlPlaneTest.java
@@ -83,7 +83,7 @@ public abstract class AbstractControlPlaneTest {
     protected abstract ControlPlane createControlPlane(final TestInfo testInfo);
 
     @BeforeEach
-    void setupControlPlane(final TestInfo testInfo) {
+    void setupControlPlane(final TestInfo testInfo) throws Exception {
         controlPlane = createControlPlane(testInfo);
 
         verify(metadataView).subscribeToTopicMetadataChanges(eq(controlPlane));
@@ -91,7 +91,7 @@ public abstract class AbstractControlPlaneTest {
         final var delta = new MetadataDelta.Builder().setImage(MetadataImage.EMPTY).build();
         delta.replay(new TopicRecord().setName(EXISTING_TOPIC_1).setTopicId(EXISTING_TOPIC_1_ID));
         delta.replay(new PartitionRecord().setTopicId(EXISTING_TOPIC_1_ID).setPartitionId(EXISTING_TOPIC_1_ID_PARTITION.partition()));
-        controlPlane.onTopicMetadataChanges(delta.topicsDelta());
+        controlPlane.onTopicMetadataChanges(delta.topicsDelta()).get();
     }
 
     @Test

--- a/storage/inkless/src/test/java/io/aiven/inkless/produce/WriterIntegrationTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/produce/WriterIntegrationTest.java
@@ -155,7 +155,7 @@ class WriterIntegrationTest {
         delta.replay(new PartitionRecord().setTopicId(TOPIC_ID_0).setPartitionId(1));
         delta.replay(new TopicRecord().setName(T1P0.topic()).setTopicId(TOPIC_ID_1));
         delta.replay(new PartitionRecord().setTopicId(TOPIC_ID_1).setPartitionId(0));
-        controlPlane.onTopicMetadataChanges(delta.topicsDelta());
+        controlPlane.onTopicMetadataChanges(delta.topicsDelta()).get();
 
         try (
             final Writer writer = new Writer(

--- a/storage/inkless/src/test/java/io/aiven/inkless/produce/WriterPropertyTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/produce/WriterPropertyTest.java
@@ -142,7 +142,7 @@ class WriterPropertyTest {
         delta.replay(new TopicRecord().setName(T1P0.topic()).setTopicId(TOPIC_ID_1));
         delta.replay(new PartitionRecord().setTopicId(TOPIC_ID_1).setPartitionId(0));
         delta.replay(new PartitionRecord().setTopicId(TOPIC_ID_1).setPartitionId(1));
-        controlPlane.onTopicMetadataChanges(delta.topicsDelta());
+        controlPlane.onTopicMetadataChanges(delta.topicsDelta()).get();
 
         Statistics.label("requestCount").collect(requestCount);
         final MockTime time = new MockTime(0, 0, 0);


### PR DESCRIPTION
To block and wait for topic creation on tests, expose future for clients to wait.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
