### PR TITLE
Remove files_to_delete table [INK-38]

### DIFF
--- a/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/CommitFileJobTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/CommitFileJobTest.java
@@ -119,7 +119,7 @@ class CommitFileJobTest {
 
         assertThat(DBUtils.getAllFiles(pgContainer.getDataSource()))
             .containsExactlyInAnyOrder(
-                new FilesRecord(EXPECTED_FILE_ID_1, "obj1", FORMAT, FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, TimeUtils.now(time), FILE_SIZE, FILE_SIZE)
+                new FilesRecord(EXPECTED_FILE_ID_1, "obj1", FORMAT, FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, TimeUtils.now(time), null, FILE_SIZE, FILE_SIZE)
             );
 
         assertThat(DBUtils.getAllBatches(pgContainer.getDataSource()))
@@ -175,8 +175,8 @@ class CommitFileJobTest {
 
         assertThat(DBUtils.getAllFiles(pgContainer.getDataSource()))
             .containsExactlyInAnyOrder(
-                new FilesRecord(EXPECTED_FILE_ID_1, "obj1", FORMAT, FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, time1, FILE_SIZE, FILE_SIZE),
-                new FilesRecord(EXPECTED_FILE_ID_2, "obj2", FORMAT, FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, time2, FILE_SIZE, FILE_SIZE)
+                new FilesRecord(EXPECTED_FILE_ID_1, "obj1", FORMAT, FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, time1, null, FILE_SIZE, FILE_SIZE),
+                new FilesRecord(EXPECTED_FILE_ID_2, "obj2", FORMAT, FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, time2, null, FILE_SIZE, FILE_SIZE)
             );
 
         assertThat(DBUtils.getAllBatches(pgContainer.getDataSource()))
@@ -221,7 +221,7 @@ class CommitFileJobTest {
 
         assertThat(DBUtils.getAllFiles(pgContainer.getDataSource()))
             .containsExactlyInAnyOrder(
-                new FilesRecord(EXPECTED_FILE_ID_1, "obj1", FORMAT, FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, TimeUtils.now(time), FILE_SIZE, FILE_SIZE)
+                new FilesRecord(EXPECTED_FILE_ID_1, "obj1", FORMAT, FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, TimeUtils.now(time), null, FILE_SIZE, FILE_SIZE)
             );
 
         assertThat(DBUtils.getAllBatches(pgContainer.getDataSource()))
@@ -255,7 +255,7 @@ class CommitFileJobTest {
 
         assertThat(DBUtils.getAllFiles(pgContainer.getDataSource()))
             .containsExactlyInAnyOrder(
-                new FilesRecord(EXPECTED_FILE_ID_1, "obj1", FORMAT, FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, TimeUtils.now(time), FILE_SIZE, FILE_SIZE)
+                new FilesRecord(EXPECTED_FILE_ID_1, "obj1", FORMAT, FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, TimeUtils.now(time), null, FILE_SIZE, FILE_SIZE)
             );
 
         assertThat(DBUtils.getAllBatches(pgContainer.getDataSource()))
@@ -289,7 +289,7 @@ class CommitFileJobTest {
 
         assertThat(DBUtils.getAllFiles(pgContainer.getDataSource()))
             .containsExactlyInAnyOrder(
-                new FilesRecord(EXPECTED_FILE_ID_1, "obj1", FORMAT, FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, TimeUtils.now(time), FILE_SIZE, FILE_SIZE)
+                new FilesRecord(EXPECTED_FILE_ID_1, "obj1", FORMAT, FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, TimeUtils.now(time), null, FILE_SIZE, FILE_SIZE)
             );
 
         assertThat(DBUtils.getAllBatches(pgContainer.getDataSource()))
@@ -330,7 +330,7 @@ class CommitFileJobTest {
 
         assertThat(DBUtils.getAllFiles(pgContainer.getDataSource()))
             .containsExactlyInAnyOrder(
-                new FilesRecord(EXPECTED_FILE_ID_1, "obj1", FORMAT, FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, TimeUtils.now(time), FILE_SIZE, FILE_SIZE)
+                new FilesRecord(EXPECTED_FILE_ID_1, "obj1", FORMAT, FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, TimeUtils.now(time), null, FILE_SIZE, FILE_SIZE)
             );
 
         assertThat(DBUtils.getAllBatches(pgContainer.getDataSource()))
@@ -361,7 +361,7 @@ class CommitFileJobTest {
 
         assertThat(DBUtils.getAllFiles(pgContainer.getDataSource()))
             .containsExactlyInAnyOrder(
-                new FilesRecord(EXPECTED_FILE_ID_1, "obj1", FORMAT, FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, TimeUtils.now(time), FILE_SIZE, FILE_SIZE)
+                new FilesRecord(EXPECTED_FILE_ID_1, "obj1", FORMAT, FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, TimeUtils.now(time), null, FILE_SIZE, FILE_SIZE)
             );
         assertThat(DBUtils.getAllBatches(pgContainer.getDataSource())).isEmpty();
     }
@@ -390,7 +390,7 @@ class CommitFileJobTest {
 
         assertThat(DBUtils.getAllFiles(pgContainer.getDataSource()))
             .containsExactlyInAnyOrder(
-                new FilesRecord(EXPECTED_FILE_ID_1, "obj1", FORMAT, FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, TimeUtils.now(time), FILE_SIZE, FILE_SIZE)
+                new FilesRecord(EXPECTED_FILE_ID_1, "obj1", FORMAT, FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, TimeUtils.now(time), null, FILE_SIZE, FILE_SIZE)
             );
 
         assertThat(DBUtils.getAllBatches(pgContainer.getDataSource()))

--- a/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/DBUtils.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/DBUtils.java
@@ -25,7 +25,6 @@ import org.jooq.Record;
 import org.jooq.SQLDialect;
 import org.jooq.generated.tables.records.BatchesRecord;
 import org.jooq.generated.tables.records.FilesRecord;
-import org.jooq.generated.tables.records.FilesToDeleteRecord;
 import org.jooq.generated.tables.records.LogsRecord;
 import org.jooq.impl.DSL;
 import org.jooq.impl.TableImpl;
@@ -37,7 +36,6 @@ import java.util.stream.Collectors;
 
 import static org.jooq.generated.Tables.BATCHES;
 import static org.jooq.generated.Tables.FILES;
-import static org.jooq.generated.Tables.FILES_TO_DELETE;
 import static org.jooq.generated.Tables.LOGS;
 import static org.jooq.impl.DSL.asterisk;
 
@@ -48,10 +46,6 @@ public class DBUtils {
 
     static Set<FilesRecord> getAllFiles(final HikariDataSource hikariDataSource) {
         return getAll(hikariDataSource, FILES, FilesRecord.class);
-    }
-
-    static Set<FilesToDeleteRecord> getAllFilesToDelete(final HikariDataSource hikariDataSource) {
-        return getAll(hikariDataSource, FILES_TO_DELETE, FilesToDeleteRecord.class);
     }
 
     static Set<BatchesRecord> getAllBatches(final HikariDataSource hikariDataSource) {

--- a/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/DeleteFilesJobTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/DeleteFilesJobTest.java
@@ -25,7 +25,6 @@ import org.apache.kafka.common.utils.Time;
 
 import org.jooq.generated.enums.FileStateT;
 import org.jooq.generated.tables.records.FilesRecord;
-import org.jooq.generated.tables.records.FilesToDeleteRecord;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -147,21 +146,17 @@ class DeleteFilesJobTest {
 
         // File 1 must be `deleting` because it contained only data from the deleted TOPIC_1.
         assertThat(DBUtils.getAllFiles(pgContainer.getDataSource())).containsExactlyInAnyOrder(
-            new FilesRecord(1L, objectKey1, FORMAT, FileReason.PRODUCE, FileStateT.deleting, BROKER_ID, filesCommittedAt, (long) file1Size, 0L),
-            new FilesRecord(2L, objectKey2, FORMAT, FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, filesCommittedAt, (long) file2Size, (long) file2Batch2Size),
-            new FilesRecord(3L, objectKey3, FORMAT, FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, filesCommittedAt, (long) file3Size, (long) file3Batch3Size)
-        );
-        assertThat(DBUtils.getAllFilesToDelete(pgContainer.getDataSource())).containsExactlyInAnyOrder(
-            new FilesToDeleteRecord(1L, topicsDeletedAt)
+            new FilesRecord(1L, objectKey1, FORMAT, FileReason.PRODUCE, FileStateT.deleting, BROKER_ID, filesCommittedAt, topicsDeletedAt, (long) file1Size, 0L),
+            new FilesRecord(2L, objectKey2, FORMAT, FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, filesCommittedAt, null, (long) file2Size, (long) file2Batch2Size),
+            new FilesRecord(3L, objectKey3, FORMAT, FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, filesCommittedAt, null, (long) file3Size, (long) file3Batch3Size)
         );
 
         new DeleteFilesJob(
             time, pgContainer.getJooqCtx(), new DeleteFilesRequest(Set.of(objectKey1)), durationCallback
         ).run();
-        assertThat(DBUtils.getAllFilesToDelete(pgContainer.getDataSource())).isEmpty();
         assertThat(DBUtils.getAllFiles(pgContainer.getDataSource())).containsExactlyInAnyOrder(
-            new FilesRecord(2L, objectKey2, FORMAT, FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, filesCommittedAt, (long) file2Size, (long) file2Batch2Size),
-            new FilesRecord(3L, objectKey3, FORMAT, FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, filesCommittedAt, (long) file3Size, (long) file3Batch3Size)
+            new FilesRecord(2L, objectKey2, FORMAT, FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, filesCommittedAt, null, (long) file2Size, (long) file2Batch2Size),
+            new FilesRecord(3L, objectKey3, FORMAT, FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, filesCommittedAt, null, (long) file3Size, (long) file3Batch3Size)
         );
 
     }

--- a/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/DeleteRecordsJobTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/DeleteRecordsJobTest.java
@@ -27,7 +27,6 @@ import org.apache.kafka.common.utils.Time;
 import org.jooq.generated.enums.FileStateT;
 import org.jooq.generated.tables.records.BatchesRecord;
 import org.jooq.generated.tables.records.FilesRecord;
-import org.jooq.generated.tables.records.FilesToDeleteRecord;
 import org.jooq.generated.tables.records.LogsRecord;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -187,12 +186,9 @@ class DeleteRecordsJobTest {
 
         // File 1 must be `deleting` because it contained only data from the fully truncated TOPIC_1.
         assertThat(DBUtils.getAllFiles(pgContainer.getDataSource())).containsExactlyInAnyOrder(
-            new FilesRecord(1L, objectKey1, FORMAT, FileReason.PRODUCE, FileStateT.deleting, BROKER_ID, filesCommittedAt, (long) file1Size, 0L),
-            new FilesRecord(2L, objectKey2, FORMAT, FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, filesCommittedAt, (long) file2Size, (long) file2Size),  // not a single batch deleted from file 2
-            new FilesRecord(3L, objectKey3, FORMAT, FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, filesCommittedAt, (long) file3Size, (long) file3Size - file3Batch2Size)
-        );
-        assertThat(DBUtils.getAllFilesToDelete(pgContainer.getDataSource())).containsExactlyInAnyOrder(
-            new FilesToDeleteRecord(1L, topicsDeletedAt)
+            new FilesRecord(1L, objectKey1, FORMAT, FileReason.PRODUCE, FileStateT.deleting, BROKER_ID, filesCommittedAt, topicsDeletedAt, (long) file1Size, 0L),
+            new FilesRecord(2L, objectKey2, FORMAT, FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, filesCommittedAt, null, (long) file2Size, (long) file2Size),  // not a single batch deleted from file 2
+            new FilesRecord(3L, objectKey3, FORMAT, FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, filesCommittedAt, null, (long) file3Size, (long) file3Size - file3Batch2Size)
         );
     }
 }

--- a/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/DeleteTopicJobTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/DeleteTopicJobTest.java
@@ -27,7 +27,6 @@ import org.apache.kafka.common.utils.Time;
 import org.jooq.generated.enums.FileStateT;
 import org.jooq.generated.tables.records.BatchesRecord;
 import org.jooq.generated.tables.records.FilesRecord;
-import org.jooq.generated.tables.records.FilesToDeleteRecord;
 import org.jooq.generated.tables.records.LogsRecord;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -161,12 +160,9 @@ class DeleteTopicJobTest {
 
         // File 1 must be `deleting` because it contained only data from the deleted TOPIC_1.
         assertThat(DBUtils.getAllFiles(pgContainer.getDataSource())).containsExactlyInAnyOrder(
-            new FilesRecord(1L, objectKey1, FORMAT, FileReason.PRODUCE, FileStateT.deleting, BROKER_ID, filesCommittedAt, (long) file1Size, 0L),
-            new FilesRecord(2L, objectKey2, FORMAT, FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, filesCommittedAt, (long) file2Size, (long) file2Batch2Size),
-            new FilesRecord(3L, objectKey3, FORMAT, FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, filesCommittedAt, (long) file3Size, (long) file3Batch3Size)
-        );
-        assertThat(DBUtils.getAllFilesToDelete(pgContainer.getDataSource())).containsExactlyInAnyOrder(
-            new FilesToDeleteRecord(1L, topicsDeletedAt)
+            new FilesRecord(1L, objectKey1, FORMAT, FileReason.PRODUCE, FileStateT.deleting, BROKER_ID, filesCommittedAt, topicsDeletedAt, (long) file1Size, 0L),
+            new FilesRecord(2L, objectKey2, FORMAT, FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, filesCommittedAt, null, (long) file2Size, (long) file2Batch2Size),
+            new FilesRecord(3L, objectKey3, FORMAT, FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, filesCommittedAt, null, (long) file3Size, (long) file3Batch3Size)
         );
     }
 }

--- a/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/FindFilesToDeleteJobTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/FindFilesToDeleteJobTest.java
@@ -47,7 +47,6 @@ import io.aiven.inkless.test_utils.PostgreSQLTestContainer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.jooq.generated.Tables.FILES;
-import static org.jooq.generated.Tables.FILES_TO_DELETE;
 
 @Testcontainers
 @ExtendWith(MockitoExtension.class)
@@ -75,16 +74,10 @@ class FindFilesToDeleteJobTest {
             final DSLContext ctx = DSL.using(connection, SQLDialect.POSTGRES);
 
             fileId = ctx.insertInto(FILES,
-                FILES.OBJECT_KEY, FILES.FORMAT, FILES.REASON, FILES.STATE, FILES.UPLOADER_BROKER_ID, FILES.COMMITTED_AT, FILES.SIZE, FILES.USED_SIZE
+                FILES.OBJECT_KEY, FILES.FORMAT, FILES.REASON, FILES.STATE, FILES.UPLOADER_BROKER_ID, FILES.COMMITTED_AT, FILES.MARKED_FOR_DELETION_AT, FILES.SIZE, FILES.USED_SIZE
             ).values(
-                OBJECT_KEY, (short) ObjectFormat.WRITE_AHEAD_MULTI_SEGMENT.id, FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, COMMITTED_AT, 1000L, 900L
+                OBJECT_KEY, (short) ObjectFormat.WRITE_AHEAD_MULTI_SEGMENT.id, FileReason.PRODUCE, FileStateT.deleting, BROKER_ID, COMMITTED_AT, MARKED_FOR_DELETION_AT, 1000L, 900L
             ).returning(FILES.FILE_ID).fetchOne(FILES.FILE_ID);
-
-            ctx.insertInto(FILES_TO_DELETE,
-                FILES_TO_DELETE.FILE_ID, FILES_TO_DELETE.MARKED_FOR_DELETION_AT
-            ).values(
-                fileId, MARKED_FOR_DELETION_AT
-            ).execute();
 
             connection.commit();
         }


### PR DESCRIPTION
It was replaced with the (already existing) `state` column in `files` + a new index to facilitate selecting files to delete.
