### PR TITLE
refactor(inkless): refactor closed file [INK-127]

### DIFF
--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/CommitBatchRequestContext.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/CommitBatchRequestContext.java
@@ -1,0 +1,12 @@
+package io.aiven.inkless.control_plane;
+
+import org.apache.kafka.common.TopicPartition;
+
+import java.util.Objects;
+
+public record CommitBatchRequestContext (int requestId, TopicPartition topicPartition, CommitBatchRequest request) {
+    public CommitBatchRequestContext {
+        Objects.requireNonNull(topicPartition, "topicPartition cannot be null");
+        Objects.requireNonNull(request, "request cannot be null");
+    }
+}

--- a/storage/inkless/src/main/java/io/aiven/inkless/produce/ActiveFile.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/produce/ActiveFile.java
@@ -32,7 +32,6 @@ class ActiveFile {
     private final BatchBuffer buffer;
     private final BatchValidator batchValidator;
 
-    private final Map<Integer, Map<TopicIdPartition, MemoryRecords>> originalRequests = new HashMap<>();
     private final Map<Integer, Map<TopicPartition, CompletableFuture<PartitionResponse>>> allFuturesByRequest = new HashMap<>();
 
     private final BrokerTopicStats brokerTopicStats;
@@ -64,7 +63,6 @@ class ActiveFile {
         Objects.requireNonNull(topicConfigs, "topicConfigs cannot be null");
 
         requestId += 1;
-        originalRequests.put(requestId, entriesPerPartition);
 
         final Map<TopicPartition, CompletableFuture<PartitionResponse>> result = new HashMap<>();
 
@@ -118,10 +116,8 @@ class ActiveFile {
         BatchBuffer.CloseResult closeResult = buffer.close();
         return new ClosedFile(
             start,
-            originalRequests,
             allFuturesByRequest,
-            closeResult.commitBatchRequests(),
-            closeResult.requestIds(),
+            closeResult.commitBatchRequestContexts(),
             closeResult.data()
         );
     }

--- a/storage/inkless/src/test/java/io/aiven/inkless/produce/ClosedFileTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/produce/ClosedFileTest.java
@@ -1,100 +1,113 @@
 // Copyright (c) 2024 Aiven, Helsinki, Finland. https://aiven.io/
 package io.aiven.inkless.produce;
 
+import org.apache.kafka.common.TopicIdPartition;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.record.TimestampType;
+import org.apache.kafka.common.requests.ProduceResponse;
 
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 import io.aiven.inkless.control_plane.CommitBatchRequest;
+import io.aiven.inkless.control_plane.CommitBatchRequestContext;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class ClosedFileTest {
+
+    static final TopicPartition TOPIC_PARTITION = new TopicPartition("t", 0);
+    static final TopicIdPartition TOPIC_ID_PARTITION = new TopicIdPartition(Uuid.randomUuid(), TOPIC_PARTITION);
+
     @Test
     void startNull() {
-        assertThatThrownBy(() -> new ClosedFile(null, Map.of(), Map.of(), List.of(), List.of(), new byte[1]))
+        assertThatThrownBy(() -> new ClosedFile(null, Map.of(), List.of(), new byte[1]))
             .isInstanceOf(NullPointerException.class)
             .hasMessage("start cannot be null");
     }
 
     @Test
-    void originalRequestsNull() {
-        assertThatThrownBy(() -> new ClosedFile(Instant.EPOCH, null, Map.of(), List.of(), List.of(), new byte[1]))
-            .isInstanceOf(NullPointerException.class)
-            .hasMessage("originalRequests cannot be null");
-    }
-
-    @Test
     void awaitingFuturesByRequestNull() {
-        assertThatThrownBy(() -> new ClosedFile(Instant.EPOCH, Map.of(), null, List.of(), List.of(), new byte[1]))
+        assertThatThrownBy(() -> new ClosedFile(Instant.EPOCH, null, List.of(), new byte[1]))
             .isInstanceOf(NullPointerException.class)
             .hasMessage("allFuturesByRequest cannot be null");
     }
 
     @Test
     void commitBatchRequestsNull() {
-        assertThatThrownBy(() -> new ClosedFile(Instant.EPOCH, Map.of(), Map.of(), null, List.of(), new byte[1]))
+        assertThatThrownBy(() -> new ClosedFile(Instant.EPOCH, Map.of(), null, new byte[1]))
             .isInstanceOf(NullPointerException.class)
-            .hasMessage("commitBatchRequests cannot be null");
-    }
-
-    @Test
-    void requestIdsNull() {
-        assertThatThrownBy(() -> new ClosedFile(Instant.EPOCH, Map.of(), Map.of(), List.of(), null, new byte[1]))
-            .isInstanceOf(NullPointerException.class)
-            .hasMessage("requestIds cannot be null");
-    }
-
-    @Test
-    void differentLengths1() {
-        assertThatThrownBy(() -> new ClosedFile(Instant.EPOCH, Map.of(1, Map.of()), Map.of(), List.of(), List.of(),new byte[1]))
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessage("originalRequests and allFuturesByRequest must be of same size");
-    }
-
-    @Test
-    void differentLengths2() {
-        assertThatThrownBy(() -> new ClosedFile(
-            Instant.EPOCH,
-            Map.of(), Map.of(),
-            List.of(CommitBatchRequest.of(null, 0, 0, 0, 0, 0, TimestampType.CREATE_TIME)),
-            List.of(),
-            new byte[1]))
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessage("commitBatchRequests and requestIds must be of same size");
+            .hasMessage("commitBatchRequestContexts cannot be null");
     }
 
     @Test
     void dataNull() {
-        assertThatThrownBy(() -> new ClosedFile(Instant.EPOCH, Map.of(), Map.of(), List.of(), List.of(), null))
+        assertThatThrownBy(() -> new ClosedFile(Instant.EPOCH, Map.of(), List.of(), null))
             .isInstanceOf(NullPointerException.class)
             .hasMessage("data cannot be null");
     }
 
     @Test
     void dataRequestMismatch() {
-        assertThatThrownBy(() -> new ClosedFile(Instant.EPOCH, Map.of(), Map.of(), List.of(), List.of(), new byte[10]))
+        assertThatThrownBy(() -> new ClosedFile(Instant.EPOCH, Map.of(), List.of(), new byte[10]))
             .isInstanceOf(IllegalArgumentException.class)
-            .hasMessage("data must be empty if commitBatchRequests is empty");
-        assertThatThrownBy(() -> new ClosedFile(Instant.EPOCH, Map.of(), Map.of(),
-            List.of(CommitBatchRequest.of(null, 0, 0, 0, 0, 0, TimestampType.CREATE_TIME)),
-            List.of(1),
-            new byte[0]))
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessage("data must be empty if commitBatchRequests is empty");
+            .hasMessage("data must be empty if commitBatchRequestContexts is empty");
+        assertThatThrownBy(() ->
+            new ClosedFile(
+                Instant.EPOCH,
+                Map.of(1, Map.of(TOPIC_PARTITION, new CompletableFuture<>())),
+                List.of(new CommitBatchRequestContext(1, TOPIC_PARTITION, CommitBatchRequest.of(TOPIC_ID_PARTITION, 0, 0, 0, 0, 0, TimestampType.CREATE_TIME))),
+                new byte[0])
+        ).isInstanceOf(IllegalArgumentException.class).hasMessage("data must be empty if commitBatchRequestContexts is empty");
     }
 
     @Test
     void size() {
-        final int size = new ClosedFile(Instant.EPOCH, Map.of(), Map.of(),
-            List.of(CommitBatchRequest.of(null, 0, 0, 0, 0, 0, TimestampType.CREATE_TIME)),
-            List.of(1),
-            new byte[10]).size();
+        final int size = new ClosedFile(
+            Instant.EPOCH,
+            Map.of(1, Map.of(TOPIC_PARTITION, new CompletableFuture<>())),
+            List.of(new CommitBatchRequestContext(1, TOPIC_PARTITION, CommitBatchRequest.of(TOPIC_ID_PARTITION, 0, 0, 0, 0, 0, TimestampType.CREATE_TIME))),
+            new byte[10]
+        ).size();
         assertThat(size).isEqualTo(10);
+    }
+
+    @Test
+    void requestIdNotFound() {
+        assertThatThrownBy(() -> new ClosedFile(
+            Instant.EPOCH,
+            Map.of(1, Map.of(TOPIC_PARTITION, new CompletableFuture<>())),
+            List.of(new CommitBatchRequestContext(2, TOPIC_PARTITION, CommitBatchRequest.of(TOPIC_ID_PARTITION, 0, 0, 0, 0, 0, TimestampType.CREATE_TIME))),
+            new byte[0]
+        )).isInstanceOf(IllegalArgumentException.class).hasMessage("Request ID 2 not found in validated futures");
+    }
+
+    @Test
+    void topicPartitionNotFound() {
+        assertThatThrownBy(() -> new ClosedFile(
+            Instant.EPOCH,
+            Map.of(1, Map.of(TOPIC_PARTITION, new CompletableFuture<>())),
+            List.of(new CommitBatchRequestContext(1, new TopicPartition("t", 1), CommitBatchRequest.of(TOPIC_ID_PARTITION, 0, 0, 0, 0, 0, TimestampType.CREATE_TIME))),
+            new byte[0]
+        )).isInstanceOf(IllegalArgumentException.class).hasMessage("Topic partition t-1 not found in validated futures for request ID 1");
+    }
+
+    @Test
+    void futureAlreadyCompleted() {
+        final CompletableFuture<ProduceResponse.PartitionResponse> future = new CompletableFuture<>();
+        future.complete(new ProduceResponse.PartitionResponse(Errors.NONE));
+        assertThatThrownBy(() -> new ClosedFile(
+            Instant.EPOCH,
+            Map.of(1, Map.of(TOPIC_PARTITION, future)),
+            List.of(new CommitBatchRequestContext(1, TOPIC_PARTITION, CommitBatchRequest.of(TOPIC_ID_PARTITION, 0, 0, 0, 0, 0, TimestampType.CREATE_TIME))),
+            new byte[0]
+        )).isInstanceOf(IllegalStateException.class).hasMessage("Future for topic partition t-0 in request ID 1 is already completed");
     }
 }

--- a/storage/inkless/src/test/java/io/aiven/inkless/produce/FileCommitterTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/produce/FileCommitterTest.java
@@ -1,6 +1,9 @@
 // Copyright (c) 2024 Aiven, Helsinki, Finland. https://aiven.io/
 package io.aiven.inkless.produce;
 
+import org.apache.kafka.common.TopicIdPartition;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.common.utils.Time;
 
@@ -30,6 +33,7 @@ import io.aiven.inkless.common.ObjectKey;
 import io.aiven.inkless.common.ObjectKeyCreator;
 import io.aiven.inkless.common.PlainObjectKey;
 import io.aiven.inkless.control_plane.CommitBatchRequest;
+import io.aiven.inkless.control_plane.CommitBatchRequestContext;
 import io.aiven.inkless.control_plane.ControlPlane;
 import io.aiven.inkless.storage_backend.common.StorageBackend;
 import io.aiven.inkless.storage_backend.common.StorageBackendException;
@@ -59,10 +63,15 @@ class FileCommitterTest {
             return OBJECT_KEY;
         }
     };
-    static final ClosedFile FILE = new ClosedFile(Instant.EPOCH, Map.of(), Map.of(),
-            List.of(CommitBatchRequest.of(null, 0, 0, 0, 0, 0, TimestampType.CREATE_TIME)),
-            List.of(1),
-            new byte[10]);
+    static final TopicPartition TOPIC_PARTITION = new TopicPartition("t", 0);
+    static final TopicIdPartition TOPIC_ID_PARTITION = new TopicIdPartition(Uuid.randomUuid(), TOPIC_PARTITION);
+
+    static final ClosedFile FILE = new ClosedFile(
+        Instant.EPOCH,
+        Map.of(1, Map.of(TOPIC_PARTITION, new CompletableFuture<>())),
+        List.of(new CommitBatchRequestContext(1, TOPIC_PARTITION, CommitBatchRequest.of(TOPIC_ID_PARTITION, 0, 0, 0, 0, 0, TimestampType.CREATE_TIME))),
+        new byte[10]
+    );
     static final KeyAlignmentStrategy KEY_ALIGNMENT_STRATEGY = new FixedBlockAlignment(Integer.MAX_VALUE);
     static final ObjectCache OBJECT_CACHE = new NullCache();
 

--- a/storage/inkless/src/test/java/io/aiven/inkless/produce/WriterMockedTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/produce/WriterMockedTest.java
@@ -126,7 +126,6 @@ class WriterMockedTest {
         // As we wrote too much, commit must be triggered.
         verify(fileCommitter).commit(closedFileCaptor.capture());
         assertThat(closedFileCaptor.getValue().start()).isEqualTo(Instant.ofEpochMilli(10));
-        assertThat(closedFileCaptor.getValue().originalRequests()).isEqualTo(Map.of(0, writeRequest));
         assertThat(closedFileCaptor.getValue().allFuturesByRequest()).hasSize(1);
     }
 
@@ -152,8 +151,6 @@ class WriterMockedTest {
 
         // As we wrote too much, commit must be triggered.
         verify(fileCommitter).commit(closedFileCaptor.capture());
-        assertThat(closedFileCaptor.getValue().originalRequests())
-            .isEqualTo(Map.of(0, writeRequest0, 1, writeRequest1));
         assertThat(closedFileCaptor.getValue().allFuturesByRequest()).hasSize(2);
     }
 
@@ -173,8 +170,6 @@ class WriterMockedTest {
         writer.tick();
 
         verify(fileCommitter).commit(closedFileCaptor.capture());
-        assertThat(closedFileCaptor.getValue().originalRequests())
-            .isEqualTo(Map.of(0, writeRequest));
         assertThat(closedFileCaptor.getValue().allFuturesByRequest()).hasSize(1);
     }
 
@@ -194,8 +189,6 @@ class WriterMockedTest {
         writer.close();
 
         verify(fileCommitter).commit(closedFileCaptor.capture());
-        assertThat(closedFileCaptor.getValue().originalRequests())
-            .isEqualTo(Map.of(0, writeRequest));
         assertThat(closedFileCaptor.getValue().allFuturesByRequest()).hasSize(1);
     }
 
@@ -217,7 +210,6 @@ class WriterMockedTest {
         assertThat(writer.write(writeRequest, TOPIC_CONFIGS)).isNotCompleted();
 
         verify(fileCommitter).commit(closedFileCaptor.capture());
-        assertThat(closedFileCaptor.getValue().originalRequests()).isEqualTo(Map.of(0, writeRequest));
         assertThat(closedFileCaptor.getValue().allFuturesByRequest()).hasSize(1);
     }
 


### PR DESCRIPTION
Drop original requests and requests ids. Instead define a CommitBatchRequestContext that wraps the request with mappers to the future (Map[RequestId, Map[TopicPartition, Future]]).

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
