### PR TITLE
fix(inkless:produce): adjust log append time based on request [INK-19]

### DIFF
--- a/storage/inkless/src/test/java/io/aiven/inkless/produce/FileCommitJobTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/produce/FileCommitJobTest.java
@@ -94,10 +94,10 @@ class FileCommitJobTest {
         );
 
         final List<CommitBatchResponse> commitBatchResponses = List.of(
-            CommitBatchResponse.of(Errors.NONE, 0, 10, 0),
+            CommitBatchResponse.success(0, 10, 0, COMMIT_BATCH_REQUESTS.get(0)),
             CommitBatchResponse.of(Errors.INVALID_TOPIC_EXCEPTION, -1, -1, -1),  // some arbitrary uploadError
-            CommitBatchResponse.of(Errors.NONE, 20, 10, 0),
-            CommitBatchResponse.of(Errors.NONE, 30, 10, 0)
+            CommitBatchResponse.success(20, 10, 0, COMMIT_BATCH_REQUESTS.get(2)),
+            CommitBatchResponse.success(30, 10, 0, COMMIT_BATCH_REQUESTS.get(3))
         );
 
         when(controlPlane.commitFile(eq(OBJECT_KEY_MAIN_PART), eq(BROKER_ID), eq(FILE_SIZE), eq(COMMIT_BATCH_REQUESTS)))
@@ -111,11 +111,11 @@ class FileCommitJobTest {
         job.run();
 
         assertThat(awaitingFuturesByRequest.get(0)).isCompletedWithValue(Map.of(
-            T0P0.topicPartition(), new PartitionResponse(Errors.NONE, 0, 10, 0),
+            T0P0.topicPartition(), new PartitionResponse(Errors.NONE, 0, -1, 0),
             T0P1.topicPartition(), new PartitionResponse(Errors.INVALID_TOPIC_EXCEPTION, -1, -1, -1)
         ));
         assertThat(awaitingFuturesByRequest.get(1)).isCompletedWithValue(Map.of(
-            T0P1.topicPartition(), new PartitionResponse(Errors.NONE, 20, 10, 0),
+            T0P1.topicPartition(), new PartitionResponse(Errors.NONE, 20, -1, 0),
             T1P0.topicPartition(), new PartitionResponse(Errors.NONE, 30, 10, 0)
         ));
         verify(commitTimeDurationCallback).accept(eq(10L));

--- a/storage/inkless/src/test/java/io/aiven/inkless/produce/WriterIntegrationTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/produce/WriterIntegrationTest.java
@@ -151,14 +151,14 @@ class WriterIntegrationTest {
             final var result3 = writeFuture3.get(10, TimeUnit.SECONDS);
 
             assertThat(result1).isEqualTo(Map.of(
-                T0P0.topicPartition(), new PartitionResponse(Errors.NONE, 0, ts1, 0),
-                T0P1.topicPartition(), new PartitionResponse(Errors.NONE, 0, ts1, 0),
+                T0P0.topicPartition(), new PartitionResponse(Errors.NONE, 0, -1, 0),
+                T0P1.topicPartition(), new PartitionResponse(Errors.NONE, 0, -1, 0),
                 T1P0.topicPartition(), new PartitionResponse(Errors.NONE, 0, ts1, 0)
             ));
 
             assertThat(result2).isEqualTo(Map.of(
-                T0P0.topicPartition(), new PartitionResponse(Errors.NONE, 101, ts1, 0),
-                T0P1.topicPartition(), new PartitionResponse(Errors.NONE, 102, ts1, 0),
+                T0P0.topicPartition(), new PartitionResponse(Errors.NONE, 101, -1, 0),
+                T0P1.topicPartition(), new PartitionResponse(Errors.NONE, 102, -1, 0),
                 T1P0.topicPartition(), new PartitionResponse(Errors.NONE, 103, ts1, 0)
             ));
 


### PR DESCRIPTION
Producers expect logAppendTime to be -1 if timestamp type is CREATE_TIME.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
