### PR TITLE
fix(inkless): move classloading to pg configure

### DIFF
--- a/core/src/test/java/kafka/server/InklessClusterTest.java
+++ b/core/src/test/java/kafka/server/InklessClusterTest.java
@@ -98,14 +98,6 @@ public class InklessClusterTest extends SharedPostgreSQLTest {
             s3Client.createBucket(CreateBucketRequest.builder().bucket(bucketName).build());
         }
 
-        // Avoid merger/cleaner waiting on class loading deadlocks between brokers
-        try {
-            Class.forName("org.jooq.generated.DefaultSchema");
-        } catch (final ClassNotFoundException e) {
-            throw new RuntimeException(e);
-        }
-
-
         cluster = new KafkaClusterTestKit.Builder(new TestKitNodes.Builder()
                 .setCombined(true)
                 .setNumBrokerNodes(2)

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/PostgresControlPlane.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/PostgresControlPlane.java
@@ -76,6 +76,14 @@ public class PostgresControlPlane extends AbstractControlPlane {
         config.setAutoCommit(false);
 
         hikariDataSource = new HikariDataSource(config);
+
+        // Avoid merger/cleaner waiting on class loading deadlocks between threads
+        try {
+            Class.forName("org.jooq.generated.DefaultSchema");
+        } catch (final ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+
         jooqCtx = DSL.using(hikariDataSource, SQLDialect.POSTGRES);
     }
 


### PR DESCRIPTION
The issue happening across brokers could also happen between cleaner/merger thread.
To avoid this, load classes as part of the configure, so when jooq context is returned schema root is loaded.