### PR TITLE
Adjust FileExtent range length in FileFetchJob [INK-140]

### DIFF
--- a/storage/inkless/src/main/java/io/aiven/inkless/consume/FileFetchJob.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/consume/FileFetchJob.java
@@ -45,7 +45,7 @@ public class FileFetchJob implements Callable<FileExtent> {
                 .setObject(object.value())
                 .setRange(new FileExtent.ByteRange()
                         .setOffset(byteRange.offset())
-                        .setLength(byteRange.size()))
+                        .setLength(buffer.limit()))
                 .setData(buffer.array());
     }
 


### PR DESCRIPTION
FileExtent created from FileFetchJob should take into account that its range it's bounded by the underlying buffer, which could be shorter than the range requested in the fetch job.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
