### PR TITLE
fix(inkless): backfill topic id on old fetch requests [INK-216]

### DIFF
--- a/storage/inkless/src/main/java/io/aiven/inkless/consume/FetchInterceptor.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/consume/FetchInterceptor.java
@@ -47,7 +47,7 @@ public class FetchInterceptor implements Closeable {
     private final TopicTypeCounter topicTypeCounter;
 
     public FetchInterceptor(final SharedState state) {
-        this(state, new Reader(state.time(), state.objectKeyCreator(), state.keyAlignmentStrategy(), state.cache(), state.controlPlane(), state.storage()));
+        this(state, new Reader(state.time(), state.objectKeyCreator(), state.keyAlignmentStrategy(), state.cache(), state.controlPlane(), state.metadata(), state.storage()));
     }
 
     public FetchInterceptor(final SharedState state, final Reader reader) {

--- a/storage/inkless/src/main/java/io/aiven/inkless/consume/FindBatchesJob.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/consume/FindBatchesJob.java
@@ -18,14 +18,17 @@
 package io.aiven.inkless.consume;
 
 import org.apache.kafka.common.TopicIdPartition;
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.requests.FetchRequest;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.server.storage.log.FetchParams;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.function.Consumer;
 
@@ -33,22 +36,26 @@ import io.aiven.inkless.TimeUtils;
 import io.aiven.inkless.control_plane.ControlPlane;
 import io.aiven.inkless.control_plane.FindBatchRequest;
 import io.aiven.inkless.control_plane.FindBatchResponse;
+import io.aiven.inkless.control_plane.MetadataView;
 
 public class FindBatchesJob implements Callable<Map<TopicIdPartition, FindBatchResponse>> {
 
     private final Time time;
     private final ControlPlane controlPlane;
+    private final MetadataView metadataView;
     private final FetchParams params;
     private final Map<TopicIdPartition, FetchRequest.PartitionData> fetchInfos;
     private final Consumer<Long> durationCallback;
 
     public FindBatchesJob(Time time,
                           ControlPlane controlPlane,
+                          MetadataView metadataView,
                           FetchParams params,
                           Map<TopicIdPartition, FetchRequest.PartitionData> fetchInfos,
                           Consumer<Long> durationCallback) {
         this.time = time;
         this.controlPlane = controlPlane;
+        this.metadataView = metadataView;
         this.params = params;
         this.fetchInfos = fetchInfos;
         this.durationCallback = durationCallback;
@@ -61,8 +68,22 @@ public class FindBatchesJob implements Callable<Map<TopicIdPartition, FindBatchR
 
     private Map<TopicIdPartition, FindBatchResponse> doWork() {
         List<FindBatchRequest> requests = new ArrayList<>();
+        Set<String> topicsWithZeroId = new HashSet<>();
         for (Map.Entry<TopicIdPartition, FetchRequest.PartitionData> fetchInfo : fetchInfos.entrySet()) {
-            requests.add(new FindBatchRequest(fetchInfo.getKey(), fetchInfo.getValue().fetchOffset, fetchInfo.getValue().maxBytes));
+            TopicIdPartition topicIdPartition = fetchInfo.getKey();
+
+            // Older fetch versions (<13) don't have topicId in the request -- backfill it for backward compatibility
+            if (topicIdPartition.topicId() == Uuid.ZERO_UUID) {
+                // if topicId from metadata is zero, then CP will not find it and return proper exception
+                final Uuid topicId = metadataView.getTopicId(topicIdPartition.topic());
+                topicIdPartition = new TopicIdPartition(
+                    topicId,
+                    topicIdPartition.topicPartition()
+                );
+                topicsWithZeroId.add(topicIdPartition.topic());
+            }
+
+            requests.add(new FindBatchRequest(topicIdPartition, fetchInfo.getValue().fetchOffset, fetchInfo.getValue().maxBytes));
         }
 
         List<FindBatchResponse> responses = controlPlane.findBatches(requests, params.maxBytes);
@@ -71,7 +92,18 @@ public class FindBatchesJob implements Callable<Map<TopicIdPartition, FindBatchR
         for (int i = 0; i < requests.size(); i++) {
             FindBatchRequest request = requests.get(i);
             FindBatchResponse response = responses.get(i);
-            out.put(request.topicIdPartition(), response);
+
+            // Older fetch versions (<13) don't have topicId in the request -- backfill it for backward compatibility
+            TopicIdPartition topicIdPartition = request.topicIdPartition();
+            if (topicsWithZeroId.contains(topicIdPartition.topic())) {
+                // Backfill topicId back to zero for older fetch versions
+                topicIdPartition = new TopicIdPartition(
+                    Uuid.ZERO_UUID,
+                    topicIdPartition.topicPartition()
+                );
+            }
+
+            out.put(topicIdPartition, response);
         }
         return out;
     }

--- a/storage/inkless/src/main/java/io/aiven/inkless/consume/Reader.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/consume/Reader.java
@@ -37,6 +37,7 @@ import io.aiven.inkless.cache.ObjectCache;
 import io.aiven.inkless.common.InklessThreadFactory;
 import io.aiven.inkless.common.ObjectKeyCreator;
 import io.aiven.inkless.control_plane.ControlPlane;
+import io.aiven.inkless.control_plane.MetadataView;
 import io.aiven.inkless.storage_backend.common.ObjectFetcher;
 
 public class Reader implements AutoCloseable {
@@ -47,6 +48,7 @@ public class Reader implements AutoCloseable {
     private final KeyAlignmentStrategy keyAlignmentStrategy;
     private final ObjectCache cache;
     private final ControlPlane controlPlane;
+    private final MetadataView metadataView;
     private final ObjectFetcher objectFetcher;
     private final ExecutorService metadataExecutor;
     private final ExecutorService fetchPlannerExecutor;
@@ -59,6 +61,7 @@ public class Reader implements AutoCloseable {
                   KeyAlignmentStrategy keyAlignmentStrategy,
                   ObjectCache cache,
                   ControlPlane controlPlane,
+                    MetadataView metadataView,
                   ObjectFetcher objectFetcher) {
         this(
             time,
@@ -66,6 +69,7 @@ public class Reader implements AutoCloseable {
             keyAlignmentStrategy,
             cache,
             controlPlane,
+            metadataView,
             objectFetcher,
             Executors.newCachedThreadPool(new InklessThreadFactory("inkless-fetch-metadata-", false)),
             Executors.newCachedThreadPool(new InklessThreadFactory("inkless-fetch-planner-", false)),
@@ -76,22 +80,24 @@ public class Reader implements AutoCloseable {
 
 
     public Reader(
-            Time time,
-            ObjectKeyCreator objectKeyCreator,
-            KeyAlignmentStrategy keyAlignmentStrategy,
-            ObjectCache cache,
-            ControlPlane controlPlane,
-            ObjectFetcher objectFetcher,
-            ExecutorService metadataExecutor,
-            ExecutorService fetchPlannerExecutor,
-            ExecutorService dataExecutor,
-            ExecutorService fetchCompleterExecutor
+        Time time,
+        ObjectKeyCreator objectKeyCreator,
+        KeyAlignmentStrategy keyAlignmentStrategy,
+        ObjectCache cache,
+        ControlPlane controlPlane,
+        MetadataView metadataView,
+        ObjectFetcher objectFetcher,
+        ExecutorService metadataExecutor,
+        ExecutorService fetchPlannerExecutor,
+        ExecutorService dataExecutor,
+        ExecutorService fetchCompleterExecutor
     ) {
         this.time = time;
         this.objectKeyCreator = objectKeyCreator;
         this.keyAlignmentStrategy = keyAlignmentStrategy;
         this.cache = cache;
         this.controlPlane = controlPlane;
+        this.metadataView = metadataView;
         this.objectFetcher = objectFetcher;
         this.metadataExecutor = metadataExecutor;
         this.fetchPlannerExecutor = fetchPlannerExecutor;
@@ -109,6 +115,7 @@ public class Reader implements AutoCloseable {
             new FindBatchesJob(
                 time,
                 controlPlane,
+                metadataView,
                 params,
                 fetchInfos,
                 fetchMetrics::findBatchesFinished

--- a/storage/inkless/src/test/java/io/aiven/inkless/consume/FindBatchesJobTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/consume/FindBatchesJobTest.java
@@ -44,6 +44,7 @@ import io.aiven.inkless.control_plane.BatchMetadata;
 import io.aiven.inkless.control_plane.ControlPlane;
 import io.aiven.inkless.control_plane.FindBatchRequest;
 import io.aiven.inkless.control_plane.FindBatchResponse;
+import io.aiven.inkless.control_plane.MetadataView;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -59,6 +60,8 @@ public class FindBatchesJobTest {
     private ControlPlane controlPlane;
     @Mock
     private FetchParams params;
+    @Mock
+    private MetadataView metadataView;
 
     @Captor
     ArgumentCaptor<List<FindBatchRequest>> requestCaptor;
@@ -81,10 +84,38 @@ public class FindBatchesJobTest {
                 new BatchInfo(1L, OBJECT_KEY_MAIN_PART, BatchMetadata.of(partition0, 0, 10, 0, 0, logAppendTimestamp, maxBatchTimestamp, TimestampType.CREATE_TIME))
             ), logStartOffset, highWatermark)
         );
-        FindBatchesJob job = new FindBatchesJob(time, controlPlane, params, fetchInfos, durationMs -> {});
+        FindBatchesJob job = new FindBatchesJob(time, controlPlane, metadataView, params, fetchInfos, durationMs -> {});
         when(controlPlane.findBatches(requestCaptor.capture(), anyInt())).thenReturn(new ArrayList<>(coordinates.values()));
         Map<TopicIdPartition, FindBatchResponse> result = job.call();
 
+        assertThat(result).isEqualTo(coordinates);
+    }
+
+    @Test
+    public void findSingleBatchWithoutTopicId() throws Exception {
+        final Uuid noTopicId = Uuid.ZERO_UUID;
+        TopicIdPartition partition0 = new TopicIdPartition(noTopicId, 0, "inkless-topic");
+        Map<TopicIdPartition, FetchRequest.PartitionData> fetchInfos = Map.of(
+            partition0, new FetchRequest.PartitionData(noTopicId, 0, 0, 1000, Optional.empty())
+        );
+        int logStartOffset = 0;
+        long logAppendTimestamp = 10L;
+        long maxBatchTimestamp = 20L;
+        int highWatermark = 1;
+
+        // Simulate the metadata view returning a topic ID for the partition
+        when(metadataView.getTopicId(partition0.topic())).thenReturn(topicId);
+
+        Map<TopicIdPartition, FindBatchResponse> coordinates = Map.of(
+            partition0, FindBatchResponse.success(List.of(
+                new BatchInfo(1L, OBJECT_KEY_MAIN_PART, BatchMetadata.of(partition0, 0, 10, 0, 0, logAppendTimestamp, maxBatchTimestamp, TimestampType.CREATE_TIME))
+            ), logStartOffset, highWatermark)
+        );
+        FindBatchesJob job = new FindBatchesJob(time, controlPlane, metadataView, params, fetchInfos, durationMs -> {});
+        when(controlPlane.findBatches(requestCaptor.capture(), anyInt())).thenReturn(new ArrayList<>(coordinates.values()));
+        Map<TopicIdPartition, FindBatchResponse> result = job.call();
+
+        // Verify that the request was made with the correct topic ID and the result is still with the original partition with no topic ID
         assertThat(result).isEqualTo(coordinates);
     }
 }

--- a/storage/inkless/src/test/java/io/aiven/inkless/consume/ReaderTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/consume/ReaderTest.java
@@ -40,6 +40,7 @@ import io.aiven.inkless.cache.ObjectCache;
 import io.aiven.inkless.common.ObjectKey;
 import io.aiven.inkless.common.ObjectKeyCreator;
 import io.aiven.inkless.control_plane.ControlPlane;
+import io.aiven.inkless.control_plane.MetadataView;
 import io.aiven.inkless.storage_backend.common.ObjectFetcher;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -58,6 +59,8 @@ public class ReaderTest {
     @Mock
     private ControlPlane controlPlane;
     @Mock
+    private MetadataView metadataView;
+    @Mock
     private ObjectFetcher objectFetcher;
     @Mock
     private ExecutorService metadataExecutor;
@@ -75,7 +78,7 @@ public class ReaderTest {
 
     @BeforeEach
     public void setup() {
-        reader = new Reader(time, OBJECT_KEY_CREATOR, KEY_ALIGNMENT_STRATEGY, OBJECT_CACHE, controlPlane, objectFetcher, metadataExecutor, fetchPlannerExecutor, dataExecutor, fetchCompleterExecutor);
+        reader = new Reader(time, OBJECT_KEY_CREATOR, KEY_ALIGNMENT_STRATEGY, OBJECT_CACHE, controlPlane, metadataView, objectFetcher, metadataExecutor, fetchPlannerExecutor, dataExecutor, fetchCompleterExecutor);
     }
 
     @Test


### PR DESCRIPTION
Kafka clients based in Fetch < version 13 will not include topic id. Kafka API will default to ZERO_UUID in those cases.

As inkless rely on topic id to find logs and batches, the consume path has to be adapted to find the right topic id.

We haven't found any other Kafka API that would require this handling so the fix is only focused on the consume path.
