### PR TITLE
refactor(inkless:produce): move req-ids to commit requests [INK-127]

### DIFF
--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/CommitBatchRequest.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/CommitBatchRequest.java
@@ -5,7 +5,8 @@ import org.apache.kafka.common.TopicIdPartition;
 import org.apache.kafka.common.record.RecordBatch;
 import org.apache.kafka.common.record.TimestampType;
 
-public record CommitBatchRequest(TopicIdPartition topicIdPartition,
+public record CommitBatchRequest(int requestId,
+                                 TopicIdPartition topicIdPartition,
                                  int byteOffset,
                                  int size,
                                  long baseOffset,
@@ -18,11 +19,13 @@ public record CommitBatchRequest(TopicIdPartition topicIdPartition,
                                  int lastSequence) {
 
     public static CommitBatchRequest of(
+        int requestId,
         TopicIdPartition topicIdPartition,
         int byteOffset,
         RecordBatch batch
     ) {
         return new CommitBatchRequest(
+            requestId,
             topicIdPartition,
             byteOffset,
             batch.sizeInBytes(),
@@ -35,6 +38,7 @@ public record CommitBatchRequest(TopicIdPartition topicIdPartition,
 
     // Accessible for testing
     public static CommitBatchRequest of(
+        int requestId,
         TopicIdPartition topicIdPartition,
         int byteOffset,
         int size,
@@ -43,12 +47,14 @@ public record CommitBatchRequest(TopicIdPartition topicIdPartition,
         long batchMaxTimestamp,
         TimestampType messageTimestampType
     ) {
-        return new CommitBatchRequest(topicIdPartition, byteOffset, size, baseOffset, lastOffset, batchMaxTimestamp, messageTimestampType,
+        return new CommitBatchRequest(
+            requestId, topicIdPartition, byteOffset, size, baseOffset, lastOffset, batchMaxTimestamp, messageTimestampType,
             RecordBatch.NO_PRODUCER_ID, RecordBatch.NO_PRODUCER_EPOCH, RecordBatch.NO_SEQUENCE, RecordBatch.NO_SEQUENCE);
     }
 
     // Visible for testing
     public static CommitBatchRequest idempotent(
+        int requestId,
         TopicIdPartition topicIdPartition,
         int byteOffset,
         int size,
@@ -61,7 +67,7 @@ public record CommitBatchRequest(TopicIdPartition topicIdPartition,
         int baseSequence,
         int lastSequence
     ) {
-        return new CommitBatchRequest(topicIdPartition, byteOffset, size, baseOffset, lastOffset, batchMaxTimestamp, messageTimestampType,
+        return new CommitBatchRequest(requestId, topicIdPartition, byteOffset, size, baseOffset, lastOffset, batchMaxTimestamp, messageTimestampType,
             producerId, producerEpoch, baseSequence, lastSequence);
     }
 

--- a/storage/inkless/src/main/java/io/aiven/inkless/produce/ActiveFile.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/produce/ActiveFile.java
@@ -108,7 +108,6 @@ class ActiveFile {
             originalRequests,
             awaitingFuturesByRequest,
             closeResult.commitBatchRequests(),
-            closeResult.requestIds(),
             closeResult.data()
         );
     }

--- a/storage/inkless/src/main/java/io/aiven/inkless/produce/BatchBuffer.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/produce/BatchBuffer.java
@@ -45,21 +45,20 @@ class BatchBuffer {
         final ByteBuffer byteBuffer = ByteBuffer.allocate(totalSize);
 
         final List<CommitBatchRequest> commitBatchRequests = new ArrayList<>();
-        final List<Integer> requestIds = new ArrayList<>();
         for (final BatchHolder batchHolder : batches) {
             commitBatchRequests.add(
                 CommitBatchRequest.of(
+                    batchHolder.requestId,
                     batchHolder.topicIdPartition(),
                     byteBuffer.position(),
                     batchHolder.batch
                 )
             );
-            requestIds.add(batchHolder.requestId);
             batchHolder.batch.writeTo(byteBuffer);
         }
 
         closed = true;
-        return new CloseResult(commitBatchRequests, requestIds, byteBuffer.array());
+        return new CloseResult(commitBatchRequests, byteBuffer.array());
     }
 
     int totalSize() {
@@ -75,10 +74,8 @@ class BatchBuffer {
      * The result of closing a batch buffer.
      *
      * @param commitBatchRequests commit batch requests matching in order the batches in {@code data}.
-     * @param requestIds          produce request IDs matching in order the batches in {@code data}.
      */
     record CloseResult(List<CommitBatchRequest> commitBatchRequests,
-                       List<Integer> requestIds,
                        byte[] data) {
     }
 }

--- a/storage/inkless/src/main/java/io/aiven/inkless/produce/ClosedFile.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/produce/ClosedFile.java
@@ -18,23 +18,16 @@ record ClosedFile(Instant start,
                   Map<Integer, Map<TopicIdPartition, MemoryRecords>> originalRequests,
                   Map<Integer, CompletableFuture<Map<TopicPartition, PartitionResponse>>> awaitingFuturesByRequest,
                   List<CommitBatchRequest> commitBatchRequests,
-                  List<Integer> requestIds,
                   byte[] data) {
     ClosedFile {
         Objects.requireNonNull(start, "start cannot be null");
         Objects.requireNonNull(originalRequests, "originalRequests cannot be null");
         Objects.requireNonNull(awaitingFuturesByRequest, "awaitingFuturesByRequest cannot be null");
         Objects.requireNonNull(commitBatchRequests, "commitBatchRequests cannot be null");
-        Objects.requireNonNull(requestIds, "requestIds cannot be null");
 
         if (originalRequests.size() != awaitingFuturesByRequest.size()) {
             throw new IllegalArgumentException(
                 "originalRequests and awaitingFuturesByRequest must be of same size");
-        }
-
-        if (commitBatchRequests.size() != requestIds.size()) {
-            throw new IllegalArgumentException(
-                "commitBatchRequests and requestIds must be of same size");
         }
 
         Objects.requireNonNull(data, "data cannot be null");

--- a/storage/inkless/src/main/java/io/aiven/inkless/produce/FileCommitJob.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/produce/FileCommitJob.java
@@ -107,10 +107,8 @@ class FileCommitJob implements Runnable {
             .collect(Collectors.toMap(Map.Entry::getKey, ignore -> new HashMap<>()));
 
         for (int i = 0; i < commitBatchResponses.size(); i++) {
-            final int requestId = file.requestIds().get(i);
-            final var result = resultsPerRequest.computeIfAbsent(requestId, ignore -> new HashMap<>());
-
             final var commitBatchRequest = file.commitBatchRequests().get(i);
+            final var result = resultsPerRequest.computeIfAbsent(commitBatchRequest.requestId(), ignore -> new HashMap<>());
             final var commitBatchResponse = commitBatchResponses.get(i);
 
             result.put(

--- a/storage/inkless/src/test/java/io/aiven/inkless/control_plane/AbstractControlPlaneTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/control_plane/AbstractControlPlaneTest.java
@@ -98,16 +98,16 @@ public abstract class AbstractControlPlaneTest {
         final String objectKey1 = "a1";
         final String objectKey2 = "a2";
 
-        final CommitBatchRequest successfulRequest1 = CommitBatchRequest.of(new TopicIdPartition(EXISTING_TOPIC_1_ID, 0, EXISTING_TOPIC_1), 1, 10, 1, 10, 1000, TimestampType.CREATE_TIME);
+        final CommitBatchRequest successfulRequest1 = CommitBatchRequest.of(0, new TopicIdPartition(EXISTING_TOPIC_1_ID, 0, EXISTING_TOPIC_1), 1, 10, 1, 10, 1000, TimestampType.CREATE_TIME);
         final List<CommitBatchResponse> commitResponse1 = controlPlane.commitFile(
             objectKey1, BROKER_ID,
             FILE_SIZE,
             List.of(
                 successfulRequest1,
                 // non-existing partition
-                CommitBatchRequest.of(new TopicIdPartition(EXISTING_TOPIC_1_ID, EXISTING_TOPIC_1_PARTITIONS + 1, EXISTING_TOPIC_1), 2, 10, 1, 10, 1000, TimestampType.CREATE_TIME),
+                CommitBatchRequest.of(0, new TopicIdPartition(EXISTING_TOPIC_1_ID, EXISTING_TOPIC_1_PARTITIONS + 1, EXISTING_TOPIC_1), 2, 10, 1, 10, 1000, TimestampType.CREATE_TIME),
                 // non-existing topic
-                CommitBatchRequest.of(new TopicIdPartition(NONEXISTENT_TOPIC_ID, 0, NONEXISTENT_TOPIC), 3, 10, 1, 10, 1000, TimestampType.CREATE_TIME)
+                CommitBatchRequest.of(0, new TopicIdPartition(NONEXISTENT_TOPIC_ID, 0, NONEXISTENT_TOPIC), 3, 10, 1, 10, 1000, TimestampType.CREATE_TIME)
             )
         );
         assertThat(commitResponse1).containsExactly(
@@ -116,14 +116,14 @@ public abstract class AbstractControlPlaneTest {
             CommitBatchResponse.of(Errors.UNKNOWN_TOPIC_OR_PARTITION, -1, -1, -1)
         );
 
-        final CommitBatchRequest successfulRequest2 = CommitBatchRequest.of(new TopicIdPartition(EXISTING_TOPIC_1_ID, 0, EXISTING_TOPIC_1), 100, 10, 1, 10, 1000, TimestampType.CREATE_TIME);
+        final CommitBatchRequest successfulRequest2 = CommitBatchRequest.of(0, new TopicIdPartition(EXISTING_TOPIC_1_ID, 0, EXISTING_TOPIC_1), 100, 10, 1, 10, 1000, TimestampType.CREATE_TIME);
         final List<CommitBatchResponse> commitResponse2 = controlPlane.commitFile(
             objectKey2, BROKER_ID,
             FILE_SIZE,
             List.of(
                 successfulRequest2,
-                CommitBatchRequest.of(new TopicIdPartition(EXISTING_TOPIC_1_ID, EXISTING_TOPIC_1_PARTITIONS + 1, EXISTING_TOPIC_1), 200, 10, 1, 10, 2000, TimestampType.CREATE_TIME),
-                CommitBatchRequest.of(new TopicIdPartition(NONEXISTENT_TOPIC_ID, 0, NONEXISTENT_TOPIC), 300, 10, 1, 10, 3000, TimestampType.CREATE_TIME)
+                CommitBatchRequest.of(0, new TopicIdPartition(EXISTING_TOPIC_1_ID, EXISTING_TOPIC_1_PARTITIONS + 1, EXISTING_TOPIC_1), 200, 10, 1, 10, 2000, TimestampType.CREATE_TIME),
+                CommitBatchRequest.of(0, new TopicIdPartition(NONEXISTENT_TOPIC_ID, 0, NONEXISTENT_TOPIC), 300, 10, 1, 10, 3000, TimestampType.CREATE_TIME)
             )
         );
         assertThat(commitResponse2).containsExactly(
@@ -155,10 +155,10 @@ public abstract class AbstractControlPlaneTest {
         final int numberOfRecordsInBatch1 = 3;
         final int numberOfRecordsInBatch2 = 2;
         controlPlane.commitFile(objectKey1, BROKER_ID, FILE_SIZE,
-            List.of(CommitBatchRequest.of(new TopicIdPartition(EXISTING_TOPIC_1_ID, 0, EXISTING_TOPIC_1), 1, 10, 0, numberOfRecordsInBatch1 - 1, 1000, TimestampType.CREATE_TIME)));
+            List.of(CommitBatchRequest.of(0, new TopicIdPartition(EXISTING_TOPIC_1_ID, 0, EXISTING_TOPIC_1), 1, 10, 0, numberOfRecordsInBatch1 - 1, 1000, TimestampType.CREATE_TIME)));
         final int lastOffset = numberOfRecordsInBatch1 + numberOfRecordsInBatch2 - 1;
         controlPlane.commitFile(objectKey2, BROKER_ID, FILE_SIZE,
-            List.of(CommitBatchRequest.of(new TopicIdPartition(EXISTING_TOPIC_1_ID, 0, EXISTING_TOPIC_1), 100, 10, numberOfRecordsInBatch1, lastOffset, 2000, TimestampType.CREATE_TIME)));
+            List.of(CommitBatchRequest.of(0, new TopicIdPartition(EXISTING_TOPIC_1_ID, 0, EXISTING_TOPIC_1), 100, 10, numberOfRecordsInBatch1, lastOffset, 2000, TimestampType.CREATE_TIME)));
 
         final long expectedLogStartOffset = 0;
         final long expectedHighWatermark = numberOfRecordsInBatch1 + numberOfRecordsInBatch2;
@@ -192,7 +192,7 @@ public abstract class AbstractControlPlaneTest {
         controlPlane.commitFile(
             objectKey, BROKER_ID, FILE_SIZE,
             List.of(
-                CommitBatchRequest.of(new TopicIdPartition(EXISTING_TOPIC_1_ID, 0, EXISTING_TOPIC_1), 11, 10, 1, 10, 1000, TimestampType.CREATE_TIME)
+                CommitBatchRequest.of(0, new TopicIdPartition(EXISTING_TOPIC_1_ID, 0, EXISTING_TOPIC_1), 11, 10, 1, 10, 1000, TimestampType.CREATE_TIME)
             )
         );
 
@@ -212,7 +212,7 @@ public abstract class AbstractControlPlaneTest {
         controlPlane.commitFile(
             objectKey, BROKER_ID, FILE_SIZE,
             List.of(
-                CommitBatchRequest.of(new TopicIdPartition(EXISTING_TOPIC_1_ID, 0, EXISTING_TOPIC_1), 11, 10, 1, 10, 1000, TimestampType.CREATE_TIME)
+                CommitBatchRequest.of(0, new TopicIdPartition(EXISTING_TOPIC_1_ID, 0, EXISTING_TOPIC_1), 11, 10, 1, 10, 1000, TimestampType.CREATE_TIME)
             )
         );
 
@@ -231,7 +231,7 @@ public abstract class AbstractControlPlaneTest {
         controlPlane.commitFile(
             objectKey, BROKER_ID, FILE_SIZE,
             List.of(
-                CommitBatchRequest.of(new TopicIdPartition(EXISTING_TOPIC_1_ID, 0, EXISTING_TOPIC_1), 11, 10, 1, 10, 1000, TimestampType.CREATE_TIME)
+                CommitBatchRequest.of(0, new TopicIdPartition(EXISTING_TOPIC_1_ID, 0, EXISTING_TOPIC_1), 11, 10, 1, 10, 1000, TimestampType.CREATE_TIME)
             )
         );
 
@@ -259,8 +259,8 @@ public abstract class AbstractControlPlaneTest {
 
         assertThatThrownBy(() -> controlPlane.commitFile(objectKey, BROKER_ID, FILE_SIZE,
             List.of(
-                CommitBatchRequest.of(new TopicIdPartition(EXISTING_TOPIC_1_ID, 0, EXISTING_TOPIC_1), 1, 10, 10, 19, 1000, TimestampType.CREATE_TIME),
-                CommitBatchRequest.of(new TopicIdPartition(EXISTING_TOPIC_1_ID, 1, EXISTING_TOPIC_1), 2, 0, 10, 19, 1000, TimestampType.CREATE_TIME)
+                CommitBatchRequest.of(0, new TopicIdPartition(EXISTING_TOPIC_1_ID, 0, EXISTING_TOPIC_1), 1, 10, 10, 19, 1000, TimestampType.CREATE_TIME),
+                CommitBatchRequest.of(0, new TopicIdPartition(EXISTING_TOPIC_1_ID, 1, EXISTING_TOPIC_1), 2, 0, 10, 19, 1000, TimestampType.CREATE_TIME)
             )
         ))
             .isInstanceOf(IllegalArgumentException.class)
@@ -282,7 +282,7 @@ public abstract class AbstractControlPlaneTest {
         final String objectKey = "a1";
         controlPlane.commitFile(objectKey, BROKER_ID, FILE_SIZE,
             List.of(
-                CommitBatchRequest.of(new TopicIdPartition(newTopic1Id, 0, newTopic1Name), 1, (int) FILE_SIZE, 0, 0, 1000, TimestampType.CREATE_TIME)
+                CommitBatchRequest.of(0, new TopicIdPartition(newTopic1Id, 0, newTopic1Name), 1, (int) FILE_SIZE, 0, 0, 1000, TimestampType.CREATE_TIME)
             ));
 
         final List<FindBatchRequest> findBatchRequests = List.of(new FindBatchRequest(new TopicIdPartition(newTopic1Id, 0, newTopic1Name), 0, Integer.MAX_VALUE));
@@ -314,14 +314,14 @@ public abstract class AbstractControlPlaneTest {
 
         controlPlane.commitFile(objectKey1, BROKER_ID, FILE_SIZE,
             List.of(
-                CommitBatchRequest.of(new TopicIdPartition(EXISTING_TOPIC_1_ID, 0, EXISTING_TOPIC_1), 1, (int) FILE_SIZE, 0, 0, 1000, TimestampType.CREATE_TIME)
+                CommitBatchRequest.of(0, new TopicIdPartition(EXISTING_TOPIC_1_ID, 0, EXISTING_TOPIC_1), 1, (int) FILE_SIZE, 0, 0, 1000, TimestampType.CREATE_TIME)
             ));
         final int file2Partition0Size = (int) FILE_SIZE / 2;
         final int file2Partition1Size = (int) FILE_SIZE - file2Partition0Size;
         controlPlane.commitFile(objectKey2, BROKER_ID, FILE_SIZE,
             List.of(
-                CommitBatchRequest.of(new TopicIdPartition(EXISTING_TOPIC_1_ID, 0, EXISTING_TOPIC_1), 1, file2Partition0Size, 0, 0, 1000, TimestampType.CREATE_TIME),
-                CommitBatchRequest.of(new TopicIdPartition(EXISTING_TOPIC_2_ID, 0, EXISTING_TOPIC_2), 1, file2Partition1Size, 1, 1, 2000, TimestampType.CREATE_TIME)
+                CommitBatchRequest.of(0, new TopicIdPartition(EXISTING_TOPIC_1_ID, 0, EXISTING_TOPIC_1), 1, file2Partition0Size, 0, 0, 1000, TimestampType.CREATE_TIME),
+                CommitBatchRequest.of(0, new TopicIdPartition(EXISTING_TOPIC_2_ID, 0, EXISTING_TOPIC_2), 1, file2Partition1Size, 1, 1, 2000, TimestampType.CREATE_TIME)
             ));
 
         final List<FindBatchRequest> findBatchRequests = List.of(new FindBatchRequest(EXISTING_TOPIC_2_ID_PARTITION_0, 0, Integer.MAX_VALUE));
@@ -352,7 +352,7 @@ public abstract class AbstractControlPlaneTest {
         controlPlane.commitFile(
             objectKey1, BROKER_ID, FILE_SIZE,
             List.of(
-                CommitBatchRequest.of(EXISTING_TOPIC_1_ID_PARTITION_0, 1, (int) FILE_SIZE, 1, 10, 1000, TimestampType.CREATE_TIME)
+                CommitBatchRequest.of(0, EXISTING_TOPIC_1_ID_PARTITION_0, 1, (int) FILE_SIZE, 1, 10, 1000, TimestampType.CREATE_TIME)
             )
         );
 
@@ -386,19 +386,19 @@ public abstract class AbstractControlPlaneTest {
         controlPlane.commitFile(
             objectKey1, BROKER_ID, FILE_SIZE,
             List.of(
-                CommitBatchRequest.of(EXISTING_TOPIC_1_ID_PARTITION_0, 1, (int) FILE_SIZE, 1, 10, 1000, TimestampType.CREATE_TIME)
+                CommitBatchRequest.of(0, EXISTING_TOPIC_1_ID_PARTITION_0, 1, (int) FILE_SIZE, 1, 10, 1000, TimestampType.CREATE_TIME)
             )
         );
         controlPlane.commitFile(
             objectKey2, BROKER_ID, FILE_SIZE,
             List.of(
-                CommitBatchRequest.of(EXISTING_TOPIC_1_ID_PARTITION_0, 2, (int) FILE_SIZE, 1, 10, 2000, TimestampType.CREATE_TIME)
+                CommitBatchRequest.of(0, EXISTING_TOPIC_1_ID_PARTITION_0, 2, (int) FILE_SIZE, 1, 10, 2000, TimestampType.CREATE_TIME)
             )
         );
         controlPlane.commitFile(
             objectKey3, BROKER_ID, FILE_SIZE,
             List.of(
-                CommitBatchRequest.of(EXISTING_TOPIC_1_ID_PARTITION_0, 3, (int) FILE_SIZE, 1, 10, 3000, TimestampType.CREATE_TIME)
+                CommitBatchRequest.of(0, EXISTING_TOPIC_1_ID_PARTITION_0, 3, (int) FILE_SIZE, 1, 10, 3000, TimestampType.CREATE_TIME)
             )
         );
 
@@ -435,7 +435,7 @@ public abstract class AbstractControlPlaneTest {
         controlPlane.commitFile(
             objectKey1, BROKER_ID, FILE_SIZE,
             List.of(
-                CommitBatchRequest.of(EXISTING_TOPIC_1_ID_PARTITION_0, 1, (int) FILE_SIZE, 1, 10, 1000, TimestampType.CREATE_TIME)
+                CommitBatchRequest.of(0, EXISTING_TOPIC_1_ID_PARTITION_0, 1, (int) FILE_SIZE, 1, 10, 1000, TimestampType.CREATE_TIME)
             )
         );
 
@@ -463,7 +463,7 @@ public abstract class AbstractControlPlaneTest {
         controlPlane.commitFile(
             objectKey1, BROKER_ID, FILE_SIZE,
             List.of(
-                CommitBatchRequest.of(EXISTING_TOPIC_1_ID_PARTITION_0, 1, (int) FILE_SIZE, 1, 10, 1000, TimestampType.CREATE_TIME)
+                CommitBatchRequest.of(0, EXISTING_TOPIC_1_ID_PARTITION_0, 1, (int) FILE_SIZE, 1, 10, 1000, TimestampType.CREATE_TIME)
             )
         );
 
@@ -491,7 +491,7 @@ public abstract class AbstractControlPlaneTest {
         controlPlane.commitFile(
             objectKey1, BROKER_ID, FILE_SIZE,
             List.of(
-                CommitBatchRequest.of(EXISTING_TOPIC_1_ID_PARTITION_0, 1, (int) FILE_SIZE, 1, 10, 1000, TimestampType.CREATE_TIME)
+                CommitBatchRequest.of(0, EXISTING_TOPIC_1_ID_PARTITION_0, 1, (int) FILE_SIZE, 1, 10, 1000, TimestampType.CREATE_TIME)
             )
         );
 
@@ -521,9 +521,9 @@ public abstract class AbstractControlPlaneTest {
         controlPlane.commitFile(
             objectKey1, BROKER_ID, FILE_SIZE,
             List.of(
-                CommitBatchRequest.of(EXISTING_TOPIC_1_ID_PARTITION_0, 1, tp0BatchSize, 1, 10, 1000, TimestampType.CREATE_TIME),
+                CommitBatchRequest.of(0, EXISTING_TOPIC_1_ID_PARTITION_0, 1, tp0BatchSize, 1, 10, 1000, TimestampType.CREATE_TIME),
                 // This batch will keep the file alive after the other batch is deleted.
-                CommitBatchRequest.of(EXISTING_TOPIC_1_ID_PARTITION_1, 100, tp1BatchSize, 1, 2, 2000, TimestampType.CREATE_TIME)
+                CommitBatchRequest.of(0, EXISTING_TOPIC_1_ID_PARTITION_1, 100, tp1BatchSize, 1, 2, 2000, TimestampType.CREATE_TIME)
             )
         );
 
@@ -549,14 +549,14 @@ public abstract class AbstractControlPlaneTest {
 
         controlPlane.commitFile(objectKey1, BROKER_ID, FILE_SIZE,
             List.of(
-                CommitBatchRequest.of(new TopicIdPartition(EXISTING_TOPIC_1_ID, 0, EXISTING_TOPIC_1), 1, (int) FILE_SIZE, 0, 0, 1000, TimestampType.CREATE_TIME)
+                CommitBatchRequest.of(0, new TopicIdPartition(EXISTING_TOPIC_1_ID, 0, EXISTING_TOPIC_1), 1, (int) FILE_SIZE, 0, 0, 1000, TimestampType.CREATE_TIME)
             ));
         final int file2Partition0Size = (int) FILE_SIZE / 2;
         final int file2Partition1Size = (int) FILE_SIZE - file2Partition0Size;
         controlPlane.commitFile(objectKey2, BROKER_ID, FILE_SIZE,
             List.of(
-                CommitBatchRequest.of(new TopicIdPartition(EXISTING_TOPIC_1_ID, 0, EXISTING_TOPIC_1), 1, file2Partition0Size, 0, 0, 1000, TimestampType.CREATE_TIME),
-                CommitBatchRequest.of(new TopicIdPartition(EXISTING_TOPIC_2_ID, 0, EXISTING_TOPIC_2), 1, file2Partition1Size, 1, 1, 2000, TimestampType.CREATE_TIME)
+                CommitBatchRequest.of(0, new TopicIdPartition(EXISTING_TOPIC_1_ID, 0, EXISTING_TOPIC_1), 1, file2Partition0Size, 0, 0, 1000, TimestampType.CREATE_TIME),
+                CommitBatchRequest.of(0, new TopicIdPartition(EXISTING_TOPIC_2_ID, 0, EXISTING_TOPIC_2), 1, file2Partition1Size, 1, 1, 2000, TimestampType.CREATE_TIME)
             ));
 
         time.sleep(1001);  // advance time
@@ -586,7 +586,7 @@ public abstract class AbstractControlPlaneTest {
             final long fileSize = FILE_MERGE_SIZE_THRESHOLD / 10;
             for (int i = 0; i < 5; i++) {
                 controlPlane.commitFile(String.format("obj%d", i), i, fileSize,
-                    List.of(CommitBatchRequest.of(EXISTING_TOPIC_1_ID_PARTITION_0, 0, (int) fileSize, 0, 100, 1000, TimestampType.CREATE_TIME))
+                    List.of(CommitBatchRequest.of(0, EXISTING_TOPIC_1_ID_PARTITION_0, 0, (int) fileSize, 0, 100, 1000, TimestampType.CREATE_TIME))
                 );
             }
 
@@ -600,9 +600,9 @@ public abstract class AbstractControlPlaneTest {
             final long fileSize = FILE_MERGE_SIZE_THRESHOLD / 2;
             final long committedAt = time.milliseconds();
             controlPlane.commitFile("obj0", 1, fileSize,
-                List.of(CommitBatchRequest.of(EXISTING_TOPIC_1_ID_PARTITION_0, 0, (int) fileSize, 0, 100, 1000, TimestampType.CREATE_TIME)));
+                List.of(CommitBatchRequest.of(0, EXISTING_TOPIC_1_ID_PARTITION_0, 0, (int) fileSize, 0, 100, 1000, TimestampType.CREATE_TIME)));
             controlPlane.commitFile("obj1", 2, fileSize,
-                List.of(CommitBatchRequest.of(EXISTING_TOPIC_1_ID_PARTITION_0, 0, (int) fileSize, 0, 100, 2000, TimestampType.CREATE_TIME)));
+                List.of(CommitBatchRequest.of(0, EXISTING_TOPIC_1_ID_PARTITION_0, 0, (int) fileSize, 0, 100, 2000, TimestampType.CREATE_TIME)));
 
             final List<FileMergeWorkItem.File> expectedFiles = List.of(
                 new FileMergeWorkItem.File(1L, "obj0", fileSize, fileSize,
@@ -630,11 +630,11 @@ public abstract class AbstractControlPlaneTest {
             final long committedAt = time.milliseconds();
             // Commit 3 files, that's enough only for 1 merge work item.
             controlPlane.commitFile("obj0", 1, fileSize,
-                List.of(CommitBatchRequest.of(EXISTING_TOPIC_1_ID_PARTITION_0, 0, (int) fileSize, 0, 100, 1000, TimestampType.CREATE_TIME)));
+                List.of(CommitBatchRequest.of(0, EXISTING_TOPIC_1_ID_PARTITION_0, 0, (int) fileSize, 0, 100, 1000, TimestampType.CREATE_TIME)));
             controlPlane.commitFile("obj1", 2, fileSize,
-                List.of(CommitBatchRequest.of(EXISTING_TOPIC_1_ID_PARTITION_0, 0, (int) fileSize, 0, 100, 2000, TimestampType.CREATE_TIME)));
+                List.of(CommitBatchRequest.of(0, EXISTING_TOPIC_1_ID_PARTITION_0, 0, (int) fileSize, 0, 100, 2000, TimestampType.CREATE_TIME)));
             controlPlane.commitFile("obj2", 3, fileSize,
-                List.of(CommitBatchRequest.of(EXISTING_TOPIC_1_ID_PARTITION_0, 0, (int) fileSize, 0, 100, 3000, TimestampType.CREATE_TIME)));
+                List.of(CommitBatchRequest.of(0, EXISTING_TOPIC_1_ID_PARTITION_0, 0, (int) fileSize, 0, 100, 3000, TimestampType.CREATE_TIME)));
 
             // Get the merge work item.
             final List<FileMergeWorkItem.File> expectedFiles1 = List.of(
@@ -648,7 +648,7 @@ public abstract class AbstractControlPlaneTest {
 
             // Commit one more file.
             controlPlane.commitFile("obj3", 1, fileSize,
-                List.of(CommitBatchRequest.of(EXISTING_TOPIC_1_ID_PARTITION_0, 0, (int) fileSize, 0, 100, 4000, TimestampType.CREATE_TIME)));
+                List.of(CommitBatchRequest.of(0, EXISTING_TOPIC_1_ID_PARTITION_0, 0, (int) fileSize, 0, 100, 4000, TimestampType.CREATE_TIME)));
 
             // Now it's enough to have one more merge work item.
             final List<FileMergeWorkItem.File> expectedFiles2 = List.of(
@@ -667,7 +667,7 @@ public abstract class AbstractControlPlaneTest {
             final long fileSize = FILE_MERGE_SIZE_THRESHOLD;
             final long committedAt = time.milliseconds();
             controlPlane.commitFile("obj0", 0, fileSize,
-                List.of(CommitBatchRequest.of(EXISTING_TOPIC_1_ID_PARTITION_0, 0, (int) fileSize, 0, 100, 1000, TimestampType.CREATE_TIME)));
+                List.of(CommitBatchRequest.of(0, EXISTING_TOPIC_1_ID_PARTITION_0, 0, (int) fileSize, 0, 100, 1000, TimestampType.CREATE_TIME)));
 
             final List<FileMergeWorkItem.File> expectedFiles = List.of(
                 new FileMergeWorkItem.File(1L, "obj0", fileSize, fileSize,
@@ -683,11 +683,11 @@ public abstract class AbstractControlPlaneTest {
             final long committedAt = time.milliseconds();
             // Commit 3 files, that's enough for 1 merge work items.
             controlPlane.commitFile("obj0", 1, batchSize,
-                List.of(CommitBatchRequest.of(EXISTING_TOPIC_1_ID_PARTITION_0, 0, (int) batchSize, 0, 100, 1000, TimestampType.CREATE_TIME)));
+                List.of(CommitBatchRequest.of(0, EXISTING_TOPIC_1_ID_PARTITION_0, 0, (int) batchSize, 0, 100, 1000, TimestampType.CREATE_TIME)));
             controlPlane.commitFile("obj1", 2, batchSize,
-                List.of(CommitBatchRequest.of(EXISTING_TOPIC_1_ID_PARTITION_0, 0, (int) batchSize, 0, 100, 2000, TimestampType.CREATE_TIME)));
+                List.of(CommitBatchRequest.of(0, EXISTING_TOPIC_1_ID_PARTITION_0, 0, (int) batchSize, 0, 100, 2000, TimestampType.CREATE_TIME)));
             controlPlane.commitFile("obj2", 3, batchSize,
-                List.of(CommitBatchRequest.of(EXISTING_TOPIC_1_ID_PARTITION_0, 0, (int) batchSize, 0, 100, 3000, TimestampType.CREATE_TIME)));
+                List.of(CommitBatchRequest.of(0, EXISTING_TOPIC_1_ID_PARTITION_0, 0, (int) batchSize, 0, 100, 3000, TimestampType.CREATE_TIME)));
 
             final List<FileMergeWorkItem.File> expectedFiles1 = List.of(
                 new FileMergeWorkItem.File(1L, "obj0", batchSize, batchSize,
@@ -711,7 +711,7 @@ public abstract class AbstractControlPlaneTest {
 
             // Commit more files and try merging again.
             controlPlane.commitFile("obj3", 1, batchSize,
-                List.of(CommitBatchRequest.of(EXISTING_TOPIC_1_ID_PARTITION_0, 0, (int) batchSize, 0, 100, 4000, TimestampType.CREATE_TIME)));
+                List.of(CommitBatchRequest.of(0, EXISTING_TOPIC_1_ID_PARTITION_0, 0, (int) batchSize, 0, 100, 4000, TimestampType.CREATE_TIME)));
 
             // File 4 is the merged file, batches 4 and 5 are in it.
             final List<FileMergeWorkItem.File> expectedFiles2= List.of(
@@ -727,7 +727,7 @@ public abstract class AbstractControlPlaneTest {
 
     @Test
     void testCommitDuplicates() {
-        final CommitBatchRequest request = CommitBatchRequest.idempotent(EXISTING_TOPIC_1_ID_PARTITION_0, 1, 10, 10, 19, time.milliseconds(), TimestampType.CREATE_TIME, 1L, (short) 3, 0, 9);
+        final CommitBatchRequest request = CommitBatchRequest.idempotent(0, EXISTING_TOPIC_1_ID_PARTITION_0, 1, 10, 10, 19, time.milliseconds(), TimestampType.CREATE_TIME, 1L, (short) 3, 0, 9);
         final CommitBatchResponse response = controlPlane.commitFile("a", BROKER_ID, FILE_SIZE, List.of(request)).get(0);
 
         assertThat(response)
@@ -754,7 +754,7 @@ public abstract class AbstractControlPlaneTest {
 
     @Test
     void testOutOfOrderNewEpoch() {
-        final CommitBatchRequest request = CommitBatchRequest.idempotent(EXISTING_TOPIC_1_ID_PARTITION_0, 1, 10, 10, 19, time.milliseconds(), TimestampType.CREATE_TIME, 1L, (short) 3, 1, 10);
+        final CommitBatchRequest request = CommitBatchRequest.idempotent(0, EXISTING_TOPIC_1_ID_PARTITION_0, 1, 10, 10, 19, time.milliseconds(), TimestampType.CREATE_TIME, 1L, (short) 3, 1, 10);
         final CommitBatchResponse response = controlPlane.commitFile("a", BROKER_ID, FILE_SIZE, List.of(request)).get(0);
 
         assertThat(response)
@@ -772,8 +772,8 @@ public abstract class AbstractControlPlaneTest {
     })
         // 15 is the first sequence number for the second batch
     void testOutOfOrderSequence(final int lastSeq, final int nextSeq) {
-        final CommitBatchRequest request0 = CommitBatchRequest.idempotent(EXISTING_TOPIC_1_ID_PARTITION_0, 1, 10, 0, 10, time.milliseconds(), TimestampType.CREATE_TIME, 1L, (short) 3, 0, lastSeq);
-        final CommitBatchRequest request1 = CommitBatchRequest.idempotent(EXISTING_TOPIC_1_ID_PARTITION_0, 2, 10, 0, 20, time.milliseconds(), TimestampType.CREATE_TIME, 1L, (short) 3, nextSeq, nextSeq + 10);
+        final CommitBatchRequest request0 = CommitBatchRequest.idempotent(0, EXISTING_TOPIC_1_ID_PARTITION_0, 1, 10, 0, 10, time.milliseconds(), TimestampType.CREATE_TIME, 1L, (short) 3, 0, lastSeq);
+        final CommitBatchRequest request1 = CommitBatchRequest.idempotent(0, EXISTING_TOPIC_1_ID_PARTITION_0, 2, 10, 0, 20, time.milliseconds(), TimestampType.CREATE_TIME, 1L, (short) 3, nextSeq, nextSeq + 10);
         final List<CommitBatchResponse> responses = controlPlane.commitFile("a", BROKER_ID, FILE_SIZE, List.of(request0, request1));
 
         assertThat(responses)
@@ -783,8 +783,8 @@ public abstract class AbstractControlPlaneTest {
 
     @Test
     void testInvalidProducerEpoch() {
-        final CommitBatchRequest request0 = CommitBatchRequest.idempotent(EXISTING_TOPIC_1_ID_PARTITION_0, 1, 10, 10, 24, time.milliseconds(), TimestampType.CREATE_TIME, 1L, (short) 3, 0, 14);
-        final CommitBatchRequest request1 = CommitBatchRequest.idempotent(EXISTING_TOPIC_1_ID_PARTITION_0, 2, 10, 25, 35, time.milliseconds(), TimestampType.CREATE_TIME, 1L, (short) 2, 15, 25);
+        final CommitBatchRequest request0 = CommitBatchRequest.idempotent(0, EXISTING_TOPIC_1_ID_PARTITION_0, 1, 10, 10, 24, time.milliseconds(), TimestampType.CREATE_TIME, 1L, (short) 3, 0, 14);
+        final CommitBatchRequest request1 = CommitBatchRequest.idempotent(0, EXISTING_TOPIC_1_ID_PARTITION_0, 2, 10, 25, 35, time.milliseconds(), TimestampType.CREATE_TIME, 1L, (short) 2, 15, 25);
         final List<CommitBatchResponse> responses = controlPlane.commitFile("a", BROKER_ID, FILE_SIZE, List.of(request0, request1));
 
         assertThat(responses)
@@ -809,9 +809,9 @@ public abstract class AbstractControlPlaneTest {
         void batchWithoutParents() {
             final long fileSize = FILE_MERGE_SIZE_THRESHOLD / 2;
             controlPlane.commitFile("obj0", 1, fileSize,
-                List.of(CommitBatchRequest.of(EXISTING_TOPIC_1_ID_PARTITION_0, 0, (int) fileSize, 0, 100, 1000, TimestampType.CREATE_TIME)));
+                List.of(CommitBatchRequest.of(0, EXISTING_TOPIC_1_ID_PARTITION_0, 0, (int) fileSize, 0, 100, 1000, TimestampType.CREATE_TIME)));
             controlPlane.commitFile("obj1", 2, fileSize,
-                List.of(CommitBatchRequest.of(EXISTING_TOPIC_1_ID_PARTITION_0, 0, (int) fileSize, 0, 100, 2000, TimestampType.CREATE_TIME)));
+                List.of(CommitBatchRequest.of(0, EXISTING_TOPIC_1_ID_PARTITION_0, 0, (int) fileSize, 0, 100, 2000, TimestampType.CREATE_TIME)));
 
             final var workItemId = controlPlane.getFileMergeWorkItem().workItemId();
 
@@ -829,9 +829,9 @@ public abstract class AbstractControlPlaneTest {
         void batchWithTooManyParents() {
             final long fileSize = FILE_MERGE_SIZE_THRESHOLD / 2;
             controlPlane.commitFile("obj0", 1, fileSize,
-                List.of(CommitBatchRequest.of(EXISTING_TOPIC_1_ID_PARTITION_0, 0, (int) fileSize, 0, 100, 1000, TimestampType.CREATE_TIME)));
+                List.of(CommitBatchRequest.of(0, EXISTING_TOPIC_1_ID_PARTITION_0, 0, (int) fileSize, 0, 100, 1000, TimestampType.CREATE_TIME)));
             controlPlane.commitFile("obj1", 2, fileSize,
-                List.of(CommitBatchRequest.of(EXISTING_TOPIC_1_ID_PARTITION_0, 0, (int) fileSize, 0, 100, 2000, TimestampType.CREATE_TIME)));
+                List.of(CommitBatchRequest.of(0, EXISTING_TOPIC_1_ID_PARTITION_0, 0, (int) fileSize, 0, 100, 2000, TimestampType.CREATE_TIME)));
 
             final var workItemId = controlPlane.getFileMergeWorkItem().workItemId();
 
@@ -850,11 +850,11 @@ public abstract class AbstractControlPlaneTest {
         void batchIsNotPartOfWorkItem() {
             final long fileSize = FILE_MERGE_SIZE_THRESHOLD / 2;
             controlPlane.commitFile("obj0", 1, fileSize,
-                List.of(CommitBatchRequest.of(EXISTING_TOPIC_1_ID_PARTITION_0, 0, (int) fileSize, 0, 100, 1000, TimestampType.CREATE_TIME)));
+                List.of(CommitBatchRequest.of(0, EXISTING_TOPIC_1_ID_PARTITION_0, 0, (int) fileSize, 0, 100, 1000, TimestampType.CREATE_TIME)));
             controlPlane.commitFile("obj1", 2, fileSize,
-                List.of(CommitBatchRequest.of(EXISTING_TOPIC_1_ID_PARTITION_0, 0, (int) fileSize, 0, 100, 2000, TimestampType.CREATE_TIME)));
+                List.of(CommitBatchRequest.of(0, EXISTING_TOPIC_1_ID_PARTITION_0, 0, (int) fileSize, 0, 100, 2000, TimestampType.CREATE_TIME)));
             controlPlane.commitFile("obj2", 3, fileSize,
-                List.of(CommitBatchRequest.of(EXISTING_TOPIC_1_ID_PARTITION_0, 0, (int) fileSize, 0, 100, 3000, TimestampType.CREATE_TIME)));
+                List.of(CommitBatchRequest.of(0, EXISTING_TOPIC_1_ID_PARTITION_0, 0, (int) fileSize, 0, 100, 3000, TimestampType.CREATE_TIME)));
 
             final FileMergeWorkItem fileMergeWorkItem = controlPlane.getFileMergeWorkItem();
             assertThat(fileMergeWorkItem.files()).hasSize(2);
@@ -888,15 +888,15 @@ public abstract class AbstractControlPlaneTest {
 
             final long committedAt = time.milliseconds();
             controlPlane.commitFile("obj1", 1, fileSize1,
-                List.of(CommitBatchRequest.of(EXISTING_TOPIC_1_ID_PARTITION_0, 0, file1Batch1Size, 0, 100, 1000, TimestampType.CREATE_TIME)));
+                List.of(CommitBatchRequest.of(0, EXISTING_TOPIC_1_ID_PARTITION_0, 0, file1Batch1Size, 0, 100, 1000, TimestampType.CREATE_TIME)));
             controlPlane.commitFile("obj2", 2, fileSize2,
                 List.of(
-                    CommitBatchRequest.of(EXISTING_TOPIC_1_ID_PARTITION_0, 0, file2Batch1Size, 0, 100, 2000, TimestampType.LOG_APPEND_TIME),
-                    CommitBatchRequest.of(EXISTING_TOPIC_1_ID_PARTITION_1, file2Batch1Size, file2Batch2Size, 0, 50, 3000, TimestampType.CREATE_TIME)
+                    CommitBatchRequest.of(0, EXISTING_TOPIC_1_ID_PARTITION_0, 0, file2Batch1Size, 0, 100, 2000, TimestampType.LOG_APPEND_TIME),
+                    CommitBatchRequest.of(0, EXISTING_TOPIC_1_ID_PARTITION_1, file2Batch1Size, file2Batch2Size, 0, 50, 3000, TimestampType.CREATE_TIME)
                 ));
             controlPlane.commitFile("obj3", 3, fileSize3,
                 List.of(
-                    CommitBatchRequest.of(EXISTING_TOPIC_1_ID_PARTITION_1, 0, file3Batch1Size, 0, 200, 4000, TimestampType.LOG_APPEND_TIME)
+                    CommitBatchRequest.of(0, EXISTING_TOPIC_1_ID_PARTITION_1, 0, file3Batch1Size, 0, 200, 4000, TimestampType.LOG_APPEND_TIME)
                 ));
 
             time.sleep(1);
@@ -959,15 +959,15 @@ public abstract class AbstractControlPlaneTest {
 
             final long committedAt = time.milliseconds();
             controlPlane.commitFile("obj1", 1, fileSize1,
-                List.of(CommitBatchRequest.of(EXISTING_TOPIC_1_ID_PARTITION_0, 0, file1Batch1Size, 0, 100, 1000, TimestampType.CREATE_TIME)));
+                List.of(CommitBatchRequest.of(0, EXISTING_TOPIC_1_ID_PARTITION_0, 0, file1Batch1Size, 0, 100, 1000, TimestampType.CREATE_TIME)));
             controlPlane.commitFile("obj2", 2, fileSize2,
                 List.of(
-                    CommitBatchRequest.of(EXISTING_TOPIC_1_ID_PARTITION_0, 0, file2Batch1Size, 0, 100, 2000, TimestampType.LOG_APPEND_TIME),
-                    CommitBatchRequest.of(EXISTING_TOPIC_2_ID_PARTITION_0, file2Batch1Size, file2Batch2Size, 0, 50, 3000, TimestampType.CREATE_TIME)
+                    CommitBatchRequest.of(0, EXISTING_TOPIC_1_ID_PARTITION_0, 0, file2Batch1Size, 0, 100, 2000, TimestampType.LOG_APPEND_TIME),
+                    CommitBatchRequest.of(0, EXISTING_TOPIC_2_ID_PARTITION_0, file2Batch1Size, file2Batch2Size, 0, 50, 3000, TimestampType.CREATE_TIME)
                 ));
             controlPlane.commitFile("obj3", 3, fileSize3,
                 List.of(
-                    CommitBatchRequest.of(EXISTING_TOPIC_2_ID_PARTITION_0, 0, file3Batch1Size, 0, 200, 4000, TimestampType.LOG_APPEND_TIME)
+                    CommitBatchRequest.of(0, EXISTING_TOPIC_2_ID_PARTITION_0, 0, file3Batch1Size, 0, 200, 4000, TimestampType.LOG_APPEND_TIME)
                 ));
 
             final var workItemId = controlPlane.getFileMergeWorkItem().workItemId();
@@ -1017,9 +1017,9 @@ public abstract class AbstractControlPlaneTest {
             final long fileSize = FILE_MERGE_SIZE_THRESHOLD / 2 + 1;
             final long committedAt = time.milliseconds();
             controlPlane.commitFile("obj1", 1, fileSize,
-                List.of(CommitBatchRequest.of(EXISTING_TOPIC_1_ID_PARTITION_0, 0, (int) fileSize, 0, 100, 1000, TimestampType.CREATE_TIME)));
+                List.of(CommitBatchRequest.of(0, EXISTING_TOPIC_1_ID_PARTITION_0, 0, (int) fileSize, 0, 100, 1000, TimestampType.CREATE_TIME)));
             controlPlane.commitFile("obj2", 3, fileSize,
-                List.of(CommitBatchRequest.of(EXISTING_TOPIC_1_ID_PARTITION_0, 0, (int) fileSize, 0, 200, 2000, TimestampType.LOG_APPEND_TIME)));
+                List.of(CommitBatchRequest.of(0, EXISTING_TOPIC_1_ID_PARTITION_0, 0, (int) fileSize, 0, 200, 2000, TimestampType.LOG_APPEND_TIME)));
 
             final var workItemId = controlPlane.getFileMergeWorkItem().workItemId();
 
@@ -1059,9 +1059,9 @@ public abstract class AbstractControlPlaneTest {
             final long fileSize = FILE_MERGE_SIZE_THRESHOLD / 2;
             final long committedAt = time.milliseconds();
             controlPlane.commitFile("obj1", 1, fileSize,
-                List.of(CommitBatchRequest.of(EXISTING_TOPIC_1_ID_PARTITION_0, 0, (int) fileSize, 0, 100, 1000, TimestampType.CREATE_TIME)));
+                List.of(CommitBatchRequest.of(0, EXISTING_TOPIC_1_ID_PARTITION_0, 0, (int) fileSize, 0, 100, 1000, TimestampType.CREATE_TIME)));
             controlPlane.commitFile("obj2", 2, fileSize,
-                List.of(CommitBatchRequest.of(EXISTING_TOPIC_1_ID_PARTITION_0, 0, (int) fileSize, 0, 100, 2000, TimestampType.CREATE_TIME)));
+                List.of(CommitBatchRequest.of(0, EXISTING_TOPIC_1_ID_PARTITION_0, 0, (int) fileSize, 0, 100, 2000, TimestampType.CREATE_TIME)));
 
             time.sleep(1);
             final Instant deletedAt = TimeUtils.now(time);
@@ -1116,7 +1116,7 @@ public abstract class AbstractControlPlaneTest {
             final long fileSize = FILE_MERGE_SIZE_THRESHOLD + 1;
             final long committedAt = time.milliseconds();
             controlPlane.commitFile("obj0", 1, fileSize,
-                List.of(CommitBatchRequest.of(EXISTING_TOPIC_1_ID_PARTITION_0, 0, (int) fileSize, 0, 100, 1000, TimestampType.CREATE_TIME)));
+                List.of(CommitBatchRequest.of(0, EXISTING_TOPIC_1_ID_PARTITION_0, 0, (int) fileSize, 0, 100, 1000, TimestampType.CREATE_TIME)));
 
             final List<FileMergeWorkItem.File> expectedFiles = List.of(
                 new FileMergeWorkItem.File(1L, "obj0", fileSize, fileSize,

--- a/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/CommitFileJobTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/CommitFileJobTest.java
@@ -78,8 +78,8 @@ class CommitFileJobTest {
     void simpleCommit() {
         final String objectKey = "obj1";
 
-        final CommitBatchRequest request1 = CommitBatchRequest.of(T0P1, 0, 100, 0, 14, 1000, TimestampType.CREATE_TIME);
-        final CommitBatchRequest request2 = CommitBatchRequest.of(T1P0, 100, 50, 0, 26, 2000, TimestampType.LOG_APPEND_TIME);
+        final CommitBatchRequest request1 = CommitBatchRequest.of(0, T0P1, 0, 100, 0, 14, 1000, TimestampType.CREATE_TIME);
+        final CommitBatchRequest request2 = CommitBatchRequest.of(0, T1P0, 100, 50, 0, 26, 2000, TimestampType.LOG_APPEND_TIME);
         final CommitFileJob job = new CommitFileJob(time, pgContainer.getJooqCtx(), objectKey, BROKER_ID, FILE_SIZE, List.of(
             request1,
             request2
@@ -119,8 +119,8 @@ class CommitFileJobTest {
         final Instant time1 = TimeUtils.now(time);
 
         final long firstFileCommittedAt = time.milliseconds();
-        final CommitBatchRequest request1 = CommitBatchRequest.of(T0P1, 0, 100, 0, 14, 1000, TimestampType.CREATE_TIME);
-        final CommitBatchRequest request2 = CommitBatchRequest.of(T1P0, 100, 50, 0, 26, 2000, TimestampType.LOG_APPEND_TIME);
+        final CommitBatchRequest request1 = CommitBatchRequest.of(0, T0P1, 0, 100, 0, 14, 1000, TimestampType.CREATE_TIME);
+        final CommitBatchRequest request2 = CommitBatchRequest.of(0, T1P0, 100, 50, 0, 26, 2000, TimestampType.LOG_APPEND_TIME);
         final CommitFileJob job1 = new CommitFileJob(time, pgContainer.getJooqCtx(), objectKey1, BROKER_ID, FILE_SIZE, List.of(
             request1,
             request2
@@ -136,8 +136,8 @@ class CommitFileJobTest {
         final Instant time2 = TimeUtils.now(time);
 
         final long secondFileCommittedAt = time.milliseconds();
-        final CommitBatchRequest request3 = CommitBatchRequest.of(T0P0, 0, 111, 0, 158, 3000, TimestampType.CREATE_TIME);
-        final CommitBatchRequest request4 = CommitBatchRequest.of(T0P1, 111, 222, 0, 244, 4000, TimestampType.CREATE_TIME);
+        final CommitBatchRequest request3 = CommitBatchRequest.of(0, T0P0, 0, 111, 0, 158, 3000, TimestampType.CREATE_TIME);
+        final CommitBatchRequest request4 = CommitBatchRequest.of(0, T0P1, 111, 222, 0, 244, 4000, TimestampType.CREATE_TIME);
         final CommitFileJob job2 = new CommitFileJob(time, pgContainer.getJooqCtx(), objectKey2, BROKER_ID, FILE_SIZE, List.of(
             request3,
             request4
@@ -183,12 +183,12 @@ class CommitFileJobTest {
 
         // Non-existent partition.
         final var t1p1 = new TopicIdPartition(TOPIC_ID_1, 10, TOPIC_1);
-        final CommitBatchRequest request1 = CommitBatchRequest.of(T0P1, 0, 100, 0, 14, 1000, TimestampType.CREATE_TIME);
-        final CommitBatchRequest request2 = CommitBatchRequest.of(T1P0, 100, 50, 0, 26, 2000, TimestampType.LOG_APPEND_TIME);
+        final CommitBatchRequest request1 = CommitBatchRequest.of(0, T0P1, 0, 100, 0, 14, 1000, TimestampType.CREATE_TIME);
+        final CommitBatchRequest request2 = CommitBatchRequest.of(0, T1P0, 100, 50, 0, 26, 2000, TimestampType.LOG_APPEND_TIME);
         final CommitFileJob job = new CommitFileJob(time, pgContainer.getJooqCtx(), objectKey, BROKER_ID, FILE_SIZE, List.of(
             request1,
             request2,
-            CommitBatchRequest.of(t1p1, 150, 1243, 82, 100, 3000, TimestampType.LOG_APPEND_TIME)
+            CommitBatchRequest.of(0, t1p1, 150, 1243, 82, 100, 3000, TimestampType.LOG_APPEND_TIME)
         ), duration -> {});
 
         final List<CommitBatchResponse> result = job.call();
@@ -224,8 +224,8 @@ class CommitFileJobTest {
     void simpleIdempotentCommit() {
         final String objectKey = "obj1";
 
-        final CommitBatchRequest request1 = CommitBatchRequest.idempotent(T0P1, 0, 100, 0, 14, 1000, TimestampType.CREATE_TIME, 1L, (short) 3, 0, 14);
-        final CommitBatchRequest request2 = CommitBatchRequest.idempotent(T1P0, 100, 50, 0, 26, 2000, TimestampType.LOG_APPEND_TIME, 1L, (short) 3, 0, 26);
+        final CommitBatchRequest request1 = CommitBatchRequest.idempotent(0, T0P1, 0, 100, 0, 14, 1000, TimestampType.CREATE_TIME, 1L, (short) 3, 0, 14);
+        final CommitBatchRequest request2 = CommitBatchRequest.idempotent(0, T1P0, 100, 50, 0, 26, 2000, TimestampType.LOG_APPEND_TIME, 1L, (short) 3, 0, 26);
         final CommitFileJob job = new CommitFileJob(time, pgContainer.getJooqCtx(), objectKey, BROKER_ID, FILE_SIZE, List.of(request1, request2), duration -> {
         });
         final List<CommitBatchResponse> result = job.call();
@@ -260,8 +260,8 @@ class CommitFileJobTest {
     void inSequenceCommit() {
         final String objectKey = "obj1";
 
-        final CommitBatchRequest request1 = CommitBatchRequest.idempotent(T0P1, 0, 100, 0, 14, 1000, TimestampType.CREATE_TIME, 1L, (short) 3, 0, 14);
-        final CommitBatchRequest request2 = CommitBatchRequest.idempotent(T0P1, 100, 50, 15, 26, 2000, TimestampType.LOG_APPEND_TIME, 1L, (short) 3, 15, 26);
+        final CommitBatchRequest request1 = CommitBatchRequest.idempotent(0, T0P1, 0, 100, 0, 14, 1000, TimestampType.CREATE_TIME, 1L, (short) 3, 0, 14);
+        final CommitBatchRequest request2 = CommitBatchRequest.idempotent(0, T0P1, 100, 50, 15, 26, 2000, TimestampType.LOG_APPEND_TIME, 1L, (short) 3, 15, 26);
         final CommitFileJob job = new CommitFileJob(time, pgContainer.getJooqCtx(), objectKey, BROKER_ID, FILE_SIZE, List.of(request1, request2), duration -> {
         });
         final List<CommitBatchResponse> result = job.call();
@@ -303,8 +303,8 @@ class CommitFileJobTest {
     void outOfOrderCommit(int lastBatchSequence, int firstBatchSequence) {
         final String objectKey = "obj1";
 
-        final CommitBatchRequest request1 = CommitBatchRequest.idempotent(T0P1, 0, 100, 0, 14, 1000, TimestampType.CREATE_TIME, 1L, (short) 3, 0, lastBatchSequence);
-        final CommitBatchRequest request2 = CommitBatchRequest.idempotent(T0P1, 100, 50, 0, 26, 2000, TimestampType.LOG_APPEND_TIME, 1L, (short) 3, firstBatchSequence, 26);
+        final CommitBatchRequest request1 = CommitBatchRequest.idempotent(0, T0P1, 0, 100, 0, 14, 1000, TimestampType.CREATE_TIME, 1L, (short) 3, 0, lastBatchSequence);
+        final CommitBatchRequest request2 = CommitBatchRequest.idempotent(0, T0P1, 100, 50, 0, 26, 2000, TimestampType.LOG_APPEND_TIME, 1L, (short) 3, firstBatchSequence, 26);
         final CommitFileJob job = new CommitFileJob(time, pgContainer.getJooqCtx(), objectKey, BROKER_ID, FILE_SIZE, List.of(request1, request2), duration -> {
         });
         final List<CommitBatchResponse> result = job.call();
@@ -337,7 +337,7 @@ class CommitFileJobTest {
     void outOfOrderCommitNewEpoch() {
         final String objectKey = "obj1";
 
-        final CommitBatchRequest request1 = CommitBatchRequest.idempotent(T0P1, 0, 100, 0, 14, 1000, TimestampType.CREATE_TIME, 1L, (short) 2, 1, 15);
+        final CommitBatchRequest request1 = CommitBatchRequest.idempotent(0, T0P1, 0, 100, 0, 14, 1000, TimestampType.CREATE_TIME, 1L, (short) 2, 1, 15);
         final CommitFileJob job = new CommitFileJob(time, pgContainer.getJooqCtx(), objectKey, BROKER_ID, FILE_SIZE, List.of(request1), duration -> {
         });
         final List<CommitBatchResponse> result = job.call();
@@ -364,8 +364,8 @@ class CommitFileJobTest {
     void invalidProducerEpoch() {
         final String objectKey = "obj1";
 
-        final CommitBatchRequest request1 = CommitBatchRequest.idempotent(T0P1, 0, 100, 0, 14, 1000, TimestampType.CREATE_TIME, 1L, (short) 3, 0, 14);
-        final CommitBatchRequest request2 = CommitBatchRequest.idempotent(T0P1, 100, 50, 0, 26, 2000, TimestampType.LOG_APPEND_TIME, 1L, (short) 2, 15, 26);
+        final CommitBatchRequest request1 = CommitBatchRequest.idempotent(0, T0P1, 0, 100, 0, 14, 1000, TimestampType.CREATE_TIME, 1L, (short) 3, 0, 14);
+        final CommitBatchRequest request2 = CommitBatchRequest.idempotent(0, T0P1, 100, 50, 0, 26, 2000, TimestampType.LOG_APPEND_TIME, 1L, (short) 2, 15, 26);
         final CommitFileJob job = new CommitFileJob(time, pgContainer.getJooqCtx(), objectKey, BROKER_ID, FILE_SIZE, List.of(request1, request2), duration -> {
         });
         final List<CommitBatchResponse> result = job.call();

--- a/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/DeleteFilesJobTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/DeleteFilesJobTest.java
@@ -89,8 +89,8 @@ class DeleteFilesJobTest {
         new CommitFileJob(
             time, pgContainer.getJooqCtx(), objectKey1, BROKER_ID, file1Size,
             List.of(
-                CommitBatchRequest.of(T0P0, 0, file1Batch1Size, 0, 11, 1000, TimestampType.CREATE_TIME),
-                CommitBatchRequest.of(T0P1, 0, file1Batch2Size, 0, 11, 1000, TimestampType.CREATE_TIME)
+                CommitBatchRequest.of(0, T0P0, 0, file1Batch1Size, 0, 11, 1000, TimestampType.CREATE_TIME),
+                CommitBatchRequest.of(0, T0P1, 0, file1Batch2Size, 0, 11, 1000, TimestampType.CREATE_TIME)
             ), durationCallback
         ).call();
 
@@ -101,8 +101,8 @@ class DeleteFilesJobTest {
         new CommitFileJob(
             time, pgContainer.getJooqCtx(), objectKey2, BROKER_ID, file2Size,
             List.of(
-                CommitBatchRequest.of(T0P0, 0, file2Batch1Size, 0, 11, 1000, TimestampType.CREATE_TIME),
-                CommitBatchRequest.of(T2P0, 0, file2Batch2Size, 0, 11, 1000, TimestampType.CREATE_TIME)
+                CommitBatchRequest.of(0, T0P0, 0, file2Batch1Size, 0, 11, 1000, TimestampType.CREATE_TIME),
+                CommitBatchRequest.of(0, T2P0, 0, file2Batch2Size, 0, 11, 1000, TimestampType.CREATE_TIME)
             ), durationCallback
         ).call();
 
@@ -114,9 +114,9 @@ class DeleteFilesJobTest {
         new CommitFileJob(
             time, pgContainer.getJooqCtx(), objectKey3, BROKER_ID, file3Size,
             List.of(
-                CommitBatchRequest.of(T0P0, 0, file1Batch1Size, 0, 11, 1000, TimestampType.CREATE_TIME),
-                CommitBatchRequest.of(T0P1, 0, file1Batch2Size, 0, 11, 1000, TimestampType.CREATE_TIME),
-                CommitBatchRequest.of(T2P0, 0, file1Batch2Size, 0, 11, 1000, TimestampType.CREATE_TIME)
+                CommitBatchRequest.of(0, T0P0, 0, file1Batch1Size, 0, 11, 1000, TimestampType.CREATE_TIME),
+                CommitBatchRequest.of(0, T0P1, 0, file1Batch2Size, 0, 11, 1000, TimestampType.CREATE_TIME),
+                CommitBatchRequest.of(0, T2P0, 0, file1Batch2Size, 0, 11, 1000, TimestampType.CREATE_TIME)
             ), durationCallback
         ).call();
 

--- a/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/DeleteRecordsJobTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/DeleteRecordsJobTest.java
@@ -104,8 +104,8 @@ class DeleteRecordsJobTest {
         new CommitFileJob(
             time, pgContainer.getJooqCtx(), objectKey1, BROKER_ID, file1Size,
             List.of(
-                CommitBatchRequest.of(T0P0, 0, file1Batch1Size, 0, 11, 1000,  TimestampType.CREATE_TIME),
-                CommitBatchRequest.of(T0P1, file1Batch1Size, file1Batch2Size, 0, 11, 1000, TimestampType.CREATE_TIME)
+                CommitBatchRequest.of(0, T0P0, 0, file1Batch1Size, 0, 11, 1000,  TimestampType.CREATE_TIME),
+                CommitBatchRequest.of(0, T0P1, file1Batch1Size, file1Batch2Size, 0, 11, 1000, TimestampType.CREATE_TIME)
             ), durationCallback
         ).call();
 
@@ -116,8 +116,8 @@ class DeleteRecordsJobTest {
         new CommitFileJob(
             time, pgContainer.getJooqCtx(), objectKey2, BROKER_ID, file2Size,
             List.of(
-                CommitBatchRequest.of(T0P0, 0, file2Batch1Size, 12, 23, 1000, TimestampType.CREATE_TIME),
-                CommitBatchRequest.of(T2P0, file2Batch1Size, file2Batch2Size, 0, 11, 1000, TimestampType.CREATE_TIME)
+                CommitBatchRequest.of(0, T0P0, 0, file2Batch1Size, 12, 23, 1000, TimestampType.CREATE_TIME),
+                CommitBatchRequest.of(0, T2P0, file2Batch1Size, file2Batch2Size, 0, 11, 1000, TimestampType.CREATE_TIME)
             ), durationCallback
         ).call();
 
@@ -129,9 +129,9 @@ class DeleteRecordsJobTest {
         new CommitFileJob(
             time, pgContainer.getJooqCtx(), objectKey3, BROKER_ID, file3Size,
             List.of(
-                CommitBatchRequest.of(T0P0, 0, file3Batch1Size, 24, 35, 1000, TimestampType.CREATE_TIME),
-                CommitBatchRequest.of(T0P1, file3Batch1Size, file3Batch2Size, 12, 23, 1000, TimestampType.CREATE_TIME),
-                CommitBatchRequest.of(T2P0, file3Batch1Size + file3Batch2Size, file3Batch3Size, 12, 23, 1000, TimestampType.CREATE_TIME)
+                CommitBatchRequest.of(0, T0P0, 0, file3Batch1Size, 24, 35, 1000, TimestampType.CREATE_TIME),
+                CommitBatchRequest.of(0, T0P1, file3Batch1Size, file3Batch2Size, 12, 23, 1000, TimestampType.CREATE_TIME),
+                CommitBatchRequest.of(0, T2P0, file3Batch1Size + file3Batch2Size, file3Batch3Size, 12, 23, 1000, TimestampType.CREATE_TIME)
             ), durationCallback
         ).call();
 

--- a/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/DeleteTopicJobTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/DeleteTopicJobTest.java
@@ -92,8 +92,8 @@ class DeleteTopicJobTest {
         new CommitFileJob(
             time, pgContainer.getJooqCtx(), objectKey1, BROKER_ID, file1Size,
             List.of(
-                CommitBatchRequest.of(T0P0, 0, file1Batch1Size, 0, 11, 1000, TimestampType.CREATE_TIME),
-                CommitBatchRequest.of(T0P1, 0, file1Batch2Size, 0, 11, 1000, TimestampType.CREATE_TIME)
+                CommitBatchRequest.of(0, T0P0, 0, file1Batch1Size, 0, 11, 1000, TimestampType.CREATE_TIME),
+                CommitBatchRequest.of(0, T0P1, 0, file1Batch2Size, 0, 11, 1000, TimestampType.CREATE_TIME)
             ), durationCallback
         ).call();
 
@@ -104,8 +104,8 @@ class DeleteTopicJobTest {
         new CommitFileJob(
             time, pgContainer.getJooqCtx(), objectKey2, BROKER_ID, file2Size,
             List.of(
-                CommitBatchRequest.of(T0P0, 0, file2Batch1Size, 0, 11, 1000, TimestampType.CREATE_TIME),
-                CommitBatchRequest.of(T2P0, 0, file2Batch2Size, 0, 11, 1000, TimestampType.CREATE_TIME)
+                CommitBatchRequest.of(0, T0P0, 0, file2Batch1Size, 0, 11, 1000, TimestampType.CREATE_TIME),
+                CommitBatchRequest.of(0, T2P0, 0, file2Batch2Size, 0, 11, 1000, TimestampType.CREATE_TIME)
             ), durationCallback
         ).call();
 
@@ -117,9 +117,9 @@ class DeleteTopicJobTest {
         new CommitFileJob(
             time, pgContainer.getJooqCtx(), objectKey3, BROKER_ID, file3Size,
             List.of(
-                CommitBatchRequest.of(T0P0, 0, file1Batch1Size, 0, 11, 1000, TimestampType.CREATE_TIME),
-                CommitBatchRequest.of(T0P1, 0, file1Batch2Size, 0, 11, 1000, TimestampType.CREATE_TIME),
-                CommitBatchRequest.of(T2P0, 0, file1Batch2Size, 0, 11, 1000, TimestampType.CREATE_TIME)
+                CommitBatchRequest.of(0, T0P0, 0, file1Batch1Size, 0, 11, 1000, TimestampType.CREATE_TIME),
+                CommitBatchRequest.of(0, T0P1, 0, file1Batch2Size, 0, 11, 1000, TimestampType.CREATE_TIME),
+                CommitBatchRequest.of(0, T2P0, 0, file1Batch2Size, 0, 11, 1000, TimestampType.CREATE_TIME)
             ), durationCallback
         ).call();
 

--- a/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/FindBatchesJobTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/FindBatchesJobTest.java
@@ -69,7 +69,7 @@ class FindBatchesJobTest {
         final CommitFileJob commitJob = new CommitFileJob(
             time, pgContainer.getJooqCtx(), objectKey1, BROKER_ID, FILE_SIZE,
             List.of(
-                CommitBatchRequest.of(T0P0, 0, 1234, 0, 11, 1000, TimestampType.CREATE_TIME)
+                CommitBatchRequest.of(0, T0P0, 0, 1234, 0, 11, 1000, TimestampType.CREATE_TIME)
             ),
             duration -> {}
         );

--- a/storage/inkless/src/test/java/io/aiven/inkless/produce/ActiveFileTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/produce/ActiveFileTest.java
@@ -109,7 +109,7 @@ class ActiveFileTest {
         assertThat(result)
             .usingRecursiveComparison()
             .ignoringFields("data")
-            .isEqualTo(new ClosedFile(start, Map.of(), Map.of(), List.of(), List.of(), new byte[0]));
+            .isEqualTo(new ClosedFile(start, Map.of(), Map.of(), List.of(), new byte[0]));
         assertThat(result.data()).isEmpty();
         assertThat(result.isEmpty()).isTrue();
     }
@@ -140,12 +140,11 @@ class ActiveFileTest {
         assertThat(result.awaitingFuturesByRequest().get(0)).isNotCompleted();
         assertThat(result.awaitingFuturesByRequest().get(1)).isNotCompleted();
         assertThat(result.commitBatchRequests()).containsExactly(
-            CommitBatchRequest.of(T0P0, 0, 78, 0, 0, 1000, TimestampType.CREATE_TIME),
-            CommitBatchRequest.of(T0P1, 78, 78, 0, 0, 2000, TimestampType.CREATE_TIME),
-            CommitBatchRequest.of(T0P1, 156, 78, 0, 0, 3000, TimestampType.CREATE_TIME),
-            CommitBatchRequest.of(T1P0, 234, 78, 0, 0, time.milliseconds(), TimestampType.LOG_APPEND_TIME)
+            CommitBatchRequest.of(0, T0P0, 0, 78, 0, 0, 1000, TimestampType.CREATE_TIME),
+            CommitBatchRequest.of(0, T0P1, 78, 78, 0, 0, 2000, TimestampType.CREATE_TIME),
+            CommitBatchRequest.of(1, T0P1, 156, 78, 0, 0, 3000, TimestampType.CREATE_TIME),
+            CommitBatchRequest.of(1, T1P0, 234, 78, 0, 0, time.milliseconds(), TimestampType.LOG_APPEND_TIME)
         );
-        assertThat(result.requestIds()).containsExactly(0, 0, 1, 1);
         assertThat(result.data()).hasSize(312);
         assertThat(result.isEmpty()).isFalse();
     }

--- a/storage/inkless/src/test/java/io/aiven/inkless/produce/ClosedFileTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/produce/ClosedFileTest.java
@@ -17,73 +17,53 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 class ClosedFileTest {
     @Test
     void startNull() {
-        assertThatThrownBy(() -> new ClosedFile(null, Map.of(), Map.of(), List.of(), List.of(), new byte[1]))
+        assertThatThrownBy(() -> new ClosedFile(null, Map.of(), Map.of(), List.of(), new byte[1]))
             .isInstanceOf(NullPointerException.class)
             .hasMessage("start cannot be null");
     }
 
     @Test
     void originalRequestsNull() {
-        assertThatThrownBy(() -> new ClosedFile(Instant.EPOCH, null, Map.of(), List.of(), List.of(), new byte[1]))
+        assertThatThrownBy(() -> new ClosedFile(Instant.EPOCH, null, Map.of(), List.of(), new byte[1]))
             .isInstanceOf(NullPointerException.class)
             .hasMessage("originalRequests cannot be null");
     }
 
     @Test
     void awaitingFuturesByRequestNull() {
-        assertThatThrownBy(() -> new ClosedFile(Instant.EPOCH, Map.of(), null, List.of(), List.of(), new byte[1]))
+        assertThatThrownBy(() -> new ClosedFile(Instant.EPOCH, Map.of(), null, List.of(), new byte[1]))
             .isInstanceOf(NullPointerException.class)
             .hasMessage("awaitingFuturesByRequest cannot be null");
     }
 
     @Test
     void commitBatchRequestsNull() {
-        assertThatThrownBy(() -> new ClosedFile(Instant.EPOCH, Map.of(), Map.of(), null, List.of(), new byte[1]))
+        assertThatThrownBy(() -> new ClosedFile(Instant.EPOCH, Map.of(), Map.of(), null, new byte[1]))
             .isInstanceOf(NullPointerException.class)
             .hasMessage("commitBatchRequests cannot be null");
     }
 
     @Test
-    void requestIdsNull() {
-        assertThatThrownBy(() -> new ClosedFile(Instant.EPOCH, Map.of(), Map.of(), List.of(), null, new byte[1]))
-            .isInstanceOf(NullPointerException.class)
-            .hasMessage("requestIds cannot be null");
-    }
-
-    @Test
-    void differentLengths1() {
-        assertThatThrownBy(() -> new ClosedFile(Instant.EPOCH, Map.of(1, Map.of()), Map.of(), List.of(), List.of(),new byte[1]))
+    void requestsWithDifferentLengths() {
+        assertThatThrownBy(() -> new ClosedFile(Instant.EPOCH, Map.of(1, Map.of()), Map.of(), List.of(), new byte[1]))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessage("originalRequests and awaitingFuturesByRequest must be of same size");
     }
 
     @Test
-    void differentLengths2() {
-        assertThatThrownBy(() -> new ClosedFile(
-            Instant.EPOCH,
-            Map.of(), Map.of(),
-            List.of(CommitBatchRequest.of(null, 0, 0, 0, 0, 0, TimestampType.CREATE_TIME)),
-            List.of(),
-            new byte[1]))
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessage("commitBatchRequests and requestIds must be of same size");
-    }
-
-    @Test
     void dataNull() {
-        assertThatThrownBy(() -> new ClosedFile(Instant.EPOCH, Map.of(), Map.of(), List.of(), List.of(), null))
+        assertThatThrownBy(() -> new ClosedFile(Instant.EPOCH, Map.of(), Map.of(), List.of(), null))
             .isInstanceOf(NullPointerException.class)
             .hasMessage("data cannot be null");
     }
 
     @Test
     void dataRequestMismatch() {
-        assertThatThrownBy(() -> new ClosedFile(Instant.EPOCH, Map.of(), Map.of(), List.of(), List.of(), new byte[10]))
+        assertThatThrownBy(() -> new ClosedFile(Instant.EPOCH, Map.of(), Map.of(), List.of(), new byte[10]))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessage("data must be empty if commitBatchRequests is empty");
         assertThatThrownBy(() -> new ClosedFile(Instant.EPOCH, Map.of(), Map.of(),
-            List.of(CommitBatchRequest.of(null, 0, 0, 0, 0, 0, TimestampType.CREATE_TIME)),
-            List.of(1),
+            List.of(CommitBatchRequest.of(1, null, 0, 0, 0, 0, 0, TimestampType.CREATE_TIME)),
             new byte[0]))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessage("data must be empty if commitBatchRequests is empty");
@@ -92,8 +72,7 @@ class ClosedFileTest {
     @Test
     void size() {
         final int size = new ClosedFile(Instant.EPOCH, Map.of(), Map.of(),
-            List.of(CommitBatchRequest.of(null, 0, 0, 0, 0, 0, TimestampType.CREATE_TIME)),
-            List.of(1),
+            List.of(CommitBatchRequest.of(1, null, 0, 0, 0, 0, 0, TimestampType.CREATE_TIME)),
             new byte[10]).size();
         assertThat(size).isEqualTo(10);
     }

--- a/storage/inkless/src/test/java/io/aiven/inkless/produce/FileCommitJobTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/produce/FileCommitJobTest.java
@@ -65,12 +65,11 @@ class FileCommitJobTest {
         1, REQUEST_1
     );
     static final List<CommitBatchRequest> COMMIT_BATCH_REQUESTS = List.of(
-        CommitBatchRequest.of(T0P0, 0, 100, 0, 9, 1000, TimestampType.CREATE_TIME),
-        CommitBatchRequest.of(T0P1, 100, 100, 0, 9, 1000, TimestampType.CREATE_TIME),
-        CommitBatchRequest.of(T0P1, 200, 100, 0, 9, 1000, TimestampType.CREATE_TIME),
-        CommitBatchRequest.of(T1P0, 300, 100, 0, 9, 1000, TimestampType.LOG_APPEND_TIME)
+        CommitBatchRequest.of(0, T0P0, 0, 100, 0, 9, 1000, TimestampType.CREATE_TIME),
+        CommitBatchRequest.of(0, T0P1, 100, 100, 0, 9, 1000, TimestampType.CREATE_TIME),
+        CommitBatchRequest.of(1, T0P1, 200, 100, 0, 9, 1000, TimestampType.CREATE_TIME),
+        CommitBatchRequest.of(1, T1P0, 300, 100, 0, 9, 1000, TimestampType.LOG_APPEND_TIME)
     );
-    static final List<Integer> REQUEST_IDS = List.of(0, 0, 1, 1);
 
     static final byte[] DATA = new byte[10];
     static final long FILE_SIZE = DATA.length;
@@ -104,7 +103,7 @@ class FileCommitJobTest {
             .thenReturn(commitBatchResponses);
         when(time.nanoseconds()).thenReturn(10_000_000L, 20_000_000L);
 
-        final ClosedFile file = new ClosedFile(Instant.EPOCH, REQUESTS, awaitingFuturesByRequest, COMMIT_BATCH_REQUESTS, REQUEST_IDS, DATA);
+        final ClosedFile file = new ClosedFile(Instant.EPOCH, REQUESTS, awaitingFuturesByRequest, COMMIT_BATCH_REQUESTS, DATA);
         final CompletableFuture<ObjectKey> uploadFuture = CompletableFuture.completedFuture(OBJECT_KEY);
         final FileCommitJob job = new FileCommitJob(BROKER_ID, file, uploadFuture, time, controlPlane, objectDeleter, commitTimeDurationCallback);
 
@@ -136,7 +135,7 @@ class FileCommitJobTest {
             .thenReturn(commitBatchResponses);
         when(time.nanoseconds()).thenReturn(10_000_000L, 20_000_000L);
 
-        final ClosedFile file = new ClosedFile(Instant.EPOCH, REQUESTS, awaitingFuturesByRequest, COMMIT_BATCH_REQUESTS, REQUEST_IDS, DATA);
+        final ClosedFile file = new ClosedFile(Instant.EPOCH, REQUESTS, awaitingFuturesByRequest, COMMIT_BATCH_REQUESTS, DATA);
         final CompletableFuture<ObjectKey> uploadFuture = CompletableFuture.completedFuture(OBJECT_KEY);
         final FileCommitJob job = new FileCommitJob(BROKER_ID, file, uploadFuture, time, controlPlane, objectDeleter, commitTimeDurationCallback);
 
@@ -156,7 +155,7 @@ class FileCommitJobTest {
 
         when(time.nanoseconds()).thenReturn(10_000_000L, 20_000_000L);
 
-        final ClosedFile file = new ClosedFile(Instant.EPOCH, REQUESTS, awaitingFuturesByRequest, COMMIT_BATCH_REQUESTS, REQUEST_IDS, DATA);
+        final ClosedFile file = new ClosedFile(Instant.EPOCH, REQUESTS, awaitingFuturesByRequest, COMMIT_BATCH_REQUESTS, DATA);
         final CompletableFuture<ObjectKey> uploadFuture = CompletableFuture.failedFuture(new StorageBackendException("test"));
         final FileCommitJob job = new FileCommitJob(BROKER_ID, file, uploadFuture, time, controlPlane, objectDeleter, commitTimeDurationCallback);
 
@@ -183,7 +182,7 @@ class FileCommitJobTest {
         when(controlPlane.commitFile(eq(OBJECT_KEY_MAIN_PART), eq(BROKER_ID), eq(FILE_SIZE), eq(COMMIT_BATCH_REQUESTS)))
             .thenThrow(new ControlPlaneException("test"));
 
-        final ClosedFile file = new ClosedFile(Instant.EPOCH, REQUESTS, awaitingFuturesByRequest, COMMIT_BATCH_REQUESTS, REQUEST_IDS, DATA);
+        final ClosedFile file = new ClosedFile(Instant.EPOCH, REQUESTS, awaitingFuturesByRequest, COMMIT_BATCH_REQUESTS, DATA);
         final CompletableFuture<ObjectKey> uploadFuture = CompletableFuture.completedFuture(OBJECT_KEY);
         final FileCommitJob job = new FileCommitJob(BROKER_ID, file, uploadFuture, time, controlPlane, objectDeleter, commitTimeDurationCallback);
 

--- a/storage/inkless/src/test/java/io/aiven/inkless/produce/FileCommitterTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/produce/FileCommitterTest.java
@@ -60,8 +60,7 @@ class FileCommitterTest {
         }
     };
     static final ClosedFile FILE = new ClosedFile(Instant.EPOCH, Map.of(), Map.of(),
-            List.of(CommitBatchRequest.of(null, 0, 0, 0, 0, 0, TimestampType.CREATE_TIME)),
-            List.of(1),
+            List.of(CommitBatchRequest.of(1, null, 0, 0, 0, 0, 0, TimestampType.CREATE_TIME)),
             new byte[10]);
     static final KeyAlignmentStrategy KEY_ALIGNMENT_STRATEGY = new FixedBlockAlignment(Integer.MAX_VALUE);
     static final ObjectCache OBJECT_CACHE = new NullCache();


### PR DESCRIPTION
Replace 2 aligned lists (commitBatchRequests and requestIds) from ClosedFile and instead add the requestId into the existing commitBatchRequest. Less moving parts.