### PR TITLE
feat(inkless:pg): add max connections config

### DIFF
--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/PostgresControlPlane.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/PostgresControlPlane.java
@@ -89,6 +89,8 @@ public class PostgresControlPlane extends AbstractControlPlane {
 
         config.setTransactionIsolation(IsolationLevel.TRANSACTION_READ_COMMITTED.name());
 
+        config.setMaximumPoolSize(controlPlaneConfig.maxConnections());
+
         // We're doing interactive transactions.
         config.setAutoCommit(false);
 

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/PostgresControlPlaneConfig.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/PostgresControlPlaneConfig.java
@@ -34,6 +34,9 @@ public class PostgresControlPlaneConfig extends AbstractControlPlaneConfig {
     public static final String PASSWORD_CONFIG = "password";
     private static final String PASSWORD_DOC = "Password";
 
+    public static final String MAX_CONNECTIONS_CONFIG = "max.connections";
+    private static final String MAX_CONNECTIONS_DOC = "Maximum number of connections to the database";
+
     public static ConfigDef configDef() {
         return baseConfigDef()
             .define(
@@ -59,6 +62,14 @@ public class PostgresControlPlaneConfig extends AbstractControlPlaneConfig {
                 null,  // can be empty
                 ConfigDef.Importance.HIGH,
                 PASSWORD_DOC
+            )
+            .define(
+                MAX_CONNECTIONS_CONFIG,
+                ConfigDef.Type.INT,
+                10,
+                ConfigDef.Range.atLeast(1),
+                ConfigDef.Importance.MEDIUM,
+                MAX_CONNECTIONS_DOC
             );
     }
 
@@ -77,5 +88,9 @@ public class PostgresControlPlaneConfig extends AbstractControlPlaneConfig {
     public String password() {
         final Password configValue = getPassword(PASSWORD_CONFIG);
         return configValue == null ? null : configValue.value();
+    }
+
+    public int maxConnections() {
+        return getInt(MAX_CONNECTIONS_CONFIG);
     }
 }

--- a/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/PostgresControlPlaneConfigTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/PostgresControlPlaneConfigTest.java
@@ -35,6 +35,7 @@ class PostgresControlPlaneConfigTest {
                 "connection.string", "jdbc:postgresql://127.0.0.1:5432/inkless",
                 "username", "username",
                 "password", "password",
+                "max.connections", "11",
                 "file.merge.size.threshold.bytes", "1234",
                 "file.merge.lock.period.ms", "4567"
             )
@@ -45,6 +46,7 @@ class PostgresControlPlaneConfigTest {
         assertThat(config.password()).isEqualTo("password");
         assertThat(config.fileMergeSizeThresholdBytes()).isEqualTo(1234);
         assertThat(config.fileMergeLockPeriod()).isEqualTo(Duration.ofMillis(4567));
+        assertThat(config.maxConnections()).isEqualTo(11);
     }
 
     @Test
@@ -62,6 +64,7 @@ class PostgresControlPlaneConfigTest {
         assertThat(config.password()).isEqualTo("password");
         assertThat(config.fileMergeSizeThresholdBytes()).isEqualTo(100 * 1024 * 1024);
         assertThat(config.fileMergeLockPeriod()).isEqualTo(Duration.ofHours(1));
+        assertThat(config.maxConnections()).isEqualTo(10);
     }
 
     @Test


### PR DESCRIPTION
Limit how many connections can be opened by a broker _or_ controller.

Each component creates up to 10 connections atm. We can customize the number per process if needed to avoid overloading PG.