### PR TITLE
INK-90: Segment cache by zone with clusterName

### DIFF
--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -339,6 +339,8 @@ class BrokerServer(
       val inklessSharedState = sharedServer.inklessControlPlane.map { controlPlane =>
         SharedState.initialize(
           time,
+          clusterId,
+          config.rack.orNull,
           config.brokerId,
           config.inklessConfig,
           inklessMetadataView,

--- a/storage/inkless/src/main/java/io/aiven/inkless/common/SharedState.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/common/SharedState.java
@@ -32,6 +32,8 @@ public record SharedState(
 
     public static SharedState initialize(
         Time time,
+        String clusterId,
+        String rack,
         int brokerId,
         InklessConfig config,
         MetadataView metadata,
@@ -48,7 +50,7 @@ public record SharedState(
             config.storage(),
             ObjectKey.create(config.objectKeyPrefix(), config.objectKeyLogPrefixMasked()),
             new FixedBlockAlignment(config.fetchCacheBlockBytes()),
-            new InfinispanCache(time),
+            new InfinispanCache(time, clusterId, rack),
             brokerTopicStats,
             defaultTopicConfigs
         );


### PR DESCRIPTION
Infinispan caches with different clusterNames don't share data, which is what we want for az-local caches.

If no racks are specified, each broker connects to a single global cache.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
