### PR TITLE
refactor(inkless:produce): set timestamp-type on batchvalidator [INK-86]

### DIFF
--- a/storage/inkless/src/main/java/io/aiven/inkless/produce/ActiveFile.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/produce/ActiveFile.java
@@ -70,9 +70,9 @@ class ActiveFile {
             }
 
             for (final var batch : entry.getValue().batches()) {
-                batchValidator.validateAndMaybeSetMaxTimestamp(batch);
+                batchValidator.validateAndMaybeSetMaxTimestamp(batch, messageTimestampType);
 
-                buffer.addBatch(topicIdPartition, messageTimestampType, batch, requestId);
+                buffer.addBatch(topicIdPartition, batch, requestId);
 
                 brokerTopicMetricMarks.bytesInRateMark.accept(topicIdPartition.topic(), batch.sizeInBytes());
                 brokerTopicMetricMarks.messagesInRateMark.accept(topicIdPartition.topic(), batch.nextOffset() - batch.baseOffset());

--- a/storage/inkless/src/main/java/io/aiven/inkless/produce/BatchValidator.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/produce/BatchValidator.java
@@ -21,10 +21,9 @@ public class BatchValidator {
         this.time = time;
     }
 
-    public void validateAndMaybeSetMaxTimestamp(final MutableRecordBatch batch) {
+    public void validateAndMaybeSetMaxTimestamp(final MutableRecordBatch batch, TimestampType timestampType) {
         Objects.requireNonNull(batch, "batch cannot be null");
-
-        final TimestampType timestampType = batch.timestampType();
+        Objects.requireNonNull(timestampType, "timestampType cannot be null");
 
         long maxBatchTimestamp = RecordBatch.NO_TIMESTAMP;
 
@@ -35,6 +34,8 @@ public class BatchValidator {
 
         if (timestampType != TimestampType.LOG_APPEND_TIME)
             batch.setMaxTimestamp(timestampType, maxBatchTimestamp);
-        // else the append time is set by the control plane and updated on read time
+        else
+            batch.setMaxTimestamp(timestampType, time.milliseconds());
+            // the append time will be updated by the control plane and updated on read time
     }
 }

--- a/storage/inkless/src/test/java/io/aiven/inkless/produce/ActiveFileTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/produce/ActiveFileTest.java
@@ -7,6 +7,7 @@ import org.apache.kafka.common.compress.Compression;
 import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.record.SimpleRecord;
 import org.apache.kafka.common.record.TimestampType;
+import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
 
 import org.junit.jupiter.api.Test;
@@ -109,7 +110,8 @@ class ActiveFileTest {
     @Test
     void closeNonEmpty() {
         final Instant start = Instant.ofEpochMilli(10);
-        final ActiveFile file = new ActiveFile(Time.SYSTEM, start);
+        final Time time = new MockTime();
+        final ActiveFile file = new ActiveFile(time, start);
         final Map<TopicIdPartition, MemoryRecords> request1 = Map.of(
             T0P0, MemoryRecords.withRecords(Compression.NONE, new SimpleRecord(1000, new byte[10])),
             T0P1, MemoryRecords.withRecords(Compression.NONE, new SimpleRecord(2000, new byte[10]))
@@ -134,7 +136,7 @@ class ActiveFileTest {
             CommitBatchRequest.of(T0P0, 0, 78, 0, 0, 1000, TimestampType.CREATE_TIME),
             CommitBatchRequest.of(T0P1, 78, 78, 0, 0, 2000, TimestampType.CREATE_TIME),
             CommitBatchRequest.of(T0P1, 156, 78, 0, 0, 3000, TimestampType.CREATE_TIME),
-            CommitBatchRequest.of(T1P0, 234, 78, 0, 0, 4000, TimestampType.LOG_APPEND_TIME)
+            CommitBatchRequest.of(T1P0, 234, 78, 0, 0, time.milliseconds(), TimestampType.LOG_APPEND_TIME)
         );
         assertThat(result.requestIds()).containsExactly(0, 0, 1, 1);
         assertThat(result.data()).hasSize(312);

--- a/storage/inkless/src/test/java/io/aiven/inkless/produce/BatchBufferTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/produce/BatchBufferTest.java
@@ -39,13 +39,13 @@ class BatchBufferTest {
 
         assertThat(buffer.totalSize()).isZero();
 
-        final MutableRecordBatch batch1 = createBatch(time, T0P0 + "-0", T0P0 + "-1", T0P0 + "-2");
-        buffer.addBatch(T0P0, TimestampType.CREATE_TIME, batch1, 0);
+        final MutableRecordBatch batch1 = createBatch(TimestampType.CREATE_TIME, time, T0P0 + "-0", T0P0 + "-1", T0P0 + "-2");
+        buffer.addBatch(T0P0, batch1, 0);
 
         assertThat(buffer.totalSize()).isEqualTo(batch1.sizeInBytes());
 
-        final MutableRecordBatch batch2 = createBatch(time, T0P0 + "-0", T0P0 + "-1", T0P0 + "-2");
-        buffer.addBatch(T0P0, TimestampType.CREATE_TIME, batch2, 1);
+        final MutableRecordBatch batch2 = createBatch(TimestampType.CREATE_TIME, time, T0P0 + "-0", T0P0 + "-1", T0P0 + "-2");
+        buffer.addBatch(T0P0, batch2, 1);
 
         assertThat(buffer.totalSize()).isEqualTo(batch1.sizeInBytes() + batch2.sizeInBytes());
     }
@@ -70,9 +70,9 @@ class BatchBufferTest {
         final Time time = new MockTime();
         final BatchBuffer buffer = new BatchBuffer();
 
-        final MutableRecordBatch batch = createBatch(time, T0P0 + "-0", T0P0 + "-1", T0P0 + "-2");
+        final MutableRecordBatch batch = createBatch(TimestampType.CREATE_TIME, time, T0P0 + "-0", T0P0 + "-1", T0P0 + "-2");
         final byte[] beforeAdding = batchToBytes(batch);
-        buffer.addBatch(T0P0, TimestampType.CREATE_TIME, batch, 0);
+        buffer.addBatch(T0P0, batch, 0);
 
         final BatchBuffer.CloseResult result = buffer.close();
         assertThat(result.commitBatchRequests()).containsExactly(
@@ -88,30 +88,30 @@ class BatchBufferTest {
         final Time time = new MockTime();
         final BatchBuffer buffer = new BatchBuffer();
 
-        final MutableRecordBatch t0p0b0 = createBatch(time, T0P0 + "-0");
-        final MutableRecordBatch t0p0b2 = createBatch(time, T0P0 + "-2");
-        final MutableRecordBatch t0p0b1 = createBatch(time, T0P0 + "-1");
+        final MutableRecordBatch t0p0b0 = createBatch(TimestampType.CREATE_TIME, time, T0P0 + "-0");
+        final MutableRecordBatch t0p0b2 = createBatch(TimestampType.CREATE_TIME, time, T0P0 + "-2");
+        final MutableRecordBatch t0p0b1 = createBatch(TimestampType.CREATE_TIME, time, T0P0 + "-1");
 
-        final MutableRecordBatch t0p1b0 = createBatch(time, T0P1 + "-0");
-        final MutableRecordBatch t0p1b1 = createBatch(time, T0P1 + "-1");
-        final MutableRecordBatch t0p1b2 = createBatch(time, T0P1 + "-2");
+        final MutableRecordBatch t0p1b0 = createBatch(TimestampType.LOG_APPEND_TIME, time, T0P1 + "-0");
+        final MutableRecordBatch t0p1b1 = createBatch(TimestampType.LOG_APPEND_TIME, time, T0P1 + "-1");
+        final MutableRecordBatch t0p1b2 = createBatch(TimestampType.LOG_APPEND_TIME, time, T0P1 + "-2");
 
-        final MutableRecordBatch t1p0b0 = createBatch(time, T1P0 + "-0");
-        final MutableRecordBatch t1p0b1 = createBatch(time, T1P0 + "-1");
-        final MutableRecordBatch t1p0b2 = createBatch(time, T1P0 + "-2");
+        final MutableRecordBatch t1p0b0 = createBatch(TimestampType.LOG_APPEND_TIME, time, T1P0 + "-0");
+        final MutableRecordBatch t1p0b1 = createBatch(TimestampType.LOG_APPEND_TIME, time, T1P0 + "-1");
+        final MutableRecordBatch t1p0b2 = createBatch(TimestampType.LOG_APPEND_TIME, time, T1P0 + "-2");
 
         final int batchSize = t0p0b0.sizeInBytes();  // expecting it to be same everywhere
-        buffer.addBatch(T0P0, TimestampType.CREATE_TIME, t0p0b0, 0);
-        buffer.addBatch(T1P0, TimestampType.LOG_APPEND_TIME, t1p0b0, 0);
-        buffer.addBatch(T0P0, TimestampType.CREATE_TIME, t0p0b1, 0);
+        buffer.addBatch(T0P0, t0p0b0, 0);
+        buffer.addBatch(T1P0, t1p0b0, 0);
+        buffer.addBatch(T0P0, t0p0b1, 0);
 
-        buffer.addBatch(T1P0, TimestampType.LOG_APPEND_TIME, t1p0b1, 1);
-        buffer.addBatch(T0P1, TimestampType.LOG_APPEND_TIME, t0p1b0, 1);
-        buffer.addBatch(T0P0, TimestampType.CREATE_TIME, t0p0b2, 1);
+        buffer.addBatch(T1P0, t1p0b1, 1);
+        buffer.addBatch(T0P1, t0p1b0, 1);
+        buffer.addBatch(T0P0, t0p0b2, 1);
 
-        buffer.addBatch(T0P1, TimestampType.LOG_APPEND_TIME, t0p1b1, 2);
-        buffer.addBatch(T0P1, TimestampType.LOG_APPEND_TIME, t0p1b2, 2);
-        buffer.addBatch(T1P0, TimestampType.LOG_APPEND_TIME, t1p0b2, 2);
+        buffer.addBatch(T0P1, t0p1b1, 2);
+        buffer.addBatch(T0P1, t0p1b2, 2);
+        buffer.addBatch(T1P0, t1p0b2, 2);
 
         // Here batches are sorted.
         final BatchBuffer.CloseResult result = buffer.close();
@@ -155,8 +155,8 @@ class BatchBufferTest {
         final Time time = new MockTime();
         final BatchBuffer buffer = new BatchBuffer();
 
-        final MutableRecordBatch batch1 = createBatch(time, T0P0 + "-0");
-        buffer.addBatch(T0P0, TimestampType.LOG_APPEND_TIME, batch1, 0);
+        final MutableRecordBatch batch1 = createBatch(TimestampType.LOG_APPEND_TIME, time, T0P0 + "-0");
+        buffer.addBatch(T0P0, batch1, 0);
         final BatchBuffer.CloseResult result1 = buffer.close();
         assertThat(result1.commitBatchRequests()).containsExactly(
             CommitBatchRequest.of(T0P0, 0, batch1.sizeInBytes(), 19, 19, time.milliseconds(), TimestampType.LOG_APPEND_TIME)
@@ -164,23 +164,28 @@ class BatchBufferTest {
         assertThat(result1.data()).containsExactly(batchToBytes(batch1));
         assertThat(result1.requestIds()).containsExactly(0);
 
-        final MutableRecordBatch batch2 = createBatch(time, T1P0 + "-0-longer");
-        assertThatThrownBy(() -> buffer.addBatch(T1P0, TimestampType.LOG_APPEND_TIME, batch2, 1))
+        final MutableRecordBatch batch2 = createBatch(TimestampType.CREATE_TIME, time, T1P0 + "-0-longer");
+        assertThatThrownBy(() -> buffer.addBatch(T1P0, batch2, 1))
             .isInstanceOf(IllegalStateException.class)
             .hasMessage("Already closed");
     }
 
-    MutableRecordBatch createBatch(Time time, String... content) {
+    MutableRecordBatch createBatch(TimestampType timestampType, Time time, String... content) {
         final SimpleRecord[] simpleRecords = Arrays.stream(content)
             .map(c -> new SimpleRecord(time.milliseconds(), c.getBytes()))
             .toArray(SimpleRecord[]::new);
         final int initialOffset = 19;  // some non-zero number
-        final MemoryRecords records = MemoryRecords.withRecords(initialOffset, Compression.NONE, simpleRecords);
+        final MemoryRecords records = MemoryRecords.withRecords(RecordBatch.CURRENT_MAGIC_VALUE, initialOffset, Compression.NONE, timestampType, simpleRecords);
         final Iterator<MutableRecordBatch> iterator = records.batches().iterator();
         if (!iterator.hasNext()) {
             return null;
         }
-        return iterator.next();
+        final MutableRecordBatch batch = iterator.next();
+        // avoid using system clock for tests
+        if (timestampType == TimestampType.LOG_APPEND_TIME) {
+            batch.setMaxTimestamp(timestampType, time.milliseconds());
+        }
+        return batch;
     }
 
     byte[] batchToBytes(final RecordBatch batch) {
@@ -194,13 +199,10 @@ class BatchBufferTest {
         final Time time = Time.SYSTEM;
         final BatchBuffer buffer = new BatchBuffer();
 
-        assertThatThrownBy(() -> buffer.addBatch(null, TimestampType.LOG_APPEND_TIME, createBatch(time), 0))
+        assertThatThrownBy(() -> buffer.addBatch(null, createBatch(TimestampType.CREATE_TIME, time), 0))
             .isInstanceOf(NullPointerException.class)
             .hasMessage("topicPartition cannot be null");
-        assertThatThrownBy(() -> buffer.addBatch(T0P0, null, createBatch(time), 0))
-            .isInstanceOf(NullPointerException.class)
-            .hasMessage("timestampType cannot be null");
-        assertThatThrownBy(() -> buffer.addBatch(T0P0, TimestampType.LOG_APPEND_TIME, null, 0))
+        assertThatThrownBy(() -> buffer.addBatch(T0P0, null, 0))
             .isInstanceOf(NullPointerException.class)
             .hasMessage("batch cannot be null");
     }


### PR DESCRIPTION
Instead of passing the type around, use the BatchValidator to set the timestamp type (similar to LogValidator)

[INK-86]

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)


[INK-86]: https://aiven.atlassian.net/browse/INK-86?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ