### PR TITLE
ci(inkless): remove disabled flag

### DIFF
--- a/.github/workflows/generate-reports.yml
+++ b/.github/workflows/generate-reports.yml
@@ -15,9 +15,6 @@
 
 name: Flaky Test Report
 
-# Inkless: disable flaky test report schedule runs
-disabled: true
-
 on:
   workflow_dispatch:      # Let us run manually
 


### PR DESCRIPTION
Workflows can be disabled manually on GitHub and don't have this field to disable.