### PR TITLE
Allow brokers to release file merge work items [INK-104]

### DIFF
--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/ControlPlane.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/ControlPlane.java
@@ -43,6 +43,8 @@ public interface ControlPlane extends Closeable, Configurable {
                                  long fileSize,
                                  List<MergedFileBatch> batches);
 
+    void releaseFileMergeWorkItem(long workItemId);
+
     static ControlPlane create(final InklessConfig config, final Time time) {
         final Class<ControlPlane> controlPlaneClass = config.controlPlaneClass();
         try {

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/InMemoryControlPlane.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/InMemoryControlPlane.java
@@ -445,6 +445,14 @@ public class InMemoryControlPlane extends AbstractControlPlane {
     }
 
     @Override
+    public synchronized void releaseFileMergeWorkItem(final long workItemId) {
+        final FileMergeWorkItem workItem = fileMergeWorkItems.remove(workItemId);
+        if (workItem == null) {
+            throw new FileMergeWorkItemNotExist(workItemId);
+        }
+    }
+
+    @Override
     public void close() throws IOException {
         // Do nothing.
     }

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/PostgresControlPlane.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/PostgresControlPlane.java
@@ -144,6 +144,11 @@ public class PostgresControlPlane extends AbstractControlPlane {
     }
 
     @Override
+    public void releaseFileMergeWorkItem(final long workItemId) {
+        throw new RuntimeException("Not implemented");
+    }
+
+    @Override
     public void close() throws IOException {
         hikariDataSource.close();
     }

--- a/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/PostgresControlPlaneTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/PostgresControlPlaneTest.java
@@ -41,4 +41,7 @@ class PostgresControlPlaneTest extends AbstractControlPlaneTest {
     @Nested
     class CommitFileMergeWorkItem {
     }
+    @Nested
+    class ReleaseFileMergeWorkItem {
+    }
 }


### PR DESCRIPTION
The purpose of this is to allow brokers to backoff in case of errors leaving the possibility for other brokers to pick up their job.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
