### PR TITLE
fix(inkless): set file start time properly

### DIFF
--- a/storage/inkless/src/main/java/io/aiven/inkless/produce/ActiveFile.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/produce/ActiveFile.java
@@ -58,7 +58,7 @@ class ActiveFile {
     private static final Logger LOGGER = LoggerFactory.getLogger(ActiveFile.class);
 
     private final Time time;
-    private final Instant start;
+    private Instant start;
 
     private int requestId = -1;
 
@@ -75,7 +75,6 @@ class ActiveFile {
                final BrokerTopicStats brokerTopicStats) {
         this.buffer = new BatchBuffer();
         this.time = time;
-        this.start = TimeUtils.durationMeasurementNow(time);
         this.brokerTopicStats = brokerTopicStats;
         this.validatorMetricsRecorder = newValidatorMetricsRecorder(brokerTopicStats.allTopicsStats());
     }
@@ -98,6 +97,10 @@ class ActiveFile {
         Objects.requireNonNull(entriesPerPartition, "entriesPerPartition cannot be null");
         Objects.requireNonNull(topicConfigs, "topicConfigs cannot be null");
         Objects.requireNonNull(requestLocal, "requestLocal cannot be null");
+
+        if (start == null) {
+            start = TimeUtils.durationMeasurementNow(time);
+        }
 
         requestId += 1;
         originalRequests.put(requestId, entriesPerPartition);

--- a/storage/inkless/src/main/java/io/aiven/inkless/produce/ClosedFile.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/produce/ClosedFile.java
@@ -51,12 +51,15 @@ record ClosedFile(Instant start,
                   Map<Integer, Map<TopicPartition, PartitionResponse>> invalidResponseByRequest,
                   byte[] data) {
     ClosedFile {
-        Objects.requireNonNull(start, "start cannot be null");
         Objects.requireNonNull(originalRequests, "originalRequests cannot be null");
         Objects.requireNonNull(awaitingFuturesByRequest, "awaitingFuturesByRequest cannot be null");
         Objects.requireNonNull(commitBatchRequests, "commitBatchRequests cannot be null");
         Objects.requireNonNull(invalidResponseByRequest, "invalidResponseByRequest cannot be null");
         Objects.requireNonNull(data, "data cannot be null");
+
+        if (!originalRequests.isEmpty() && start == null) {
+            throw new IllegalArgumentException("start time cannot be null if there are requests processed");
+        }
 
         // Validate request maps have matching sizes
         if (originalRequests.size() != awaitingFuturesByRequest.size()) {

--- a/storage/inkless/src/test/java/io/aiven/inkless/produce/ClosedFileTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/produce/ClosedFileTest.java
@@ -42,13 +42,6 @@ class ClosedFileTest {
     static final TopicIdPartition TID0P0 = new TopicIdPartition(Uuid.randomUuid(), T0P0);
 
     @Test
-    void startNull() {
-        assertThatThrownBy(() -> new ClosedFile(null, Map.of(), Map.of(), List.of(), Map.of(), new byte[1]))
-            .isInstanceOf(NullPointerException.class)
-            .hasMessage("start cannot be null");
-    }
-
-    @Test
     void originalRequestsNull() {
         assertThatThrownBy(() -> new ClosedFile(Instant.EPOCH, null, Map.of(), List.of(), Map.of(), new byte[1]))
             .isInstanceOf(NullPointerException.class)
@@ -154,5 +147,31 @@ class ClosedFileTest {
                 new byte[10]).size())
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessage("Total number of valid and invalid responses doesn't match original requests for request id 1");
+    }
+
+    @Test
+    void allowEmpty() {
+        final int size = new ClosedFile(null,
+            Map.of(),
+            Map.of(),
+            List.of(),
+            Map.of(),
+            new byte[0]).size();
+        assertThat(size).isEqualTo(0);
+    }
+
+    @Test
+    void nullStartWithRequests() {
+        assertThatThrownBy(() ->
+            new ClosedFile(
+                null,
+                Map.of(1, Map.of(TID0P0, MemoryRecords.EMPTY)),
+                Map.of(1, new CompletableFuture<>()),
+                List.of(CommitBatchRequest.of(1, TID0P0, 0, 0, 0, 0, 0, TimestampType.CREATE_TIME)),
+                Map.of(),
+                new byte[10]).size()
+        )
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("start time cannot be null if there are requests processed");
     }
 }


### PR DESCRIPTION
Start time is measured on initialization which has wrong values: when an active file is initialized at the startup (leading to very large initial start time); and similarly if there is a period of no writes, the last rotation will start the counter at a very far time. To measure this correctly, only initialize on the first add to the batch.
