### PR TITLE
Allow producing to classic and inkless topics in the same request [INK-183]

### DIFF
--- a/docs/inkless/FEATURES.md
+++ b/docs/inkless/FEATURES.md
@@ -30,7 +30,6 @@ If not specified above, features are untested and assumed to be inoperable.
 
 ### Inkless topics supported (possibly with limitations)
 - `PRODUCE`
-    - can't produce to Inkless and classic topics in the same request;
     - upload parallelism is underutilized;
     - Inkless topics can’t participate in transactions.
 - `FETCH`

--- a/storage/inkless/src/test/java/io/aiven/inkless/merge/FileMergerIntegrationTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/merge/FileMergerIntegrationTest.java
@@ -53,7 +53,6 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -61,11 +60,12 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -82,7 +82,7 @@ import io.aiven.inkless.control_plane.FindBatchRequest;
 import io.aiven.inkless.control_plane.FindBatchResponse;
 import io.aiven.inkless.control_plane.InMemoryControlPlane;
 import io.aiven.inkless.control_plane.MetadataView;
-import io.aiven.inkless.produce.AppendInterceptor;
+import io.aiven.inkless.produce.AppendHandler;
 import io.aiven.inkless.produce.WriterTestUtils;
 import io.aiven.inkless.storage_backend.s3.S3Storage;
 import io.aiven.inkless.test_utils.MinioContainer;
@@ -99,7 +99,6 @@ import software.amazon.awssdk.services.s3.model.S3Object;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
-import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.STRICT_STUBS)
@@ -204,12 +203,12 @@ class FileMergerIntegrationTest {
 
         createTopics(controlPlane);
 
-        final AppendInterceptor appendInterceptor = new AppendInterceptor(sharedState);
+        final AppendHandler appendHandler = new AppendHandler(sharedState);
         final FetchInterceptor fetchInterceptor = new FetchInterceptor(sharedState);
         final FileMerger fileMerger = new FileMerger(sharedState);
 
         // Write a bunch of records.
-        writeRecords(appendInterceptor);
+        writeRecords(appendHandler);
 
         // Consume the high watermarks and the records themselves for future comparison.
         final Map<TopicIdPartition, Long> highWatermarks1 = getHighWatermarks(controlPlane);
@@ -256,11 +255,9 @@ class FileMergerIntegrationTest {
         controlPlane.createTopicAndPartitions(createTopicsRequests);
     }
 
-    private void writeRecords(final AppendInterceptor appendInterceptor) {
+    private void writeRecords(final AppendHandler appendHandler) {
         final WriterTestUtils.RecordCreator recordCreator = new WriterTestUtils.RecordCreator();
-        final AtomicInteger produceResponseCallbackCalls = new AtomicInteger(WRITE_ITERATIONS);
-        final Consumer<Map<TopicPartition, ProduceResponse.PartitionResponse>> responseCallback =
-            (r) -> produceResponseCallbackCalls.decrementAndGet();
+        var futures = new ArrayList<CompletableFuture<Map<TopicPartition, ProduceResponse.PartitionResponse>>>();
 
         for (int i = 0; i < WRITE_ITERATIONS; i++) {
             final HashMap<TopicPartition, MemoryRecords> records = new HashMap<>();
@@ -270,12 +267,14 @@ class FileMergerIntegrationTest {
                     records.put(tidp.topicPartition(), recordCreator.create(tidp.topicPartition(), i));
                 }
             }
-            assertThat(appendInterceptor.intercept(records, responseCallback, RequestLocal.noCaching())).isTrue();
+            futures.add(appendHandler.handle(records, RequestLocal.noCaching()));
         }
 
-        await().atMost(Duration.ofSeconds(60))
-            .pollDelay(Duration.ofMillis(100))
-            .until(() -> produceResponseCallbackCalls.get() == 0);
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).orTimeout(60, TimeUnit.SECONDS);
+        futures.forEach(response -> {
+            response.join()
+                .forEach((tp, partitionResponse) -> assertThat(partitionResponse.error).isEqualTo(Errors.NONE));
+        });
     }
 
     private Map<TopicIdPartition, Long> getHighWatermarks(final ControlPlane controlPlane) {


### PR DESCRIPTION
`AppendHandler` is now able to handle Inkless produce requests separately from classic topics produce requests. In this way it's now possible to produce to classic and inkless topics within the same request.