### PR TITLE
Reduce control plane reliance on quorum metadata [INK-81]

### DIFF
--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/AbstractControlPlane.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/AbstractControlPlane.java
@@ -50,11 +50,11 @@ public abstract class AbstractControlPlane implements ControlPlane {
     }
 
     private boolean partitionExistsInMetadataForCommitBatchRequest(final CommitBatchRequest request) {
-        final String topicName = request.topicPartition().topic();
+        final String topicName = request.topicIdPartition().topic();
         final Uuid topicId = metadataView.getTopicId(topicName);
         final Set<TopicPartition> partitions = metadataView.getTopicPartitions(topicName);
         return topicId != Uuid.ZERO_UUID
-            && partitions.contains(request.topicPartition());
+            && partitions.contains(request.topicIdPartition().topicPartition());
     }
 
     protected abstract Iterator<CommitBatchResponse> commitFileForExistingPartitions(

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/CommitBatchRequest.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/CommitBatchRequest.java
@@ -1,10 +1,10 @@
 // Copyright (c) 2024 Aiven, Helsinki, Finland. https://aiven.io/
 package io.aiven.inkless.control_plane;
 
-import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.TopicIdPartition;
 import org.apache.kafka.common.record.TimestampType;
 
-public record CommitBatchRequest(TopicPartition topicPartition,
+public record CommitBatchRequest(TopicIdPartition topicIdPartition,
                                  int byteOffset,
                                  int size,
                                  long numberOfRecords,

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/InMemoryControlPlane.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/InMemoryControlPlane.java
@@ -71,10 +71,7 @@ public class InMemoryControlPlane extends AbstractControlPlane {
     private CommitBatchResponse commitFileForExistingPartition(final long now,
                                                                final FileInfo fileInfo,
                                                                final CommitBatchRequest request) {
-        final String topicName = request.topicPartition().topic();
-        final Uuid topicId = metadataView.getTopicId(topicName);
-
-        final TopicIdPartition topicIdPartition = new TopicIdPartition(topicId, request.topicPartition());
+        final TopicIdPartition topicIdPartition = request.topicIdPartition();
         final LogInfo logInfo = logs.get(topicIdPartition);
         final TreeMap<Long, BatchInfoInternal> coordinates = this.batches.get(topicIdPartition);
         // This can't really happen as non-existing partitions should be filtered out earlier.

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/PostgresControlPlane.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/PostgresControlPlane.java
@@ -66,13 +66,10 @@ public class PostgresControlPlane extends AbstractControlPlane {
         final int uploaderBrokerId,
         final long fileSize,
         final Stream<CommitBatchRequest> requests) {
-        final var requestExtras = requests.map(r -> new CommitFileJob.CommitBatchRequestExtra(
-            r,
-            metadataView.getTopicId(r.topicPartition().topic())
-        )).toList();
+        final var requestsJson = requests.map(CommitFileJob.CommitBatchRequestJson::new).toList();
         final CommitFileJob job = new CommitFileJob(
             time, hikariDataSource,
-            objectKey, uploaderBrokerId, fileSize, requestExtras,
+            objectKey, uploaderBrokerId, fileSize, requestsJson,
             metrics::onCommitFileCompleted);
         return job.call().iterator();
     }

--- a/storage/inkless/src/main/java/io/aiven/inkless/produce/ClosedFile.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/produce/ClosedFile.java
@@ -1,6 +1,7 @@
 // Copyright (c) 2024 Aiven, Helsinki, Finland. https://aiven.io/
 package io.aiven.inkless.produce;
 
+import org.apache.kafka.common.TopicIdPartition;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.requests.ProduceResponse.PartitionResponse;
@@ -14,7 +15,7 @@ import java.util.concurrent.CompletableFuture;
 import io.aiven.inkless.control_plane.CommitBatchRequest;
 
 record ClosedFile(Instant start,
-                  Map<Integer, Map<TopicPartition, MemoryRecords>> originalRequests,
+                  Map<Integer, Map<TopicIdPartition, MemoryRecords>> originalRequests,
                   Map<Integer, CompletableFuture<Map<TopicPartition, PartitionResponse>>> awaitingFuturesByRequest,
                   List<CommitBatchRequest> commitBatchRequests,
                   List<Integer> requestIds,

--- a/storage/inkless/src/main/java/io/aiven/inkless/produce/FileCommitJob.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/produce/FileCommitJob.java
@@ -95,7 +95,7 @@ class FileCommitJob implements Runnable {
             final var commitBatchRequest = file.commitBatchRequests().get(i);
             final var commitBatchResponse = commitBatchResponses.get(i);
             result.put(
-                commitBatchRequest.topicPartition(),
+                commitBatchRequest.topicIdPartition().topicPartition(),
                 new ProduceResponse.PartitionResponse(
                     commitBatchResponse.errors(),
                     commitBatchResponse.assignedOffset(),
@@ -116,7 +116,7 @@ class FileCommitJob implements Runnable {
             final var originalRequest = file.originalRequests().get(entry.getKey());
             final var result = originalRequest.entrySet().stream()
                 .collect(Collectors.toMap(
-                    Map.Entry::getKey,
+                    kv -> kv.getKey().topicPartition(),
                     ignore -> new ProduceResponse.PartitionResponse(Errors.KAFKA_STORAGE_ERROR, "Error commiting data")));
             entry.getValue().complete(result);
         }

--- a/storage/inkless/src/main/java/io/aiven/inkless/produce/Writer.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/produce/Writer.java
@@ -1,6 +1,7 @@
 // Copyright (c) 2024 Aiven, Helsinki, Finland. https://aiven.io/
 package io.aiven.inkless.produce;
 
+import org.apache.kafka.common.TopicIdPartition;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.record.TimestampType;
@@ -105,7 +106,7 @@ class Writer implements Closeable {
     }
 
     CompletableFuture<Map<TopicPartition, PartitionResponse>> write(
-        final Map<TopicPartition, MemoryRecords> entriesPerPartition,
+        final Map<TopicIdPartition, MemoryRecords> entriesPerPartition,
         final Map<String, TimestampType> timestampTypes
     ) {
         Objects.requireNonNull(entriesPerPartition, "entriesPerPartition cannot be null");

--- a/storage/inkless/src/test/java/io/aiven/inkless/control_plane/AbstractControlPlaneTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/control_plane/AbstractControlPlaneTest.java
@@ -42,6 +42,7 @@ public abstract class AbstractControlPlaneTest {
     static final String EXISTING_TOPIC_2 = "topic-existing-2";
     static final Uuid EXISTING_TOPIC_2_ID = new Uuid(20, 20);
     static final TopicIdPartition EXISTING_TOPIC_2_ID_PARTITION = new TopicIdPartition(EXISTING_TOPIC_2_ID, 0, EXISTING_TOPIC_2);
+    static final Uuid NONEXISTENT_TOPIC_ID = Uuid.ONE_UUID;
     static final String NONEXISTENT_TOPIC = "topic-nonexistent";
 
     @Mock
@@ -103,9 +104,9 @@ public abstract class AbstractControlPlaneTest {
             objectKey1, BROKER_ID,
             FILE_SIZE,
             List.of(
-                new CommitBatchRequest(new TopicPartition(EXISTING_TOPIC_1, 0), 1, 10, 10, 1000, TimestampType.CREATE_TIME),
-                new CommitBatchRequest(new TopicPartition(EXISTING_TOPIC_1, 1), 2, 10, 10, 1000, TimestampType.CREATE_TIME),
-                new CommitBatchRequest(new TopicPartition(NONEXISTENT_TOPIC, 0), 3, 10, 10, 1000, TimestampType.CREATE_TIME)
+                new CommitBatchRequest(new TopicIdPartition(EXISTING_TOPIC_1_ID, 0, EXISTING_TOPIC_1), 1, 10, 10, 1000, TimestampType.CREATE_TIME),
+                new CommitBatchRequest(new TopicIdPartition(EXISTING_TOPIC_1_ID, 1, EXISTING_TOPIC_1), 2, 10, 10, 1000, TimestampType.CREATE_TIME),
+                new CommitBatchRequest(new TopicIdPartition(NONEXISTENT_TOPIC_ID, 0, NONEXISTENT_TOPIC), 3, 10, 10, 1000, TimestampType.CREATE_TIME)
             )
         );
         assertThat(commitResponse1).containsExactly(
@@ -118,9 +119,9 @@ public abstract class AbstractControlPlaneTest {
             objectKey2, BROKER_ID,
             FILE_SIZE,
             List.of(
-                new CommitBatchRequest(new TopicPartition(EXISTING_TOPIC_1, 0), 100, 10, 10, 1000, TimestampType.CREATE_TIME),
-                new CommitBatchRequest(new TopicPartition(EXISTING_TOPIC_1, 1), 200, 10, 10, 2000, TimestampType.CREATE_TIME),
-                new CommitBatchRequest(new TopicPartition(NONEXISTENT_TOPIC, 0), 300, 10, 10, 3000, TimestampType.CREATE_TIME)
+                new CommitBatchRequest(new TopicIdPartition(EXISTING_TOPIC_1_ID, 0, EXISTING_TOPIC_1), 100, 10, 10, 1000, TimestampType.CREATE_TIME),
+                new CommitBatchRequest(new TopicIdPartition(EXISTING_TOPIC_1_ID, 1, EXISTING_TOPIC_1), 200, 10, 10, 2000, TimestampType.CREATE_TIME),
+                new CommitBatchRequest(new TopicIdPartition(NONEXISTENT_TOPIC_ID, 0, NONEXISTENT_TOPIC), 300, 10, 10, 3000, TimestampType.CREATE_TIME)
             )
         );
         assertThat(commitResponse2).containsExactly(
@@ -152,9 +153,9 @@ public abstract class AbstractControlPlaneTest {
         final int numberOfRecordsInBatch1 = 3;
         final int numberOfRecordsInBatch2 = 2;
         controlPlane.commitFile(objectKey1, BROKER_ID, FILE_SIZE,
-            List.of(new CommitBatchRequest(new TopicPartition(EXISTING_TOPIC_1, 0), 1, 10, numberOfRecordsInBatch1, 1000, TimestampType.CREATE_TIME)));
+            List.of(new CommitBatchRequest(new TopicIdPartition(EXISTING_TOPIC_1_ID, 0, EXISTING_TOPIC_1), 1, 10, numberOfRecordsInBatch1, 1000, TimestampType.CREATE_TIME)));
         controlPlane.commitFile(objectKey2, BROKER_ID, FILE_SIZE,
-            List.of(new CommitBatchRequest(new TopicPartition(EXISTING_TOPIC_1, 0), 100, 10, numberOfRecordsInBatch2, 2000, TimestampType.CREATE_TIME)));
+            List.of(new CommitBatchRequest(new TopicIdPartition(EXISTING_TOPIC_1_ID, 0, EXISTING_TOPIC_1), 100, 10, numberOfRecordsInBatch2, 2000, TimestampType.CREATE_TIME)));
 
         final long expectedLogStartOffset = 0;
         final long expectedHighWatermark = numberOfRecordsInBatch1 + numberOfRecordsInBatch2;
@@ -188,7 +189,7 @@ public abstract class AbstractControlPlaneTest {
         controlPlane.commitFile(
             objectKey, BROKER_ID, FILE_SIZE,
             List.of(
-                new CommitBatchRequest(new TopicPartition(EXISTING_TOPIC_1, 0), 11, 10, 10, 1000, TimestampType.CREATE_TIME)
+                new CommitBatchRequest(new TopicIdPartition(EXISTING_TOPIC_1_ID, 0, EXISTING_TOPIC_1), 11, 10, 10, 1000, TimestampType.CREATE_TIME)
             )
         );
 
@@ -224,7 +225,7 @@ public abstract class AbstractControlPlaneTest {
         controlPlane.commitFile(
             objectKey, BROKER_ID, FILE_SIZE,
             List.of(
-                new CommitBatchRequest(new TopicPartition(EXISTING_TOPIC_1, 0), 11, 10, 10, 1000, TimestampType.CREATE_TIME)
+                new CommitBatchRequest(new TopicIdPartition(EXISTING_TOPIC_1_ID, 0, EXISTING_TOPIC_1), 11, 10, 10, 1000, TimestampType.CREATE_TIME)
             )
         );
 
@@ -244,7 +245,7 @@ public abstract class AbstractControlPlaneTest {
         controlPlane.commitFile(
             objectKey, BROKER_ID, FILE_SIZE,
             List.of(
-                new CommitBatchRequest(new TopicPartition(EXISTING_TOPIC_1, 0), 11, 10, 10, 1000, TimestampType.CREATE_TIME)
+                new CommitBatchRequest(new TopicIdPartition(EXISTING_TOPIC_1_ID, 0, EXISTING_TOPIC_1), 11, 10, 10, 1000, TimestampType.CREATE_TIME)
             )
         );
 
@@ -264,7 +265,7 @@ public abstract class AbstractControlPlaneTest {
         controlPlane.commitFile(
             objectKey, BROKER_ID, FILE_SIZE,
             List.of(
-                new CommitBatchRequest(new TopicPartition(EXISTING_TOPIC_1, 0), 11, 10, 10, 1000, TimestampType.CREATE_TIME)
+                new CommitBatchRequest(new TopicIdPartition(EXISTING_TOPIC_1_ID, 0, EXISTING_TOPIC_1), 11, 10, 10, 1000, TimestampType.CREATE_TIME)
             )
         );
 
@@ -294,8 +295,8 @@ public abstract class AbstractControlPlaneTest {
 
         assertThatThrownBy(() -> controlPlane.commitFile(objectKey, BROKER_ID, FILE_SIZE,
             List.of(
-                new CommitBatchRequest(new TopicPartition(EXISTING_TOPIC_1, 0), 1, 10, 10, 1000, TimestampType.CREATE_TIME),
-                new CommitBatchRequest(new TopicPartition(EXISTING_TOPIC_1, 1), 2, 0, 10, 1000, TimestampType.CREATE_TIME)
+                new CommitBatchRequest(new TopicIdPartition(EXISTING_TOPIC_1_ID, 0, EXISTING_TOPIC_1), 1, 10, 10, 1000, TimestampType.CREATE_TIME),
+                new CommitBatchRequest(new TopicIdPartition(EXISTING_TOPIC_1_ID, 1, EXISTING_TOPIC_1), 2, 0, 10, 1000, TimestampType.CREATE_TIME)
             )
         ))
             .isInstanceOf(IllegalArgumentException.class)
@@ -332,7 +333,7 @@ public abstract class AbstractControlPlaneTest {
         final String objectKey = "a1";
         controlPlane.commitFile(objectKey, BROKER_ID, FILE_SIZE,
             List.of(
-                new CommitBatchRequest(new TopicPartition(newTopic1Name, 0), 1, (int) FILE_SIZE, 1, 1000, TimestampType.CREATE_TIME)
+                new CommitBatchRequest(new TopicIdPartition(newTopic1Id, 0, newTopic1Name), 1, (int) FILE_SIZE, 1, 1000, TimestampType.CREATE_TIME)
             ));
 
         final List<FindBatchRequest> findBatchRequests = List.of(new FindBatchRequest(new TopicIdPartition(newTopic1Id, 0, newTopic1Name), 0, Integer.MAX_VALUE));
@@ -364,14 +365,14 @@ public abstract class AbstractControlPlaneTest {
 
         controlPlane.commitFile(objectKey1, BROKER_ID, FILE_SIZE,
             List.of(
-                new CommitBatchRequest(new TopicPartition(EXISTING_TOPIC_1, 0), 1, (int) FILE_SIZE, 1, 1000, TimestampType.CREATE_TIME)
+                new CommitBatchRequest(new TopicIdPartition(EXISTING_TOPIC_1_ID, 0, EXISTING_TOPIC_1), 1, (int) FILE_SIZE, 1, 1000, TimestampType.CREATE_TIME)
             ));
         final int file2Partition0Size = (int) FILE_SIZE / 2;
         final int file2Partition1Size = (int) FILE_SIZE - file2Partition0Size;
         controlPlane.commitFile(objectKey2, BROKER_ID, FILE_SIZE,
             List.of(
-                new CommitBatchRequest(new TopicPartition(EXISTING_TOPIC_1, 0), 1, file2Partition0Size, 1, 1000, TimestampType.CREATE_TIME),
-                new CommitBatchRequest(new TopicPartition(EXISTING_TOPIC_2, 0), 1, file2Partition1Size, 2, 2000, TimestampType.CREATE_TIME)
+                new CommitBatchRequest(new TopicIdPartition(EXISTING_TOPIC_1_ID, 0, EXISTING_TOPIC_1), 1, file2Partition0Size, 1, 1000, TimestampType.CREATE_TIME),
+                new CommitBatchRequest(new TopicIdPartition(EXISTING_TOPIC_2_ID, 0, EXISTING_TOPIC_1), 1, file2Partition1Size, 2, 2000, TimestampType.CREATE_TIME)
             ));
 
         final List<FindBatchRequest> findBatchRequests = List.of(new FindBatchRequest(EXISTING_TOPIC_2_ID_PARTITION, 0, Integer.MAX_VALUE));

--- a/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/CommitFileJobTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/CommitFileJobTest.java
@@ -1,7 +1,7 @@
 // Copyright (c) 2024 Aiven, Helsinki, Finland. https://aiven.io/
 package io.aiven.inkless.control_plane.postgres;
 
-import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.TopicIdPartition;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.record.TimestampType;
@@ -39,9 +39,9 @@ class CommitFileJobTest extends SharedPostgreSQLTest {
     static final String TOPIC_1 = "topic1";
     static final Uuid TOPIC_ID_0 = new Uuid(10, 12);
     static final Uuid TOPIC_ID_1 = new Uuid(555, 333);
-    static final TopicPartition T0P0 = new TopicPartition(TOPIC_0, 0);
-    static final TopicPartition T0P1 = new TopicPartition(TOPIC_0, 1);
-    static final TopicPartition T1P0 = new TopicPartition(TOPIC_1, 0);
+    static final TopicIdPartition T0P0 = new TopicIdPartition(TOPIC_ID_0, 0, TOPIC_0);
+    static final TopicIdPartition T0P1 = new TopicIdPartition(TOPIC_ID_0, 1, TOPIC_0);
+    static final TopicIdPartition T1P0 = new TopicIdPartition(TOPIC_ID_1, 0, TOPIC_1);
 
     static final long EXPECTED_FILE_ID_1 = 1;
     static final long EXPECTED_FILE_ID_2 = 2;
@@ -66,8 +66,8 @@ class CommitFileJobTest extends SharedPostgreSQLTest {
         when(time.milliseconds()).thenReturn(123456L);
 
         final CommitFileJob job = new CommitFileJob(time, hikariDataSource, objectKey, BROKER_ID, FILE_SIZE, List.of(
-            new CommitFileJob.CommitBatchRequestExtra(new CommitBatchRequest(T0P1, 0, 100, 15, 1000, TimestampType.CREATE_TIME), TOPIC_ID_0),
-            new CommitFileJob.CommitBatchRequestExtra(new CommitBatchRequest(T1P0, 100, 50, 27, 2000, TimestampType.LOG_APPEND_TIME), TOPIC_ID_1)
+            new CommitFileJob.CommitBatchRequestJson(new CommitBatchRequest(T0P1, 0, 100, 15, 1000, TimestampType.CREATE_TIME)),
+            new CommitFileJob.CommitBatchRequestJson(new CommitBatchRequest(T1P0, 100, 50, 27, 2000, TimestampType.LOG_APPEND_TIME))
         ), duration -> {});
         final List<CommitBatchResponse> result = job.call();
 
@@ -103,8 +103,8 @@ class CommitFileJobTest extends SharedPostgreSQLTest {
         when(time.milliseconds()).thenReturn(1000L);
 
         final CommitFileJob job1 = new CommitFileJob(time, hikariDataSource, objectKey1, BROKER_ID, FILE_SIZE, List.of(
-            new CommitFileJob.CommitBatchRequestExtra(new CommitBatchRequest(T0P1, 0, 100, 15, 1000, TimestampType.CREATE_TIME), TOPIC_ID_0),
-            new CommitFileJob.CommitBatchRequestExtra(new CommitBatchRequest(T1P0, 100, 50, 27, 2000, TimestampType.LOG_APPEND_TIME), TOPIC_ID_1)
+            new CommitFileJob.CommitBatchRequestJson(new CommitBatchRequest(T0P1, 0, 100, 15, 1000, TimestampType.CREATE_TIME)),
+            new CommitFileJob.CommitBatchRequestJson(new CommitBatchRequest(T1P0, 100, 50, 27, 2000, TimestampType.LOG_APPEND_TIME))
         ), duration -> {});
         final List<CommitBatchResponse> result1 = job1.call();
 
@@ -116,8 +116,8 @@ class CommitFileJobTest extends SharedPostgreSQLTest {
         when(time.milliseconds()).thenReturn(2000L);
 
         final CommitFileJob job2 = new CommitFileJob(time, hikariDataSource, objectKey2, BROKER_ID, FILE_SIZE, List.of(
-            new CommitFileJob.CommitBatchRequestExtra(new CommitBatchRequest(T0P0, 0, 111, 159, 3000, TimestampType.CREATE_TIME), TOPIC_ID_0),
-            new CommitFileJob.CommitBatchRequestExtra(new CommitBatchRequest(T0P1, 111, 222, 245, 4000, TimestampType.CREATE_TIME), TOPIC_ID_0)
+            new CommitFileJob.CommitBatchRequestJson(new CommitBatchRequest(T0P0, 0, 111, 159, 3000, TimestampType.CREATE_TIME)),
+            new CommitFileJob.CommitBatchRequestJson(new CommitBatchRequest(T0P1, 111, 222, 245, 4000, TimestampType.CREATE_TIME))
         ), duration -> {});
         final List<CommitBatchResponse> result2 = job2.call();
 
@@ -156,11 +156,11 @@ class CommitFileJobTest extends SharedPostgreSQLTest {
         when(time.milliseconds()).thenReturn(123456L);
 
         // Non-existent partition.
-        final var t1p1 = new TopicPartition(TOPIC_1, 10);
+        final var t1p1 = new TopicIdPartition(TOPIC_ID_1, 10, TOPIC_1);
         final CommitFileJob job = new CommitFileJob(time, hikariDataSource, objectKey, BROKER_ID, FILE_SIZE, List.of(
-            new CommitFileJob.CommitBatchRequestExtra(new CommitBatchRequest(T0P1, 0, 100, 15, 1000, TimestampType.CREATE_TIME), TOPIC_ID_0),
-            new CommitFileJob.CommitBatchRequestExtra(new CommitBatchRequest(T1P0, 100, 50, 27, 2000, TimestampType.LOG_APPEND_TIME), TOPIC_ID_1),
-            new CommitFileJob.CommitBatchRequestExtra(new CommitBatchRequest(t1p1, 150, 1243, 82, 3000, TimestampType.LOG_APPEND_TIME), TOPIC_ID_1)
+            new CommitFileJob.CommitBatchRequestJson(new CommitBatchRequest(T0P1, 0, 100, 15, 1000, TimestampType.CREATE_TIME)),
+            new CommitFileJob.CommitBatchRequestJson(new CommitBatchRequest(T1P0, 100, 50, 27, 2000, TimestampType.LOG_APPEND_TIME)),
+            new CommitFileJob.CommitBatchRequestJson(new CommitBatchRequest(t1p1, 150, 1243, 82, 3000, TimestampType.LOG_APPEND_TIME))
         ), duration -> {});
 
         final List<CommitBatchResponse> result = job.call();

--- a/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/DeleteTopicJobTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/DeleteTopicJobTest.java
@@ -1,7 +1,7 @@
 // Copyright (c) 2024 Aiven, Helsinki, Finland. https://aiven.io/
 package io.aiven.inkless.control_plane.postgres;
 
-import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.TopicIdPartition;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.common.utils.Time;
@@ -39,10 +39,10 @@ class DeleteTopicJobTest extends SharedPostgreSQLTest {
     static final Uuid TOPIC_ID_0 = new Uuid(10, 12);
     static final Uuid TOPIC_ID_1 = new Uuid(555, 333);
     static final Uuid TOPIC_ID_2 = new Uuid(5555, 3333);
-    static final TopicPartition T0P0 = new TopicPartition(TOPIC_0, 0);
-    static final TopicPartition T0P1 = new TopicPartition(TOPIC_0, 1);
-    static final TopicPartition T1P0 = new TopicPartition(TOPIC_1, 0);
-    static final TopicPartition T2P0 = new TopicPartition(TOPIC_2, 0);
+    static final TopicIdPartition T0P0 = new TopicIdPartition(TOPIC_ID_0, 0, TOPIC_0);
+    static final TopicIdPartition T0P1 = new TopicIdPartition(TOPIC_ID_0, 1, TOPIC_0);
+    static final TopicIdPartition T1P0 = new TopicIdPartition(TOPIC_ID_1, 0, TOPIC_1);
+    static final TopicIdPartition T2P0 = new TopicIdPartition(TOPIC_ID_2, 0, TOPIC_2);
 
     @Mock
     Time time;
@@ -81,8 +81,8 @@ class DeleteTopicJobTest extends SharedPostgreSQLTest {
         new CommitFileJob(
             time, hikariDataSource, objectKey1, BROKER_ID, file1Size,
             List.of(
-                new CommitFileJob.CommitBatchRequestExtra(new CommitBatchRequest(T0P0, 0, file1Batch1Size, 12, 1000, TimestampType.CREATE_TIME), TOPIC_ID_0),
-                new CommitFileJob.CommitBatchRequestExtra(new CommitBatchRequest(T0P1, 0, file1Batch2Size, 12, 1000, TimestampType.CREATE_TIME), TOPIC_ID_0)
+                new CommitFileJob.CommitBatchRequestJson(new CommitBatchRequest(T0P0, 0, file1Batch1Size, 12, 1000, TimestampType.CREATE_TIME)),
+                new CommitFileJob.CommitBatchRequestJson(new CommitBatchRequest(T0P1, 0, file1Batch2Size, 12, 1000, TimestampType.CREATE_TIME))
             ), durationCallback
         ).call();
 
@@ -93,8 +93,8 @@ class DeleteTopicJobTest extends SharedPostgreSQLTest {
         new CommitFileJob(
             time, hikariDataSource, objectKey2, BROKER_ID, file2Size,
             List.of(
-                new CommitFileJob.CommitBatchRequestExtra(new CommitBatchRequest(T0P0, 0, file2Batch1Size, 12, 1000, TimestampType.CREATE_TIME), TOPIC_ID_0),
-                new CommitFileJob.CommitBatchRequestExtra(new CommitBatchRequest(T2P0, 0, file2Batch2Size, 12, 1000, TimestampType.CREATE_TIME), TOPIC_ID_2)
+                new CommitFileJob.CommitBatchRequestJson(new CommitBatchRequest(T0P0, 0, file2Batch1Size, 12, 1000, TimestampType.CREATE_TIME)),
+                new CommitFileJob.CommitBatchRequestJson(new CommitBatchRequest(T2P0, 0, file2Batch2Size, 12, 1000, TimestampType.CREATE_TIME))
             ), durationCallback
         ).call();
 
@@ -106,9 +106,9 @@ class DeleteTopicJobTest extends SharedPostgreSQLTest {
         new CommitFileJob(
             time, hikariDataSource, objectKey3, BROKER_ID, file3Size,
             List.of(
-                new CommitFileJob.CommitBatchRequestExtra(new CommitBatchRequest(T0P0, 0, file1Batch1Size, 12, 1000, TimestampType.CREATE_TIME), TOPIC_ID_0),
-                new CommitFileJob.CommitBatchRequestExtra(new CommitBatchRequest(T0P1, 0, file1Batch2Size, 12, 1000, TimestampType.CREATE_TIME), TOPIC_ID_0),
-                new CommitFileJob.CommitBatchRequestExtra(new CommitBatchRequest(T2P0, 0, file1Batch2Size, 12, 1000, TimestampType.CREATE_TIME), TOPIC_ID_2)
+                new CommitFileJob.CommitBatchRequestJson(new CommitBatchRequest(T0P0, 0, file1Batch1Size, 12, 1000, TimestampType.CREATE_TIME)),
+                new CommitFileJob.CommitBatchRequestJson(new CommitBatchRequest(T0P1, 0, file1Batch2Size, 12, 1000, TimestampType.CREATE_TIME)),
+                new CommitFileJob.CommitBatchRequestJson(new CommitBatchRequest(T2P0, 0, file1Batch2Size, 12, 1000, TimestampType.CREATE_TIME))
             ), durationCallback
         ).call();
 

--- a/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/FindBatchesJobTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/FindBatchesJobTest.java
@@ -2,7 +2,6 @@
 package io.aiven.inkless.control_plane.postgres;
 
 import org.apache.kafka.common.TopicIdPartition;
-import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.record.TimestampType;
@@ -39,9 +38,9 @@ class FindBatchesJobTest extends SharedPostgreSQLTest {
     static final String TOPIC_1 = "topic1";
     static final Uuid TOPIC_ID_0 = new Uuid(10, 12);
     static final Uuid TOPIC_ID_1 = new Uuid(555, 333);
-    static final TopicPartition T0P0 = new TopicPartition(TOPIC_0, 0);
-    static final TopicPartition T0P1 = new TopicPartition(TOPIC_0, 1);
-    static final TopicPartition T1P0 = new TopicPartition(TOPIC_1, 0);
+    static final TopicIdPartition T0P0 = new TopicIdPartition(TOPIC_ID_0, 0, TOPIC_0);
+    static final TopicIdPartition T0P1 = new TopicIdPartition(TOPIC_ID_0, 1, TOPIC_0);
+    static final TopicIdPartition T1P0 = new TopicIdPartition(TOPIC_ID_1, 0, TOPIC_1);
 
     @Mock
     Time time;
@@ -64,7 +63,7 @@ class FindBatchesJobTest extends SharedPostgreSQLTest {
         final CommitFileJob commitJob = new CommitFileJob(
             time, hikariDataSource, objectKey1, BROKER_ID, FILE_SIZE,
             List.of(
-                new CommitFileJob.CommitBatchRequestExtra(new CommitBatchRequest(T0P0, 0, 1234, 12, 1000, TimestampType.CREATE_TIME), TOPIC_ID_0)
+                new CommitFileJob.CommitBatchRequestJson(new CommitBatchRequest(T0P0, 0, 1234, 12, 1000, TimestampType.CREATE_TIME))
             ),
             duration -> {}
         );

--- a/storage/inkless/src/test/java/io/aiven/inkless/produce/ActiveFileTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/produce/ActiveFileTest.java
@@ -1,7 +1,8 @@
 // Copyright (c) 2024 Aiven, Helsinki, Finland. https://aiven.io/
 package io.aiven.inkless.produce;
 
-import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.TopicIdPartition;
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.compress.Compression;
 import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.record.SimpleRecord;
@@ -20,11 +21,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class ActiveFileTest {
+    static final Uuid TOPIC_ID_0 = new Uuid(1000, 1000);
+    static final Uuid TOPIC_ID_1 = new Uuid(2000, 2000);
     static final String TOPIC_0 = "topic0";
     static final String TOPIC_1 = "topic1";
-    static final TopicPartition T0P0 = new TopicPartition(TOPIC_0, 0);
-    static final TopicPartition T0P1 = new TopicPartition(TOPIC_0, 1);
-    static final TopicPartition T1P0 = new TopicPartition(TOPIC_1, 0);
+    static final TopicIdPartition T0P0 = new TopicIdPartition(TOPIC_ID_0, 0, TOPIC_0);
+    static final TopicIdPartition T0P1 = new TopicIdPartition(TOPIC_ID_0, 1, TOPIC_0);
+    static final TopicIdPartition T1P0 = new TopicIdPartition(TOPIC_ID_1, 0, TOPIC_1);
 
     static final Map<String, TimestampType> TIMESTAMP_TYPES = Map.of(
         TOPIC_0, TimestampType.CREATE_TIME,
@@ -107,12 +110,12 @@ class ActiveFileTest {
     void closeNonEmpty() {
         final Instant start = Instant.ofEpochMilli(10);
         final ActiveFile file = new ActiveFile(Time.SYSTEM, start);
-        final Map<TopicPartition, MemoryRecords> request1 = Map.of(
+        final Map<TopicIdPartition, MemoryRecords> request1 = Map.of(
             T0P0, MemoryRecords.withRecords(Compression.NONE, new SimpleRecord(1000, new byte[10])),
             T0P1, MemoryRecords.withRecords(Compression.NONE, new SimpleRecord(2000, new byte[10]))
         );
         file.add(request1, TIMESTAMP_TYPES);
-        final Map<TopicPartition, MemoryRecords> request2 = Map.of(
+        final Map<TopicIdPartition, MemoryRecords> request2 = Map.of(
             T0P1, MemoryRecords.withRecords(Compression.NONE, new SimpleRecord(3000, new byte[10])),
             T1P0, MemoryRecords.withRecords(Compression.NONE, new SimpleRecord(4000, new byte[10]))
         );

--- a/storage/inkless/src/test/java/io/aiven/inkless/produce/AppendInterceptorTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/produce/AppendInterceptorTest.java
@@ -2,6 +2,7 @@
 package io.aiven.inkless.produce;
 
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.compress.Compression;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.record.MemoryRecords;
@@ -264,6 +265,7 @@ public class AppendInterceptorTest {
             CompletableFuture.completedFuture(writeResult)
         );
 
+        when(metadataView.getTopicId(eq("inkless"))).thenReturn(new Uuid(123, 456));
         when(metadataView.isInklessTopic(eq("inkless"))).thenReturn(true);
         when(metadataView.getTopicConfig(any())).thenReturn(new Properties());
         final AppendInterceptor interceptor = new AppendInterceptor(
@@ -288,6 +290,7 @@ public class AppendInterceptorTest {
             CompletableFuture.failedFuture(exception)
         );
 
+        when(metadataView.getTopicId(eq("inkless"))).thenReturn(new Uuid(123, 456));
         when(metadataView.isInklessTopic(eq("inkless"))).thenReturn(true);
         when(metadataView.getTopicConfig(any())).thenReturn(new Properties());
         final AppendInterceptor interceptor = new AppendInterceptor(

--- a/storage/inkless/src/test/java/io/aiven/inkless/produce/BatchBufferTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/produce/BatchBufferTest.java
@@ -1,7 +1,8 @@
 // Copyright (c) 2024 Aiven, Helsinki, Finland. https://aiven.io/
 package io.aiven.inkless.produce;
 
-import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.TopicIdPartition;
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.compress.Compression;
 import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.record.MutableRecordBatch;
@@ -23,9 +24,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class BatchBufferTest {
-    private static final TopicPartition T0P0 = new TopicPartition("topic0", 0);
-    private static final TopicPartition T0P1 = new TopicPartition("topic0", 1);
-    private static final TopicPartition T1P0 = new TopicPartition("topic1", 0);
+    static final Uuid TOPIC_ID_0 = new Uuid(1000, 1000);
+    static final Uuid TOPIC_ID_1 = new Uuid(2000, 2000);
+    static final String TOPIC_0 = "topic0";
+    static final String TOPIC_1 = "topic1";
+    private static final TopicIdPartition T0P0 = new TopicIdPartition(TOPIC_ID_0, 0, TOPIC_0);
+    private static final TopicIdPartition T0P1 = new TopicIdPartition(TOPIC_ID_0, 1, TOPIC_0);
+    private static final TopicIdPartition T1P0 = new TopicIdPartition(TOPIC_ID_1, 0, TOPIC_1);
 
     @Test
     void totalSize() {

--- a/storage/inkless/src/test/java/io/aiven/inkless/produce/WriterMockedTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/produce/WriterMockedTest.java
@@ -1,7 +1,8 @@
 // Copyright (c) 2024 Aiven, Helsinki, Finland. https://aiven.io/
 package io.aiven.inkless.produce;
 
-import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.TopicIdPartition;
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.common.utils.Time;
@@ -40,10 +41,12 @@ import static org.mockito.Mockito.when;
 class WriterMockedTest {
     static final String TOPIC_0 = "topic0";
     static final String TOPIC_1 = "topic1";
-    static final TopicPartition T0P0 = new TopicPartition(TOPIC_0, 0);
-    static final TopicPartition T0P1 = new TopicPartition(TOPIC_0, 1);
-    static final TopicPartition T1P0 = new TopicPartition(TOPIC_1, 0);
-    static final TopicPartition T1P1 = new TopicPartition(TOPIC_1, 1);
+    static final Uuid TOPIC_ID_0 = new Uuid(0, 1);
+    static final Uuid TOPIC_ID_1 = new Uuid(0, 2);
+    static final TopicIdPartition T0P0 = new TopicIdPartition(TOPIC_ID_0, 0, TOPIC_0);
+    static final TopicIdPartition T0P1 = new TopicIdPartition(TOPIC_ID_0, 1, TOPIC_0);
+    static final TopicIdPartition T1P0 = new TopicIdPartition(TOPIC_ID_1, 0, TOPIC_1);
+    static final TopicIdPartition T1P1 = new TopicIdPartition(TOPIC_ID_1, 1, TOPIC_1);
 
     static final Map<String, TimestampType> TIMESTAMP_TYPES = Map.of(
         TOPIC_0, TimestampType.CREATE_TIME,
@@ -88,8 +91,8 @@ class WriterMockedTest {
         final Writer writer = new Writer(
             time, Duration.ofMillis(1), 8 * 1024, commitTickScheduler, fileCommitter, writerMetrics, brokerTopicMetricMarks);
 
-        final Map<TopicPartition, MemoryRecords> writeRequest = Map.of(
-            T0P0, recordCreator.create(T0P0, 100)
+        final Map<TopicIdPartition, MemoryRecords> writeRequest = Map.of(
+            T0P0, recordCreator.create(T0P0.topicPartition(), 100)
         );
         writer.write(writeRequest, TIMESTAMP_TYPES);
 
@@ -103,11 +106,11 @@ class WriterMockedTest {
         final Writer writer = new Writer(
             time, Duration.ofMillis(1), 15908, commitTickScheduler, fileCommitter, writerMetrics, brokerTopicMetricMarks);
 
-        final Map<TopicPartition, MemoryRecords> writeRequest = Map.of(
-            T0P0, recordCreator.create(T0P0, 100),
-            T0P1, recordCreator.create(T0P1, 100),
-            T1P0, recordCreator.create(T1P0, 100),
-            T1P1, recordCreator.create(T1P1, 100)
+        final Map<TopicIdPartition, MemoryRecords> writeRequest = Map.of(
+            T0P0, recordCreator.create(T0P0.topicPartition(), 100),
+            T0P1, recordCreator.create(T0P1.topicPartition(), 100),
+            T1P0, recordCreator.create(T1P0.topicPartition(), 100),
+            T1P1, recordCreator.create(T1P1.topicPartition(), 100)
         );
         assertThat(writer.write(writeRequest, TIMESTAMP_TYPES)).isNotCompleted();
 
@@ -123,17 +126,17 @@ class WriterMockedTest {
         final Writer writer = new Writer(
             time, Duration.ofMillis(1), 8 * 1024, commitTickScheduler, fileCommitter, writerMetrics, brokerTopicMetricMarks);
 
-        final Map<TopicPartition, MemoryRecords> writeRequest0 = Map.of(
-            T0P0, recordCreator.create(T0P0, 1),
-            T0P1, recordCreator.create(T0P1, 1),
-            T1P0, recordCreator.create(T1P0, 1),
-            T1P1, recordCreator.create(T1P1, 1)
+        final Map<TopicIdPartition, MemoryRecords> writeRequest0 = Map.of(
+            T0P0, recordCreator.create(T0P0.topicPartition(), 1),
+            T0P1, recordCreator.create(T0P1.topicPartition(), 1),
+            T1P0, recordCreator.create(T1P0.topicPartition(), 1),
+            T1P1, recordCreator.create(T1P1.topicPartition(), 1)
         );
-        final Map<TopicPartition, MemoryRecords> writeRequest1 = Map.of(
-            T0P0, recordCreator.create(T0P0, 100),
-            T0P1, recordCreator.create(T0P1, 100),
-            T1P0, recordCreator.create(T1P0, 100),
-            T1P1, recordCreator.create(T1P1, 100)
+        final Map<TopicIdPartition, MemoryRecords> writeRequest1 = Map.of(
+            T0P0, recordCreator.create(T0P0.topicPartition(), 100),
+            T0P1, recordCreator.create(T0P1.topicPartition(), 100),
+            T1P0, recordCreator.create(T1P0.topicPartition(), 100),
+            T1P1, recordCreator.create(T1P1.topicPartition(), 100)
         );
         assertThat(writer.write(writeRequest0, TIMESTAMP_TYPES)).isNotCompleted();
         assertThat(writer.write(writeRequest1, TIMESTAMP_TYPES)).isNotCompleted();
@@ -150,11 +153,11 @@ class WriterMockedTest {
         final Writer writer = new Writer(
             time, Duration.ofMillis(1), 8 * 1024, commitTickScheduler, fileCommitter, writerMetrics, brokerTopicMetricMarks);
 
-        final Map<TopicPartition, MemoryRecords> writeRequest = Map.of(
-            T0P0, recordCreator.create(T0P0, 1),
-            T0P1, recordCreator.create(T0P1, 1),
-            T1P0, recordCreator.create(T1P0, 1),
-            T1P1, recordCreator.create(T1P1, 1)
+        final Map<TopicIdPartition, MemoryRecords> writeRequest = Map.of(
+            T0P0, recordCreator.create(T0P0.topicPartition(), 1),
+            T0P1, recordCreator.create(T0P1.topicPartition(), 1),
+            T1P0, recordCreator.create(T1P0.topicPartition(), 1),
+            T1P1, recordCreator.create(T1P1.topicPartition(), 1)
         );
         assertThat(writer.write(writeRequest, TIMESTAMP_TYPES)).isNotCompleted();
 
@@ -171,11 +174,11 @@ class WriterMockedTest {
         final Writer writer = new Writer(
             time, Duration.ofMillis(1), 8 * 1024, commitTickScheduler, fileCommitter, writerMetrics, brokerTopicMetricMarks);
 
-        final Map<TopicPartition, MemoryRecords> writeRequest = Map.of(
-            T0P0, recordCreator.create(T0P0, 1),
-            T0P1, recordCreator.create(T0P1, 1),
-            T1P0, recordCreator.create(T1P0, 1),
-            T1P1, recordCreator.create(T1P1, 1)
+        final Map<TopicIdPartition, MemoryRecords> writeRequest = Map.of(
+            T0P0, recordCreator.create(T0P0.topicPartition(), 1),
+            T0P1, recordCreator.create(T0P1.topicPartition(), 1),
+            T1P0, recordCreator.create(T1P0.topicPartition(), 1),
+            T1P1, recordCreator.create(T1P1.topicPartition(), 1)
         );
         assertThat(writer.write(writeRequest, TIMESTAMP_TYPES)).isNotCompleted();
 
@@ -192,11 +195,11 @@ class WriterMockedTest {
         final Writer writer = new Writer(
             time, Duration.ofMillis(1), 8 * 1024, commitTickScheduler, fileCommitter, writerMetrics, brokerTopicMetricMarks);
 
-        final Map<TopicPartition, MemoryRecords> writeRequest = Map.of(
-            T0P0, recordCreator.create(T0P0, 100),
-            T0P1, recordCreator.create(T0P1, 100),
-            T1P0, recordCreator.create(T1P0, 100),
-            T1P1, recordCreator.create(T1P1, 100)
+        final Map<TopicIdPartition, MemoryRecords> writeRequest = Map.of(
+            T0P0, recordCreator.create(T0P0.topicPartition(), 100),
+            T0P1, recordCreator.create(T0P1.topicPartition(), 100),
+            T1P0, recordCreator.create(T1P0.topicPartition(), 100),
+            T1P1, recordCreator.create(T1P1.topicPartition(), 100)
         );
         assertThat(writer.write(writeRequest, TIMESTAMP_TYPES)).isNotCompleted();
 
@@ -259,7 +262,7 @@ class WriterMockedTest {
         reset(commitTickScheduler);
         reset(fileCommitter);
 
-        final var writeResult = writer.write(Map.of(T0P0, recordCreator.create(T0P0, 10)), TIMESTAMP_TYPES);
+        final var writeResult = writer.write(Map.of(T0P0, recordCreator.create(T0P0.topicPartition(), 10)), TIMESTAMP_TYPES);
 
         assertThat(writeResult).isCompletedExceptionally();
         assertThatThrownBy(writeResult::get)
@@ -279,11 +282,11 @@ class WriterMockedTest {
         final InterruptedException interruptedException = new InterruptedException();
         doThrow(interruptedException).when(fileCommitter).commit(any());
 
-        final Map<TopicPartition, MemoryRecords> writeRequest = Map.of(
-            T0P0, recordCreator.create(T0P0, 100),
-            T0P1, recordCreator.create(T0P1, 100),
-            T1P0, recordCreator.create(T1P0, 100),
-            T1P1, recordCreator.create(T1P1, 100)
+        final Map<TopicIdPartition, MemoryRecords> writeRequest = Map.of(
+            T0P0, recordCreator.create(T0P0.topicPartition(), 100),
+            T0P1, recordCreator.create(T0P1.topicPartition(), 100),
+            T1P0, recordCreator.create(T1P0.topicPartition(), 100),
+            T1P1, recordCreator.create(T1P1.topicPartition(), 100)
         );
 
         assertThatThrownBy(() -> writer.write(writeRequest, TIMESTAMP_TYPES))


### PR DESCRIPTION
This change removes the necessity of the control plane to find topic IDs for files being committed.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
