### PR TITLE
fix(inkless:merger): lazily fetch object

### DIFF
--- a/storage/inkless/src/main/java/io/aiven/inkless/consume/FetchCompleterJob.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/consume/FetchCompleterJob.java
@@ -172,7 +172,9 @@ public class FetchCompleterJob implements Supplier<Map<TopicIdPartition, FetchPa
         for (FileExtent file : files) {
             // TODO INK-77: A single batch may be broken up across multiple FileExtents
             if (new ByteRange(file.range().offset(), file.range().length()).contains(batch.metadata().range())) {
-                ByteBuffer buffer = ByteBuffer.wrap(file.data()).slice(Math.toIntExact(batch.metadata().byteOffset() - file.range().offset()), Math.toIntExact(batch.metadata().byteSize()));
+                final int index = Math.toIntExact(batch.metadata().byteOffset() - file.range().offset());
+                final int length = Math.toIntExact(batch.metadata().byteSize());
+                ByteBuffer buffer = ByteBuffer.wrap(file.data()).slice(index, length);
                 MemoryRecords records = MemoryRecords.readableRecords(buffer);
                 Iterator<MutableRecordBatch> iterator = records.batches().iterator();
                 if (!iterator.hasNext()) {

--- a/storage/inkless/src/test/java/io/aiven/inkless/merge/FileMergerIntegrationTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/merge/FileMergerIntegrationTest.java
@@ -33,7 +33,6 @@ import org.testcontainers.containers.localstack.LocalStackContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -65,7 +64,6 @@ import io.aiven.inkless.control_plane.InMemoryControlPlane;
 import io.aiven.inkless.control_plane.MetadataView;
 import io.aiven.inkless.produce.AppendInterceptor;
 import io.aiven.inkless.produce.WriterTestUtils;
-import io.aiven.inkless.storage_backend.common.StorageBackendException;
 import io.aiven.inkless.storage_backend.s3.S3Storage;
 import io.aiven.inkless.test_utils.S3TestContainer;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
@@ -160,7 +158,7 @@ class FileMergerIntegrationTest {
     }
 
     @Test
-    void test() throws InterruptedException, IOException, StorageBackendException {
+    void test() throws Exception {
         final ControlPlane controlPlane = new InMemoryControlPlane(time);
         controlPlane.configure(Map.of(
             "file.merge.size.threshold.bytes", Long.toString(FILE_MERGE_THRESHOLD)


### PR DESCRIPTION
Eagerly fetching files cause too many connections open and eventually fails with timeout.
To avoid this, pass a supplier to the merging process.