### PR TITLE
refactor(inkless): rotate before overflowing buffer

### DIFF
--- a/storage/inkless/src/main/java/io/aiven/inkless/produce/Writer.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/produce/Writer.java
@@ -160,10 +160,13 @@ class Writer implements Closeable {
             if (openedAt == null) {
                 openedAt = TimeUtils.durationMeasurementNow(time);
             }
-
+            final var sizeBefore = this.activeFile.size();
             final var result = this.activeFile.add(entriesPerPartition, topicConfigs, requestLocal);
             writerMetrics.requestAdded();
-            if (this.activeFile.size() >= maxBufferSize) {
+            // Estimate the size of the active file after adding the next entries to avoid having files too large.
+            final int currentSize = this.activeFile.size();
+            final int sizeAdded = currentSize - sizeBefore;
+            if (currentSize + sizeAdded >= maxBufferSize) {
                 if (this.scheduledTick != null) {
                     this.scheduledTick.cancel(false);
                     this.scheduledTick = null;

--- a/storage/inkless/src/test/java/io/aiven/inkless/produce/WriterMockedTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/produce/WriterMockedTest.java
@@ -176,6 +176,26 @@ class WriterMockedTest {
     }
 
     @Test
+    void committingDueToOverfillBeforeNextTick() throws InterruptedException {
+        when(time.nanoseconds()).thenReturn(10_000_000L);
+
+        final Writer writer = new Writer(
+            time, Duration.ofMillis(1), 8 * 1024, commitTickScheduler, fileCommitter, writerMetrics, brokerTopicStats);
+
+        // Size is not 8Ki but is close enough to trigger a commit before the next write.
+        final Map<TopicIdPartition, MemoryRecords> writeRequest = Map.of(
+            T0P0, recordCreator.create(T0P0.topicPartition(), 100),
+            T1P1, recordCreator.create(T1P1.topicPartition(), 100)
+        );
+        assertThat(writer.write(writeRequest, TOPIC_CONFIGS, REQUEST_LOCAL)).isNotCompleted();
+
+        verify(fileCommitter).commit(closedFileCaptor.capture());
+        assertThat(closedFileCaptor.getValue().start()).isEqualTo(Instant.ofEpochMilli(10));
+        assertThat(closedFileCaptor.getValue().originalRequests()).isEqualTo(Map.of(0, writeRequest));
+        assertThat(closedFileCaptor.getValue().awaitingFuturesByRequest()).hasSize(1);
+    }
+
+    @Test
     void committingOnTick() throws InterruptedException {
         final Writer writer = new Writer(
             time, Duration.ofMillis(1), 8 * 1024, commitTickScheduler, fileCommitter, writerMetrics, brokerTopicStats);


### PR DESCRIPTION
Based on the size added to the buffer, estimated if the next batch (assuming same size) will overflow the buffer.
The goal is to keep the upload size below the configured upper bound to control the upload latencies.
