### PR TITLE
refactor(inkless:test): consolidate s3 containers to minio [INK-19]

### DIFF
--- a/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/s3/integration/S3StorageMetricsTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/s3/integration/S3StorageMetricsTest.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.containers.localstack.LocalStackContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
@@ -21,12 +20,8 @@ import io.aiven.inkless.common.ByteRange;
 import io.aiven.inkless.common.ObjectKey;
 import io.aiven.inkless.storage_backend.common.fixtures.TestObjectKey;
 import io.aiven.inkless.storage_backend.s3.S3Storage;
+import io.aiven.inkless.test_utils.MinioContainer;
 import io.aiven.inkless.test_utils.S3TestContainer;
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
-import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.InstanceOfAssertFactories.DOUBLE;
@@ -36,7 +31,7 @@ import static org.assertj.core.api.InstanceOfAssertFactories.DOUBLE;
 class S3StorageMetricsTest {
 
     @Container
-    private static final LocalStackContainer LOCALSTACK = S3TestContainer.localstack();
+    private static final MinioContainer S3_CONTAINER = S3TestContainer.minio();
 
     private static final MBeanServer MBEAN_SERVER = ManagementFactory.getPlatformMBeanServer();
 
@@ -46,20 +41,7 @@ class S3StorageMetricsTest {
 
     @BeforeAll
     static void setupS3() {
-        final var clientBuilder = S3Client.builder();
-        clientBuilder.region(Region.of(LOCALSTACK.getRegion()))
-            .endpointOverride(LOCALSTACK.getEndpointOverride(LocalStackContainer.Service.S3))
-            .credentialsProvider(
-                StaticCredentialsProvider.create(
-                    AwsBasicCredentials.create(
-                        LOCALSTACK.getAccessKey(),
-                        LOCALSTACK.getSecretKey()
-                    )
-                )
-            );
-        try (final S3Client s3Client = clientBuilder.build()) {
-            s3Client.createBucket(CreateBucketRequest.builder().bucket(BUCKET_NAME).build());
-        }
+        S3_CONTAINER.createBucket(BUCKET_NAME);
     }
 
     @BeforeEach
@@ -67,10 +49,10 @@ class S3StorageMetricsTest {
         storage = new S3Storage();
         final Map<String, Object> configs = Map.of(
             "s3.bucket.name", BUCKET_NAME,
-            "s3.region", LOCALSTACK.getRegion(),
-            "s3.endpoint.url", LOCALSTACK.getEndpointOverride(LocalStackContainer.Service.S3).toString(),
-            "aws.access.key.id", LOCALSTACK.getAccessKey(),
-            "aws.secret.access.key", LOCALSTACK.getSecretKey(),
+            "s3.region", S3_CONTAINER.getRegion(),
+            "s3.endpoint.url", S3_CONTAINER.getEndpoint(),
+            "aws.access.key.id", S3_CONTAINER.getAccessKey(),
+            "aws.secret.access.key", S3_CONTAINER.getSecretKey(),
             "s3.path.style.access.enabled", true
         );
         storage.configure(configs);

--- a/storage/inkless/src/test/java/io/aiven/inkless/test_utils/S3TestContainer.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/test_utils/S3TestContainer.java
@@ -1,16 +1,7 @@
 // Copyright (c) 2024 Aiven, Helsinki, Finland. https://aiven.io/
 package io.aiven.inkless.test_utils;
 
-import org.testcontainers.containers.localstack.LocalStackContainer;
-import org.testcontainers.utility.DockerImageName;
-
 public final class S3TestContainer {
-    public static LocalStackContainer localstack() {
-        return new LocalStackContainer(
-            DockerImageName.parse("localstack/localstack:3.8.1")
-        ).withServices(LocalStackContainer.Service.S3);
-    }
-
     public static MinioContainer minio() {
         return new MinioContainer();
     }


### PR DESCRIPTION
Remove localstack that has show incomplete feature-parity with S3 (e.g. delete limits).
With MinIO console can be used to quickly validate objects.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
