### PR TITLE
INK-214: log.inkless.enable should only apply to non-internal topics.

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -729,7 +729,8 @@ public class ReplicationControlManager {
         Map<String, String> creationConfigs = translateCreationConfigs(topic.configs());
         Map<Integer, PartitionRegistration> newParts = new HashMap<>();
 
-        boolean inklessEnabled = Boolean.parseBoolean(creationConfigs.getOrDefault(INKLESS_ENABLE_CONFIG, "" + defaultInklessEnable));
+        boolean inklessEnabledByDefault = defaultInklessEnable && !Topic.isInternal(topic.name());
+        boolean inklessEnabled = Boolean.parseBoolean(creationConfigs.getOrDefault(INKLESS_ENABLE_CONFIG, "" + inklessEnabledByDefault));
         if (inklessEnabled) {
             if (Math.abs(topic.replicationFactor()) != 1) {
                 return new ApiError(Errors.INVALID_REPLICATION_FACTOR,


### PR DESCRIPTION
This is a bug introduced in #251 that causes internal topics (such as `__consumer_offsets`) to be created as inkless topics when log.inkless.enable is specified. Some integration tests explicitly create these internal topics, and trigger this behavior.