### PR TITLE
INK-89: Fix hit rate graphs

### DIFF
--- a/docker/extra/grafana/dashboards/data/kafka-inkless.json
+++ b/docker/extra/grafana/dashboards/data/kafka-inkless.json
@@ -619,7 +619,7 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 12,
+        "w": 8,
         "x": 0,
         "y": 18
       },
@@ -725,8 +725,8 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 12,
-        "x": 12,
+        "w": 8,
+        "x": 8,
         "y": 18
       },
       "id": 10,
@@ -765,6 +765,109 @@
         }
       ],
       "title": "Fetch File time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 18
+      },
+      "id": 35,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last",
+            "max",
+            "min"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        {
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "rate(kafka_inkless_consume_inklessfetchmetrics_cachehitcount_count{host=~\"$host\"}[$__rate_interval]) / rate(kafka_inkless_consume_inklessfetchmetrics_cachequerytime_count{host=~\"$host\"}[$__rate_interval])",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "legendFormat": "{{host}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Cache Hit Ratio",
       "type": "timeseries"
     },
     {
@@ -1155,7 +1258,11 @@
       "id": 32,
       "options": {
         "legend": {
-          "calcs": [],
+          "calcs": [
+            "last",
+            "max",
+            "min"
+          ],
           "displayMode": "list",
           "placement": "bottom",
           "showLegend": true
@@ -1173,7 +1280,7 @@
           "expr": "kafka_inkless_consume_inklessfetchmetrics_cachequerytime{quantile=\"$quantile\"}",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
-          "legendFormat": "__auto",
+          "legendFormat": "{{quantile}}@{{host}}",
           "range": true,
           "refId": "A",
           "useBackend": false
@@ -1252,7 +1359,11 @@
       "id": 33,
       "options": {
         "legend": {
-          "calcs": [],
+          "calcs": [
+            "last",
+            "max",
+            "min"
+          ],
           "displayMode": "list",
           "placement": "bottom",
           "showLegend": true
@@ -1270,13 +1381,131 @@
           "expr": "kafka_inkless_consume_inklessfetchmetrics_cachestoretime{quantile=\"$quantile\"}",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
-          "legendFormat": "__auto",
+          "legendFormat": "{{quantile}}@{{host}}",
           "range": true,
           "refId": "A",
           "useBackend": false
         }
       ],
       "title": "Cache Store Time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 34
+      },
+      "id": 34,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last",
+            "max",
+            "min"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        {
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "rate(kafka_inkless_consume_inklessfetchmetrics_cachehitcount_count{host=~\"$host\"}[$__rate_interval])",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "legendFormat": "hits@{{host}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "rate(kafka_inkless_consume_inklessfetchmetrics_cachemisscount_count{host=~\"$host\"}[$__rate_interval])",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "misses@{{host}}",
+          "range": true,
+          "refId": "B",
+          "useBackend": false
+        }
+      ],
+      "title": "Cache Request Rates",
       "type": "timeseries"
     },
     {

--- a/docker/extra/prometheus-jmx-exporter/kafka.yml
+++ b/docker/extra/prometheus-jmx-exporter/kafka.yml
@@ -63,8 +63,8 @@ rules:
     type: GAUGE
     labels:
       quantile: "0.$3"
-  - pattern: io.aiven.inkless.consume<type=(.+), name=(.+)><>(Count|Value|OneMinuteRate)
-    name: kafka_inkless_consume_$1_$2
+  - pattern: io.aiven.inkless.consume<type=(.+), name=(.+)><>(Count|Value)
+    name: kafka_inkless_consume_$1_$2_$3
   - pattern: io.aiven.inkless.control_plane.postgres<type=(.+), name=(.+)><>(\d+)thPercentile
     name: kafka_inkless_controlplane_$1_$2
     type: GAUGE

--- a/storage/inkless/src/main/java/io/aiven/inkless/consume/InklessFetchMetrics.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/consume/InklessFetchMetrics.java
@@ -5,7 +5,6 @@ import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.server.metrics.KafkaMetricsGroup;
 
 import com.groupcdg.pitest.annotations.CoverageIgnore;
-import com.yammer.metrics.core.Gauge;
 import com.yammer.metrics.core.Histogram;
 import com.yammer.metrics.core.Meter;
 
@@ -26,7 +25,6 @@ public class InklessFetchMetrics {
     private static final String CACHE_STORE_TIME = "CacheStoreTime";
     private static final String CACHE_HIT_COUNT = "CacheHitCount";
     private static final String CACHE_MISS_COUNT = "CacheMissCount";
-    private static final String CACHE_HIT_RATIO = "CacheHitRatio";
     private static final String FETCH_FILE_TIME = "FetchFileTime";
     private static final String FETCH_COMPLETION_TIME = "FetchCompletionTime";
 
@@ -40,7 +38,6 @@ public class InklessFetchMetrics {
     private final Histogram cacheStoreTimeHistogram;
     private final Meter cacheHits;
     private final Meter cacheMisses;
-    private final Gauge<Double> cacheHitRatio;
     private final Histogram fetchFileTimeHistogram;
     private final Histogram fetchCompletionTimeHistogram;
 
@@ -53,7 +50,6 @@ public class InklessFetchMetrics {
         cacheStoreTimeHistogram = metricsGroup.newHistogram(CACHE_STORE_TIME, true, Map.of());
         cacheHits = metricsGroup.newMeter(CACHE_HIT_COUNT, "hits", TimeUnit.SECONDS, Map.of());
         cacheMisses = metricsGroup.newMeter(CACHE_MISS_COUNT, "misses", TimeUnit.SECONDS, Map.of());
-        cacheHitRatio = metricsGroup.newGauge(CACHE_HIT_RATIO, () -> computeRatio(cacheHits, cacheMisses), Map.of());
         fetchFileTimeHistogram = metricsGroup.newHistogram(FETCH_FILE_TIME, true, Map.of());
         fetchCompletionTimeHistogram = metricsGroup.newHistogram(FETCH_COMPLETION_TIME, true, Map.of());
     }
@@ -81,16 +77,10 @@ public class InklessFetchMetrics {
 
     public void cacheHit(final boolean hit) {
         if (hit) {
-            cacheHits.count();
+            cacheHits.mark();
         } else {
-            cacheMisses.count();
+            cacheMisses.mark();
         }
-    }
-
-    private static double computeRatio(Meter cacheHits, Meter cacheMisses) {
-        double hits = cacheHits.oneMinuteRate();
-        double misses = cacheMisses.oneMinuteRate();
-        return hits / Math.min(1, hits + misses);
     }
 
     public void fetchFileFinished(final long durationMs) {

--- a/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/s3/S3StorageConfig.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/s3/S3StorageConfig.java
@@ -143,6 +143,7 @@ public class S3StorageConfig extends AbstractConfig {
             );
     }
 
+    @SuppressWarnings({"this-escape"})
     public S3StorageConfig(final Map<String, ?> props) {
         super(configDef(), props);
         validate();


### PR DESCRIPTION
We don't need a separate gauge for the ratio or OneMinuteRates, we can compute the hit rate in grafana from just the counts. and it will be more responsive and less misleading.

Also fix an unrelated this-escape warning on Java 21+

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
