### PR TITLE
chore(inkless:cache): use random port for infinispan

### DIFF
--- a/storage/inkless/src/main/java/io/aiven/inkless/cache/InfinispanCache.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/cache/InfinispanCache.java
@@ -49,7 +49,8 @@ public class InfinispanCache implements ObjectCache {
         this.time = time;
         GlobalConfigurationBuilder globalConfig = GlobalConfigurationBuilder.defaultClusteredBuilder();
         globalConfig.transport()
-                .clusterName(clusterName(clusterId, rack));
+            .clusterName(clusterName(clusterId, rack))
+            .addProperty("configurationFile", "jgroups-udp.xml"); // Set bind port to 0
         globalConfig.serialization()
                 .addContextInitializers()
                 .marshaller(new KafkaMarshaller())

--- a/storage/inkless/src/main/resources/jgroups-udp.xml
+++ b/storage/inkless/src/main/resources/jgroups-udp.xml
@@ -1,0 +1,64 @@
+<config xmlns="urn:org:jgroups"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-5.3.xsd">
+    <!-- jgroups.udp.address is deprecated and will be removed, see ISPN-11867 -->
+    <UDP bind_addr="${jgroups.bind.address,jgroups.udp.address:SITE_LOCAL}"
+         bind_port="${jgroups.bind.port,jgroups.udp.port:0}"
+         mcast_addr="${jgroups.mcast_addr:239.6.7.8}"
+         mcast_port="${jgroups.mcast_port:46655}"
+         tos="0"
+         ucast_send_buf_size="1m"
+         mcast_send_buf_size="1m"
+         ucast_recv_buf_size="20m"
+         mcast_recv_buf_size="25m"
+         ip_ttl="${jgroups.ip_ttl:2}"
+         ip_mcast="${jgroups.ip_mcast:true}"
+         thread_naming_pattern="pl"
+
+         diag.enabled="${jgroups.diag.enabled:false}"
+         diag.enable_tcp="${jgroups.diag.enable_tcp:false}"
+         diag.enable_udp="${jgroups.diag.enable_udp:true}"
+
+         bundler_type="${jgroups.bundler.type:transfer-queue}"
+         bundler.max_size="${jgroups.bundler.max_size:64000}"
+
+         thread_pool.min_threads="${jgroups.thread_pool.min_threads:0}"
+         thread_pool.max_threads="${jgroups.thread_pool.max_threads:200}"
+         thread_pool.keep_alive_time="60000"
+         thread_pool.thread_dumps_enabled="${jgroups.thread_dumps_enabled:false}"
+
+         use_virtual_threads="${jgroups.thread.virtual,org.infinispan.threads.virtual:false}"
+    />
+    <RED/>
+    <PING num_discovery_runs="3"/>
+    <MERGE3 min_interval="10000"
+            max_interval="30000"
+    />
+    <FD_SOCK2 offset="${jgroups.fd.port-offset:50000}"/>
+    <FD_ALL3/>
+    <VERIFY_SUSPECT2 timeout="1000"/>
+    <pbcast.NAKACK2 xmit_interval="100"
+                    xmit_table_num_rows="50"
+                    xmit_table_msgs_per_row="1024"
+                    xmit_table_max_compaction_time="30000"
+                    resend_last_seqno="true"
+    />
+    <UNICAST3 xmit_interval="100"
+              xmit_table_num_rows="50"
+              xmit_table_msgs_per_row="1024"
+              xmit_table_max_compaction_time="30000"
+    />
+    <pbcast.STABLE desired_avg_gossip="5000"
+                   max_bytes="1M"
+    />
+    <pbcast.GMS print_local_addr="false"
+                join_timeout="${jgroups.join_timeout:2000}"
+    />
+    <UFC max_credits="${jgroups.max_credits:4m}"
+         min_threshold="0.40"
+    />
+    <MFC max_credits="${jgroups.max_credits:4m}"
+         min_threshold="0.40"
+    />
+    <FRAG4 frag_size="${jgroups.frag_size:60000}"/>
+</config>


### PR DESCRIPTION
Using fixed port (7800) with the 10 port range by default causes clashes on concurrent tests.
The configuration passed is the default one but with bind_port=0 to use any ephemeral port.