### PR TITLE
fix(inkless:test): wait for Postgres container to be ready

### DIFF
--- a/storage/inkless/src/test/java/io/aiven/inkless/test_utils/PostgreSQLTestContainer.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/test_utils/PostgreSQLTestContainer.java
@@ -1,6 +1,8 @@
 // Copyright (c) 2024 Aiven, Helsinki, Finland. https://aiven.io/
 package io.aiven.inkless.test_utils;
 
+import org.testcontainers.containers.wait.strategy.Wait;
+
 public class PostgreSQLTestContainer {
     public static final String USERNAME = "test";
     public static final String PASSWORD = "test";
@@ -8,6 +10,7 @@ public class PostgreSQLTestContainer {
     public static InklessPostgreSQLContainer container() {
         return new InklessPostgreSQLContainer("postgres:17.2")
             .withUsername(USERNAME)
-            .withUsername(PASSWORD);
+            .withUsername(PASSWORD)
+            .waitingFor(Wait.forListeningPort());
     }
 }


### PR DESCRIPTION
Running tests locally might fail due to Postgres container not being ready.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
