### PR TITLE
Solve one-produce-request-at-time problem

### DIFF
--- a/core/src/main/scala/kafka/network/InklessSendQueue.java
+++ b/core/src/main/scala/kafka/network/InklessSendQueue.java
@@ -1,0 +1,53 @@
+// Copyright (c) 2025 Aiven, Helsinki, Finland. https://aiven.io/
+package kafka.network;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Comparator;
+import java.util.PriorityQueue;
+
+/**
+ * The response queue for a connection.
+ *
+ * <p>This queue arranges responses by their correlation ID, expecting no gaps and the strict order.
+ */
+class InklessSendQueue {
+    private static final Logger LOGGER = LoggerFactory.getLogger(InklessSendQueue.class);
+
+    private static final Comparator<RequestChannel.SendResponse> CORRELATION_ID_COMPARATOR =
+        Comparator.comparing((RequestChannel.SendResponse r) -> r.request().header().correlationId());
+    private final PriorityQueue<RequestChannel.SendResponse> queue = new PriorityQueue<>(CORRELATION_ID_COMPARATOR);
+    private int nextCorrelationId;
+
+    InklessSendQueue(final int startCorrelationId) {
+//        LOGGER.info("Starting with correlation ID {}", startCorrelationId);
+        this.nextCorrelationId = startCorrelationId;
+    }
+
+    void add(final RequestChannel.SendResponse response) {
+//        LOGGER.info("Adding response with correlation ID {}", response.request().header().correlationId());
+        if (response.request().header().correlationId() < nextCorrelationId) {
+            throw new IllegalStateException("Expected min correlation ID " + nextCorrelationId);
+        }
+        queue.add(response);
+    }
+
+    boolean nextReady() {
+        final RequestChannel.SendResponse peeked = queue.peek();
+        if (peeked == null) {
+            return false;
+        }
+        final int correlationId = peeked.request().header().correlationId();
+//        LOGGER.info("Peeked correlation ID {}, expecting {}", peeked.request().header().correlationId(), nextCorrelationId);
+        return correlationId == nextCorrelationId;
+    }
+
+    RequestChannel.SendResponse take() {
+        if (!nextReady()) {
+            throw new IllegalStateException();
+        }
+        nextCorrelationId += 1;
+        return queue.remove();
+    }
+}

--- a/storage/inkless/src/main/java/io/aiven/inkless/common/SharedState.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/common/SharedState.java
@@ -16,6 +16,7 @@ import io.aiven.inkless.cache.ObjectCache;
 import io.aiven.inkless.config.InklessConfig;
 import io.aiven.inkless.control_plane.ControlPlane;
 import io.aiven.inkless.control_plane.MetadataView;
+import io.aiven.inkless.network.InklessConnectionUpgradeTracker;
 import io.aiven.inkless.storage_backend.common.StorageBackend;
 
 public record SharedState(
@@ -29,7 +30,8 @@ public record SharedState(
         KeyAlignmentStrategy keyAlignmentStrategy,
         ObjectCache cache,
         BrokerTopicStats brokerTopicStats,
-        Supplier<LogConfig> defaultTopicConfigs
+        Supplier<LogConfig> defaultTopicConfigs,
+        InklessConnectionUpgradeTracker inklessConnectionUpgradeTracker
 ) implements Closeable {
 
     public static SharedState initialize(
@@ -41,7 +43,8 @@ public record SharedState(
         MetadataView metadata,
         ControlPlane controlPlane,
         BrokerTopicStats brokerTopicStats,
-        Supplier<LogConfig> defaultTopicConfigs
+        Supplier<LogConfig> defaultTopicConfigs,
+        InklessConnectionUpgradeTracker inklessConnectionUpgradeTracker
     ) {
         return new SharedState(
             time,
@@ -54,7 +57,8 @@ public record SharedState(
             new FixedBlockAlignment(config.fetchCacheBlockBytes()),
             new InfinispanCache(time, clusterId, rack),
             brokerTopicStats,
-            defaultTopicConfigs
+            defaultTopicConfigs,
+            inklessConnectionUpgradeTracker
         );
     }
 

--- a/storage/inkless/src/main/java/io/aiven/inkless/network/InklessConnectionUpgradeTracker.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/network/InklessConnectionUpgradeTracker.java
@@ -1,0 +1,51 @@
+// Copyright (c) 2025 Aiven, Helsinki, Finland. https://aiven.io/
+package io.aiven.inkless.network;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+import io.aiven.inkless.control_plane.MetadataView;
+
+/**
+ * Tracks whether a connection is Inkless-upgraded.
+ *
+ * <p>For each upgraded connection, remembers the correlation ID at the moment of upgrade (used later for response queueing).
+ */
+public class InklessConnectionUpgradeTracker {
+    private static final Logger LOGGER = LoggerFactory.getLogger(InklessConnectionUpgradeTracker.class);
+
+    private final MetadataView metadataView;
+    // Key: connection ID, value: correlation ID at the moment of upgrade
+    private final ConcurrentHashMap<String, Integer> upgradedConnection = new ConcurrentHashMap<>();
+
+    public InklessConnectionUpgradeTracker(final MetadataView metadataView) {
+        this.metadataView = metadataView;
+    }
+
+    public boolean isConnectionUpgraded(final String connectionId) {
+        return upgradedConnection.containsKey(connectionId);
+    }
+
+    public int upgradeCorrelationId(final String connectionId) {
+        final Integer result = upgradedConnection.get(connectionId);
+        if (result != null) {
+            return result;
+        } else {
+            throw new IllegalStateException();
+        }
+    }
+
+    public void upgradeConnection(final String connectionId, final int correlationId) {
+        upgradedConnection.computeIfAbsent(connectionId, ignore -> {
+            LOGGER.info("Upgrading connection {}", connectionId);
+            return correlationId;
+        });
+    }
+
+    public void closeConnection(final String connectionId) {
+        // TODO call
+        upgradedConnection.remove(connectionId);
+    }
+}


### PR DESCRIPTION
The Kafka network subsystem is organized in a way that allows handling only one request per connection simultaneously. When the request is received, the connection is muted (which means, no further requests are selected by `Selector`). Only when the request is processed and the response is sent to the client, the channel is unmuted to let the following request it. This is fine for normal Kafka, where produce requests are normally quick. However, in Inkless normally we have up up to 250+ ms delay while the active file is filled, uploaded, and committed. This is the major bottleneck for single producer throughput. More details could be found [here](https://aiven-io.slack.com/archives/C06G4TBQ6AW/p1733939393895899).

This commit is a proof-of-concept solution to this problem. The core idea is "upgrading" the connection. When the first Inkless Produce request is handled, the connection is "upgraded". After this moment, it's not expecting to receive any other request type nor even non-Inkless produce. Upgraded Inkless connections are handled differently in several key ways:
1. They aren't muted when a request is received. This allows to accept requests in the pipelined fashion, hand them over to the `InklessAppendInterceptor` before the previous ones are handled and responded to. The Inkless produce machinery already has some queueing and support for parallel upload.
2. There's a response queue, `InklessSendQueue`. It enables serializing responses by correlation ID (otherwise, the client will fail) and sending them downstream to the connection only when the connection is ready to send them further to the client.
3. If an unexpected request comes, the connection fails.

# TODO

1. The assumption that if there are produce requests in the connection, there will be only produce requests in the future seems correct for any sensibly implemented client. However, there's two exceptions to this: periodic metadata updates and telemetry sending. It seems, the Java client uses the same connection used for produce requests. A way to handle this must be found. Potentially, another unelegant hack will be needed. For example, there requests may be handled in parallel to Inkless produce.
2. Connection muting is a back pressure mechanism. Disabling it, we're opening the broker to all sorts of overload and QoS perils. A correct end-to-end back pressure mechanism must be implemented for Inkless produce.
3. Connection muting is also used for client quotas. This must also be taken into account.
