### PR TITLE
fix(inkless:ci): fail-fast all test suites [INK-124]

### DIFF
--- a/.github/workflows/inkless-nightly.yml
+++ b/.github/workflows/inkless-nightly.yml
@@ -45,21 +45,23 @@ jobs:
         id: junit-test
         env:
           TIMEOUT_MINUTES: 30
+          GRADLE_ARGS: >-
+            --build-cache --no-scan 
+            -PtestLoggingEvents=started,passed,skipped,failed 
+            -PmaxParallelForks=2 
+            -PmaxTestRetries=1 -PmaxTestRetryFailures=3 
+            -PmaxQuarantineTestRetries=3 -PmaxQuarantineTestRetryFailures=0 
+            -PcommitId=xxxxxxxxxxxxxxxx
         # Point to inkless tests
         run: |
           set +e
           ./.github/scripts/thread-dump.sh &
           # inkless tests
-          timeout ${TIMEOUT_MINUTES}m ./gradlew --build-cache --continue --no-scan \
-          -PtestLoggingEvents=started,passed,skipped,failed \
-          -PmaxParallelForks=2 \
-          -PmaxTestRetries=1 -PmaxTestRetryFailures=3 \
-          -PmaxQuarantineTestRetries=3 -PmaxQuarantineTestRetryFailures=0 \
-          -PcommitId=xxxxxxxxxxxxxxxx \
-          :storage:inkless:test :storage:inkless:integrationTest && \
-          ./gradlew :metadata:test --tests "org.apache.kafka.controller.*" && \
-          ./gradlew :core:test --tests "*Inkless*" && \
-          ./gradlew :core:test --tests "kafka.api.*Producer*Test"
+          timeout ${TIMEOUT_MINUTES}m \
+          ./gradlew ${GRADLE_ARGS} :storage:inkless:test :storage:inkless:integrationTest && \
+          ./gradlew ${GRADLE_ARGS} :metadata:test --tests "org.apache.kafka.controller.*" && \
+          ./gradlew ${GRADLE_ARGS} :core:test --tests "*Inkless*" && \
+          ./gradlew ${GRADLE_ARGS} :core:test --tests "kafka.api.*Producer*Test"
           exitcode="$?"
           echo "exitcode=$exitcode" >> $GITHUB_OUTPUT
       - name: Archive JUnit HTML reports

--- a/.github/workflows/inkless.yml
+++ b/.github/workflows/inkless.yml
@@ -106,20 +106,22 @@ jobs:
         id: junit-test
         env:
           TIMEOUT_MINUTES: 30
+          GRADLE_ARGS: >-
+            --build-cache --no-scan 
+            -PtestLoggingEvents=started,passed,skipped,failed 
+            -PmaxParallelForks=2 
+            -PmaxTestRetries=1 -PmaxTestRetryFailures=3 
+            -PmaxQuarantineTestRetries=3 -PmaxQuarantineTestRetryFailures=0 
+            -PcommitId=xxxxxxxxxxxxxxxx
         # Point to inkless tests
         run: |
           set +e
           ./.github/scripts/thread-dump.sh &
           # inkless tests
-          timeout ${TIMEOUT_MINUTES}m ./gradlew --build-cache --continue --no-scan \
-          -PtestLoggingEvents=started,passed,skipped,failed \
-          -PmaxParallelForks=2 \
-          -PmaxTestRetries=1 -PmaxTestRetryFailures=3 \
-          -PmaxQuarantineTestRetries=3 -PmaxQuarantineTestRetryFailures=0 \
-          -PcommitId=xxxxxxxxxxxxxxxx \
-          :storage:inkless:test :storage:inkless:integrationTest && \
-          ./gradlew :metadata:test --tests "org.apache.kafka.controller.*" && \
-          ./gradlew :core:test --tests "*Inkless*"
+          timeout ${TIMEOUT_MINUTES}m \
+          ./gradlew ${GRADLE_ARGS} :storage:inkless:test :storage:inkless:integrationTest && \
+          ./gradlew ${GRADLE_ARGS} :metadata:test --tests "org.apache.kafka.controller.*" && \
+          ./gradlew ${GRADLE_ARGS} :core:test --tests "*Inkless*"
           exitcode="$?"
           echo "exitcode=$exitcode" >> $GITHUB_OUTPUT
       - name: Archive JUnit HTML reports


### PR DESCRIPTION
Currently the initial inkless test mistakingly continues but the result is not stopping the pipeline.

This happened here: https://github.com/aiven/inkless/actions/runs/13853199477/job/38764586313?pr=218

Instead, this PR is removing the `--continue` and failing fast as the inkless tests are easier to retry than Kafka.
