### PR TITLE
 chore(inkless:tools): add compose for inkless multi-node cluster [INK-62]

### DIFF
--- a/docker/examples/docker-compose-files/inkless-cluster/docker-compose.yml
+++ b/docker/examples/docker-compose-files/inkless-cluster/docker-compose.yml
@@ -1,0 +1,143 @@
+services:
+  broker: &base-broker
+    image: kafka/test:4.0.0-inkless-SNAPSHOT
+    restart: unless-stopped
+    ports:
+      - "9092:9092"
+      - "7070:7070" # prometheus metrics
+      - "9999:9999" # jmx port
+    environment: &base-broker-env
+      CLUSTER_ID: "4L6g3nShT-eMCtK--X86sw"
+      KAFKA_PROCESS_ROLES: "broker,controller"
+      KAFKA_NODE_ID: 1
+      KAFKA_BROKER_RACK: "az1"
+      KAFKA_CONTROLLER_QUORUM_VOTERS: "1@broker:19093,2@broker2:19093,101@broker101:19093,102@broker102:19093"
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: "CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT"
+      KAFKA_ADVERTISED_LISTENERS: "PLAINTEXT_HOST://localhost:9092,PLAINTEXT://broker:19092"
+      KAFKA_LISTENERS: "CONTROLLER://:19093,PLAINTEXT_HOST://:9092,PLAINTEXT://:19092"
+      KAFKA_INTER_BROKER_LISTENER_NAME: "PLAINTEXT"
+      KAFKA_CONTROLLER_LISTENER_NAMES: "CONTROLLER"
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 3
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 2
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 3
+      KAFKA_LOG_DIRS: "/tmp/kraft-combined-logs"
+
+      # Inkless
+
+      ## Control Plane
+      ### Postgresql
+      KAFKA_INKLESS_CONTROL_PLANE_CLASS: "io.aiven.inkless.control_plane.postgres.PostgresControlPlane"
+      KAFKA_INKLESS_CONTROL_PLANE_CONNECTION_STRING: "jdbc:postgresql://postgres:5432/inkless"
+      KAFKA_INKLESS_CONTROL_PLANE_USERNAME: "admin"
+      KAFKA_INKLESS_CONTROL_PLANE_PASSWORD: "admin"
+
+      ## In-memory control plane
+      # KAFKA_INKLESS_CONTROL_PLANE_CLASS: "io.aiven.inkless.control_plane.InMemoryControlPlane"
+
+      ## Storage
+      ### Minio
+      KAFKA_INKLESS_STORAGE_BACKEND_CLASS: "io.aiven.inkless.storage_backend.s3.S3Storage"
+      KAFKA_INKLESS_STORAGE_S3_PATH_STYLE_ACCESS_ENABLED: "true"
+      KAFKA_INKLESS_STORAGE_S3_BUCKET_NAME: "inkless"
+      KAFKA_INKLESS_STORAGE_S3_REGION: "us-east-1"
+      KAFKA_INKLESS_STORAGE_S3_ENDPOINT_URL: "http://minio:9000"
+      KAFKA_INKLESS_STORAGE_AWS_ACCESS_KEY_ID: "minioadmin"
+      KAFKA_INKLESS_STORAGE_AWS_SECRET_ACCESS_KEY: "minioadmin"
+
+      ### In-memory storage
+      # KAFKA_INKLESS_STORAGE_BACKEND_CLASS: "io.aiven.inkless.storage_backend.in_memory.InMemoryStorage"
+
+      # JMX
+      KAFKA_JMX_PORT: 9999
+      EXTRA_ARGS: -javaagent:/opt/prometheus-jmx-exporter/jmx_prometheus_javaagent.jar=7070:/opt/prometheus-jmx-exporter/kafka.yml
+    volumes:
+      - ./../../../extra/prometheus-jmx-exporter:/opt/prometheus-jmx-exporter
+    depends_on:
+      - postgres
+      - minio
+
+  broker2:
+    <<: *base-broker
+    ports:
+      - "9093:9093"
+      - "17070:7070" # prometheus metrics
+      - "19999:9999" # jmx port
+    environment:
+      <<: *base-broker-env
+      KAFKA_NODE_ID: 2
+      KAFKA_LISTENERS: "CONTROLLER://:19093,PLAINTEXT_HOST://:9093,PLAINTEXT://:19092"
+      KAFKA_ADVERTISED_LISTENERS: "PLAINTEXT_HOST://localhost:9093,PLAINTEXT://broker2:19092"
+
+  broker101:
+    <<: *base-broker
+    ports:
+      - "9094:9094"
+      - "17071:7070" # prometheus metrics
+      - "18999:9999" # jmx port
+    environment:
+      <<: *base-broker-env
+      KAFKA_NODE_ID: 101
+      KAFKA_LISTENERS: "CONTROLLER://:19093,PLAINTEXT_HOST://:9094,PLAINTEXT://:19092"
+      KAFKA_ADVERTISED_LISTENERS: "PLAINTEXT_HOST://localhost:9094,PLAINTEXT://broker101:19092"
+      KAFKA_BROKER_RACK: "az2"
+
+  broker102:
+    <<: *base-broker
+    ports:
+      - "9095:9095"
+      - "17072:7070" # prometheus metrics
+      - "17999:9999" # jmx port
+    environment:
+      <<: *base-broker-env
+      KAFKA_NODE_ID: 102
+      KAFKA_LISTENERS: "CONTROLLER://:19093,PLAINTEXT_HOST://:9095,PLAINTEXT://:19092"
+      KAFKA_ADVERTISED_LISTENERS: "PLAINTEXT_HOST://localhost:9095,PLAINTEXT://broker102:19092"
+      KAFKA_BROKER_RACK: "az2"
+
+  # Postgresql for control plane
+  postgres:
+    image: postgres:17.2
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_DB: "inkless"
+      POSTGRES_USER: "admin"
+      POSTGRES_PASSWORD: "admin"
+
+  # Object storage
+  minio:
+    image: quay.io/minio/minio
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    command: server /data --console-address ":9001"
+
+  minio-create_bucket:
+    image: quay.io/minio/mc
+    restart: "no"
+    depends_on:
+      - minio
+    entrypoint: >
+      /bin/sh -c "
+      until /usr/bin/mc config host add local http://minio:9000 minioadmin minioadmin; do
+        echo 'Waiting for Minio...';
+        sleep 5;
+      done;
+      /usr/bin/mc mb local/inkless;
+      exit 0;
+      "
+
+  # Monitoring
+  prometheus:
+    image: prom/prometheus:latest
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./../../../extra/prometheus/config/:/etc/prometheus/
+  grafana:
+    image: grafana/grafana:latest
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./../../../extra/grafana/:/etc/grafana/provisioning/

--- a/docker/extra/grafana/dashboards/data/kafka-inkless.json
+++ b/docker/extra/grafana/dashboards/data/kafka-inkless.json
@@ -105,10 +105,16 @@
       "id": 15,
       "options": {
         "legend": {
-          "calcs": [],
-          "displayMode": "list",
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
           "placement": "bottom",
-          "showLegend": true
+          "showLegend": true,
+          "sortBy": "Last *",
+          "sortDesc": true
         },
         "tooltip": {
           "mode": "single",
@@ -119,11 +125,11 @@
       "targets": [
         {
           "disableTextWrap": false,
-          "editorMode": "code",
-          "expr": "rate(kafka_network_requestmetrics_requestspersec{}[$__rate_interval])",
+          "editorMode": "builder",
+          "expr": "rate(kafka_network_requestmetrics_requestspersec{host=~\"$host\"}[$__rate_interval])",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
-          "legendFormat": "{{request}} v{{version}}",
+          "legendFormat": "{{request}} v{{version}} @ {{host}}",
           "range": true,
           "refId": "A",
           "useBackend": false
@@ -217,8 +223,8 @@
       "targets": [
         {
           "disableTextWrap": false,
-          "editorMode": "code",
-          "expr": "rate(kafka_server_brokertopicmetrics_bytesinpersec{topic!=\"\"}[$__rate_interval])",
+          "editorMode": "builder",
+          "expr": "sum by(topic) (rate(kafka_server_brokertopicmetrics_bytesinpersec{topic!=\"\", host=~\"$host\"}[$__rate_interval]))",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "legendFormat": "{{topic}}",
@@ -301,10 +307,16 @@
       "id": 18,
       "options": {
         "legend": {
-          "calcs": [],
-          "displayMode": "list",
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
           "placement": "bottom",
-          "showLegend": true
+          "showLegend": true,
+          "sortBy": "Last *",
+          "sortDesc": true
         },
         "tooltip": {
           "mode": "single",
@@ -315,11 +327,11 @@
       "targets": [
         {
           "disableTextWrap": false,
-          "editorMode": "code",
-          "expr": "rate(kafka_network_requestmetrics_requestspersec{request=\"Produce\"}[$__rate_interval])",
+          "editorMode": "builder",
+          "expr": "rate(kafka_network_requestmetrics_requestspersec{request=\"Produce\", host=~\"$host\"}[$__rate_interval])",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
-          "legendFormat": "{{request}} v{{version}}",
+          "legendFormat": "{{request}} v{{version}} @ {{host}}",
           "range": true,
           "refId": "A",
           "useBackend": false
@@ -399,10 +411,16 @@
       "id": 19,
       "options": {
         "legend": {
-          "calcs": [],
-          "displayMode": "list",
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
           "placement": "bottom",
-          "showLegend": true
+          "showLegend": true,
+          "sortBy": "Last *",
+          "sortDesc": true
         },
         "tooltip": {
           "mode": "single",
@@ -413,11 +431,11 @@
       "targets": [
         {
           "disableTextWrap": false,
-          "editorMode": "code",
-          "expr": "rate(kafka_network_requestmetrics_requestspersec{request=\"FetchConsumer\"}[$__rate_interval])",
+          "editorMode": "builder",
+          "expr": "rate(kafka_network_requestmetrics_requestspersec{request=\"FetchConsumer\", host=~\"$host\"}[$__rate_interval])",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
-          "legendFormat": "{{request}} v{{version}}",
+          "legendFormat": "{{request}} v{{version}} @ {{host}}",
           "range": true,
           "refId": "A",
           "useBackend": false
@@ -511,8 +529,8 @@
       "targets": [
         {
           "disableTextWrap": false,
-          "editorMode": "code",
-          "expr": "rate(kafka_server_brokertopicmetrics_bytesoutpersec{topic!=\"\"}[$__rate_interval])",
+          "editorMode": "builder",
+          "expr": "sum by(topic) (rate(kafka_server_brokertopicmetrics_bytesoutpersec{topic!=\"\", host=~\"$host\"}[$__rate_interval]))",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "legendFormat": "{{topic}}",
@@ -631,10 +649,10 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "kafka_inkless_consume_inklessfetchmetrics_fetchtotaltime{quantile=\"$quantile\"}",
+          "expr": "kafka_inkless_consume_inklessfetchmetrics_fetchtotaltime{quantile=\"$quantile\", host=~\"$host\"}",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
-          "legendFormat": "{{quantile}}",
+          "legendFormat": "{{quantile}}@{{host}}",
           "range": true,
           "refId": "A",
           "useBackend": false
@@ -737,10 +755,10 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "kafka_inkless_consume_inklessfetchmetrics_fetchfiletime{quantile=\"$quantile\"}",
+          "expr": "kafka_inkless_consume_inklessfetchmetrics_fetchfiletime{quantile=\"$quantile\", host=~\"$host\"}",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
-          "legendFormat": "{{quantile}}",
+          "legendFormat": "{{quantile}}@{{host}}",
           "range": true,
           "refId": "A",
           "useBackend": false
@@ -843,10 +861,10 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "kafka_inkless_consume_inklessfetchmetrics_findbatchestime{quantile=\"$quantile\"}",
+          "expr": "kafka_inkless_consume_inklessfetchmetrics_findbatchestime{quantile=\"$quantile\", host=~\"$host\"}",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
-          "legendFormat": "{{quantile}}",
+          "legendFormat": "{{quantile}}@{{host}}",
           "range": true,
           "refId": "A",
           "useBackend": false
@@ -949,10 +967,10 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "kafka_inkless_consume_inklessfetchmetrics_fetchplantime{quantile=\"$quantile\"}",
+          "expr": "kafka_inkless_consume_inklessfetchmetrics_fetchplantime{quantile=\"$quantile\", host=~\"$host\"}",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
-          "legendFormat": "{{quantile}}",
+          "legendFormat": "{{quantile}}@{{host}}",
           "range": true,
           "refId": "A",
           "useBackend": false
@@ -1055,10 +1073,10 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "kafka_inkless_consume_inklessfetchmetrics_fetchcompletiontime{quantile=\"$quantile\"}",
+          "expr": "kafka_inkless_consume_inklessfetchmetrics_fetchcompletiontime{quantile=\"$quantile\", host=~\"$host\"}",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
-          "legendFormat": "{{quantile}}",
+          "legendFormat": "{{quantile}}@{{host}}",
           "range": true,
           "refId": "A",
           "useBackend": false
@@ -1174,10 +1192,10 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "kafka_inkless_produce_filecommitter_filetotallifetime{quantile=\"$quantile\"}",
+          "expr": "kafka_inkless_produce_filecommitter_filetotallifetime{quantile=\"$quantile\", host=~\"$host\"}",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
-          "legendFormat": "{{quantile}}",
+          "legendFormat": "{{quantile}}@{{host}}",
           "range": true,
           "refId": "A",
           "useBackend": false
@@ -1276,10 +1294,10 @@
         {
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "kafka_inkless_produce_filecommitter_filesize{quantile=\"$quantile\"}",
+          "expr": "kafka_inkless_produce_filecommitter_filesize{quantile=\"$quantile\", host=~\"$host\"}",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
-          "legendFormat": "{{quantile}}",
+          "legendFormat": "{{quantile}}@{{host}}",
           "range": true,
           "refId": "A",
           "useBackend": false
@@ -1382,10 +1400,10 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "kafka_inkless_produce_filecommitter_fileuploadandcommittime{quantile=\"$quantile\"}",
+          "expr": "kafka_inkless_produce_filecommitter_fileuploadandcommittime{quantile=\"$quantile\", host=~\"$host\"}",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
-          "legendFormat": "{{quantile}}",
+          "legendFormat": "{{quantile}}@{{host}}",
           "range": true,
           "refId": "A",
           "useBackend": false
@@ -1488,10 +1506,10 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "kafka_inkless_produce_filecommitter_fileuploadtime{quantile=\"$quantile\"}",
+          "expr": "kafka_inkless_produce_filecommitter_fileuploadtime{quantile=\"$quantile\", host=~\"$host\"}",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
-          "legendFormat": "{{quantile}}",
+          "legendFormat": "{{quantile}}@{{host}}",
           "range": true,
           "refId": "A",
           "useBackend": false
@@ -1594,10 +1612,10 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "kafka_inkless_produce_filecommitter_filecommittime{quantile=\"$quantile\"}",
+          "expr": "kafka_inkless_produce_filecommitter_filecommittime{quantile=\"$quantile\", host=~\"$host\"}",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
-          "legendFormat": "{{quantile}}",
+          "legendFormat": "{{quantile}}@{{host}}",
           "range": true,
           "refId": "A",
           "useBackend": false
@@ -1694,10 +1712,10 @@
         {
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "rate(io_aiven_inkless_produce_writermetrics_value[$__rate_interval])",
+          "expr": "rate(io_aiven_inkless_produce_writermetrics_value{host=~\"$host\"}[$__rate_interval])",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
-          "legendFormat": "{{name}}",
+          "legendFormat": "{{name}}@{{host}}",
           "range": true,
           "refId": "A",
           "useBackend": false
@@ -1794,10 +1812,10 @@
         {
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "rate(io_aiven_inkless_produce_filecommitter_value{name=\"FileCommitRate\"}[$__rate_interval])",
+          "expr": "rate(io_aiven_inkless_produce_filecommitter_value{name=\"FileCommitRate\", host=~\"$host\"}[$__rate_interval])",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
-          "legendFormat": "{{name}}",
+          "legendFormat": "{{name}}@{{host}}",
           "range": true,
           "refId": "A",
           "useBackend": false
@@ -1809,11 +1827,11 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "rate(io_aiven_inkless_produce_filecommitter_value{name=\"FileUploadRate\"}[$__rate_interval])",
+          "expr": "rate(io_aiven_inkless_produce_filecommitter_value{name=\"FileUploadRate\", host=~\"$host\"}[$__rate_interval])",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
-          "legendFormat": "{{name}}",
+          "legendFormat": "{{name}}@{{broker}}",
           "range": true,
           "refId": "B",
           "useBackend": false
@@ -1896,7 +1914,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 164
+            "y": 156
           },
           "id": 23,
           "options": {
@@ -1920,10 +1938,10 @@
             {
               "disableTextWrap": false,
               "editorMode": "builder",
-              "expr": "rate(aiven_inkless_server_s3_s3_client_metrics_put_object_requests[$__rate_interval])",
+              "expr": "rate(aiven_inkless_server_s3_s3_client_metrics_put_object_requests{host=~\"$host\"}[$__rate_interval])",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
-              "legendFormat": "Value",
+              "legendFormat": "{{host}}",
               "range": true,
               "refId": "A",
               "useBackend": false
@@ -1996,7 +2014,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 164
+            "y": 156
           },
           "id": 24,
           "options": {
@@ -2020,10 +2038,10 @@
             {
               "disableTextWrap": false,
               "editorMode": "builder",
-              "expr": "rate(aiven_inkless_server_s3_s3_client_metrics_get_object_requests[$__rate_interval])",
+              "expr": "rate(aiven_inkless_server_s3_s3_client_metrics_get_object_requests{host=~\"$host\"}[$__rate_interval])",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
-              "legendFormat": "Value",
+              "legendFormat": "{{host}}",
               "range": true,
               "refId": "A",
               "useBackend": false
@@ -2108,7 +2126,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 61
+            "y": 165
           },
           "id": 26,
           "options": {
@@ -2136,7 +2154,7 @@
               },
               "disableTextWrap": false,
               "editorMode": "builder",
-              "expr": "kafka_inkless_controlplane_postgrescontrolplane_commitfilequerytime{quantile=\"$quantile\"}",
+              "expr": "sum by(host) (kafka_inkless_controlplane_postgrescontrolplane_commitfilequerytime{quantile=\"$quantile\", host=~\"$host\"})",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
               "legendFormat": "{{quantile}}",
@@ -2210,7 +2228,7 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 61
+            "y": 165
           },
           "id": 27,
           "options": {
@@ -2238,10 +2256,10 @@
               },
               "disableTextWrap": false,
               "editorMode": "builder",
-              "expr": "kafka_inkless_controlplane_postgrescontrolplane_findbatchesquerytime{quantile=\"$quantile\"}",
+              "expr": "sum by(host) (kafka_inkless_controlplane_postgrescontrolplane_findbatchesquerytime{quantile=\"$quantile\", host=~\"$host\"})",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
-              "legendFormat": "Find Batches {{quantile}}",
+              "legendFormat": "Find Batches {{quantile}}@{{host}}",
               "range": true,
               "refId": "A",
               "useBackend": false
@@ -2253,12 +2271,12 @@
               },
               "disableTextWrap": false,
               "editorMode": "builder",
-              "expr": "kafka_inkless_controlplane_postgrescontrolplane_getlogsquerytime{quantile=\"$quantile\"}",
+              "expr": "sum by(host) (kafka_inkless_controlplane_postgrescontrolplane_getlogsquerytime{quantile=\"$quantile\", host=~\"$host\"})",
               "fullMetaSearch": false,
               "hide": false,
               "includeNullMetadata": true,
               "instant": false,
-              "legendFormat": "Get Log {{quantile}}",
+              "legendFormat": "Get Log {{quantile}}@{{host}}",
               "range": true,
               "refId": "B",
               "useBackend": false
@@ -2329,7 +2347,7 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 61
+            "y": 165
           },
           "id": 28,
           "options": {
@@ -2357,10 +2375,10 @@
               },
               "disableTextWrap": false,
               "editorMode": "builder",
-              "expr": "kafka_inkless_controlplane_postgres_postgrescontrolplane_topiccreatequerytime{quantile=\"$quantile\"}",
+              "expr": "sum by(host) (kafka_inkless_controlplane_postgrescontrolplane_topiccreatequerytime{quantile=\"$quantile\", host=~\"$host\"})",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
-              "legendFormat": "Topic create {{quantile}}",
+              "legendFormat": "Topic create {{quantile}}@{{host}}",
               "range": true,
               "refId": "A",
               "useBackend": false
@@ -2372,12 +2390,12 @@
               },
               "disableTextWrap": false,
               "editorMode": "builder",
-              "expr": "kafka_inkless_controlplane_postgrescontrolplane_topicdeletequerytime{quantile=\"$quantile\"}",
+              "expr": "sum by(host) (kafka_inkless_controlplane_postgrescontrolplane_topicdeletequerytime{quantile=\"$quantile\", host=~\"$host\"})",
               "fullMetaSearch": false,
               "hide": false,
               "includeNullMetadata": true,
               "instant": false,
-              "legendFormat": "Topic delete {{quantile}}",
+              "legendFormat": "Topic delete {{quantile}}@{{host}}",
               "range": true,
               "refId": "B",
               "useBackend": false
@@ -2447,7 +2465,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 69
+            "y": 173
           },
           "id": 29,
           "options": {
@@ -2475,7 +2493,7 @@
               },
               "disableTextWrap": false,
               "editorMode": "builder",
-              "expr": "rate(kafka_inkless_controlplane_postgrescontrolplane_commitfilequeryrate[$__rate_interval])",
+              "expr": "sum(rate(kafka_inkless_controlplane_postgrescontrolplane_commitfilequeryrate{host=~\"$host\"}[$__rate_interval]))",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
               "legendFormat": "Commit File ops",
@@ -2548,7 +2566,7 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 69
+            "y": 173
           },
           "id": 30,
           "options": {
@@ -2576,7 +2594,7 @@
               },
               "disableTextWrap": false,
               "editorMode": "builder",
-              "expr": "rate(kafka_inkless_controlplane_postgrescontrolplane_findbatchesqueryrate[$__rate_interval])",
+              "expr": "sum(rate(kafka_inkless_controlplane_postgrescontrolplane_findbatchesqueryrate{host=~\"$host\"}[$__rate_interval]))",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
               "legendFormat": "Find Batches ops",
@@ -2591,7 +2609,7 @@
               },
               "disableTextWrap": false,
               "editorMode": "builder",
-              "expr": "rate(kafka_inkless_controlplane_postgrescontrolplane_getlogsqueryrate[$__rate_interval])",
+              "expr": "sum(rate(kafka_inkless_controlplane_postgrescontrolplane_getlogsqueryrate{host=~\"$host\"}[$__rate_interval]))",
               "fullMetaSearch": false,
               "hide": false,
               "includeNullMetadata": true,
@@ -2665,7 +2683,7 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 69
+            "y": 173
           },
           "id": 31,
           "options": {
@@ -2693,7 +2711,7 @@
               },
               "disableTextWrap": false,
               "editorMode": "builder",
-              "expr": "rate(kafka_inkless_controlplane_postgrescontrolplane_topiccreatequeryrate[$__rate_interval])",
+              "expr": "sum(rate(kafka_inkless_controlplane_postgrescontrolplane_topiccreatequeryrate{host=~\"$host\"}[$__rate_interval]))",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
               "legendFormat": "Create ops",
@@ -2708,7 +2726,7 @@
               },
               "disableTextWrap": false,
               "editorMode": "builder",
-              "expr": "rate(kafka_inkless_controlplane_postgrescontrolplane_topicdeletequeryrate[$__rate_interval])",
+              "expr": "sum(rate(kafka_inkless_controlplane_postgrescontrolplane_topicdeletequeryrate{host=~\"$host\"}[$__rate_interval]))",
               "fullMetaSearch": false,
               "hide": false,
               "includeNullMetadata": true,
@@ -2773,6 +2791,28 @@
         ],
         "query": "0.50, 0.75, 0.95, 0.98, 0.99, 0.999",
         "type": "custom"
+      },
+      {
+        "allValue": "(.+)",
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "definition": "label_values(kafka_server_app_info_start_time_ms,host)",
+        "description": "",
+        "includeAll": true,
+        "label": "Host",
+        "name": "host",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(kafka_server_app_info_start_time_ms,host)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "sort": 2,
+        "type": "query"
       }
     ]
   },

--- a/docker/extra/prometheus/config/prometheus.yml
+++ b/docker/extra/prometheus/config/prometheus.yml
@@ -10,3 +10,14 @@ scrape_configs:
   - job_name: 'kafka'
     static_configs:
     - targets: ['broker:7070']
+      labels:
+        host: 'broker'
+    - targets: ['broker2:7070']
+      labels:
+        host: 'broker2'
+    - targets: ['broker101:7070']
+      labels:
+        host: 'broker101'
+    - targets: ['broker102:7070']
+      labels:
+        host: 'broker102'


### PR DESCRIPTION
Cluster with 4 nodes to simulate distribution within one AZ and multiple AZs.

[INK-62]

[INK-62]: https://aiven.atlassian.net/browse/INK-62?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ