### PR TITLE
refactor(inkless): use temporal files for file merging [INK-203]

### DIFF
--- a/storage/inkless/src/main/java/io/aiven/inkless/config/InklessConfig.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/config/InklessConfig.java
@@ -21,6 +21,7 @@ import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.utils.Utils;
 
+import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Map;
 
@@ -87,6 +88,10 @@ public class InklessConfig extends AbstractConfig {
     public static final String FILE_MERGER_INTERVAL_MS_CONFIG = "file.merger.interval.ms";
     private static final String FILE_MERGER_INTERVAL_MS_DOC = "The interval with which to merge files.";
     private static final int FILE_MERGER_INTERVAL_MS_DEFAULT = 60 * 1000;  // 1 minute
+
+    public static final String FILE_MERGER_TEMP_DIR_CONFIG = "file.merger.temp.dir";
+    private static final String FILE_MERGER_TEMP_DIR_DOC = "The temporary directory for file merging.";
+    private static final String FILE_MERGER_TEMP_DIR_DEFAULT = "/tmp/inkless/merger";
 
     public static ConfigDef configDef() {
         final ConfigDef configDef = new ConfigDef();
@@ -194,6 +199,14 @@ public class InklessConfig extends AbstractConfig {
             ConfigDef.Importance.LOW,
             FILE_MERGER_INTERVAL_MS_DOC
         );
+        configDef.define(
+            FILE_MERGER_TEMP_DIR_CONFIG,
+            ConfigDef.Type.STRING,
+            FILE_MERGER_TEMP_DIR_DEFAULT,
+            new ConfigDef.NonNullValidator(),
+            ConfigDef.Importance.LOW,
+            FILE_MERGER_TEMP_DIR_DOC
+        );
 
         return configDef;
     }
@@ -259,5 +272,10 @@ public class InklessConfig extends AbstractConfig {
 
     public Duration fileMergerInterval() {
         return Duration.ofMillis(getInt(FILE_MERGER_INTERVAL_MS_CONFIG));
+    }
+
+    public Path fileMergeWorkDir() {
+        final String path = getString(FILE_MERGER_TEMP_DIR_CONFIG);
+        return Path.of(path);
     }
 }

--- a/storage/inkless/src/test/java/io/aiven/inkless/merge/MockInputStream.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/merge/MockInputStream.java
@@ -80,7 +80,10 @@ public class MockInputStream extends InputStream {
             throw new IllegalStateException();
         }
         if (endGap != null) {
-            buffer.position(buffer.position() + endGap);
+            final int remaining = buffer.remaining();
+            if (remaining >= endGap) {
+                buffer.position(buffer.position() + endGap);
+            }
         }
         stream.close();
         wasClosed = true;


### PR DESCRIPTION
By sequentually downloading all files to merge to a temporal directory and use the local files for the merging process, we avoid having all fetched objects open while merging.
This should avoid having too many connections open to S3.

The disk used is cleaned after each merge run.

(Hide whitespaces on files changed for easier review)