### PR TITLE
fix(inkless:demo): fix minio mc command

### DIFF
--- a/docker/examples/docker-compose-files/inkless-cluster/docker-compose.yml
+++ b/docker/examples/docker-compose-files/inkless-cluster/docker-compose.yml
@@ -122,7 +122,7 @@ services:
       - minio
     entrypoint: >
       /bin/sh -c "
-      until /usr/bin/mc config host add local http://minio:9000 minioadmin minioadmin; do
+      until /usr/bin/mc alias set local http://minio:9000 minioadmin minioadmin; do
         echo 'Waiting for Minio...';
         sleep 5;
       done;

--- a/docker/examples/docker-compose-files/inkless/docker-compose.s3-local.yml
+++ b/docker/examples/docker-compose-files/inkless/docker-compose.s3-local.yml
@@ -32,7 +32,7 @@ services:
       - storage
     entrypoint: >
       /bin/sh -c "
-      until /usr/bin/mc config host add local http://storage:9000 minioadmin minioadmin; do
+      until /usr/bin/mc alias set local http://storage:9000 minioadmin minioadmin; do
         echo 'Waiting for Minio...';
         sleep 5;
       done;


### PR DESCRIPTION
`config host add` has been deprecated and removed from CLI, breaking demo.