### PR TITLE
fix(inkless:produce): validate empty files [INK-19]

### DIFF
--- a/storage/inkless/src/main/java/io/aiven/inkless/produce/AppendInterceptor.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/produce/AppendInterceptor.java
@@ -91,6 +91,14 @@ public class AppendInterceptor implements Closeable {
             return true;
         }
 
+        if (entriesPerPartition.isEmpty()) {
+            // Empty produce request are expected to be filtered out at the KafkaApis level.
+            // adding for safety.
+            LOGGER.warn("Empty produce request");
+            responseCallback.accept(Map.of());
+            return true;
+        }
+
         final Map<TopicIdPartition, MemoryRecords> entriesPerPartitionEnriched;
         try {
             entriesPerPartitionEnriched = TopicIdEnricher.enrich(state.metadata(), entriesPerPartition);

--- a/storage/inkless/src/main/java/io/aiven/inkless/produce/ClosedFile.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/produce/ClosedFile.java
@@ -38,9 +38,17 @@ record ClosedFile(Instant start,
         }
 
         Objects.requireNonNull(data, "data cannot be null");
+
+        if (commitBatchRequests.isEmpty() != (data.length == 0)) {
+            throw new IllegalArgumentException("data must be empty if commitBatchRequests is empty");
+        }
     }
 
     int size() {
         return data.length;
+    }
+
+    public boolean isEmpty() {
+        return data.length == 0;
     }
 }

--- a/storage/inkless/src/test/java/io/aiven/inkless/produce/ActiveFileTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/produce/ActiveFileTest.java
@@ -105,6 +105,7 @@ class ActiveFileTest {
             .ignoringFields("data")
             .isEqualTo(new ClosedFile(start, Map.of(), Map.of(), List.of(), List.of(), new byte[0]));
         assertThat(result.data()).isEmpty();
+        assertThat(result.isEmpty()).isTrue();
     }
 
     @Test
@@ -140,5 +141,6 @@ class ActiveFileTest {
         );
         assertThat(result.requestIds()).containsExactly(0, 0, 1, 1);
         assertThat(result.data()).hasSize(312);
+        assertThat(result.isEmpty()).isFalse();
     }
 }

--- a/storage/inkless/src/test/java/io/aiven/inkless/produce/AppendInterceptorTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/produce/AppendInterceptorTest.java
@@ -224,6 +224,21 @@ public class AppendInterceptorTest {
     }
 
     @Test
+    public void emptyRequests() {
+        final AppendInterceptor interceptor = new AppendInterceptor(
+            new SharedState(time, BROKER_ID, inklessConfig, metadataView, controlPlane, storageBackend,
+                OBJECT_KEY_CREATOR, KEY_ALIGNMENT_STRATEGY, OBJECT_CACHE, brokerTopicStats, DEFAULT_TOPIC_CONFIGS), writer);
+
+        final Map<TopicPartition, MemoryRecords> entriesPerPartition = Map.of();
+
+        final boolean result = interceptor.intercept(entriesPerPartition, responseCallback);
+        assertThat(result).isFalse();
+
+        verify(responseCallback, never()).accept(any());
+        verify(writer, never()).write(any(), anyMap());
+    }
+
+    @Test
     public void acceptNonIdempotentNotTransactionalProduceForInklessTopics() {
         final Map<TopicPartition, MemoryRecords> entriesPerPartition = Map.of(
             new TopicPartition("inkless", 0),

--- a/storage/inkless/src/test/java/io/aiven/inkless/produce/ClosedFileTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/produce/ClosedFileTest.java
@@ -76,10 +76,25 @@ class ClosedFileTest {
             .hasMessage("data cannot be null");
     }
 
+    @Test
+    void dataRequestMismatch() {
+        assertThatThrownBy(() -> new ClosedFile(Instant.EPOCH, Map.of(), Map.of(), List.of(), List.of(), new byte[10]))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("data must be empty if commitBatchRequests is empty");
+        assertThatThrownBy(() -> new ClosedFile(Instant.EPOCH, Map.of(), Map.of(),
+            List.of(CommitBatchRequest.of(null, 0, 0, 0, 0, 0, TimestampType.CREATE_TIME)),
+            List.of(1),
+            new byte[0]))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("data must be empty if commitBatchRequests is empty");
+    }
 
     @Test
     void size() {
-        final int size = new ClosedFile(Instant.EPOCH, Map.of(), Map.of(), List.of(), List.of(), new byte[10]).size();
+        final int size = new ClosedFile(Instant.EPOCH, Map.of(), Map.of(),
+            List.of(CommitBatchRequest.of(null, 0, 0, 0, 0, 0, TimestampType.CREATE_TIME)),
+            List.of(1),
+            new byte[10]).size();
         assertThat(size).isEqualTo(10);
     }
 }

--- a/storage/inkless/src/test/java/io/aiven/inkless/produce/FileCommitterTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/produce/FileCommitterTest.java
@@ -1,6 +1,7 @@
 // Copyright (c) 2024 Aiven, Helsinki, Finland. https://aiven.io/
 package io.aiven.inkless.produce;
 
+import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.common.utils.Time;
 
 import org.junit.jupiter.api.Test;
@@ -28,6 +29,7 @@ import io.aiven.inkless.cache.ObjectCache;
 import io.aiven.inkless.common.ObjectKey;
 import io.aiven.inkless.common.ObjectKeyCreator;
 import io.aiven.inkless.common.PlainObjectKey;
+import io.aiven.inkless.control_plane.CommitBatchRequest;
 import io.aiven.inkless.control_plane.ControlPlane;
 import io.aiven.inkless.storage_backend.common.StorageBackend;
 import io.aiven.inkless.storage_backend.common.StorageBackendException;
@@ -57,7 +59,10 @@ class FileCommitterTest {
             return OBJECT_KEY;
         }
     };
-    static final ClosedFile FILE = new ClosedFile(Instant.EPOCH, Map.of(), Map.of(), List.of(), List.of(), new byte[10]);
+    static final ClosedFile FILE = new ClosedFile(Instant.EPOCH, Map.of(), Map.of(),
+            List.of(CommitBatchRequest.of(null, 0, 0, 0, 0, 0, TimestampType.CREATE_TIME)),
+            List.of(1),
+            new byte[10]);
     static final KeyAlignmentStrategy KEY_ALIGNMENT_STRATEGY = new FixedBlockAlignment(Integer.MAX_VALUE);
     static final ObjectCache OBJECT_CACHE = new NullCache();
 

--- a/storage/inkless/src/test/java/io/aiven/inkless/produce/WriterMockedTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/produce/WriterMockedTest.java
@@ -334,4 +334,13 @@ class WriterMockedTest {
             .isInstanceOf(NullPointerException.class)
             .hasMessage("timestampTypes cannot be null");
     }
+
+    @Test
+    void writeEmptyRequests() {
+        final Writer writer = new Writer(time, Duration.ofMillis(1), 8 * 1024, commitTickScheduler, fileCommitter, writerMetrics, brokerTopicMetricMarks);
+
+        assertThatThrownBy(() -> writer.write(Map.of(), TIMESTAMP_TYPES))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("entriesPerPartition cannot be empty");
+    }
 }


### PR DESCRIPTION
when closing a file, there is no validation of empty files/requests, so empty files may be updated--even on non-inkless topics

This is not supposed to happen at runtime: https://github.com/aiven/inkless/blob/a920074ee47d049dc6adc635c83efa65a3397b61/core/src/main/scala/kafka/server/KafkaApis.scala#L745-L746
but it may happen on tests or when inkless is disabled.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
