### PR TITLE
refactor(kafka:core): UnifiedLog analyzeAndValidateRecords to storage [INK-127]

### DIFF
--- a/core/src/test/scala/unit/kafka/log/UnifiedLogTest.scala
+++ b/core/src/test/scala/unit/kafka/log/UnifiedLogTest.scala
@@ -17,13 +17,13 @@
 
 package kafka.log
 
-import kafka.common.{OffsetsOutOfOrderException, UnexpectedAppendOffsetException}
+import kafka.common.UnexpectedAppendOffsetException
 import kafka.log.remote.RemoteLogManager
 import kafka.server.{DelayedRemoteListOffsets, KafkaConfig}
 import kafka.utils.TestUtils
 import org.apache.kafka.common.compress.Compression
 import org.apache.kafka.common.config.TopicConfig
-import org.apache.kafka.common.{InvalidRecordException, TopicPartition, Uuid}
+import org.apache.kafka.common.{InvalidRecordException, OffsetsOutOfOrderException, TopicPartition, Uuid}
 import org.apache.kafka.common.errors._
 import org.apache.kafka.common.internals.Topic
 import org.apache.kafka.common.message.FetchResponseData

--- a/server-common/src/main/java/org/apache/kafka/common/OffsetsOutOfOrderException.java
+++ b/server-common/src/main/java/org/apache/kafka/common/OffsetsOutOfOrderException.java
@@ -1,11 +1,11 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
+ * contributor license agreements. See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
  * The ASF licenses this file to You under the Apache License, Version 2.0
  * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- * 
+ * the License. You may obtain a copy of the License at
+ *
  *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -15,11 +15,13 @@
  * limitations under the License.
  */
 
-package kafka.common
+package org.apache.kafka.common;
 
 /**
  * Indicates the follower received records with non-monotonically increasing offsets
  */
-class OffsetsOutOfOrderException(message: String) extends RuntimeException(message) {
+public class OffsetsOutOfOrderException extends RuntimeException {
+    public OffsetsOutOfOrderException(String message) {
+        super(message);
+    }
 }
-


### PR DESCRIPTION
Validation in Kafka requests happen in 2 steps, overall validation of records, and the a more details validation (LogValidator). This PR focuses on the first one located at UnifiedLog. The goal is to make these reusable for Inkless.

Fully moves validation of batches and records to Java by moving the analyzeAndValidateRecords from UnifiedLog into its Java versions as an static method to be reused outside UnifiedLog (i.e. Inkless).

Along this method, moving OffsetsOutOfOrderException from scala on core to java on storage as well.

