### PR TITLE
refactor(inkless): use fixed thread pools for upload/cache

### DIFF
--- a/storage/inkless/src/main/java/io/aiven/inkless/config/InklessConfig.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/config/InklessConfig.java
@@ -97,6 +97,13 @@ public class InklessConfig extends AbstractConfig {
     private static final String FILE_MERGER_TEMP_DIR_DOC = "The temporary directory for file merging.";
     private static final String FILE_MERGER_TEMP_DIR_DEFAULT = "/tmp/inkless/merger";
 
+    public static final String PRODUCE_UPLOAD_THREAD_POOL_SIZE_CONFIG = "produce.upload.thread.pool.size";
+    private static final String PRODUCE_UPLOAD_THREAD_POOL_SIZE_DOC = "Thread pool size to concurrently upload files to remote storage";
+    // Given that S3 upload is ~400ms P99, and commits to PG are ~50ms P99, defaulting to 8
+    // to avoid starting an upload if 8 commits are executing sequentially
+    private static final int PRODUCE_UPLOAD_THREAD_POOL_SIZE_DEFAULT = 8;
+
+
     public static ConfigDef configDef() {
         final ConfigDef configDef = new ConfigDef();
 
@@ -219,6 +226,14 @@ public class InklessConfig extends AbstractConfig {
             ConfigDef.Importance.LOW,
             CONSUME_CACHE_MAX_COUNT_DOC
         );
+        configDef.define(
+            PRODUCE_UPLOAD_THREAD_POOL_SIZE_CONFIG,
+            ConfigDef.Type.INT,
+            PRODUCE_UPLOAD_THREAD_POOL_SIZE_DEFAULT,
+            ConfigDef.Range.atLeast(1),
+            ConfigDef.Importance.LOW,
+            PRODUCE_UPLOAD_THREAD_POOL_SIZE_DOC
+        );
 
         return configDef;
     }
@@ -293,5 +308,9 @@ public class InklessConfig extends AbstractConfig {
 
     public Long cacheMaxCount() {
         return getLong(CONSUME_CACHE_MAX_COUNT_CONFIG);
+    }
+
+    public int produceUploadThreadPoolSize() {
+        return getInt(PRODUCE_UPLOAD_THREAD_POOL_SIZE_CONFIG);
     }
 }

--- a/storage/inkless/src/main/java/io/aiven/inkless/produce/AppendHandler.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/produce/AppendHandler.java
@@ -65,6 +65,7 @@ public class AppendHandler implements Closeable {
                 state.config().produceBufferMaxBytes(),
                 state.config().produceMaxUploadAttempts(),
                 state.config().produceUploadBackoff(),
+                state.config().produceUploadThreadPoolSize(),
                 state.brokerTopicStats()
             )
         );

--- a/storage/inkless/src/main/java/io/aiven/inkless/produce/FileCommitter.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/produce/FileCommitter.java
@@ -81,12 +81,14 @@ class FileCommitter implements Closeable {
                   final ObjectCache objectCache,
                   final Time time,
                   final int maxFileUploadAttempts,
-                  final Duration fileUploadRetryBackoff) {
+                  final Duration fileUploadRetryBackoff,
+                  final int fileUploaderThreadPoolSize) {
         this(brokerId, controlPlane, objectKeyCreator, storage, keyAlignmentStrategy, objectCache, time, maxFileUploadAttempts, fileUploadRetryBackoff,
-            Executors.newCachedThreadPool(new InklessThreadFactory("inkless-file-uploader-", false)),
+            Executors.newFixedThreadPool(fileUploaderThreadPoolSize, new InklessThreadFactory("inkless-file-uploader-", false)),
             // It must be single-thread to preserve the commit order.
             Executors.newSingleThreadExecutor(new InklessThreadFactory("inkless-file-committer-", false)),
-            Executors.newCachedThreadPool(new InklessThreadFactory("inkless-file-cache-store-", false)),
+            // Reuse the same thread pool size as uploads, as there are no more concurrency expected to handle
+            Executors.newFixedThreadPool(fileUploaderThreadPoolSize, new InklessThreadFactory("inkless-file-cache-store-", false)),
             new FileCommitterMetrics(time)
         );
     }

--- a/storage/inkless/src/main/java/io/aiven/inkless/produce/Writer.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/produce/Writer.java
@@ -93,16 +93,19 @@ class Writer implements Closeable {
            final int maxBufferSize,
            final int maxFileUploadAttempts,
            final Duration fileUploadRetryBackoff,
-           final BrokerTopicStats brokerTopicStats) {
+           final int fileUploaderThreadPoolSize,
+           final BrokerTopicStats brokerTopicStats
+    ) {
         this(
             time,
             commitInterval,
             maxBufferSize,
             Executors.newScheduledThreadPool(1, new InklessThreadFactory("inkless-file-commit-ticker-", true)),
             new FileCommitter(
-                    brokerId, controlPlane, objectKeyCreator, storage,
-                    keyAlignmentStrategy, objectCache, time,
-                    maxFileUploadAttempts, fileUploadRetryBackoff),
+                brokerId, controlPlane, objectKeyCreator, storage,
+                keyAlignmentStrategy, objectCache, time,
+                maxFileUploadAttempts, fileUploadRetryBackoff,
+                fileUploaderThreadPoolSize),
             new WriterMetrics(time),
             brokerTopicStats
         );

--- a/storage/inkless/src/test/java/io/aiven/inkless/config/InklessConfigTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/config/InklessConfigTest.java
@@ -48,6 +48,7 @@ class InklessConfigTest {
         configs.put("inkless.file.cleaner.retention.period.ms", "200");
         configs.put("inkless.file.merger.interval.ms", "100");
         configs.put("inkless.consume.cache.max.count", "100");
+        configs.put("inkless.produce.upload.thread.pool.size", "16");
         final InklessConfig config = new InklessConfig(new AbstractConfig(new ConfigDef(), configs));
         assertThat(config.controlPlaneClass()).isEqualTo(InMemoryControlPlane.class);
         assertThat(config.controlPlaneConfig()).isEqualTo(Map.of("class", controlPlaneClass));
@@ -61,6 +62,7 @@ class InklessConfigTest {
         assertThat(config.fileCleanerRetentionPeriod()).isEqualTo(Duration.ofMillis(200));
         assertThat(config.fileMergerInterval()).isEqualTo(Duration.ofMillis(100));
         assertThat(config.cacheMaxCount()).isEqualTo(100);
+        assertThat(config.produceUploadThreadPoolSize()).isEqualTo(16);
     }
 
     @Test
@@ -84,6 +86,7 @@ class InklessConfigTest {
         assertThat(config.fileCleanerRetentionPeriod()).isEqualTo(Duration.ofMinutes(1));
         assertThat(config.fileMergerInterval()).isEqualTo(Duration.ofMinutes(1));
         assertThat(config.cacheMaxCount()).isEqualTo(1000);
+        assertThat(config.produceUploadThreadPoolSize()).isEqualTo(8);
     }
 
     @Test
@@ -101,6 +104,7 @@ class InklessConfigTest {
         configs.put("file.cleaner.retention.period.ms", "200");
         configs.put("file.merger.interval.ms", "100");
         configs.put("consume.cache.max.count", "100");
+        configs.put("produce.upload.thread.pool.size", "16");
         final var config = new InklessConfig(
             configs
         );
@@ -116,6 +120,7 @@ class InklessConfigTest {
         assertThat(config.fileCleanerRetentionPeriod()).isEqualTo(Duration.ofMillis(200));
         assertThat(config.fileMergerInterval()).isEqualTo(Duration.ofMillis(100));
         assertThat(config.cacheMaxCount()).isEqualTo(100);
+        assertThat(config.produceUploadThreadPoolSize()).isEqualTo(16);
     }
 
     @Test

--- a/storage/inkless/src/test/java/io/aiven/inkless/produce/FileCommitterTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/produce/FileCommitterTest.java
@@ -226,56 +226,56 @@ class FileCommitterTest {
             new FileCommitter(
                     BROKER_ID, null, OBJECT_KEY_CREATOR,
                 storage, KEY_ALIGNMENT_STRATEGY, OBJECT_CACHE, time,
-                    100, Duration.ofMillis(1)))
+                    100, Duration.ofMillis(1), 8))
             .isInstanceOf(NullPointerException.class)
             .hasMessage("controlPlane cannot be null");
         assertThatThrownBy(() ->
             new FileCommitter(
                     BROKER_ID, controlPlane, null, storage,
                     KEY_ALIGNMENT_STRATEGY, OBJECT_CACHE, time,
-                    100, Duration.ofMillis(1)))
+                    100, Duration.ofMillis(1), 8))
             .isInstanceOf(NullPointerException.class)
             .hasMessage("objectKeyCreator cannot be null");
         assertThatThrownBy(() ->
             new FileCommitter(
                     BROKER_ID, controlPlane, OBJECT_KEY_CREATOR, null,
                     KEY_ALIGNMENT_STRATEGY, OBJECT_CACHE, time,
-                    100, Duration.ofMillis(1)))
+                    100, Duration.ofMillis(1), 8))
             .isInstanceOf(NullPointerException.class)
             .hasMessage("storage cannot be null");
         assertThatThrownBy(() ->
             new FileCommitter(
                     BROKER_ID, controlPlane, OBJECT_KEY_CREATOR, storage,
                     null, OBJECT_CACHE, time,
-                    100, Duration.ofMillis(1)))
+                    100, Duration.ofMillis(1), 8))
             .isInstanceOf(NullPointerException.class)
             .hasMessage("keyAlignmentStrategy cannot be null");
         assertThatThrownBy(() ->
             new FileCommitter(
                     BROKER_ID, controlPlane, OBJECT_KEY_CREATOR, storage,
                     KEY_ALIGNMENT_STRATEGY, null, time,
-                    100, Duration.ofMillis(1)))
+                    100, Duration.ofMillis(1), 8))
             .isInstanceOf(NullPointerException.class)
             .hasMessage("objectCache cannot be null");
         assertThatThrownBy(() ->
             new FileCommitter(
                     BROKER_ID, controlPlane, OBJECT_KEY_CREATOR, storage,
                     KEY_ALIGNMENT_STRATEGY, OBJECT_CACHE, null,
-                    100, Duration.ofMillis(1)))
+                    100, Duration.ofMillis(1), 8))
             .isInstanceOf(NullPointerException.class)
             .hasMessage("time cannot be null");
         assertThatThrownBy(() ->
             new FileCommitter(
                     BROKER_ID, controlPlane, OBJECT_KEY_CREATOR, storage,
                     KEY_ALIGNMENT_STRATEGY, OBJECT_CACHE, time,
-                    0, Duration.ofMillis(1)))
+                    0, Duration.ofMillis(1), 8))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessage("maxFileUploadAttempts must be positive");
         assertThatThrownBy(() ->
             new FileCommitter(
                     BROKER_ID, controlPlane, OBJECT_KEY_CREATOR, storage,
                     KEY_ALIGNMENT_STRATEGY, OBJECT_CACHE, time,
-                    100, null))
+                    100, null, 8))
             .isInstanceOf(NullPointerException.class)
             .hasMessage("fileUploadRetryBackoff cannot be null");
         assertThatThrownBy(() ->
@@ -310,6 +310,12 @@ class FileCommitterTest {
                     executorServiceUpload, executorServiceCommit, executorServiceCacheStore, null))
             .isInstanceOf(NullPointerException.class)
             .hasMessage("metrics cannot be null");
+        assertThatThrownBy(() ->
+            new FileCommitter(
+                BROKER_ID, controlPlane, OBJECT_KEY_CREATOR, storage,
+                KEY_ALIGNMENT_STRATEGY, OBJECT_CACHE, time,
+                3, Duration.ofMillis(1), 0)) // pool size has to be positive
+            .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test

--- a/storage/inkless/src/test/java/io/aiven/inkless/produce/WriterIntegrationTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/produce/WriterIntegrationTest.java
@@ -129,6 +129,7 @@ class WriterIntegrationTest {
                 10 * 1024,
                 1,
                 Duration.ofMillis(10),
+                8,
                 new BrokerTopicStats()
             )
         ) {


### PR DESCRIPTION
Cached thread polls are unbounded. As concurrent uploads wait for commits to complete, the amound of uploads can grow without limits, affecting cpu utilization and increasing latencies. To bound the uploads to the expected commit latencies, this PR proposes to use fixed thread pool (8 by default) to be able to upload up to 8 files concurrently, these uploads have a P99 of 400ms on S3. As sequential commits can have a P99 of 50ms on PG, having 8 commits queued would already account for doubling the upload time. This is an initial estimation and the values could be updated and the defaults changed as this setup is tested; but having configurable thread pools should benefit in the long term.

Some examples on memory usage:
Without fixed pool:
<img width="751" alt="image" src="https://github.com/user-attachments/assets/700a7d58-f9df-497e-8d92-00f36bc18d18" />

With fixed pool:
<img width="757" alt="image" src="https://github.com/user-attachments/assets/89e1af83-bda1-414e-890f-6ca30228ade5" />
