### PR TITLE
Aggregate files split by KeyAlignmentStrategy [INK-77]

### DIFF
--- a/core/src/test/java/kafka/server/InklessClusterTest.java
+++ b/core/src/test/java/kafka/server/InklessClusterTest.java
@@ -106,6 +106,8 @@ public class InklessClusterTest {
             .setConfigProp(InklessConfig.PREFIX + InklessConfig.STORAGE_PREFIX + S3StorageConfig.AWS_ACCESS_KEY_ID_CONFIG, s3Container.getAccessKey())
             .setConfigProp(InklessConfig.PREFIX + InklessConfig.STORAGE_PREFIX + S3StorageConfig.AWS_SECRET_ACCESS_KEY_CONFIG, s3Container.getSecretKey())
             .setConfigProp(InklessConfig.PREFIX + InklessConfig.STORAGE_PREFIX + S3StorageConfig.AWS_SECRET_ACCESS_KEY_CONFIG, s3Container.getSecretKey())
+            // Decrease cache block bytes to test cache split due to alignment
+            .setConfigProp(InklessConfig.PREFIX + InklessConfig.CONSUME_CACHE_BLOCK_BYTES_CONFIG, 16 * 1024)
             .build();
         cluster.format();
         cluster.startup();

--- a/storage/inkless/src/main/java/io/aiven/inkless/cache/FixedBlockAlignment.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/cache/FixedBlockAlignment.java
@@ -33,10 +33,6 @@ public class FixedBlockAlignment implements KeyAlignmentStrategy {
             for (long blockIndex = firstBlock; blockIndex <= lastBlock; blockIndex++) {
                 keys.add(new ByteRange(blockSize * blockIndex, blockSize));
             }
-            if (firstBlock != lastBlock) {
-                // TODO INK-77: For ranges which cross multiple blocks, issue multiple requests and concatenate them later.
-                keys.add(requestRange);
-            }
         }
         return Collections.unmodifiableSet(keys);
     }

--- a/storage/inkless/src/test/java/io/aiven/inkless/cache/FixedBlockAlignmentTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/cache/FixedBlockAlignmentTest.java
@@ -65,23 +65,20 @@ public class FixedBlockAlignmentTest {
         ));
     }
 
-    // TODO INK-77: irregular-sized byte ranges should not be emitted
     @Test
     public void testRangeOverMultipleBlocks() {
         assertRanges(maxBlockSize, List.of(
                 new ByteRange(Integer.MAX_VALUE - 10L, 20)
         ), Set.of(
                 new ByteRange(0, Integer.MAX_VALUE),
-                new ByteRange(Integer.MAX_VALUE, Integer.MAX_VALUE),
-                new ByteRange(Integer.MAX_VALUE - 10L, 20)
+                new ByteRange(Integer.MAX_VALUE, Integer.MAX_VALUE)
         ));
         assertRanges(kilobyteBlockSize, List.of(
                 new ByteRange(990, 1020)
         ), Set.of(
                 new ByteRange(0, 1000),
                 new ByteRange(1000, 1000),
-                new ByteRange(2000, 1000),
-                new ByteRange(990, 1020)
+                new ByteRange(2000, 1000)
         ));
     }
 


### PR DESCRIPTION
A file related to a single batch might be split into several blocks by the selected KeyAlignmentStrategy. In case of FixedBlockAlignment, if the file is bigger than the block size, it will be split into two or more files. With these changes it's now possible to re-assemble all the records related to that batch.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
