### PR TITLE
fix(inkless): add inkless.enable to dynamic config test

### DIFF
--- a/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
@@ -1128,6 +1128,9 @@ class KafkaConfigTest {
         case QuotaConfig.FOLLOWER_REPLICATION_THROTTLED_REPLICAS_CONFIG =>
         // topic only config
         case QuotaConfig.LEADER_REPLICATION_THROTTLED_REPLICAS_CONFIG =>
+        // inkless topic only config
+        case TopicConfig.INKLESS_ENABLE_CONFIG =>
+          assertDynamic(kafkaConfigProp, true, () => config.logInklessEnable)
         // topic only config
         case prop =>
           fail(prop + " must be explicitly checked for dynamic updatability. Note that LogConfig(s) require that KafkaConfig value lookups are dynamic and not static values.")


### PR DESCRIPTION
Dynamic server config tests are failing with new log inkless enable config: https://github.com/aiven/inkless/actions/runs/14795091429

`testDynamicLogConfigs()`
```
org.opentest4j.AssertionFailedError: inkless.enable must be explicitly checked for dynamic updatability. Note that LogConfig(s) require that KafkaConfig value lookups are dynamic and not static values.
	at app//org.junit.jupiter.api.AssertionUtils.fail(AssertionUtils.java:38)
	at app//org.junit.jupiter.api.Assertions.fail(Assertions.java:138)
	at app//kafka.server.KafkaConfigTest.$anonfun$testDynamicLogConfigs$1(KafkaConfigTest.scala:1133)
	at java.base@17.0.15/java.util.HashMap.forEach(HashMap.java:1421)
	at java.base@17.0.15/java.util.Collections$UnmodifiableMap.forEach(Collections.java:1553)
	at app//kafka.server.KafkaConfigTest.testDynamicLogConfigs(KafkaConfigTest.scala:1069)
	at java.base@17.0.15/java.lang.reflect.Method.invoke(Method.java:569)
	at java.base@17.0.15/java.util.ArrayList.forEach(ArrayList.java:1511)
	at java.base@17.0.15/java.util.ArrayList.forEach(ArrayList.java:1511)
```

Adding it to fix the test. 
