### PR TITLE
fix(inkless): avoid instantiating LogConfig on inkless check

### DIFF
--- a/core/src/main/scala/kafka/server/MetadataCache.scala
+++ b/core/src/main/scala/kafka/server/MetadataCache.scala
@@ -141,7 +141,7 @@ trait MetadataCache extends ConfigRepository {
     ignoreTopicsWithExceptions: Boolean
   ): DescribeTopicPartitionsResponseData
 
-  def isInklessTopic(topic: String, defaultConfig: Supplier[Map[_, _]]): Boolean
+  def isInklessTopic(topic: String, defaultConfig: Supplier[Map[String, _]]): Boolean
 }
 
 object MetadataCache {

--- a/core/src/main/scala/kafka/server/metadata/InklessMetadataView.scala
+++ b/core/src/main/scala/kafka/server/metadata/InklessMetadataView.scala
@@ -29,7 +29,7 @@ import java.{lang, util}
 import scala.collection.Map
 import scala.jdk.CollectionConverters.{IterableHasAsJava, SetHasAsJava}
 
-class InklessMetadataView(val metadataCache: KRaftMetadataCache, val defaultConfig: Supplier[Map[_, _]]) extends MetadataView {
+class InklessMetadataView(val metadataCache: KRaftMetadataCache, val defaultConfig: Supplier[Map[String, _]]) extends MetadataView {
   override def getAliveBrokers: lang.Iterable[BrokerMetadata] = {
     metadataCache.getAliveBrokers().asJava
   }

--- a/core/src/test/scala/kafka/server/metadata/InklessKRaftMetadataCacheTest.java
+++ b/core/src/test/scala/kafka/server/metadata/InklessKRaftMetadataCacheTest.java
@@ -57,7 +57,7 @@ class InklessKRaftMetadataCacheTest {
         "regular_topic_disabled,false,false", "regular_topic_disabled,true,false",
     })
     void isInklessTopic(final String topicName, final boolean defaultInklessEnable, final boolean expectedIsInkless) {
-        Supplier<Map<?, ?>> defaultConfig = () -> CollectionConverters.asScala(
+        Supplier<Map<String, ?>> defaultConfig = () -> CollectionConverters.asScala(
             defaultInklessEnable ?
                 Collections.singletonMap(TopicConfig.INKLESS_ENABLE_CONFIG, "true") :
                 Collections.emptyMap()


### PR DESCRIPTION
Creating a LogConfig per isInklessTopic validation leads to a large number of instances consuming a large amount of memory. Instead infer values out of existing map/properties.

Causes ~80% allocation on high load

<img width="1410" alt="image" src="https://github.com/user-attachments/assets/b8a39a4d-dbb7-4c25-ad19-8108171bef35" />
