### PR TITLE
Don't track file used_size explicitly in PG [INK-38]

### DIFF
--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/FileMergeWorkItem.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/FileMergeWorkItem.java
@@ -30,7 +30,6 @@ public record FileMergeWorkItem(long workItemId,
                        String objectKey,
                        ObjectFormat format,
                        long size,
-                       long usedSize,
                        List<BatchInfo> batches) {
     }
 }

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/InMemoryControlPlane.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/InMemoryControlPlane.java
@@ -427,7 +427,6 @@ public class InMemoryControlPlane extends AbstractControlPlane {
                 fileInfo.objectKey,
                 fileInfo.format,
                 fileInfo.fileSize,
-                fileInfo.usedSize,
                 batchesFromFileToMerge(fileInfo)
             ));
             totalMergeableSize += fileInfo.fileSize;

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/GetFileMergeWorkItemJob.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/GetFileMergeWorkItemJob.java
@@ -97,7 +97,6 @@ public class GetFileMergeWorkItemJob implements Callable<FileMergeWorkItem> {
                             r.getObjectKey(),
                             ObjectFormat.forId(r.getFormat().byteValue()),
                             r.getSize(),
-                            r.getUsedSize(),
                             Arrays.stream(r.getBatches())
                                 .map(b -> {
                                         final var m = b.getMetadata();

--- a/storage/inkless/src/test/java/io/aiven/inkless/control_plane/AbstractControlPlaneTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/control_plane/AbstractControlPlaneTest.java
@@ -864,9 +864,9 @@ public abstract class AbstractControlPlaneTest {
                     List.of(CommitBatchRequest.of(0, EXISTING_TOPIC_1_ID_PARTITION_0, 0, (int) fileSize, 0, 100, 2000, TimestampType.CREATE_TIME)));
 
             final List<FileMergeWorkItem.File> expectedFiles = List.of(
-                new FileMergeWorkItem.File(1L, "obj0", ObjectFormat.WRITE_AHEAD_MULTI_SEGMENT, fileSize, fileSize,
+                new FileMergeWorkItem.File(1L, "obj0", ObjectFormat.WRITE_AHEAD_MULTI_SEGMENT, fileSize,
                     List.of(new BatchInfo(1, "obj0", BatchMetadata.of(EXISTING_TOPIC_1_ID_PARTITION_0, 0, fileSize, 0, 100, committedAt, 1000, TimestampType.CREATE_TIME)))),
-                new FileMergeWorkItem.File(2L, "obj1", ObjectFormat.WRITE_AHEAD_MULTI_SEGMENT, fileSize, fileSize,
+                new FileMergeWorkItem.File(2L, "obj1", ObjectFormat.WRITE_AHEAD_MULTI_SEGMENT, fileSize,
                     List.of(new BatchInfo(2, "obj1", BatchMetadata.of(EXISTING_TOPIC_1_ID_PARTITION_0, 0, fileSize, 101, 201, committedAt, 2000, TimestampType.CREATE_TIME)))
                 )
             );
@@ -897,9 +897,9 @@ public abstract class AbstractControlPlaneTest {
 
             // Get the merge work item.
             final List<FileMergeWorkItem.File> expectedFiles1 = List.of(
-                new FileMergeWorkItem.File(1L, "obj0", ObjectFormat.WRITE_AHEAD_MULTI_SEGMENT, fileSize, fileSize,
+                new FileMergeWorkItem.File(1L, "obj0", ObjectFormat.WRITE_AHEAD_MULTI_SEGMENT, fileSize,
                     List.of(new BatchInfo(1, "obj0", BatchMetadata.of(EXISTING_TOPIC_1_ID_PARTITION_0, 0, fileSize, 0, 100, committedAt, 1000, TimestampType.CREATE_TIME)))),
-                new FileMergeWorkItem.File(2L, "obj1", ObjectFormat.WRITE_AHEAD_MULTI_SEGMENT, fileSize, fileSize,
+                new FileMergeWorkItem.File(2L, "obj1", ObjectFormat.WRITE_AHEAD_MULTI_SEGMENT, fileSize,
                     List.of(new BatchInfo(2, "obj1", BatchMetadata.of(EXISTING_TOPIC_1_ID_PARTITION_0, 0, fileSize, 101, 201, committedAt, 2000, TimestampType.CREATE_TIME))))
             );
             assertThat(controlPlane.getFileMergeWorkItem())
@@ -911,9 +911,9 @@ public abstract class AbstractControlPlaneTest {
 
             // Now it's enough to have one more merge work item.
             final List<FileMergeWorkItem.File> expectedFiles2 = List.of(
-                new FileMergeWorkItem.File(3L, "obj2", ObjectFormat.WRITE_AHEAD_MULTI_SEGMENT, fileSize, fileSize,
+                new FileMergeWorkItem.File(3L, "obj2", ObjectFormat.WRITE_AHEAD_MULTI_SEGMENT, fileSize,
                     List.of(new BatchInfo(3, "obj2", BatchMetadata.of(EXISTING_TOPIC_1_ID_PARTITION_0, 0, fileSize, 202, 302, committedAt, 3000, TimestampType.CREATE_TIME)))),
-                new FileMergeWorkItem.File(4L, "obj3", ObjectFormat.WRITE_AHEAD_MULTI_SEGMENT, fileSize, fileSize,
+                new FileMergeWorkItem.File(4L, "obj3", ObjectFormat.WRITE_AHEAD_MULTI_SEGMENT, fileSize,
                     List.of(new BatchInfo(4, "obj3", BatchMetadata.of(EXISTING_TOPIC_1_ID_PARTITION_0, 0, fileSize, 303, 403, committedAt, 4000, TimestampType.CREATE_TIME))))
             );
             assertThat(controlPlane.getFileMergeWorkItem())
@@ -929,7 +929,7 @@ public abstract class AbstractControlPlaneTest {
                     List.of(CommitBatchRequest.of(0, EXISTING_TOPIC_1_ID_PARTITION_0, 0, (int) fileSize, 0, 100, 1000, TimestampType.CREATE_TIME)));
 
             final List<FileMergeWorkItem.File> expectedFiles = List.of(
-                new FileMergeWorkItem.File(1L, "obj0", ObjectFormat.WRITE_AHEAD_MULTI_SEGMENT, fileSize, fileSize,
+                new FileMergeWorkItem.File(1L, "obj0", ObjectFormat.WRITE_AHEAD_MULTI_SEGMENT, fileSize,
                     List.of(new BatchInfo(1, "obj0", BatchMetadata.of(EXISTING_TOPIC_1_ID_PARTITION_0, 0, fileSize, 0, 100, committedAt, 1000, TimestampType.CREATE_TIME))))
             );
             assertThat(controlPlane.getFileMergeWorkItem())
@@ -949,9 +949,9 @@ public abstract class AbstractControlPlaneTest {
                     List.of(CommitBatchRequest.of(0, EXISTING_TOPIC_1_ID_PARTITION_0, 0, (int) batchSize, 0, 100, 3000, TimestampType.CREATE_TIME)));
 
             final List<FileMergeWorkItem.File> expectedFiles1 = List.of(
-                new FileMergeWorkItem.File(1L, "obj0", ObjectFormat.WRITE_AHEAD_MULTI_SEGMENT, batchSize, batchSize,
+                new FileMergeWorkItem.File(1L, "obj0", ObjectFormat.WRITE_AHEAD_MULTI_SEGMENT, batchSize,
                     List.of(new BatchInfo(1, "obj0", BatchMetadata.of(EXISTING_TOPIC_1_ID_PARTITION_0, 0, batchSize, 0, 100, committedAt, 1000, TimestampType.CREATE_TIME)))),
-                new FileMergeWorkItem.File(2L, "obj1", ObjectFormat.WRITE_AHEAD_MULTI_SEGMENT, batchSize, batchSize,
+                new FileMergeWorkItem.File(2L, "obj1", ObjectFormat.WRITE_AHEAD_MULTI_SEGMENT, batchSize,
                     List.of(new BatchInfo(2, "obj1", BatchMetadata.of(EXISTING_TOPIC_1_ID_PARTITION_0, 0, batchSize, 101, 201, committedAt, 2000, TimestampType.CREATE_TIME))))
             );
             assertThat(controlPlane.getFileMergeWorkItem())
@@ -974,9 +974,9 @@ public abstract class AbstractControlPlaneTest {
 
             // File 4 is the merged file, batches 4 and 5 are in it.
             final List<FileMergeWorkItem.File> expectedFiles2= List.of(
-                new FileMergeWorkItem.File(3L, "obj2", ObjectFormat.WRITE_AHEAD_MULTI_SEGMENT, batchSize, batchSize,
+                new FileMergeWorkItem.File(3L, "obj2", ObjectFormat.WRITE_AHEAD_MULTI_SEGMENT, batchSize,
                     List.of(new BatchInfo(3, "obj2", BatchMetadata.of(EXISTING_TOPIC_1_ID_PARTITION_0, 0, batchSize, 202, 302, committedAt, 3000, TimestampType.CREATE_TIME)))),
-                new FileMergeWorkItem.File(5L, "obj3", ObjectFormat.WRITE_AHEAD_MULTI_SEGMENT, batchSize, batchSize,
+                new FileMergeWorkItem.File(5L, "obj3", ObjectFormat.WRITE_AHEAD_MULTI_SEGMENT, batchSize,
                     List.of(new BatchInfo(6, "obj3", BatchMetadata.of(EXISTING_TOPIC_1_ID_PARTITION_0, 0, batchSize, 303, 403, committedAt, 4000, TimestampType.CREATE_TIME))))
             );
             assertThat(controlPlane.getFileMergeWorkItem())
@@ -1491,7 +1491,7 @@ public abstract class AbstractControlPlaneTest {
                     List.of(CommitBatchRequest.of(0, EXISTING_TOPIC_1_ID_PARTITION_0, 0, (int) fileSize, 0, 100, 1000, TimestampType.CREATE_TIME)));
 
             final List<FileMergeWorkItem.File> expectedFiles = List.of(
-                new FileMergeWorkItem.File(1L, "obj0", ObjectFormat.WRITE_AHEAD_MULTI_SEGMENT, fileSize, fileSize,
+                new FileMergeWorkItem.File(1L, "obj0", ObjectFormat.WRITE_AHEAD_MULTI_SEGMENT, fileSize,
                     List.of(new BatchInfo(1, "obj0", BatchMetadata.of(EXISTING_TOPIC_1_ID_PARTITION_0, 0, fileSize, 0, 100, committedAt, 1000, TimestampType.CREATE_TIME)))
                 )
             );

--- a/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/CommitFileJobTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/CommitFileJobTest.java
@@ -119,7 +119,7 @@ class CommitFileJobTest {
 
         assertThat(DBUtils.getAllFiles(pgContainer.getDataSource()))
             .containsExactlyInAnyOrder(
-                new FilesRecord(EXPECTED_FILE_ID_1, "obj1", FORMAT, FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, TimeUtils.now(time), null, FILE_SIZE, FILE_SIZE)
+                new FilesRecord(EXPECTED_FILE_ID_1, "obj1", FORMAT, FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, TimeUtils.now(time), null, FILE_SIZE)
             );
 
         assertThat(DBUtils.getAllBatches(pgContainer.getDataSource()))
@@ -175,8 +175,8 @@ class CommitFileJobTest {
 
         assertThat(DBUtils.getAllFiles(pgContainer.getDataSource()))
             .containsExactlyInAnyOrder(
-                new FilesRecord(EXPECTED_FILE_ID_1, "obj1", FORMAT, FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, time1, null, FILE_SIZE, FILE_SIZE),
-                new FilesRecord(EXPECTED_FILE_ID_2, "obj2", FORMAT, FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, time2, null, FILE_SIZE, FILE_SIZE)
+                new FilesRecord(EXPECTED_FILE_ID_1, "obj1", FORMAT, FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, time1, null, FILE_SIZE),
+                new FilesRecord(EXPECTED_FILE_ID_2, "obj2", FORMAT, FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, time2, null, FILE_SIZE)
             );
 
         assertThat(DBUtils.getAllBatches(pgContainer.getDataSource()))
@@ -222,7 +222,7 @@ class CommitFileJobTest {
 
         assertThat(DBUtils.getAllFiles(pgContainer.getDataSource()))
             .containsExactlyInAnyOrder(
-                new FilesRecord(EXPECTED_FILE_ID_1, "obj1", FORMAT, FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, TimeUtils.now(time), null, FILE_SIZE, FILE_SIZE - request3BatchSize)
+                new FilesRecord(EXPECTED_FILE_ID_1, "obj1", FORMAT, FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, TimeUtils.now(time), null, FILE_SIZE)
             );
 
         assertThat(DBUtils.getAllBatches(pgContainer.getDataSource()))
@@ -256,7 +256,7 @@ class CommitFileJobTest {
 
         assertThat(DBUtils.getAllFiles(pgContainer.getDataSource()))
             .containsExactlyInAnyOrder(
-                new FilesRecord(EXPECTED_FILE_ID_1, "obj1", FORMAT, FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, TimeUtils.now(time), null, FILE_SIZE, FILE_SIZE)
+                new FilesRecord(EXPECTED_FILE_ID_1, "obj1", FORMAT, FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, TimeUtils.now(time), null, FILE_SIZE)
             );
 
         assertThat(DBUtils.getAllBatches(pgContainer.getDataSource()))
@@ -290,7 +290,7 @@ class CommitFileJobTest {
 
         assertThat(DBUtils.getAllFiles(pgContainer.getDataSource()))
             .containsExactlyInAnyOrder(
-                new FilesRecord(EXPECTED_FILE_ID_1, "obj1", FORMAT, FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, TimeUtils.now(time), null, FILE_SIZE, FILE_SIZE)
+                new FilesRecord(EXPECTED_FILE_ID_1, "obj1", FORMAT, FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, TimeUtils.now(time), null, FILE_SIZE)
             );
 
         assertThat(DBUtils.getAllBatches(pgContainer.getDataSource()))
@@ -332,7 +332,7 @@ class CommitFileJobTest {
 
         assertThat(DBUtils.getAllFiles(pgContainer.getDataSource()))
             .containsExactlyInAnyOrder(
-                new FilesRecord(EXPECTED_FILE_ID_1, "obj1", FORMAT, FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, TimeUtils.now(time), null, FILE_SIZE, FILE_SIZE - request2BatchSize)
+                new FilesRecord(EXPECTED_FILE_ID_1, "obj1", FORMAT, FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, TimeUtils.now(time), null, FILE_SIZE)
             );
 
         assertThat(DBUtils.getAllBatches(pgContainer.getDataSource()))
@@ -362,9 +362,11 @@ class CommitFileJobTest {
                 new LogsRecord(TOPIC_ID_1, 0, TOPIC_1, 0L, 0L)
             );
 
+        // The file will be deleted because its only batch is rejected.
+        final Instant now = TimeUtils.now(time);
         assertThat(DBUtils.getAllFiles(pgContainer.getDataSource()))
             .containsExactlyInAnyOrder(
-                new FilesRecord(EXPECTED_FILE_ID_1, "obj1", FORMAT, FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, TimeUtils.now(time), null, FILE_SIZE, FILE_SIZE - request1BatchSize)
+                new FilesRecord(EXPECTED_FILE_ID_1, "obj1", FORMAT, FileReason.PRODUCE, FileStateT.deleting, BROKER_ID, now, now, FILE_SIZE)
             );
         assertThat(DBUtils.getAllBatches(pgContainer.getDataSource())).isEmpty();
     }
@@ -394,7 +396,7 @@ class CommitFileJobTest {
 
         assertThat(DBUtils.getAllFiles(pgContainer.getDataSource()))
             .containsExactlyInAnyOrder(
-                new FilesRecord(EXPECTED_FILE_ID_1, "obj1", FORMAT, FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, TimeUtils.now(time), null, FILE_SIZE, FILE_SIZE - request2BatchSize)
+                new FilesRecord(EXPECTED_FILE_ID_1, "obj1", FORMAT, FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, TimeUtils.now(time), null, FILE_SIZE)
             );
 
         assertThat(DBUtils.getAllBatches(pgContainer.getDataSource()))

--- a/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/DeleteRecordsJobTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/DeleteRecordsJobTest.java
@@ -186,9 +186,9 @@ class DeleteRecordsJobTest {
 
         // File 1 must be `deleting` because it contained only data from the fully truncated TOPIC_1.
         assertThat(DBUtils.getAllFiles(pgContainer.getDataSource())).containsExactlyInAnyOrder(
-            new FilesRecord(1L, objectKey1, FORMAT, FileReason.PRODUCE, FileStateT.deleting, BROKER_ID, filesCommittedAt, topicsDeletedAt, (long) file1Size, 0L),
-            new FilesRecord(2L, objectKey2, FORMAT, FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, filesCommittedAt, null, (long) file2Size, (long) file2Size),  // not a single batch deleted from file 2
-            new FilesRecord(3L, objectKey3, FORMAT, FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, filesCommittedAt, null, (long) file3Size, (long) file3Size - file3Batch2Size)
+            new FilesRecord(1L, objectKey1, FORMAT, FileReason.PRODUCE, FileStateT.deleting, BROKER_ID, filesCommittedAt, topicsDeletedAt, (long) file1Size),
+            new FilesRecord(2L, objectKey2, FORMAT, FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, filesCommittedAt, null, (long) file2Size),  // not a single batch deleted from file 2
+            new FilesRecord(3L, objectKey3, FORMAT, FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, filesCommittedAt, null, (long) file3Size)
         );
     }
 }

--- a/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/DeleteTopicJobTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/DeleteTopicJobTest.java
@@ -160,9 +160,9 @@ class DeleteTopicJobTest {
 
         // File 1 must be `deleting` because it contained only data from the deleted TOPIC_1.
         assertThat(DBUtils.getAllFiles(pgContainer.getDataSource())).containsExactlyInAnyOrder(
-            new FilesRecord(1L, objectKey1, FORMAT, FileReason.PRODUCE, FileStateT.deleting, BROKER_ID, filesCommittedAt, topicsDeletedAt, (long) file1Size, 0L),
-            new FilesRecord(2L, objectKey2, FORMAT, FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, filesCommittedAt, null, (long) file2Size, (long) file2Batch2Size),
-            new FilesRecord(3L, objectKey3, FORMAT, FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, filesCommittedAt, null, (long) file3Size, (long) file3Batch3Size)
+            new FilesRecord(1L, objectKey1, FORMAT, FileReason.PRODUCE, FileStateT.deleting, BROKER_ID, filesCommittedAt, topicsDeletedAt, (long) file1Size),
+            new FilesRecord(2L, objectKey2, FORMAT, FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, filesCommittedAt, null, (long) file2Size),
+            new FilesRecord(3L, objectKey3, FORMAT, FileReason.PRODUCE, FileStateT.uploaded, BROKER_ID, filesCommittedAt, null, (long) file3Size)
         );
     }
 }

--- a/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/FindFilesToDeleteJobTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/FindFilesToDeleteJobTest.java
@@ -74,9 +74,9 @@ class FindFilesToDeleteJobTest {
             final DSLContext ctx = DSL.using(connection, SQLDialect.POSTGRES);
 
             fileId = ctx.insertInto(FILES,
-                FILES.OBJECT_KEY, FILES.FORMAT, FILES.REASON, FILES.STATE, FILES.UPLOADER_BROKER_ID, FILES.COMMITTED_AT, FILES.MARKED_FOR_DELETION_AT, FILES.SIZE, FILES.USED_SIZE
+                FILES.OBJECT_KEY, FILES.FORMAT, FILES.REASON, FILES.STATE, FILES.UPLOADER_BROKER_ID, FILES.COMMITTED_AT, FILES.MARKED_FOR_DELETION_AT, FILES.SIZE
             ).values(
-                OBJECT_KEY, (short) ObjectFormat.WRITE_AHEAD_MULTI_SEGMENT.id, FileReason.PRODUCE, FileStateT.deleting, BROKER_ID, COMMITTED_AT, MARKED_FOR_DELETION_AT, 1000L, 900L
+                OBJECT_KEY, (short) ObjectFormat.WRITE_AHEAD_MULTI_SEGMENT.id, FileReason.PRODUCE, FileStateT.deleting, BROKER_ID, COMMITTED_AT, MARKED_FOR_DELETION_AT, 1000L
             ).returning(FILES.FILE_ID).fetchOne(FILES.FILE_ID);
 
             connection.commit();

--- a/storage/inkless/src/test/java/io/aiven/inkless/merge/FileMergerMockedTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/merge/FileMergerMockedTest.java
@@ -141,7 +141,7 @@ class FileMergerMockedTest {
         final int file1UsedSize = file1Size;
         final byte[] file1Batch1 = MockInputStream.generateData(file1Batch1Size, "file1Batch1");
 
-        final FileMergeWorkItem.File file1InWorkItem = new FileMergeWorkItem.File(file1Id, obj1, ObjectFormat.WRITE_AHEAD_MULTI_SEGMENT, file1Size, file1UsedSize, List.of(
+        final FileMergeWorkItem.File file1InWorkItem = new FileMergeWorkItem.File(file1Id, obj1, ObjectFormat.WRITE_AHEAD_MULTI_SEGMENT, file1Size, List.of(
             new BatchInfo(batch1Id, obj1, BatchMetadata.of(T1P0, 0, file1Batch1Size, 1L, 11L, 1L, 2L, TimestampType.CREATE_TIME))
         ));
 
@@ -221,7 +221,7 @@ class FileMergerMockedTest {
         final List<BatchInfo> file1Batches = directBatchOrder
             ? List.of(file1Batch1InWorkItem, file1Batch2InWorkItem)
             : List.of(file1Batch2InWorkItem, file1Batch1InWorkItem);
-        final FileMergeWorkItem.File file1InWorkItem = new FileMergeWorkItem.File(file1Id, obj1, ObjectFormat.WRITE_AHEAD_MULTI_SEGMENT, file1Size, file1UsedSize, file1Batches);
+        final FileMergeWorkItem.File file1InWorkItem = new FileMergeWorkItem.File(file1Id, obj1, ObjectFormat.WRITE_AHEAD_MULTI_SEGMENT, file1Size, file1Batches);
 
         final MockInputStream file1 = new MockInputStream(file1Size);
         file1.addGap(file1Gap1Size);
@@ -248,7 +248,7 @@ class FileMergerMockedTest {
         final List<BatchInfo> file2Batches = directBatchOrder
             ? List.of(file2Batch1InWorkItem, file2Batch2InWorkItem)
             : List.of(file2Batch2InWorkItem, file2Batch1InWorkItem);
-        final FileMergeWorkItem.File file2InWorkItem = new FileMergeWorkItem.File(file2Id, obj2, ObjectFormat.WRITE_AHEAD_MULTI_SEGMENT, file2Size, file2UsedSize, file2Batches);
+        final FileMergeWorkItem.File file2InWorkItem = new FileMergeWorkItem.File(file2Id, obj2, ObjectFormat.WRITE_AHEAD_MULTI_SEGMENT, file2Size, file2Batches);
 
         final MockInputStream file2 = new MockInputStream(file2Size);
         file2.addBatch(file2Batch1);
@@ -321,7 +321,7 @@ class FileMergerMockedTest {
 
         bindFilesToObjectNames(Map.of(obj1, file1));
 
-        final FileMergeWorkItem.File file1InWorkItem = new FileMergeWorkItem.File(1, obj1, ObjectFormat.WRITE_AHEAD_MULTI_SEGMENT, 10, 10, List.of(
+        final FileMergeWorkItem.File file1InWorkItem = new FileMergeWorkItem.File(1, obj1, ObjectFormat.WRITE_AHEAD_MULTI_SEGMENT, 10, List.of(
             new BatchInfo(batch1Id, obj1, BatchMetadata.of(T1P0, 0, 10, 1L, 11L, 1L, 2L, TimestampType.CREATE_TIME))
         ));
         when(controlPlane.getFileMergeWorkItem()).thenReturn(
@@ -353,7 +353,6 @@ class FileMergerMockedTest {
 
         final int file1Batch1Size = 100;
         final int file1Size = file1Batch1Size;
-        final int file1UsedSize = file1Size;
         final byte[] file1Batch1 = MockInputStream.generateData(file1Batch1Size, "file1Batch1");
 
         final MockInputStream file1 = new MockInputStream(file1Size);
@@ -367,7 +366,7 @@ class FileMergerMockedTest {
         }).when(storage).upload(any(ObjectKey.class), any(InputStream.class), anyLong());
         bindFilesToObjectNames(Map.of(obj1, file1));
 
-        final FileMergeWorkItem.File file1InWorkItem = new FileMergeWorkItem.File(file1Id, obj1, ObjectFormat.WRITE_AHEAD_MULTI_SEGMENT, file1Size, file1UsedSize, List.of(
+        final FileMergeWorkItem.File file1InWorkItem = new FileMergeWorkItem.File(file1Id, obj1, ObjectFormat.WRITE_AHEAD_MULTI_SEGMENT, file1Size, List.of(
             new BatchInfo(batch1Id, obj1, BatchMetadata.of(T1P0, 0, file1Batch1Size, 1L, 11L, 1L, 2L, TimestampType.CREATE_TIME))
         ));
         when(controlPlane.getFileMergeWorkItem()).thenReturn(
@@ -413,7 +412,7 @@ class FileMergerMockedTest {
         }).when(storage).upload(any(ObjectKey.class), any(InputStream.class), anyLong());
         bindFilesToObjectNames(Map.of(obj1, file1));
 
-        final FileMergeWorkItem.File file1InWorkItem = new FileMergeWorkItem.File(file1Id, obj1, ObjectFormat.WRITE_AHEAD_MULTI_SEGMENT, file1Size, file1UsedSize, List.of(
+        final FileMergeWorkItem.File file1InWorkItem = new FileMergeWorkItem.File(file1Id, obj1, ObjectFormat.WRITE_AHEAD_MULTI_SEGMENT, file1Size, List.of(
             new BatchInfo(batch1Id, obj1, BatchMetadata.of(T1P0, 0, file1Batch1Size, 1L, 11L, 1L, 2L, TimestampType.CREATE_TIME))
         ));
         when(controlPlane.getFileMergeWorkItem())
@@ -459,7 +458,7 @@ class FileMergerMockedTest {
         }).when(storage).upload(any(ObjectKey.class), any(InputStream.class), anyLong());
         bindFilesToObjectNames(Map.of(obj1, file1));
 
-        final FileMergeWorkItem.File file1InWorkItem = new FileMergeWorkItem.File(file1Id, obj1, ObjectFormat.WRITE_AHEAD_MULTI_SEGMENT, file1Size, file1UsedSize, List.of(
+        final FileMergeWorkItem.File file1InWorkItem = new FileMergeWorkItem.File(file1Id, obj1, ObjectFormat.WRITE_AHEAD_MULTI_SEGMENT, file1Size, List.of(
             new BatchInfo(batch1Id, obj1, BatchMetadata.of(T1P0, 0, file1Batch1Size, 1L, 11L, 1L, 2L, TimestampType.CREATE_TIME))
         ));
         when(controlPlane.getFileMergeWorkItem())


### PR DESCRIPTION
Instead, rely on references from existing batches. This will prevent various types of bugs with forgotten changes of `used_size`.
