### PR TITLE
Add new `merge` file reason [INK-101]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2461,7 +2461,13 @@ project(':storage:inkless') {
                   .withName("TIMESTAMP_TYPE_T")
                   .withUserType("org.apache.kafka.common.record.TimestampType")
                   .withIncludeExpression("TIMESTAMP_TYPE")
-                  .withConverter("io.aiven.inkless.control_plane.postgres.converters.ShortToTimestampTypeConverter")
+                  .withConverter("io.aiven.inkless.control_plane.postgres.converters.ShortToTimestampTypeConverter"),
+
+                new ForcedType()
+                  .withName("FILE_REASON_T")
+                  .withUserType("io.aiven.inkless.control_plane.FileReason")
+                  .withIncludeExpression("REASON")
+                  .withConverter("io.aiven.inkless.control_plane.postgres.converters.FileReasonTToFileReasonConverter")
         )
       }
       basePackageName.set("org.jooq.generated")

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/FileReason.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/FileReason.java
@@ -1,0 +1,33 @@
+// Copyright (c) 2025 Aiven, Helsinki, Finland. https://aiven.io/
+package io.aiven.inkless.control_plane;
+
+/**
+ * The reasons why a file on the remote storage exists.
+ */
+public enum FileReason {
+    /**
+     * Uploaded by a broker as the result of producing.
+     */
+    PRODUCE("produce"),
+
+    /**
+     * Uploaded by a broker as the result of merging.
+     */
+    MERGE("merge");
+
+    public final String name;
+
+    FileReason(final String name) {
+        this.name = name;
+    }
+
+    public static FileReason fromName(final String name) {
+        if (PRODUCE.name.equals(name)) {
+            return PRODUCE;
+        } else if (MERGE.name.equals(name)) {
+            return MERGE;
+        } else {
+            throw new IllegalArgumentException("Unknown name " + name);
+        }
+    }
+}

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/converters/FileReasonTToFileReasonConverter.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/converters/FileReasonTToFileReasonConverter.java
@@ -1,0 +1,29 @@
+// Copyright (c) 2025 Aiven, Helsinki, Finland. https://aiven.io/
+package io.aiven.inkless.control_plane.postgres.converters;
+
+import org.jooq.generated.enums.FileReasonT;
+import org.jooq.impl.AbstractConverter;
+
+import io.aiven.inkless.control_plane.FileReason;
+
+public class FileReasonTToFileReasonConverter extends AbstractConverter<FileReasonT, FileReason> {
+    public FileReasonTToFileReasonConverter() {
+        super(FileReasonT.class, FileReason.class);
+    }
+
+    @Override
+    public FileReason from(final FileReasonT databaseObject) {
+        if (databaseObject == null) {
+            return null;
+        }
+        return FileReason.fromName(databaseObject.getLiteral());
+    }
+
+    @Override
+    public FileReasonT to(final FileReason userObject) {
+        if (userObject == null) {
+            return null;
+        }
+        return FileReasonT.lookupLiteral(userObject.name);
+    }
+}

--- a/storage/inkless/src/main/resources/db/migration/V1__Create_tables.sql
+++ b/storage/inkless/src/main/resources/db/migration/V1__Create_tables.sql
@@ -39,7 +39,9 @@ CREATE TABLE logs (
 -- The reasons why a file on the remote storage exists.
 CREATE TYPE file_reason_t AS ENUM (
     -- Uploaded by a broker as the result of producing.
-    'produce'
+    'produce',
+    -- Uploaded by a broker as the result of merging.
+    'merge'
 );
 
 CREATE TYPE file_state_t AS ENUM (

--- a/storage/inkless/src/test/java/io/aiven/inkless/control_plane/FileReasonTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/control_plane/FileReasonTest.java
@@ -1,0 +1,22 @@
+// Copyright (c) 2024 Aiven, Helsinki, Finland. https://aiven.io/
+package io.aiven.inkless.control_plane;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class FileReasonTest {
+    @Test
+    void fromName() {
+        assertThat(FileReason.fromName("produce")).isEqualTo(FileReason.PRODUCE);
+        assertThat(FileReason.fromName("merge")).isEqualTo(FileReason.MERGE);
+    }
+
+    @Test
+    void nameUnknown() {
+        assertThatThrownBy(() -> FileReason.fromName("x"))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Unknown name x");
+    }
+}

--- a/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/CommitFileJobTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/CommitFileJobTest.java
@@ -8,7 +8,6 @@ import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
 
-import org.jooq.generated.enums.FileReasonT;
 import org.jooq.generated.enums.FileStateT;
 import org.jooq.generated.tables.records.BatchesRecord;
 import org.jooq.generated.tables.records.FilesRecord;
@@ -24,6 +23,7 @@ import io.aiven.inkless.TimeUtils;
 import io.aiven.inkless.control_plane.CommitBatchRequest;
 import io.aiven.inkless.control_plane.CommitBatchResponse;
 import io.aiven.inkless.control_plane.CreateTopicAndPartitionsRequest;
+import io.aiven.inkless.control_plane.FileReason;
 import io.aiven.inkless.test_utils.SharedPostgreSQLTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -81,7 +81,7 @@ class CommitFileJobTest extends SharedPostgreSQLTest {
 
         assertThat(DBUtils.getAllFiles(hikariDataSource))
             .containsExactlyInAnyOrder(
-                new FilesRecord(EXPECTED_FILE_ID_1, "obj1", FileReasonT.produce, FileStateT.uploaded, BROKER_ID, TimeUtils.now(time), FILE_SIZE, FILE_SIZE)
+                new FilesRecord(EXPECTED_FILE_ID_1, "obj1", FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, TimeUtils.now(time), FILE_SIZE, FILE_SIZE)
             );
 
         assertThat(DBUtils.getAllBatches(hikariDataSource))
@@ -137,8 +137,8 @@ class CommitFileJobTest extends SharedPostgreSQLTest {
 
         assertThat(DBUtils.getAllFiles(hikariDataSource))
             .containsExactlyInAnyOrder(
-                new FilesRecord(EXPECTED_FILE_ID_1, "obj1", FileReasonT.produce, FileStateT.uploaded, BROKER_ID, time1, FILE_SIZE, FILE_SIZE),
-                new FilesRecord(EXPECTED_FILE_ID_2, "obj2", FileReasonT.produce, FileStateT.uploaded, BROKER_ID, time2, FILE_SIZE, FILE_SIZE)
+                new FilesRecord(EXPECTED_FILE_ID_1, "obj1", FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, time1, FILE_SIZE, FILE_SIZE),
+                new FilesRecord(EXPECTED_FILE_ID_2, "obj2", FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, time2, FILE_SIZE, FILE_SIZE)
             );
 
         assertThat(DBUtils.getAllBatches(hikariDataSource))
@@ -183,7 +183,7 @@ class CommitFileJobTest extends SharedPostgreSQLTest {
 
         assertThat(DBUtils.getAllFiles(hikariDataSource))
             .containsExactlyInAnyOrder(
-                new FilesRecord(EXPECTED_FILE_ID_1, "obj1", FileReasonT.produce, FileStateT.uploaded, BROKER_ID, TimeUtils.now(time), FILE_SIZE, FILE_SIZE)
+                new FilesRecord(EXPECTED_FILE_ID_1, "obj1", FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, TimeUtils.now(time), FILE_SIZE, FILE_SIZE)
             );
 
         assertThat(DBUtils.getAllBatches(hikariDataSource))

--- a/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/DeleteRecordsJobTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/DeleteRecordsJobTest.java
@@ -7,7 +7,6 @@ import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.common.utils.Time;
 
-import org.jooq.generated.enums.FileReasonT;
 import org.jooq.generated.enums.FileStateT;
 import org.jooq.generated.tables.records.BatchesRecord;
 import org.jooq.generated.tables.records.FilesRecord;
@@ -31,6 +30,7 @@ import io.aiven.inkless.control_plane.CommitBatchRequest;
 import io.aiven.inkless.control_plane.CreateTopicAndPartitionsRequest;
 import io.aiven.inkless.control_plane.DeleteRecordsRequest;
 import io.aiven.inkless.control_plane.DeleteRecordsResponse;
+import io.aiven.inkless.control_plane.FileReason;
 import io.aiven.inkless.test_utils.SharedPostgreSQLTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -151,9 +151,9 @@ class DeleteRecordsJobTest extends SharedPostgreSQLTest {
 
         // File 1 must be `deleting` because it contained only data from the fully truncated TOPIC_1.
         assertThat(DBUtils.getAllFiles(hikariDataSource)).containsExactlyInAnyOrder(
-            new FilesRecord(1L, objectKey1, FileReasonT.produce, FileStateT.deleting, BROKER_ID, filesCommittedAt, (long) file1Size, 0L),
-            new FilesRecord(2L, objectKey2, FileReasonT.produce, FileStateT.uploaded, BROKER_ID, filesCommittedAt, (long) file2Size, (long) file2Size),  // not a single batch deleted from file 2
-            new FilesRecord(3L, objectKey3, FileReasonT.produce, FileStateT.uploaded, BROKER_ID, filesCommittedAt, (long) file3Size, (long) file3Size - file3Batch2Size)
+            new FilesRecord(1L, objectKey1, FileReason.PRODUCE, FileStateT.deleting, BROKER_ID, filesCommittedAt, (long) file1Size, 0L),
+            new FilesRecord(2L, objectKey2, FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, filesCommittedAt, (long) file2Size, (long) file2Size),  // not a single batch deleted from file 2
+            new FilesRecord(3L, objectKey3, FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, filesCommittedAt, (long) file3Size, (long) file3Size - file3Batch2Size)
         );
         assertThat(DBUtils.getAllFilesToDelete(hikariDataSource)).containsExactlyInAnyOrder(
             new FilesToDeleteRecord(1L, topicsDeletedAt)

--- a/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/DeleteTopicJobTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/DeleteTopicJobTest.java
@@ -7,7 +7,6 @@ import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
 
-import org.jooq.generated.enums.FileReasonT;
 import org.jooq.generated.enums.FileStateT;
 import org.jooq.generated.tables.records.BatchesRecord;
 import org.jooq.generated.tables.records.FilesRecord;
@@ -24,6 +23,7 @@ import java.util.function.Consumer;
 import io.aiven.inkless.TimeUtils;
 import io.aiven.inkless.control_plane.CommitBatchRequest;
 import io.aiven.inkless.control_plane.CreateTopicAndPartitionsRequest;
+import io.aiven.inkless.control_plane.FileReason;
 import io.aiven.inkless.test_utils.SharedPostgreSQLTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -125,9 +125,9 @@ class DeleteTopicJobTest extends SharedPostgreSQLTest {
 
         // File 1 must be `deleting` because it contained only data from the deleted TOPIC_1.
         assertThat(DBUtils.getAllFiles(hikariDataSource)).containsExactlyInAnyOrder(
-            new FilesRecord(1L, objectKey1, FileReasonT.produce, FileStateT.deleting, BROKER_ID, filesCommittedAt, (long) file1Size, 0L),
-            new FilesRecord(2L, objectKey2, FileReasonT.produce, FileStateT.uploaded, BROKER_ID, filesCommittedAt, (long) file2Size, (long) file2Batch2Size),
-            new FilesRecord(3L, objectKey3, FileReasonT.produce, FileStateT.uploaded, BROKER_ID, filesCommittedAt, (long) file3Size, (long) file3Batch3Size)
+            new FilesRecord(1L, objectKey1, FileReason.PRODUCE, FileStateT.deleting, BROKER_ID, filesCommittedAt, (long) file1Size, 0L),
+            new FilesRecord(2L, objectKey2, FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, filesCommittedAt, (long) file2Size, (long) file2Batch2Size),
+            new FilesRecord(3L, objectKey3, FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, filesCommittedAt, (long) file3Size, (long) file3Batch3Size)
         );
         assertThat(DBUtils.getAllFilesToDelete(hikariDataSource)).containsExactlyInAnyOrder(
             new FilesToDeleteRecord(1L, topicsDeletedAt)

--- a/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/FindFilesToDeleteJobTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/FindFilesToDeleteJobTest.java
@@ -5,7 +5,6 @@ import org.apache.kafka.common.utils.Time;
 
 import org.jooq.DSLContext;
 import org.jooq.SQLDialect;
-import org.jooq.generated.enums.FileReasonT;
 import org.jooq.generated.enums.FileStateT;
 import org.jooq.impl.DSL;
 import org.junit.jupiter.api.BeforeEach;
@@ -20,6 +19,7 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.time.Instant;
 
+import io.aiven.inkless.control_plane.FileReason;
 import io.aiven.inkless.control_plane.FileToDelete;
 import io.aiven.inkless.test_utils.SharedPostgreSQLTest;
 
@@ -48,7 +48,7 @@ class FindFilesToDeleteJobTest extends SharedPostgreSQLTest {
             fileId = ctx.insertInto(FILES,
                 FILES.OBJECT_KEY, FILES.REASON, FILES.STATE, FILES.UPLOADER_BROKER_ID, FILES.COMMITTED_AT, FILES.SIZE, FILES.USED_SIZE
             ).values(
-                OBJECT_KEY, FileReasonT.produce, FileStateT.uploaded, BROKER_ID, COMMITTED_AT, 1000L, 900L
+                OBJECT_KEY, FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, COMMITTED_AT, 1000L, 900L
             ).returning(FILES.FILE_ID).fetchOne(FILES.FILE_ID);
 
             ctx.insertInto(FILES_TO_DELETE,

--- a/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/converters/FileReasonTToFileReasonConverterTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/converters/FileReasonTToFileReasonConverterTest.java
@@ -1,0 +1,32 @@
+// Copyright (c) 2025 Aiven, Helsinki, Finland. https://aiven.io/
+package io.aiven.inkless.control_plane.postgres.converters;
+
+
+import org.jooq.generated.enums.FileReasonT;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import io.aiven.inkless.control_plane.FileReason;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FileReasonTToFileReasonConverterTest {
+    @ParameterizedTest
+    @MethodSource("testArguments")
+    void test(final FileReasonT dbObject, final FileReason userObject) {
+        final var converter = new FileReasonTToFileReasonConverter();
+        assertThat(converter.from(dbObject)).isEqualTo(userObject);
+        assertThat(converter.to(userObject)).isEqualTo(dbObject);
+    }
+
+    private static Stream<Arguments> testArguments() {
+        return Stream.of(
+            Arguments.of(null, null),
+            Arguments.of(FileReasonT.produce, FileReason.PRODUCE),
+            Arguments.of(FileReasonT.merge, FileReason.MERGE)
+        );
+    }
+}


### PR DESCRIPTION
It was made a forced type in jOOQ because it will be needed in `InMemoryControlPlane` as well and it's not great to use DB types there.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
