### PR TITLE
fix(inkless:consume): return hwm when auto reset to latest [INK-20]

### DIFF
--- a/core/src/test/java/kafka/server/InklessClusterTest.java
+++ b/core/src/test/java/kafka/server/InklessClusterTest.java
@@ -26,6 +26,7 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.consumer.internals.AutoOffsetResetStrategy;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerConfig;
@@ -179,8 +180,11 @@ public class InklessClusterTest {
     }
 
     private static void consume(TimestampType timestampType, Map<String, Object> clientConfigs, String topicName, long now, int numRecords) {
+        final Map<String, Object> consumerConfigs = new HashMap<>(clientConfigs);
+        // by default is latest and nothing would get consumed.
+        consumerConfigs.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, AutoOffsetResetStrategy.EARLIEST.name());
         int recordsConsumed = 0;
-        try (Consumer<byte[], byte[]> consumer = new KafkaConsumer<>(clientConfigs)) {
+        try (Consumer<byte[], byte[]> consumer = new KafkaConsumer<>(consumerConfigs)) {
             consumer.assign(Collections.singletonList(new TopicPartition(topicName, 0)));
             ConsumerRecords<byte[], byte[]> poll = consumer.poll(Duration.ofSeconds(30));
             for (ConsumerRecord<byte[], byte[]> record : poll) {

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/ListOffsetsJob.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/ListOffsetsJob.java
@@ -82,7 +82,7 @@ public class ListOffsetsJob implements Callable<List<ListOffsetsResponse>> {
         if (timestamp == ListOffsetsRequest.EARLIEST_TIMESTAMP) {
             return ListOffsetsResponse.success(request.topicIdPartition(), timestamp, logInfo.logStartOffset());
         } else if (timestamp == ListOffsetsRequest.LATEST_TIMESTAMP) {
-            return ListOffsetsResponse.success(request.topicIdPartition(), timestamp, logInfo.logStartOffset());
+            return ListOffsetsResponse.success(request.topicIdPartition(), timestamp, logInfo.highWatermark());
         }
         LOGGER.error("listOffset request for timestamp {} in {} unsupported", timestamp, request.topicIdPartition());
         return new ListOffsetsResponse(Errors.UNKNOWN_SERVER_ERROR, request.topicIdPartition(), -1, -1);


### PR DESCRIPTION
Listing offsets from earliest or latest is returning the same offset: the first.
This assumption is used on the InklessClusterTest. 

Fixing both to align with regular Consumer expectations.