### PR TITLE
fix(inkless): fix config records validation for internal topics using inkless

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -890,7 +890,7 @@ public class ReplicationControlManager {
             }
         }
         if (Topic.isInternal(topic.name()) && !inklessSet) {
-            configRecords.add(new ApiMessageAndVersion(new ConfigRecord()
+            validConfigRecord.add(new ApiMessageAndVersion(new ConfigRecord()
                 .setName(INKLESS_ENABLE_CONFIG)
                 .setValue("false")
                 .setResourceName(topic.name())


### PR DESCRIPTION
`configRecords.add` was throwing `UnsupportedOperationException` and `kafka.server.MetadataRequestTest#testIsInternal` was failing.