### PR TITLE
feat(inkless): delete files marked for deletion [INK-79]

### DIFF
--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -17,9 +17,9 @@
 package kafka.server
 
 import com.yammer.metrics.core.Meter
-import io.aiven.inkless.DeleteRecordsInterceptor
 import io.aiven.inkless.common.SharedState
 import io.aiven.inkless.consume.{FetchInterceptor, FetchOffsetInterceptor}
+import io.aiven.inkless.delete.{DeleteRecordsInterceptor, FileCleaner}
 import io.aiven.inkless.produce.AppendInterceptor
 import kafka.cluster.{Partition, PartitionListener}
 import kafka.controller.{KafkaController, StateChangeLogger}
@@ -329,6 +329,7 @@ class ReplicaManager(val config: KafkaConfig,
   private val inklessFetchInterceptor: Option[FetchInterceptor] = inklessSharedState.map(new FetchInterceptor(_))
   private val inklessFetchOffsetInterceptor: Option[FetchOffsetInterceptor] = inklessSharedState.map(new FetchOffsetInterceptor(_))
   private val inklessDeleteRecordsInterceptor: Option[DeleteRecordsInterceptor] = inklessSharedState.map(new DeleteRecordsInterceptor(_))
+  private val inklessFileCleaner: Option[FileCleaner] = inklessSharedState.map(new FileCleaner(_))
 
   /* epoch of the controller that last changed the leader */
   @volatile private[server] var controllerEpoch: Int = KafkaController.InitialControllerEpoch
@@ -430,6 +431,11 @@ class ReplicaManager(val config: KafkaConfig,
     logDirFailureHandler.start()
     addPartitionsToTxnManager.foreach(_.start())
     remoteLogManager.foreach(rlm => rlm.setDelayedOperationPurgatory(delayedRemoteListOffsetsPurgatory))
+
+    // Inkless threads
+    inklessSharedState.map { sharedState =>
+      scheduler.schedule("inkless-file-cleaner", () => inklessFileCleaner.foreach(_.run()), 0L, sharedState.config().fileCleanerInterval().toMillis)
+    }
   }
 
   private def maybeRemoveTopicMetrics(topic: String): Unit = {

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -19,6 +19,7 @@ package kafka.server
 
 import com.yammer.metrics.core.{Gauge, Meter, Timer}
 import io.aiven.inkless.common.SharedState
+import io.aiven.inkless.config.InklessConfig
 import io.aiven.inkless.produce.AppendInterceptor
 import kafka.cluster.PartitionTest.MockPartitionListener
 import kafka.cluster.Partition
@@ -6900,6 +6901,7 @@ class ReplicaManagerTest {
       when(logManagerMock.liveLogDirs).thenReturn(Seq.empty)
       val sharedState = mock(classOf[SharedState])
       when(sharedState.time()).thenReturn(Time.SYSTEM)
+      when(sharedState.config()).thenReturn(new InklessConfig(new util.HashMap[String, Object]()))
 
       val logDirFailureChannel = new LogDirFailureChannel(config.logDirs.size)
 

--- a/storage/inkless/src/main/java/io/aiven/inkless/config/InklessConfig.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/config/InklessConfig.java
@@ -60,6 +60,14 @@ public class InklessConfig extends AbstractConfig {
     private static final String CONSUME_CACHE_BLOCK_BYTES_DOC = "The number of bytes to fetch as a single block from object storage when serving fetch requests.";
     private static final int CONSUME_CACHE_BLOCK_BYTES_DEFAULT = 16 * 1024 * 1024;  // 16 MiB
 
+    public static final String FILE_CLEANER_INTERVAL_MS_CONFIG = "file.cleaner.interval.ms";
+    private static final String FILE_CLEANER_INTERVAL_MS_DOC = "The interval with which to clean up files marked for deletion.";
+    private static final int FILE_CLEANER_INTERVAL_MS_DEFAULT = 5 * 60 * 1000;  // 5 minute
+
+    public static final String FILE_CLEANER_RETENTION_PERIOD_MS_CONFIG = "file.cleaner.retention.period.ms";
+    private static final String FILE_CLEANER_RETENTION_PERIOD_MS_DOC = "The retention period for files marked for deletion.";
+    private static final int FILE_CLEANER_RETENTION_PERIOD_MS_DEFAULT = 10 * 60 * 1000;  // 10 minute
+
     public static ConfigDef configDef() {
         final ConfigDef configDef = new ConfigDef();
 
@@ -140,6 +148,24 @@ public class InklessConfig extends AbstractConfig {
                 CONSUME_CACHE_BLOCK_BYTES_DOC
         );
 
+        configDef.define(
+            FILE_CLEANER_INTERVAL_MS_CONFIG,
+            ConfigDef.Type.INT,
+            FILE_CLEANER_INTERVAL_MS_DEFAULT,
+            ConfigDef.Range.atLeast(1),
+            ConfigDef.Importance.LOW,
+            FILE_CLEANER_INTERVAL_MS_DOC
+        );
+
+        configDef.define(
+            FILE_CLEANER_RETENTION_PERIOD_MS_CONFIG,
+            ConfigDef.Type.INT,
+            FILE_CLEANER_RETENTION_PERIOD_MS_DEFAULT,
+            ConfigDef.Range.atLeast(1),
+            ConfigDef.Importance.LOW,
+            FILE_CLEANER_RETENTION_PERIOD_MS_DOC
+        );
+
         return configDef;
     }
 
@@ -147,8 +173,7 @@ public class InklessConfig extends AbstractConfig {
         this(config.originalsWithPrefix(InklessConfig.PREFIX));
     }
 
-    // Visible for testing
-    InklessConfig(final Map<String, ?> props) {
+    public InklessConfig(final Map<String, ?> props) {
         super(configDef(), props);
     }
 
@@ -193,5 +218,13 @@ public class InklessConfig extends AbstractConfig {
 
     public int fetchCacheBlockBytes() {
         return getInt(CONSUME_CACHE_BLOCK_BYTES_CONFIG);
+    }
+
+    public Duration fileCleanerInterval() {
+        return Duration.ofMillis(getInt(FILE_CLEANER_INTERVAL_MS_CONFIG));
+    }
+
+    public Duration fileCleanerRetentionPeriod() {
+        return Duration.ofMillis(getInt(FILE_CLEANER_RETENTION_PERIOD_MS_CONFIG));
     }
 }

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/ControlPlane.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/ControlPlane.java
@@ -31,6 +31,8 @@ public interface ControlPlane extends Closeable, Configurable {
 
     List<FileToDelete> getFilesToDelete();
 
+    void deleteFiles(DeleteFilesRequest request);
+
     List<ListOffsetsResponse> listOffsets(List<ListOffsetsRequest> requests);
 
     static ControlPlane create(final InklessConfig config, final Time time) {

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/DeleteFilesRequest.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/DeleteFilesRequest.java
@@ -1,0 +1,7 @@
+// Copyright (c) 2025 Aiven, Helsinki, Finland. https://aiven.io/
+package io.aiven.inkless.control_plane;
+
+import java.util.Set;
+
+public record DeleteFilesRequest(Set<String> objectKeyPaths) {
+}

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/FileToDelete.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/FileToDelete.java
@@ -4,5 +4,4 @@ import java.time.Instant;
 
 public record FileToDelete(String objectKey,
                            Instant markedForDeletionAt) {
-    // TODO there will be more fields here, such as various timestamps to the deletion deadline, deletion moment, etc.
 }

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/DeleteFilesJob.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/DeleteFilesJob.java
@@ -1,0 +1,53 @@
+// Copyright (c) 2025 Aiven, Helsinki, Finland. https://aiven.io/
+package io.aiven.inkless.control_plane.postgres;
+
+import org.apache.kafka.common.utils.Time;
+
+import org.jooq.Configuration;
+import org.jooq.DSLContext;
+import org.jooq.generated.Routines;
+
+import java.util.Set;
+import java.util.function.Consumer;
+
+import io.aiven.inkless.TimeUtils;
+import io.aiven.inkless.control_plane.DeleteFilesRequest;
+
+public class DeleteFilesJob implements Runnable {
+    private final Time time;
+    private final DSLContext jooqCtx;
+    private final Consumer<Long> durationCallback;
+
+    final Set<String> objectKeyPaths;
+
+    public DeleteFilesJob(Time time,
+                          DSLContext jooqCtx,
+                          DeleteFilesRequest request,
+                          Consumer<Long> durationCallback) {
+        this.time = time;
+        this.jooqCtx = jooqCtx;
+        this.durationCallback = durationCallback;
+        this.objectKeyPaths = request.objectKeyPaths();
+    }
+
+    @Override
+    public void run() {
+        if (objectKeyPaths.isEmpty()) {
+            return;
+        }
+
+        try {
+            TimeUtils.measureDurationMs(time, this::runOnce, durationCallback);
+        } catch (final Exception e) {
+            // TODO add retry with backoff
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void runOnce() {
+        jooqCtx.transaction((final Configuration conf) -> {
+            final String[] paths = this.objectKeyPaths.toArray(new String[0]);
+            Routines.deleteFilesV1(conf, paths);
+        });
+    }
+}

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/PostgresControlPlaneMetrics.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/PostgresControlPlaneMetrics.java
@@ -18,12 +18,14 @@ public class PostgresControlPlaneMetrics implements Closeable {
     private static final String COMMIT_FILE_QUERY_TIME = "CommitFileQueryTime";
     private static final String TOPIC_DELETE_QUERY_TIME = "TopicDeleteQueryTime";
     private static final String TOPIC_CREATE_QUERY_TIME = "TopicCreateQueryTime";
+    private static final String FILES_DELETE_QUERY_TIME = "FilesDeleteQueryTime";
 
     public static final String FIND_BATCHES_QUERY_RATE = "FindBatchesQueryRate";
     public static final String GET_LOGS_QUERY_RATE = "GetLogsQueryRate";
     public static final String COMMIT_FILE_QUERY_RATE = "CommitFileQueryRate";
     public static final String TOPIC_CREATE_QUERY_RATE = "TopicCreateQueryRate";
     public static final String TOPIC_DELETE_QUERY_RATE = "TopicDeleteQueryRate";
+    public static final String FILES_DELETE_QUERY_RATE = "FilesDeleteQueryRate";
 
     final Time time;
 
@@ -33,12 +35,14 @@ public class PostgresControlPlaneMetrics implements Closeable {
     private final Histogram commitFileQueryTimeHistogram;
     private final Histogram topicDeleteQueryTimeHistogram;
     private final Histogram topicCreateQueryTimeHistogram;
+    private final Histogram filesDeleteQueryTimeHistogram;
 
     private final LongAdder findBatchesQueryRate = new LongAdder();
     private final LongAdder getLogsQueryRate = new LongAdder();
     private final LongAdder commitFileQueryRate = new LongAdder();
     private final LongAdder topicCreateQueryRate = new LongAdder();
     private final LongAdder topicDeleteQueryRate = new LongAdder();
+    private final LongAdder filesDeleteQueryRate = new LongAdder();
 
     public PostgresControlPlaneMetrics(Time time) {
         this.time = Objects.requireNonNull(time, "time cannot be null");
@@ -48,12 +52,14 @@ public class PostgresControlPlaneMetrics implements Closeable {
         commitFileQueryTimeHistogram = metricsGroup.newHistogram(COMMIT_FILE_QUERY_TIME, true, Map.of());
         topicDeleteQueryTimeHistogram = metricsGroup.newHistogram(TOPIC_DELETE_QUERY_TIME, true, Map.of());
         topicCreateQueryTimeHistogram = metricsGroup.newHistogram(TOPIC_CREATE_QUERY_TIME, true, Map.of());
+        filesDeleteQueryTimeHistogram = metricsGroup.newHistogram(FILES_DELETE_QUERY_TIME, true, Map.of());
 
         metricsGroup.newGauge(FIND_BATCHES_QUERY_RATE, findBatchesQueryRate::intValue);
         metricsGroup.newGauge(GET_LOGS_QUERY_RATE, getLogsQueryRate::intValue);
         metricsGroup.newGauge(COMMIT_FILE_QUERY_RATE, commitFileQueryRate::intValue);
         metricsGroup.newGauge(TOPIC_CREATE_QUERY_RATE, topicCreateQueryRate::intValue);
         metricsGroup.newGauge(TOPIC_DELETE_QUERY_RATE, topicDeleteQueryRate::intValue);
+        metricsGroup.newGauge(FILES_DELETE_QUERY_RATE, filesDeleteQueryRate::intValue);
     }
 
     public void onFindBatchesCompleted(Long duration) {
@@ -79,6 +85,11 @@ public class PostgresControlPlaneMetrics implements Closeable {
     public void onTopicCreateCompleted(Long duration) {
         topicCreateQueryTimeHistogram.update(duration);
         topicCreateQueryRate.increment();
+    }
+
+    public void onFilesDeleteCompleted(Long duration) {
+        filesDeleteQueryTimeHistogram.update(duration);
+        filesDeleteQueryRate.increment();
     }
 
     @Override

--- a/storage/inkless/src/main/java/io/aiven/inkless/delete/DeleteRecordsInterceptor.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/delete/DeleteRecordsInterceptor.java
@@ -1,5 +1,5 @@
 // Copyright (c) 2025 Aiven, Helsinki, Finland. https://aiven.io/
-package io.aiven.inkless;
+package io.aiven.inkless.delete;
 
 import org.apache.kafka.common.TopicIdPartition;
 import org.apache.kafka.common.TopicPartition;

--- a/storage/inkless/src/main/java/io/aiven/inkless/delete/FileCleaner.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/delete/FileCleaner.java
@@ -1,0 +1,87 @@
+// Copyright (c) 2025 Aiven, Helsinki, Finland. https://aiven.io/
+package io.aiven.inkless.delete;
+
+import org.apache.kafka.common.utils.Time;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import io.aiven.inkless.TimeUtils;
+import io.aiven.inkless.common.ObjectKey;
+import io.aiven.inkless.common.ObjectKeyCreator;
+import io.aiven.inkless.common.SharedState;
+import io.aiven.inkless.control_plane.ControlPlane;
+import io.aiven.inkless.control_plane.DeleteFilesRequest;
+import io.aiven.inkless.control_plane.FileToDelete;
+import io.aiven.inkless.storage_backend.common.StorageBackend;
+import io.aiven.inkless.storage_backend.common.StorageBackendException;
+
+public class FileCleaner implements Runnable {
+    private static final Logger LOGGER = LoggerFactory.getLogger(FileCleaner.class);
+
+    final Time time;
+    final ControlPlane controlPlane;
+    final StorageBackend storage;
+    final ObjectKeyCreator objectKeyCreator;
+    final Duration retentionPeriod;
+
+    public FileCleaner(SharedState sharedState) {
+        this(
+            sharedState.time(),
+            sharedState.controlPlane(),
+            sharedState.storage(),
+            sharedState.objectKeyCreator(),
+            sharedState.config().fileCleanerRetentionPeriod()
+        );
+    }
+
+    // package-private constructor for testing
+    FileCleaner(Time time,
+                ControlPlane controlPlane,
+                StorageBackend storage,
+                ObjectKeyCreator objectKeyCreator,
+                Duration retentionPeriod) {
+        this.time = time;
+        this.controlPlane = controlPlane;
+        this.storage = storage;
+        this.objectKeyCreator = objectKeyCreator;
+        this.retentionPeriod = retentionPeriod;
+    }
+
+
+    @Override
+    public void run() {
+        try {
+            final var now = TimeUtils.now(time);
+            LOGGER.info("Running file cleaner at {}", now);
+
+            // find all files that are marked for deletion
+            final Set<String> objectKeyPaths = controlPlane.getFilesToDelete()
+                .stream()
+                .filter(f -> Duration.between(f.markedForDeletionAt(), now).compareTo(retentionPeriod) > 0)
+                .map(FileToDelete::objectKey).collect(Collectors.toSet());
+            if (objectKeyPaths.isEmpty()) {
+                LOGGER.info("No files to delete");
+                return;
+            }
+
+            // delete files from storage backend
+            final Set<ObjectKey> objectKeys = objectKeyPaths.stream()
+                .map(objectKeyCreator::from)
+                .collect(Collectors.toSet());
+            storage.delete(objectKeys);
+            // update control plane
+            final DeleteFilesRequest request = new DeleteFilesRequest(objectKeyPaths);
+            controlPlane.deleteFiles(request);
+
+            LOGGER.info("Deleted {} files", objectKeyPaths.size());
+            // TODO add control-plane exception handling to always retry
+        } catch (StorageBackendException e) {
+            LOGGER.warn("Failed to delete files", e);
+        }
+    }
+}

--- a/storage/inkless/src/test/java/io/aiven/inkless/config/InklessConfigTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/config/InklessConfigTest.java
@@ -28,7 +28,9 @@ class InklessConfigTest {
             "inkless.produce.buffer.max.bytes", "1024",
             "inkless.produce.max.upload.attempts", "5",
             "inkless.produce.upload.backoff.ms", "30",
-            "inkless.storage.backend.class", ConfigTestStorageBackend.class.getCanonicalName()
+            "inkless.storage.backend.class", ConfigTestStorageBackend.class.getCanonicalName(),
+            "inkless.file.cleaner.interval.ms", "100",
+            "inkless.file.cleaner.retention.period.ms", "200"
         )));
         assertThat(config.controlPlaneClass()).isEqualTo(InMemoryControlPlane.class);
         assertThat(config.controlPlaneConfig()).isEqualTo(Map.of("class", controlPlaneClass));
@@ -38,6 +40,8 @@ class InklessConfigTest {
         assertThat(config.produceMaxUploadAttempts()).isEqualTo(5);
         assertThat(config.produceUploadBackoff()).isEqualTo(Duration.ofMillis(30));
         assertThat(config.storage()).isInstanceOf(ConfigTestStorageBackend.class);
+        assertThat(config.fileCleanerInterval()).isEqualTo(Duration.ofMillis(100));
+        assertThat(config.fileCleanerRetentionPeriod()).isEqualTo(Duration.ofMillis(200));
     }
 
     @Test
@@ -57,6 +61,8 @@ class InklessConfigTest {
         assertThat(config.produceMaxUploadAttempts()).isEqualTo(3);
         assertThat(config.produceUploadBackoff()).isEqualTo(Duration.ofMillis(10));
         assertThat(config.storage()).isInstanceOf(ConfigTestStorageBackend.class);
+        assertThat(config.fileCleanerInterval()).isEqualTo(Duration.ofMinutes(5));
+        assertThat(config.fileCleanerRetentionPeriod()).isEqualTo(Duration.ofMinutes(10));
     }
 
     @Test
@@ -70,7 +76,9 @@ class InklessConfigTest {
                 "produce.buffer.max.bytes", "1024",
                 "produce.max.upload.attempts", "5",
                 "produce.upload.backoff.ms", "30",
-                "storage.backend.class", ConfigTestStorageBackend.class.getCanonicalName()
+                "storage.backend.class", ConfigTestStorageBackend.class.getCanonicalName(),
+                "file.cleaner.interval.ms", "100",
+                "file.cleaner.retention.period.ms", "200"
             )
         );
         assertThat(config.controlPlaneClass()).isEqualTo(InMemoryControlPlane.class);
@@ -81,6 +89,8 @@ class InklessConfigTest {
         assertThat(config.produceMaxUploadAttempts()).isEqualTo(5);
         assertThat(config.produceUploadBackoff()).isEqualTo(Duration.ofMillis(30));
         assertThat(config.storage()).isInstanceOf(ConfigTestStorageBackend.class);
+        assertThat(config.fileCleanerInterval()).isEqualTo(Duration.ofMillis(100));
+        assertThat(config.fileCleanerRetentionPeriod()).isEqualTo(Duration.ofMillis(200));
     }
 
     @Test

--- a/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/DeleteFilesJobTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/DeleteFilesJobTest.java
@@ -1,0 +1,135 @@
+// Copyright (c) 2025 Aiven, Helsinki, Finland. https://aiven.io/
+package io.aiven.inkless.control_plane.postgres;
+
+import org.apache.kafka.common.TopicIdPartition;
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.record.TimestampType;
+import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.common.utils.Time;
+
+import org.jooq.generated.enums.FileStateT;
+import org.jooq.generated.tables.records.FilesRecord;
+import org.jooq.generated.tables.records.FilesToDeleteRecord;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Consumer;
+
+import io.aiven.inkless.TimeUtils;
+import io.aiven.inkless.control_plane.CommitBatchRequest;
+import io.aiven.inkless.control_plane.CreateTopicAndPartitionsRequest;
+import io.aiven.inkless.control_plane.DeleteFilesRequest;
+import io.aiven.inkless.control_plane.FileReason;
+import io.aiven.inkless.test_utils.SharedPostgreSQLTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DeleteFilesJobTest extends SharedPostgreSQLTest {
+    static final int BROKER_ID = 11;
+
+    static final String TOPIC_0 = "topic0";
+    static final String TOPIC_1 = "topic1";
+    static final String TOPIC_2 = "topic2";
+    static final Uuid TOPIC_ID_0 = new Uuid(10, 12);
+    static final Uuid TOPIC_ID_1 = new Uuid(555, 333);
+    static final Uuid TOPIC_ID_2 = new Uuid(5555, 3333);
+    static final TopicIdPartition T0P0 = new TopicIdPartition(TOPIC_ID_0, 0, TOPIC_0);
+    static final TopicIdPartition T0P1 = new TopicIdPartition(TOPIC_ID_0, 1, TOPIC_0);
+    static final TopicIdPartition T1P0 = new TopicIdPartition(TOPIC_ID_1, 0, TOPIC_1);
+    static final TopicIdPartition T2P0 = new TopicIdPartition(TOPIC_ID_2, 0, TOPIC_2);
+
+    Time time = new MockTime();
+    Consumer<Long> durationCallback = duration -> {};
+
+    @BeforeEach
+    void createTopics() {
+        final Set<CreateTopicAndPartitionsRequest> createTopicAndPartitionsRequests = Set.of(
+            new CreateTopicAndPartitionsRequest(TOPIC_ID_0, TOPIC_0, 2),
+            new CreateTopicAndPartitionsRequest(TOPIC_ID_1, TOPIC_1, 1),
+            new CreateTopicAndPartitionsRequest(TOPIC_ID_2, TOPIC_2, 1)
+        );
+        new TopicsAndPartitionsCreateJob(Time.SYSTEM, jooqCtx, createTopicAndPartitionsRequests, durationCallback)
+            .run();
+    }
+
+
+    @Test void test() {
+        final String objectKey1 = "obj1";
+        final String objectKey2 = "obj2";
+        final String objectKey3 = "obj3";
+
+        final Instant filesCommittedAt = TimeUtils.now(time);
+
+        // TOPIC_0 - non-empty, deleted
+        // TOPIC_1 - empty, deleted
+        // TOPIC_2 - non-empty, not deleted
+
+        // TOPIC_0, both partitions.
+        final int file1Batch1Size = 1000;
+        final int file1Batch2Size = 2000;
+        final int file1Size = file1Batch1Size + file1Batch2Size;
+        new CommitFileJob(
+            time, jooqCtx, objectKey1, BROKER_ID, file1Size,
+            List.of(
+                CommitBatchRequest.of(T0P0, 0, file1Batch1Size, 0, 11, 1000, TimestampType.CREATE_TIME),
+                CommitBatchRequest.of(T0P1, 0, file1Batch2Size, 0, 11, 1000, TimestampType.CREATE_TIME)
+            ), durationCallback
+        ).call();
+
+        // TOPIC_0, partition 0 and TOPIC_2, partition 0
+        final int file2Batch1Size = 1000;
+        final int file2Batch2Size = 2000;
+        final int file2Size = file2Batch1Size + file2Batch2Size;
+        new CommitFileJob(
+            time, jooqCtx, objectKey2, BROKER_ID, file2Size,
+            List.of(
+                CommitBatchRequest.of(T0P0, 0, file2Batch1Size, 0, 11, 1000, TimestampType.CREATE_TIME),
+                CommitBatchRequest.of(T2P0, 0, file2Batch2Size, 0, 11, 1000, TimestampType.CREATE_TIME)
+            ), durationCallback
+        ).call();
+
+        // TOPIC_0, both partitions and TOPIC_2, partition 0
+        final int file3Batch1Size = 1000;
+        final int file3Batch2Size = 2000;
+        final int file3Batch3Size = 3000;
+        final int file3Size = file3Batch1Size + file3Batch2Size + file3Batch3Size;
+        new CommitFileJob(
+            time, jooqCtx, objectKey3, BROKER_ID, file3Size,
+            List.of(
+                CommitBatchRequest.of(T0P0, 0, file1Batch1Size, 0, 11, 1000, TimestampType.CREATE_TIME),
+                CommitBatchRequest.of(T0P1, 0, file1Batch2Size, 0, 11, 1000, TimestampType.CREATE_TIME),
+                CommitBatchRequest.of(T2P0, 0, file1Batch2Size, 0, 11, 1000, TimestampType.CREATE_TIME)
+            ), durationCallback
+        ).call();
+
+        time.sleep(1000);  // advance time
+        final Instant topicsDeletedAt = TimeUtils.now(time);
+        final Uuid nonexistentTopicId = Uuid.ONE_UUID;
+        new DeleteTopicJob(time, jooqCtx, Set.of(
+            TOPIC_ID_0, TOPIC_ID_1, nonexistentTopicId
+        ), durationCallback).run();
+
+        // File 1 must be `deleting` because it contained only data from the deleted TOPIC_1.
+        assertThat(DBUtils.getAllFiles(hikariDataSource)).containsExactlyInAnyOrder(
+            new FilesRecord(1L, objectKey1, FileReason.PRODUCE, FileStateT.deleting, BROKER_ID, filesCommittedAt, (long) file1Size, 0L),
+            new FilesRecord(2L, objectKey2, FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, filesCommittedAt, (long) file2Size, (long) file2Batch2Size),
+            new FilesRecord(3L, objectKey3, FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, filesCommittedAt, (long) file3Size, (long) file3Batch3Size)
+        );
+        assertThat(DBUtils.getAllFilesToDelete(hikariDataSource)).containsExactlyInAnyOrder(
+            new FilesToDeleteRecord(1L, topicsDeletedAt)
+        );
+
+        new DeleteFilesJob(
+            time, jooqCtx, new DeleteFilesRequest(Set.of(objectKey1)), durationCallback
+        ).run();
+        assertThat(DBUtils.getAllFilesToDelete(hikariDataSource)).isEmpty();
+        assertThat(DBUtils.getAllFiles(hikariDataSource)).containsExactlyInAnyOrder(
+            new FilesRecord(2L, objectKey2, FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, filesCommittedAt, (long) file2Size, (long) file2Batch2Size),
+            new FilesRecord(3L, objectKey3, FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, filesCommittedAt, (long) file3Size, (long) file3Batch3Size)
+        );
+
+    }
+}

--- a/storage/inkless/src/test/java/io/aiven/inkless/delete/DeleteRecordsInterceptorTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/delete/DeleteRecordsInterceptorTest.java
@@ -1,5 +1,5 @@
 // Copyright (c) 2025 Aiven, Helsinki, Finland. https://aiven.io/
-package io.aiven.inkless;
+package io.aiven.inkless.delete;
 
 import org.apache.kafka.common.TopicIdPartition;
 import org.apache.kafka.common.TopicPartition;

--- a/storage/inkless/src/test/java/io/aiven/inkless/delete/FileCleanerTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/delete/FileCleanerTest.java
@@ -1,0 +1,98 @@
+// Copyright (c) 2025 Aiven, Helsinki, Finland. https://aiven.io/
+package io.aiven.inkless.delete;
+
+import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.common.utils.Time;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import io.aiven.inkless.TimeUtils;
+import io.aiven.inkless.common.ObjectKey;
+import io.aiven.inkless.common.ObjectKeyCreator;
+import io.aiven.inkless.control_plane.ControlPlane;
+import io.aiven.inkless.control_plane.DeleteFilesRequest;
+import io.aiven.inkless.control_plane.FileToDelete;
+import io.aiven.inkless.storage_backend.common.StorageBackend;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.STRICT_STUBS)
+class FileCleanerTest {
+    public static final Duration RETENTION_PERIOD = Duration.ofMinutes(10);
+    Time time = new MockTime();
+    
+    @Mock
+    ControlPlane controlPlane;
+    @Mock
+    StorageBackend storageBackend;
+
+    static final ObjectKeyCreator OBJECT_KEY_CREATOR = ObjectKey.creator("", false);
+
+    @Test
+    void empty() throws Exception {
+        final var cleaner = new FileCleaner(time, controlPlane, storageBackend, OBJECT_KEY_CREATOR, RETENTION_PERIOD);
+        when(controlPlane.getFilesToDelete()).thenReturn(List.of());
+
+        cleaner.run();
+
+        verify(storageBackend, times(0)).delete(Set.of());
+    }
+
+    @Test
+    void singleWithinRetention() throws Exception {
+        final var cleaner = new FileCleaner(time, controlPlane, storageBackend, OBJECT_KEY_CREATOR, RETENTION_PERIOD);
+        final var objectKey = OBJECT_KEY_CREATOR.from("key");
+        final var now = TimeUtils.now(time);
+        when(controlPlane.getFilesToDelete())
+            .thenReturn(List.of(new FileToDelete(objectKey.value(), now.minus(Duration.ofMinutes(15)))));
+
+        cleaner.run();
+
+        verify(storageBackend, times(1)).delete(Set.of(objectKey));
+        verify(controlPlane, times(1)).deleteFiles(new DeleteFilesRequest(Set.of(objectKey.value())));
+    }
+
+    @Test
+    void singleOutsideRetention() throws Exception {
+        final var cleaner = new FileCleaner(time, controlPlane, storageBackend, OBJECT_KEY_CREATOR, RETENTION_PERIOD);
+        final var objectKey = OBJECT_KEY_CREATOR.from("key");
+        final var now = TimeUtils.now(time);
+        when(controlPlane.getFilesToDelete())
+            .thenReturn(List.of(new FileToDelete(objectKey.value(), now.minus(Duration.ofMinutes(5)))));
+
+        cleaner.run();
+
+        verify(storageBackend, times(0)).delete(Set.of());
+    }
+
+    @Test
+    void multiple() throws Exception {
+        final var cleaner = new FileCleaner(time, controlPlane, storageBackend, OBJECT_KEY_CREATOR, RETENTION_PERIOD);
+        final var objectKeys = List.of(OBJECT_KEY_CREATOR.from("key1"), OBJECT_KEY_CREATOR.create("key3"));
+        when(controlPlane.getFilesToDelete())
+            .thenReturn(List.of(
+                new FileToDelete(objectKeys.get(0).value(), TimeUtils.now(time).minus(Duration.ofMinutes(15))),
+                new FileToDelete(OBJECT_KEY_CREATOR.create("key2").value(), TimeUtils.now(time).minus(Duration.ofMinutes(5))),
+                new FileToDelete(objectKeys.get(1).value(), TimeUtils.now(time).minus(Duration.ofMinutes(15)))
+            ));
+
+        cleaner.run();
+
+        verify(storageBackend, times(1)).delete(new HashSet<>(objectKeys));
+        verify(controlPlane, times(1)).deleteFiles(new DeleteFilesRequest(objectKeys.stream().map(ObjectKey::value).collect(Collectors.toSet())));
+    }
+}


### PR DESCRIPTION
Add a scheduled job on ReplicaManager to run file cleaner at a config-based interval.
File Cleaner finds files to delete and based on the time marked for deletion and retention period it deletes the objects from the object storage and from control plane.

If there is a need to keep track of deleted files/batches, it can be implemented in a separate task: https://aiven.atlassian.net/browse/INK-102

[INK-79]

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)


[INK-79]: https://aiven.atlassian.net/browse/INK-79?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ