### PR TITLE
INK-196: Fix build for benchmarks merge conflicts with #211

### DIFF
--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/fetcher/ReplicaFetcherThreadBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/fetcher/ReplicaFetcherThreadBenchmark.java
@@ -123,7 +123,7 @@ public class ReplicaFetcherThreadBenchmark {
         KafkaConfig config =  KafkaConfig.fromProps(TestUtils.createBrokerConfig(
             0, true, true, 9092, Option.empty(), Option.empty(),
             Option.empty(), true, false, 0, false, 0, false, 0, Option.empty(), 1, true, 1,
-            (short) 1, false));
+            (short) 1, false, Option.empty()));
         LogConfig logConfig = createLogConfig();
 
         BrokerTopicStats brokerTopicStats = new BrokerTopicStats(false);

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/server/CheckpointBench.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/server/CheckpointBench.java
@@ -103,7 +103,7 @@ public class CheckpointBench {
         this.brokerProperties = KafkaConfig.fromProps(TestUtils.createBrokerConfig(
                 0, true, true, 9092, Option.empty(), Option.empty(),
                 Option.empty(), true, false, 0, false, 0, false, 0, Option.empty(), 1, true, 1,
-                (short) 1, false));
+                (short) 1, false, Option.empty()));
         this.metrics = new Metrics();
         this.time = new MockTime();
         this.failureChannel = new LogDirFailureChannel(brokerProperties.logDirs().size());

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/server/PartitionCreationBench.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/server/PartitionCreationBench.java
@@ -110,7 +110,7 @@ public class PartitionCreationBench {
         this.brokerProperties = KafkaConfig.fromProps(TestUtils.createBrokerConfig(
                 0, true, true, 9092, Option.empty(), Option.empty(),
                 Option.empty(), true, false, 0, false, 0, false, 0, Option.empty(), 1, true, 1,
-                (short) 1, false));
+                (short) 1, false, Option.empty()));
         this.metrics = new Metrics();
         this.time = Time.SYSTEM;
         this.failureChannel = new LogDirFailureChannel(brokerProperties.logDirs().size());


### PR DESCRIPTION
Java users of this class need to explicitly provide an argument, and can't use the scala defaults. This causes a build failure when this new argument was added in #211 but these classes were not updated.
