### PR TITLE
refactor(inkless): run append completer directly

### DIFF
--- a/storage/inkless/src/main/java/io/aiven/inkless/config/InklessConfig.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/config/InklessConfig.java
@@ -97,6 +97,13 @@ public class InklessConfig extends AbstractConfig {
     private static final String FILE_MERGER_TEMP_DIR_DOC = "The temporary directory for file merging.";
     private static final String FILE_MERGER_TEMP_DIR_DEFAULT = "/tmp/inkless/merger";
 
+    public static final String PRODUCE_UPLOAD_THREAD_POOL_SIZE_CONFIG = "produce.upload.thread.pool.size";
+    private static final String PRODUCE_UPLOAD_THREAD_POOL_SIZE_DOC = "Thread pool size to concurrently upload files to remote storage";
+    // Given that S3 upload is ~400ms P99, and commits to PG are ~50ms P99, defaulting to 8
+    // to avoid starting an upload if 8 commits are executing sequentially
+    private static final int PRODUCE_UPLOAD_THREAD_POOL_SIZE_DEFAULT = 8;
+
+
     public static ConfigDef configDef() {
         final ConfigDef configDef = new ConfigDef();
 
@@ -219,6 +226,14 @@ public class InklessConfig extends AbstractConfig {
             ConfigDef.Importance.LOW,
             CONSUME_CACHE_MAX_COUNT_DOC
         );
+        configDef.define(
+            PRODUCE_UPLOAD_THREAD_POOL_SIZE_CONFIG,
+            ConfigDef.Type.INT,
+            PRODUCE_UPLOAD_THREAD_POOL_SIZE_DEFAULT,
+            ConfigDef.Range.atLeast(1),
+            ConfigDef.Importance.LOW,
+            PRODUCE_UPLOAD_THREAD_POOL_SIZE_DOC
+        );
 
         return configDef;
     }
@@ -293,5 +308,9 @@ public class InklessConfig extends AbstractConfig {
 
     public Long cacheMaxCount() {
         return getLong(CONSUME_CACHE_MAX_COUNT_CONFIG);
+    }
+
+    public int produceUploadThreadPoolSize() {
+        return getInt(PRODUCE_UPLOAD_THREAD_POOL_SIZE_CONFIG);
     }
 }

--- a/storage/inkless/src/main/java/io/aiven/inkless/produce/AppendHandler.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/produce/AppendHandler.java
@@ -65,6 +65,7 @@ public class AppendHandler implements Closeable {
                 state.config().produceBufferMaxBytes(),
                 state.config().produceMaxUploadAttempts(),
                 state.config().produceUploadBackoff(),
+                state.config().produceUploadThreadPoolSize(),
                 state.brokerTopicStats()
             )
         );

--- a/storage/inkless/src/main/java/io/aiven/inkless/produce/FileCommitter.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/produce/FileCommitter.java
@@ -81,12 +81,14 @@ class FileCommitter implements Closeable {
                   final ObjectCache objectCache,
                   final Time time,
                   final int maxFileUploadAttempts,
-                  final Duration fileUploadRetryBackoff) {
+                  final Duration fileUploadRetryBackoff,
+                  final int fileUploaderThreadPoolSize) {
         this(brokerId, controlPlane, objectKeyCreator, storage, keyAlignmentStrategy, objectCache, time, maxFileUploadAttempts, fileUploadRetryBackoff,
-            Executors.newCachedThreadPool(new InklessThreadFactory("inkless-file-uploader-", false)),
+            Executors.newFixedThreadPool(fileUploaderThreadPoolSize, new InklessThreadFactory("inkless-file-uploader-", false)),
             // It must be single-thread to preserve the commit order.
             Executors.newSingleThreadExecutor(new InklessThreadFactory("inkless-file-committer-", false)),
-            Executors.newCachedThreadPool(new InklessThreadFactory("inkless-file-cache-store-", false)),
+            // Reuse the same thread pool size as uploads, as there are no more concurrency expected to handle
+            Executors.newFixedThreadPool(fileUploaderThreadPoolSize, new InklessThreadFactory("inkless-file-cache-store-", false)),
             new FileCommitterMetrics(time)
         );
     }

--- a/storage/inkless/src/main/java/io/aiven/inkless/produce/FileCommitter.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/produce/FileCommitter.java
@@ -67,7 +67,6 @@ class FileCommitter implements Closeable {
     private final Duration fileUploadRetryBackoff;
     private final ExecutorService executorServiceUpload;
     private final ExecutorService executorServiceCommit;
-    private final ExecutorService executorServiceComplete;
     private final ExecutorService executorServiceCacheStore;
 
     private final AtomicInteger totalFilesInProgress = new AtomicInteger(0);
@@ -87,7 +86,6 @@ class FileCommitter implements Closeable {
             Executors.newCachedThreadPool(new InklessThreadFactory("inkless-file-uploader-", false)),
             // It must be single-thread to preserve the commit order.
             Executors.newSingleThreadExecutor(new InklessThreadFactory("inkless-file-committer-", false)),
-            Executors.newCachedThreadPool(new InklessThreadFactory("inkless-file-uploader-finisher-", false)),
             Executors.newCachedThreadPool(new InklessThreadFactory("inkless-file-cache-store-", false)),
             new FileCommitterMetrics(time)
         );
@@ -105,7 +103,6 @@ class FileCommitter implements Closeable {
                   final Duration fileUploadRetryBackoff,
                   final ExecutorService executorServiceUpload,
                   final ExecutorService executorServiceCommit,
-                  final ExecutorService executorServiceComplete,
                   final ExecutorService executorServiceCacheStore,
                   final FileCommitterMetrics metrics) {
         this.brokerId = brokerId;
@@ -125,8 +122,6 @@ class FileCommitter implements Closeable {
             "executorServiceUpload cannot be null");
         this.executorServiceCommit = Objects.requireNonNull(executorServiceCommit,
             "executorServiceCommit cannot be null");
-        this.executorServiceComplete = Objects.requireNonNull(executorServiceComplete,
-                "executorServiceComplete cannot be null");
         this.executorServiceCacheStore = Objects.requireNonNull(executorServiceCacheStore,
                 "executorServiceCacheStore cannot be null");
 
@@ -142,7 +137,7 @@ class FileCommitter implements Closeable {
         lock.lock();
         try {
             final Instant uploadAndCommitStart = TimeUtils.durationMeasurementNow(time);
-            Future<List<CommitBatchResponse>> commitFuture;
+            CompletableFuture<List<CommitBatchResponse>> commitFuture;
             if (file.isEmpty()) {
                 // If the file is empty, skip uploading and committing, but proceed with the later steps.
                 commitFuture = CompletableFuture.completedFuture(Collections.emptyList());
@@ -193,8 +188,14 @@ class FileCommitter implements Closeable {
                 );
                 executorServiceCacheStore.submit(cacheStoreJob);
             }
-            final AppendCompleterJob completerJob = new AppendCompleterJob(file, commitFuture, time, metrics::appendCompletionFinished);
-            executorServiceComplete.submit(completerJob);
+            commitFuture.whenComplete((commitBatchResponses, throwable) -> {
+                final AppendCompleter completerJob = new AppendCompleter(file);
+                if (commitBatchResponses != null) {
+                    completerJob.finishCommitSuccessfully(commitBatchResponses);
+                } else {
+                    completerJob.finishCommitWithError();
+                }
+            });
         } finally {
             lock.unlock();
         }

--- a/storage/inkless/src/main/java/io/aiven/inkless/produce/FileCommitterMetrics.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/produce/FileCommitterMetrics.java
@@ -42,7 +42,6 @@ class FileCommitterMetrics implements Closeable {
     private static final String FILE_UPLOAD_RATE = "FileUploadRate";
     private static final String FILE_COMMIT_TIME = "FileCommitTime";
     private static final String FILE_COMMIT_RATE = "FileCommitRate";
-    private static final String APPEND_COMPLETION_TIME = "AppendCompletionTime";
     private static final String CACHE_STORE_TIME = "CacheStoreTime";
     private static final String COMMIT_QUEUE_FILES = "CommitQueueFiles";
     private static final String COMMIT_QUEUE_BYTES = "CommitQueueBytes";
@@ -56,7 +55,6 @@ class FileCommitterMetrics implements Closeable {
     private final Histogram fileUploadAndCommitTimeHistogram;
     private final Histogram fileUploadTimeHistogram;
     private final Histogram fileCommitTimeHistogram;
-    private final Histogram appendCompletionTimeHistogram;
     private final Histogram fileSizeHistogram;
     private final Histogram batchesCountHistogram;
     private final Histogram cacheStoreTimeHistogram;
@@ -71,7 +69,6 @@ class FileCommitterMetrics implements Closeable {
         metricsGroup.newGauge(FILE_UPLOAD_RATE, fileUploadRate::intValue);
         fileCommitTimeHistogram = metricsGroup.newHistogram(FILE_COMMIT_TIME, true, Map.of());
         metricsGroup.newGauge(FILE_COMMIT_RATE, fileCommitRate::intValue);
-        appendCompletionTimeHistogram = metricsGroup.newHistogram(APPEND_COMPLETION_TIME, true, Map.of());
         fileSizeHistogram = metricsGroup.newHistogram(FILE_SIZE, true, Map.of());
         batchesCountHistogram = metricsGroup.newHistogram(BATCHES_COUNT, true, Map.of());
         cacheStoreTimeHistogram = metricsGroup.newHistogram(CACHE_STORE_TIME, true, Map.of());
@@ -101,10 +98,6 @@ class FileCommitterMetrics implements Closeable {
     void fileCommitFinished(final long durationMs) {
         fileCommitTimeHistogram.update(durationMs);
         fileCommitRate.increment();
-    }
-
-    public void appendCompletionFinished(final long durationMs) {
-        appendCompletionTimeHistogram.update(durationMs);
     }
 
     void fileFinished(final Instant fileStart, final Instant uploadAndCommitStart) {

--- a/storage/inkless/src/main/java/io/aiven/inkless/produce/Writer.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/produce/Writer.java
@@ -93,16 +93,19 @@ class Writer implements Closeable {
            final int maxBufferSize,
            final int maxFileUploadAttempts,
            final Duration fileUploadRetryBackoff,
-           final BrokerTopicStats brokerTopicStats) {
+           final int fileUploaderThreadPoolSize,
+           final BrokerTopicStats brokerTopicStats
+    ) {
         this(
             time,
             commitInterval,
             maxBufferSize,
             Executors.newScheduledThreadPool(1, new InklessThreadFactory("inkless-file-commit-ticker-", true)),
             new FileCommitter(
-                    brokerId, controlPlane, objectKeyCreator, storage,
-                    keyAlignmentStrategy, objectCache, time,
-                    maxFileUploadAttempts, fileUploadRetryBackoff),
+                brokerId, controlPlane, objectKeyCreator, storage,
+                keyAlignmentStrategy, objectCache, time,
+                maxFileUploadAttempts, fileUploadRetryBackoff,
+                fileUploaderThreadPoolSize),
             new WriterMetrics(time),
             brokerTopicStats
         );

--- a/storage/inkless/src/test/java/io/aiven/inkless/config/InklessConfigTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/config/InklessConfigTest.java
@@ -48,6 +48,7 @@ class InklessConfigTest {
         configs.put("inkless.file.cleaner.retention.period.ms", "200");
         configs.put("inkless.file.merger.interval.ms", "100");
         configs.put("inkless.consume.cache.max.count", "100");
+        configs.put("inkless.produce.upload.thread.pool.size", "16");
         final InklessConfig config = new InklessConfig(new AbstractConfig(new ConfigDef(), configs));
         assertThat(config.controlPlaneClass()).isEqualTo(InMemoryControlPlane.class);
         assertThat(config.controlPlaneConfig()).isEqualTo(Map.of("class", controlPlaneClass));
@@ -61,6 +62,7 @@ class InklessConfigTest {
         assertThat(config.fileCleanerRetentionPeriod()).isEqualTo(Duration.ofMillis(200));
         assertThat(config.fileMergerInterval()).isEqualTo(Duration.ofMillis(100));
         assertThat(config.cacheMaxCount()).isEqualTo(100);
+        assertThat(config.produceUploadThreadPoolSize()).isEqualTo(16);
     }
 
     @Test
@@ -84,6 +86,7 @@ class InklessConfigTest {
         assertThat(config.fileCleanerRetentionPeriod()).isEqualTo(Duration.ofMinutes(1));
         assertThat(config.fileMergerInterval()).isEqualTo(Duration.ofMinutes(1));
         assertThat(config.cacheMaxCount()).isEqualTo(1000);
+        assertThat(config.produceUploadThreadPoolSize()).isEqualTo(8);
     }
 
     @Test
@@ -101,6 +104,7 @@ class InklessConfigTest {
         configs.put("file.cleaner.retention.period.ms", "200");
         configs.put("file.merger.interval.ms", "100");
         configs.put("consume.cache.max.count", "100");
+        configs.put("produce.upload.thread.pool.size", "16");
         final var config = new InklessConfig(
             configs
         );
@@ -116,6 +120,7 @@ class InklessConfigTest {
         assertThat(config.fileCleanerRetentionPeriod()).isEqualTo(Duration.ofMillis(200));
         assertThat(config.fileMergerInterval()).isEqualTo(Duration.ofMillis(100));
         assertThat(config.cacheMaxCount()).isEqualTo(100);
+        assertThat(config.produceUploadThreadPoolSize()).isEqualTo(16);
     }
 
     @Test

--- a/storage/inkless/src/test/java/io/aiven/inkless/produce/FileCommitterTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/produce/FileCommitterTest.java
@@ -226,56 +226,56 @@ class FileCommitterTest {
             new FileCommitter(
                     BROKER_ID, null, OBJECT_KEY_CREATOR,
                 storage, KEY_ALIGNMENT_STRATEGY, OBJECT_CACHE, time,
-                    100, Duration.ofMillis(1)))
+                    100, Duration.ofMillis(1), 8))
             .isInstanceOf(NullPointerException.class)
             .hasMessage("controlPlane cannot be null");
         assertThatThrownBy(() ->
             new FileCommitter(
                     BROKER_ID, controlPlane, null, storage,
                     KEY_ALIGNMENT_STRATEGY, OBJECT_CACHE, time,
-                    100, Duration.ofMillis(1)))
+                    100, Duration.ofMillis(1), 8))
             .isInstanceOf(NullPointerException.class)
             .hasMessage("objectKeyCreator cannot be null");
         assertThatThrownBy(() ->
             new FileCommitter(
                     BROKER_ID, controlPlane, OBJECT_KEY_CREATOR, null,
                     KEY_ALIGNMENT_STRATEGY, OBJECT_CACHE, time,
-                    100, Duration.ofMillis(1)))
+                    100, Duration.ofMillis(1), 8))
             .isInstanceOf(NullPointerException.class)
             .hasMessage("storage cannot be null");
         assertThatThrownBy(() ->
             new FileCommitter(
                     BROKER_ID, controlPlane, OBJECT_KEY_CREATOR, storage,
                     null, OBJECT_CACHE, time,
-                    100, Duration.ofMillis(1)))
+                    100, Duration.ofMillis(1), 8))
             .isInstanceOf(NullPointerException.class)
             .hasMessage("keyAlignmentStrategy cannot be null");
         assertThatThrownBy(() ->
             new FileCommitter(
                     BROKER_ID, controlPlane, OBJECT_KEY_CREATOR, storage,
                     KEY_ALIGNMENT_STRATEGY, null, time,
-                    100, Duration.ofMillis(1)))
+                    100, Duration.ofMillis(1), 8))
             .isInstanceOf(NullPointerException.class)
             .hasMessage("objectCache cannot be null");
         assertThatThrownBy(() ->
             new FileCommitter(
                     BROKER_ID, controlPlane, OBJECT_KEY_CREATOR, storage,
                     KEY_ALIGNMENT_STRATEGY, OBJECT_CACHE, null,
-                    100, Duration.ofMillis(1)))
+                    100, Duration.ofMillis(1), 8))
             .isInstanceOf(NullPointerException.class)
             .hasMessage("time cannot be null");
         assertThatThrownBy(() ->
             new FileCommitter(
                     BROKER_ID, controlPlane, OBJECT_KEY_CREATOR, storage,
                     KEY_ALIGNMENT_STRATEGY, OBJECT_CACHE, time,
-                    0, Duration.ofMillis(1)))
+                    0, Duration.ofMillis(1), 8))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessage("maxFileUploadAttempts must be positive");
         assertThatThrownBy(() ->
             new FileCommitter(
                     BROKER_ID, controlPlane, OBJECT_KEY_CREATOR, storage,
                     KEY_ALIGNMENT_STRATEGY, OBJECT_CACHE, time,
-                    100, null))
+                    100, null, 8))
             .isInstanceOf(NullPointerException.class)
             .hasMessage("fileUploadRetryBackoff cannot be null");
         assertThatThrownBy(() ->
@@ -310,6 +310,12 @@ class FileCommitterTest {
                     executorServiceUpload, executorServiceCommit, executorServiceCacheStore, null))
             .isInstanceOf(NullPointerException.class)
             .hasMessage("metrics cannot be null");
+        assertThatThrownBy(() ->
+            new FileCommitter(
+                BROKER_ID, controlPlane, OBJECT_KEY_CREATOR, storage,
+                KEY_ALIGNMENT_STRATEGY, OBJECT_CACHE, time,
+                3, Duration.ofMillis(1), 0)) // pool size has to be positive
+            .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test

--- a/storage/inkless/src/test/java/io/aiven/inkless/produce/FileCommitterTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/produce/FileCommitterTest.java
@@ -101,8 +101,6 @@ class FileCommitterTest {
     @Mock
     ExecutorService executorServiceCommit;
     @Mock
-    ExecutorService executorServiceComplete;
-    @Mock
     ExecutorService executorServiceCacheStore;
     @Mock
     FileCommitterMetrics metrics;
@@ -111,8 +109,6 @@ class FileCommitterTest {
     ArgumentCaptor<Callable<ObjectKey>> uploadCallableCaptor;
     @Captor
     ArgumentCaptor<Runnable> commitRunnableCaptor;
-    @Captor
-    ArgumentCaptor<Runnable> completeRunnableCaptor;
 
     @Test
     @SuppressWarnings("unchecked")
@@ -130,7 +126,7 @@ class FileCommitterTest {
                 BROKER_ID, controlPlane, OBJECT_KEY_CREATOR, storage,
                 KEY_ALIGNMENT_STRATEGY, OBJECT_CACHE, time,
                 3, Duration.ofMillis(100),
-                executorServiceUpload, executorServiceCommit, executorServiceComplete, executorServiceCacheStore,
+                executorServiceUpload, executorServiceCommit, executorServiceCacheStore,
                 metrics);
 
         verify(metrics).initTotalFilesInProgressMetric(any());
@@ -153,11 +149,6 @@ class FileCommitterTest {
         final Runnable commitRunnable = commitRunnableCaptor.getValue();
 
         commitRunnable.run();
-
-        verify(executorServiceComplete).submit(completeRunnableCaptor.capture());
-        final Runnable completeRunnable = completeRunnableCaptor.getValue();
-
-        completeRunnable.run();
 
         assertThat(committer.totalFilesInProgress()).isZero();
         assertThat(committer.totalBytesInProgress()).isZero();
@@ -184,7 +175,7 @@ class FileCommitterTest {
                 BROKER_ID, controlPlane, OBJECT_KEY_CREATOR, storage,
                 KEY_ALIGNMENT_STRATEGY, OBJECT_CACHE, time,
                 3, Duration.ofMillis(100),
-                executorServiceUpload, executorServiceCommit, executorServiceComplete, executorServiceCacheStore,
+                executorServiceUpload, executorServiceCommit, executorServiceCacheStore,
                 metrics);
 
         assertThat(committer.totalFilesInProgress()).isZero();
@@ -205,11 +196,6 @@ class FileCommitterTest {
 
         commitRunnable.run();
 
-        verify(executorServiceComplete).submit(completeRunnableCaptor.capture());
-        final Runnable completeRunnable = completeRunnableCaptor.getValue();
-
-        completeRunnable.run();
-
         assertThat(committer.totalFilesInProgress()).isZero();
         assertThat(committer.totalBytesInProgress()).isZero();
 
@@ -225,7 +211,7 @@ class FileCommitterTest {
                 BROKER_ID, controlPlane, OBJECT_KEY_CREATOR, storage,
                 KEY_ALIGNMENT_STRATEGY, OBJECT_CACHE, time,
                 3, Duration.ofMillis(100),
-                executorServiceUpload, executorServiceCommit, executorServiceComplete, executorServiceCacheStore, metrics);
+                executorServiceUpload, executorServiceCommit, executorServiceCacheStore, metrics);
 
         committer.close();
 
@@ -297,7 +283,7 @@ class FileCommitterTest {
                     BROKER_ID, controlPlane, OBJECT_KEY_CREATOR, storage,
                     KEY_ALIGNMENT_STRATEGY, OBJECT_CACHE, time,
                     3, Duration.ofMillis(100),
-                    null, executorServiceCommit, executorServiceComplete, executorServiceCacheStore, metrics))
+                    null, executorServiceCommit, executorServiceCacheStore, metrics))
             .isInstanceOf(NullPointerException.class)
             .hasMessage("executorServiceUpload cannot be null");
         assertThatThrownBy(() ->
@@ -305,23 +291,15 @@ class FileCommitterTest {
                     BROKER_ID, controlPlane, OBJECT_KEY_CREATOR, storage,
                     KEY_ALIGNMENT_STRATEGY, OBJECT_CACHE, time,
                     3, Duration.ofMillis(100),
-                    executorServiceUpload, null, executorServiceComplete, executorServiceCacheStore, metrics))
+                    executorServiceUpload, null, executorServiceCacheStore, metrics))
             .isInstanceOf(NullPointerException.class)
             .hasMessage("executorServiceCommit cannot be null");
-        assertThatThrownBy(() ->
-                new FileCommitter(
-                        BROKER_ID, controlPlane, OBJECT_KEY_CREATOR, storage,
-                        KEY_ALIGNMENT_STRATEGY, OBJECT_CACHE, time,
-                        3, Duration.ofMillis(100),
-                        executorServiceUpload, executorServiceCommit, null, executorServiceCacheStore, metrics))
-                .isInstanceOf(NullPointerException.class)
-                .hasMessage("executorServiceComplete cannot be null");
         assertThatThrownBy(() ->
             new FileCommitter(
                     BROKER_ID, controlPlane, OBJECT_KEY_CREATOR, storage,
                     KEY_ALIGNMENT_STRATEGY, OBJECT_CACHE, time,
                     3, Duration.ofMillis(100),
-                    executorServiceUpload, executorServiceCommit, executorServiceComplete, null, metrics))
+                    executorServiceUpload, executorServiceCommit, null, metrics))
             .isInstanceOf(NullPointerException.class)
             .hasMessage("executorServiceCacheStore cannot be null");
         assertThatThrownBy(() ->
@@ -329,7 +307,7 @@ class FileCommitterTest {
                     BROKER_ID, controlPlane, OBJECT_KEY_CREATOR, storage,
                     KEY_ALIGNMENT_STRATEGY, OBJECT_CACHE, time,
                     3, Duration.ofMillis(100),
-                    executorServiceUpload, executorServiceCommit, executorServiceComplete, executorServiceCacheStore, null))
+                    executorServiceUpload, executorServiceCommit, executorServiceCacheStore, null))
             .isInstanceOf(NullPointerException.class)
             .hasMessage("metrics cannot be null");
     }
@@ -340,7 +318,7 @@ class FileCommitterTest {
                 BROKER_ID, controlPlane, OBJECT_KEY_CREATOR, storage,
                 KEY_ALIGNMENT_STRATEGY, OBJECT_CACHE,
                 time, 3, Duration.ofMillis(100),
-                executorServiceUpload, executorServiceCommit, executorServiceComplete, executorServiceCacheStore, metrics);
+                executorServiceUpload, executorServiceCommit, executorServiceCacheStore, metrics);
         assertThatThrownBy(() -> committer.commit(null))
             .isInstanceOf(NullPointerException.class)
             .hasMessage("file cannot be null");

--- a/storage/inkless/src/test/java/io/aiven/inkless/produce/WriterIntegrationTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/produce/WriterIntegrationTest.java
@@ -129,6 +129,7 @@ class WriterIntegrationTest {
                 10 * 1024,
                 1,
                 Duration.ofMillis(10),
+                8,
                 new BrokerTopicStats()
             )
         ) {

--- a/storage/inkless/src/test/java/io/aiven/inkless/produce/WriterPropertyTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/produce/WriterPropertyTest.java
@@ -237,7 +237,6 @@ class WriterPropertyTest {
             Duration.ZERO,
             uploaderHandler.executorService,
             committerHandler.executorService,
-            completerHandler.executorService,
             cacheStoreHandler.executorService,
             mock(FileCommitterMetrics.class)
         );


### PR DESCRIPTION
Instead of running this as a separate thread, run directly on the same thread as it is not an IO task.
Reduces thread allocation.