### PR TITLE
chore(inkless:build): bump jooq docker

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ plugins {
   id 'com.diffplug.spotless' version "6.25.0"
 
   id 'info.solidsoft.pitest' version '1.15.0' apply false
-  id 'dev.monosoul.jooq-docker'  version "6.1.16" apply false
+  id 'dev.monosoul.jooq-docker'  version "6.1.19" apply false
 }
 
 ext {


### PR DESCRIPTION
For some reason the current version was failing to download images locally. Bumping the version seem to fix it.
