### PR TITLE
Add retention by time and size [INK-251]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2398,6 +2398,9 @@ project(':storage:inkless') {
     implementation libs.commonsIo
     implementation libs.infinispan
     compileOnly libs.infinispanAnnotations // Workaround for ISPN-12461
+    implementation(libs.caffeine) {
+      exclude group: 'org.checkerframework', module: 'checker-qual'
+    }
 
     testImplementation project(':clients').sourceSets.test.output.classesDirs
     testImplementation project(':test-common')

--- a/build.gradle
+++ b/build.gradle
@@ -2398,9 +2398,6 @@ project(':storage:inkless') {
     implementation libs.commonsIo
     implementation libs.infinispan
     compileOnly libs.infinispanAnnotations // Workaround for ISPN-12461
-    implementation(libs.caffeine) {
-      exclude group: 'org.checkerframework', module: 'checker-qual'
-    }
 
     testImplementation project(':clients').sourceSets.test.output.classesDirs
     testImplementation project(':test-common')

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -412,7 +412,7 @@ class ReplicaManager(val config: KafkaConfig,
 
     // Inkless threads
     inklessSharedState.map { sharedState =>
-      scheduler.schedule("inkless-retention-enforcer", () => inklessRetentionEnforcer.foreach(_.run()), 500L, 500L)  // the real interval is inside
+      scheduler.schedule("inkless-retention-enforcer", () => inklessRetentionEnforcer.foreach(_.run()), config.logInitialTaskDelayMs, 500L)  // the real interval is inside
 
       scheduler.schedule("inkless-file-cleaner", () => inklessFileCleaner.foreach(_.run()), sharedState.config().fileCleanerInterval().toMillis, sharedState.config().fileCleanerInterval().toMillis)
 

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -19,7 +19,7 @@ package kafka.server
 import com.yammer.metrics.core.Meter
 import io.aiven.inkless.common.SharedState
 import io.aiven.inkless.consume.{FetchInterceptor, FetchOffsetHandler}
-import io.aiven.inkless.delete.{DeleteRecordsInterceptor, FileCleaner}
+import io.aiven.inkless.delete.{DeleteRecordsInterceptor, FileCleaner, RetentionEnforcer}
 import io.aiven.inkless.merge.FileMerger
 import io.aiven.inkless.produce.AppendHandler
 import kafka.cluster.{Partition, PartitionListener}
@@ -319,6 +319,7 @@ class ReplicaManager(val config: KafkaConfig,
   private val inklessFetchInterceptor: Option[FetchInterceptor] = inklessSharedState.map(new FetchInterceptor(_))
   private val inklessFetchOffsetHandler: Option[FetchOffsetHandler] = inklessSharedState.map(new FetchOffsetHandler(_))
   private val inklessDeleteRecordsInterceptor: Option[DeleteRecordsInterceptor] = inklessSharedState.map(new DeleteRecordsInterceptor(_))
+  private val inklessRetentionEnforcer: Option[RetentionEnforcer] = inklessSharedState.map(new RetentionEnforcer(_))
   private val inklessFileCleaner: Option[FileCleaner] = inklessSharedState.map(new FileCleaner(_))
   // FIXME: FileMerger is having issues with hanging queries. Disabling until fixed.
   private val inklessFileMerger: Option[FileMerger] = None // inklessSharedState.map(new FileMerger(_))
@@ -411,6 +412,8 @@ class ReplicaManager(val config: KafkaConfig,
 
     // Inkless threads
     inklessSharedState.map { sharedState =>
+      scheduler.schedule("inkless-retention-enforcer", () => inklessRetentionEnforcer.foreach(_.run()), 500L, 500L)  // the real interval is inside
+
       scheduler.schedule("inkless-file-cleaner", () => inklessFileCleaner.foreach(_.run()), sharedState.config().fileCleanerInterval().toMillis, sharedState.config().fileCleanerInterval().toMillis)
 
       // There are internal delays in case of errors or absence of work items, no need for extra delays here.
@@ -2688,6 +2691,7 @@ class ReplicaManager(val config: KafkaConfig,
     addPartitionsToTxnManager.foreach(_.shutdown())
     inklessAppendHandler.foreach(_.close())
     inklessFetchInterceptor.foreach(_.close())
+    inklessRetentionEnforcer.foreach(_.close())
     inklessSharedState.foreach(_.close())
     info("Shut down completely")
   }

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -20,6 +20,7 @@ package kafka.server
 import com.yammer.metrics.core.{Gauge, Meter, Timer}
 import io.aiven.inkless.common.SharedState
 import io.aiven.inkless.config.InklessConfig
+import io.aiven.inkless.control_plane.MetadataView
 import io.aiven.inkless.produce.AppendHandler
 import kafka.cluster.PartitionTest.MockPartitionListener
 import kafka.cluster.Partition
@@ -6370,6 +6371,8 @@ class ReplicaManagerTest {
       val sharedState = mock(classOf[SharedState])
       when(sharedState.time()).thenReturn(Time.SYSTEM)
       when(sharedState.config()).thenReturn(new InklessConfig(new util.HashMap[String, Object]()))
+      val inklessMetadata = mock(classOf[MetadataView])
+      when(sharedState.metadata()).thenReturn(inklessMetadata)
 
       val logDirFailureChannel = new LogDirFailureChannel(config.logDirs.size)
 

--- a/storage/inkless/src/main/java/io/aiven/inkless/config/InklessConfig.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/config/InklessConfig.java
@@ -81,6 +81,13 @@ public class InklessConfig extends AbstractConfig {
     private static final String CONSUME_CACHE_MAX_COUNT_DOC = "The maximum number of objects to cache in memory.";
     private static final int CONSUME_CACHE_MAX_COUNT_DEFAULT = 1000;
 
+    public static final String RETENTION_ENFORCEMENT_INTERVAL_MS_CONFIG = "retention.enforcement.interval.ms";
+    private static final String RETENTION_ENFORCEMENT_INTERVAL_MS_DOC = "The interval with which to enforce retention policies on a partition. " +
+        "This interval is approximate, because each scheduling event is randomized. " +
+        "The retention enforcement mechanism also takes into account the total number of brokers in the cluster: " +
+        "the more brokers, the less frequently each one of them enforces retention policy.";
+    private static final int RETENTION_ENFORCEMENT_INTERVAL_MS_DEFAULT = 5 * 60 * 1000;  // 5 minutes
+
     public static final String FILE_CLEANER_INTERVAL_MS_CONFIG = "file.cleaner.interval.ms";
     private static final String FILE_CLEANER_INTERVAL_MS_DOC = "The interval with which to clean up files marked for deletion.";
     private static final int FILE_CLEANER_INTERVAL_MS_DEFAULT = 5 * 60 * 1000;  // 5 minutes
@@ -182,6 +189,15 @@ public class InklessConfig extends AbstractConfig {
                 CONSUME_CACHE_BLOCK_BYTES_DEFAULT,
                 ConfigDef.Importance.LOW,
                 CONSUME_CACHE_BLOCK_BYTES_DOC
+        );
+
+        configDef.define(
+            RETENTION_ENFORCEMENT_INTERVAL_MS_CONFIG,
+            ConfigDef.Type.INT,
+            RETENTION_ENFORCEMENT_INTERVAL_MS_DEFAULT,
+            ConfigDef.Range.atLeast(1),
+            ConfigDef.Importance.LOW,
+            RETENTION_ENFORCEMENT_INTERVAL_MS_DOC
         );
 
         configDef.define(
@@ -287,6 +303,10 @@ public class InklessConfig extends AbstractConfig {
 
     public int fetchCacheBlockBytes() {
         return getInt(CONSUME_CACHE_BLOCK_BYTES_CONFIG);
+    }
+
+    public Duration retentionEnforcementInterval() {
+        return Duration.ofMillis(getInt(RETENTION_ENFORCEMENT_INTERVAL_MS_CONFIG));
     }
 
     public Duration fileCleanerInterval() {

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/ControlPlane.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/ControlPlane.java
@@ -48,6 +48,8 @@ public interface ControlPlane extends Closeable, Configurable {
 
     void deleteTopics(Set<Uuid> topicIds);
 
+    List<EnforceRetentionResponse> enforceRetention(List<EnforceRetentionRequest> requests);
+
     List<FileToDelete> getFilesToDelete();
 
     void deleteFiles(DeleteFilesRequest request);

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/EnforceRetentionRequest.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/EnforceRetentionRequest.java
@@ -1,0 +1,26 @@
+/*
+ * Inkless
+ * Copyright (C) 2025 Aiven OY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.aiven.inkless.control_plane;
+
+import org.apache.kafka.common.Uuid;
+
+public record EnforceRetentionRequest(Uuid topicId,
+                                      int partition,
+                                      long retentionBytes,
+                                      long retentionMs) {
+}

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/EnforceRetentionResponse.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/EnforceRetentionResponse.java
@@ -1,0 +1,36 @@
+/*
+ * Inkless
+ * Copyright (C) 2025 Aiven OY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.aiven.inkless.control_plane;
+
+import org.apache.kafka.common.protocol.Errors;
+
+public record EnforceRetentionResponse(Errors errors,
+                                       int batchesDeleted,
+                                       long bytesDeleted,
+                                       long logStartOffset) {
+
+    public static EnforceRetentionResponse success(final int batchesDeleted,
+                                                   final long bytesDeleted,
+                                                   final long newLogStartOffset) {
+        return new EnforceRetentionResponse(Errors.NONE, batchesDeleted, bytesDeleted, newLogStartOffset);
+    }
+
+    public static EnforceRetentionResponse unknownTopicOrPartition() {
+        return new EnforceRetentionResponse(Errors.UNKNOWN_TOPIC_OR_PARTITION, -1, -1, -1);
+    }
+}

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/InMemoryControlPlane.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/InMemoryControlPlane.java
@@ -329,7 +329,9 @@ public class InMemoryControlPlane extends AbstractControlPlane {
             long bytesDeleted = 0;
 
             // Enforce the size retention.
-            if (request.retentionBytes() >= 0) {
+            if (request.retentionBytes() >= 0
+                // Does it even make sense to start iterating?
+                && logInfo.byteSize > request.retentionBytes()) {
                 long accumulatedSize = 0;
                 // Note the reverse order.
                 for (final BatchInfoInternal batch : coordinates.descendingMap().values()) {

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/InMemoryControlPlane.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/InMemoryControlPlane.java
@@ -360,7 +360,9 @@ public class InMemoryControlPlane extends AbstractControlPlane {
             logInfo.byteSize -= bytesDeleted;
             if (coordinates.isEmpty()) {
                 logInfo.logStartOffset = logInfo.highWatermark;
-                assert logInfo.byteSize == 0;
+                if (logInfo.byteSize != 0) {
+                    throw new RuntimeException(String.format("Log size expected to be 0, but it's %d", logInfo.byteSize));
+                }
             } else {
                 logInfo.logStartOffset = coordinates.firstEntry().getValue().batchInfo().metadata().baseOffset();
             }

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/MetadataView.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/MetadataView.java
@@ -18,20 +18,25 @@
 package io.aiven.inkless.control_plane;
 
 import org.apache.kafka.admin.BrokerMetadata;
-import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.TopicIdPartition;
 import org.apache.kafka.common.Uuid;
 
+import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
 public interface MetadataView {
+    Map<String, Object> getDefaultConfig();
+
     Iterable<BrokerMetadata> getAliveBrokers();
 
-    Set<TopicPartition> getTopicPartitions(String topicName);
+    Integer getBrokerCount();
 
     Uuid getTopicId(String topicName);
 
     boolean isInklessTopic(String topicName);
 
     Properties getTopicConfig(String topicName);
+
+    Set<TopicIdPartition> getInklessTopicPartitions();
 }

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/EnforceRetentionJob.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/EnforceRetentionJob.java
@@ -1,0 +1,138 @@
+/*
+ * Inkless
+ * Copyright (C) 2025 Aiven OY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.aiven.inkless.control_plane.postgres;
+
+import org.apache.kafka.common.TopicIdPartition;
+import org.apache.kafka.common.utils.Time;
+
+import org.jooq.Configuration;
+import org.jooq.DSLContext;
+import org.jooq.generated.udt.EnforceRetentionResponseV1;
+import org.jooq.generated.udt.records.EnforceRetentionRequestV1Record;
+import org.jooq.generated.udt.records.EnforceRetentionResponseV1Record;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.function.Consumer;
+
+import io.aiven.inkless.TimeUtils;
+import io.aiven.inkless.control_plane.ControlPlaneException;
+import io.aiven.inkless.control_plane.EnforceRetentionRequest;
+import io.aiven.inkless.control_plane.EnforceRetentionResponse;
+
+import static org.jooq.generated.Tables.ENFORCE_RETENTION_V1;
+
+public class EnforceRetentionJob implements Callable<List<EnforceRetentionResponse>> {
+    private final Time time;
+    private final DSLContext jooqCtx;
+    private final List<EnforceRetentionRequest> requests;
+    private final Consumer<Long> durationCallback;
+
+    public EnforceRetentionJob(final Time time,
+                               final DSLContext jooqCtx,
+                               final List<EnforceRetentionRequest> requests,
+                               final Consumer<Long> durationCallback) {
+        this.time = time;
+        this.jooqCtx = jooqCtx;
+        this.requests = requests;
+        this.durationCallback = durationCallback;
+    }
+
+    @Override
+    public List<EnforceRetentionResponse> call() throws Exception {
+        if (requests.isEmpty()) {
+            return List.of();
+        }
+        return JobUtils.run(this::runOnce, time, durationCallback);
+    }
+
+    private List<EnforceRetentionResponse> runOnce() {
+        return jooqCtx.transactionResult((final Configuration conf) -> {
+            final Instant now = TimeUtils.now(time);
+
+            final EnforceRetentionRequestV1Record[] jooqRequests = requests.stream().map(r ->
+                new EnforceRetentionRequestV1Record(
+                    r.topicId(),
+                    r.partition(),
+                    r.retentionBytes(),
+                    r.retentionMs()
+                )).toArray(EnforceRetentionRequestV1Record[]::new);
+
+            try {
+                final List<EnforceRetentionResponseV1Record> functionResult = conf.dsl().select(
+                    EnforceRetentionResponseV1.TOPIC_ID,
+                    EnforceRetentionResponseV1.PARTITION,
+                    EnforceRetentionResponseV1.ERROR,
+                    EnforceRetentionResponseV1.BATCHES_DELETED,
+                    EnforceRetentionResponseV1.BYTES_DELETED,
+                    EnforceRetentionResponseV1.LOG_START_OFFSET
+                ).from(ENFORCE_RETENTION_V1.call(
+                    now, jooqRequests
+                )).fetchInto(EnforceRetentionResponseV1Record.class);
+                return processFunctionResult(functionResult);
+            } catch (RuntimeException e) {
+                throw new ControlPlaneException("Error enforcing retention", e);
+            }
+        });
+    }
+
+    private List<EnforceRetentionResponse> processFunctionResult(
+        final List<EnforceRetentionResponseV1Record> functionResult
+    ) {
+        if (functionResult.size() != requests.size()) {
+            throw new RuntimeException(String.format("Expected %d items, returned %d", requests.size(), functionResult.size()));
+        }
+
+        // The PG function reorders requests in safe locking order. We're reverting that here.
+
+        // Technically there may be multiple requests for a partition, handle this situation.
+        final Map<TopicIdPartition, List<EnforceRetentionResponseV1Record>> resultMap = new HashMap<>();
+        for (var record : functionResult) {
+            resultMap.computeIfAbsent(
+                // We don't care about the topic name.
+                new TopicIdPartition(record.getTopicId(), record.getPartition(), null),
+                k -> new ArrayList<>()
+            ).add(record);
+        }
+
+        final List<EnforceRetentionResponse> responses = new ArrayList<>();
+        for (final var request : requests) {
+            final TopicIdPartition key = new TopicIdPartition(request.topicId(), request.partition(), null);
+            final var records = resultMap.get(key);
+            if (records == null || records.isEmpty()) {
+                throw new RuntimeException("No result found for request: " + request);
+            }
+            final var record = records.remove(0);
+            final EnforceRetentionResponse response;
+            if (record.getError() == null) {
+                response = EnforceRetentionResponse.success(record.getBatchesDeleted(), record.getBytesDeleted(), record.getLogStartOffset());
+            } else {
+                response = switch (record.getError()) {
+                    case unknown_topic_or_partition ->
+                        EnforceRetentionResponse.unknownTopicOrPartition();
+                };
+            }
+            responses.add(response);
+        }
+        return responses;
+    }
+}

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/PostgresControlPlane.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/PostgresControlPlane.java
@@ -49,6 +49,8 @@ import io.aiven.inkless.control_plane.CreateTopicAndPartitionsRequest;
 import io.aiven.inkless.control_plane.DeleteFilesRequest;
 import io.aiven.inkless.control_plane.DeleteRecordsRequest;
 import io.aiven.inkless.control_plane.DeleteRecordsResponse;
+import io.aiven.inkless.control_plane.EnforceRetentionRequest;
+import io.aiven.inkless.control_plane.EnforceRetentionResponse;
 import io.aiven.inkless.control_plane.FileMergeWorkItem;
 import io.aiven.inkless.control_plane.FileMergeWorkItemNotExist;
 import io.aiven.inkless.control_plane.FileToDelete;
@@ -152,6 +154,11 @@ public class PostgresControlPlane extends AbstractControlPlane {
     public List<DeleteRecordsResponse> deleteRecords(final List<DeleteRecordsRequest> requests) {
         final DeleteRecordsJob job = new DeleteRecordsJob(time, jooqCtx, requests, metrics::onDeleteRecordsCompleted);
         return job.call();
+    }
+
+    @Override
+    public List<EnforceRetentionResponse> enforceRetention(final List<EnforceRetentionRequest> requests) {
+        throw new RuntimeException("Not implemented");
     }
 
     @Override

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/PostgresControlPlane.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/PostgresControlPlane.java
@@ -158,7 +158,12 @@ public class PostgresControlPlane extends AbstractControlPlane {
 
     @Override
     public List<EnforceRetentionResponse> enforceRetention(final List<EnforceRetentionRequest> requests) {
-        throw new RuntimeException("Not implemented");
+        try {
+            final EnforceRetentionJob job = new EnforceRetentionJob(time, jooqCtx, requests, metrics::onEnforceRetentionCompleted);
+            return job.call();
+        } catch (final Exception e) {
+            throw new ControlPlaneException("Failed to enforce retention", e);
+        }
     }
 
     @Override

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/PostgresControlPlaneMetrics.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/PostgresControlPlaneMetrics.java
@@ -40,6 +40,7 @@ public class PostgresControlPlaneMetrics implements Closeable {
     private final QueryMetrics fileDeleteMetrics = new QueryMetrics("FilesDelete");
     private final QueryMetrics listOffsetsMetrics = new QueryMetrics("ListOffsets");
     private final QueryMetrics deleteRecordsMetrics = new QueryMetrics("DeleteRecords");
+    private final QueryMetrics enforceRetentionMetrics = new QueryMetrics("EnforceRetention");
     private final QueryMetrics getFilesToDeleteMetrics = new QueryMetrics("GetFilesToDelete");
     private final QueryMetrics getFileMergeWorkItemMetrics = new QueryMetrics("GetFileMergeWorkItem");
     private final QueryMetrics releaseFileMergeWorkItemMetrics = new QueryMetrics("ReleaseFileMergeWorkItem");
@@ -86,6 +87,10 @@ public class PostgresControlPlaneMetrics implements Closeable {
         deleteRecordsMetrics.record(duration);
     }
 
+    public void onEnforceRetentionCompleted(Long duration) {
+        enforceRetentionMetrics.record(duration);
+    }
+
     public void onGetFilesToDeleteCompleted(Long duration) {
         getFilesToDeleteMetrics.record(duration);
     }
@@ -117,6 +122,7 @@ public class PostgresControlPlaneMetrics implements Closeable {
         fileDeleteMetrics.remove();
         listOffsetsMetrics.remove();
         deleteRecordsMetrics.remove();
+        enforceRetentionMetrics.remove();
         getFilesToDeleteMetrics.remove();
         getFileMergeWorkItemMetrics.remove();
         releaseFileMergeWorkItemMetrics.remove();

--- a/storage/inkless/src/main/java/io/aiven/inkless/delete/RetentionEnforcementScheduler.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/delete/RetentionEnforcementScheduler.java
@@ -39,6 +39,14 @@ import io.aiven.inkless.control_plane.MetadataView;
 
 /**
  * The class responsible for scheduling per partition retention enforcement.
+ *
+ * <p>The scheduler tries to ensure that retention enforcement is performed for each partition
+ * every {@code enforcementInterval} approximately across all brokers.
+ * "Approximately" means that there's a  randomization component. The number of milliseconds to wait is selected randomly from {@code [0..2*enforcementInterval)}.
+ * As there is no coordination across brokers, each scheduler just multiply the interval to randomly choose from by the number of brokers,
+ * keeping the global frequency on average the same.
+ *
+ * <p>The global coordination is not needed because the control plane must do the appropriate locking, so we're not trying to avoid collisions.</p>
  */
 class RetentionEnforcementScheduler {
     private static final Logger LOGGER = LoggerFactory.getLogger(RetentionEnforcementScheduler.class);

--- a/storage/inkless/src/main/java/io/aiven/inkless/delete/RetentionEnforcementScheduler.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/delete/RetentionEnforcementScheduler.java
@@ -1,0 +1,150 @@
+/*
+ * Inkless
+ * Copyright (C) 2025 Aiven OY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.aiven.inkless.delete;
+
+import org.apache.kafka.common.TopicIdPartition;
+import org.apache.kafka.common.utils.Time;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.PriorityQueue;
+import java.util.Set;
+import java.util.random.RandomGenerator;
+
+import io.aiven.inkless.TimeUtils;
+import io.aiven.inkless.control_plane.MetadataView;
+
+/**
+ * The class responsible for scheduling per partition retention enforcement.
+ */
+class RetentionEnforcementScheduler {
+    private static final Logger LOGGER = LoggerFactory.getLogger(RetentionEnforcementScheduler.class);
+
+    /**
+     * How ofter we update the known partitions.
+     * <p>This may be a bit heavy to update this info on each call.
+     */
+    private static final Duration KNOWN_PARTITION_UPDATE_INTERVAL = Duration.ofMinutes(5);
+
+    private final Time time;
+    private final MetadataView metadataView;
+    private final Duration enforcementInterval;
+    private final RandomGenerator random;
+
+    private Instant lastKnownPartitionsUpdate = Instant.MIN;
+    private Set<TopicIdPartition> knownPartitions = new HashSet<>();
+
+    private final PriorityQueue<TopicIdPartitionWithNextEnforcementTime> partitionsByNextEnforcementTime = new PriorityQueue<>(
+        TopicIdPartitionWithNextEnforcementTime.timeComparator()
+    );
+
+    public RetentionEnforcementScheduler(final Time time,
+                                         final MetadataView metadataView,
+                                         final Duration enforcementInterval,
+                                         final RandomGenerator random) {
+        this.time = Objects.requireNonNull(time, "time cannot be null");
+        this.metadataView = Objects.requireNonNull(metadataView, "metadataView cannot be null");
+        this.enforcementInterval = Objects.requireNonNull(enforcementInterval, "enforcementInterval cannot be null");
+        this.random = Objects.requireNonNull(random, "random cannot be null");
+    }
+
+    List<TopicIdPartition> getReadyPartitions() {
+        final Instant now = TimeUtils.now(time);
+
+        updateKnownPartitionsIfNeeded(now);
+
+        final List<TopicIdPartition> result = new ArrayList<>();
+        TopicIdPartitionWithNextEnforcementTime tidpwt;
+        // These peek() and poll() are guaranteed to work with the same item
+        // if there's no concurrent modification (which should be the case).
+        while ((tidpwt = partitionsByNextEnforcementTime.peek()) != null && tidpwt.nextEnforcementTime().isBefore(now)) {
+            partitionsByNextEnforcementTime.poll();
+            final TopicIdPartition partition = tidpwt.topicIdPartition();
+            // Filter out previously deleted partitions.
+            if (knownPartitions.contains(partition)) {
+                result.add(partition);
+            } else {
+                LOGGER.debug("Partition removed: {}", partition);
+            }
+        }
+
+        // We need to reschedule the taken partitions.
+        for (final TopicIdPartition partition : result) {
+            schedulePartition(now, partition);
+        }
+
+        return result;
+    }
+
+    private void updateKnownPartitionsIfNeeded(final Instant now) {
+        if (lastKnownPartitionsUpdate.plus(KNOWN_PARTITION_UPDATE_INTERVAL).isBefore(now)) {
+            final Set<TopicIdPartition> newKnownPartitions = metadataView.getInklessTopicPartitions();
+            for (final TopicIdPartition partition : newKnownPartitions) {
+                // Schedule the new partitions.
+                if (!this.knownPartitions.contains(partition)) {
+                    LOGGER.debug("Partition added: {}", partition);
+                    schedulePartition(now, partition);
+                }
+            }
+            this.knownPartitions = newKnownPartitions;
+            lastKnownPartitionsUpdate = now;
+        }
+    }
+
+    private void schedulePartition(final Instant now, final TopicIdPartition partition) {
+        partitionsByNextEnforcementTime.add(
+            new TopicIdPartitionWithNextEnforcementTime(partition, nextCheck(now)
+        ));
+    }
+
+    private Instant nextCheck(final Instant now) {
+        // TODO consider adaptive checking:
+        // If a partition is infrequently written to, we can proportionally decrease the enforcing frequency for it.
+
+        // brokerCount may be 0, for example when the first broker is just starting.
+        // Defaulting to 1 in this case.
+        final int effectiveBrokerCount = Math.max(1, metadataView.getBrokerCount());
+        final long bound =
+            // Multiply by 2 because on average we'll get enforcementInterval
+            2 * enforcementInterval.toMillis()
+            // The more brokers we have, the less frequently we should actually check.
+            * effectiveBrokerCount;
+        return now.plusMillis(random.nextLong(bound));
+    }
+
+    // Visible for testing.
+    record TopicIdPartitionWithNextEnforcementTime(TopicIdPartition topicIdPartition,
+                                                   Instant nextEnforcementTime) {
+        private static Comparator<TopicIdPartitionWithNextEnforcementTime> timeComparator() {
+            return Comparator.comparing(TopicIdPartitionWithNextEnforcementTime::nextEnforcementTime);
+        }
+    }
+
+    // Visible for testing.
+    List<TopicIdPartitionWithNextEnforcementTime> dumpQueue() {
+        return partitionsByNextEnforcementTime.stream().toList();
+    }
+}

--- a/storage/inkless/src/main/java/io/aiven/inkless/delete/RetentionEnforcer.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/delete/RetentionEnforcer.java
@@ -92,12 +92,15 @@ public class RetentionEnforcer implements Runnable, Closeable {
             final LogConfig topicConfig = topicConfigs.computeIfAbsent(partition.topic(),
                 t -> LogConfig.fromProps(metadataView.getDefaultConfig(), metadataView.getTopicConfig(t)));
 
-            requests.add(new EnforceRetentionRequest(
-                partition.topicId(),
-                partition.partition(),
-                topicConfig.retentionSize,
-                topicConfig.retentionMs
-            ));
+            // This check must be done here and not at scheduling, because the config may change at any moment.
+            if (topicConfig.delete) {
+                requests.add(new EnforceRetentionRequest(
+                    partition.topicId(),
+                    partition.partition(),
+                    topicConfig.retentionSize,
+                    topicConfig.retentionMs
+                ));
+            }
         }
 
         if (requests.isEmpty()) {

--- a/storage/inkless/src/main/java/io/aiven/inkless/delete/RetentionEnforcer.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/delete/RetentionEnforcer.java
@@ -1,0 +1,167 @@
+/*
+ * Inkless
+ * Copyright (C) 2025 Aiven OY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.aiven.inkless.delete;
+
+import org.apache.kafka.common.TopicIdPartition;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.storage.internals.log.LogConfig;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Random;
+
+import io.aiven.inkless.TimeUtils;
+import io.aiven.inkless.common.SharedState;
+import io.aiven.inkless.control_plane.ControlPlane;
+import io.aiven.inkless.control_plane.EnforceRetentionRequest;
+import io.aiven.inkless.control_plane.EnforceRetentionResponse;
+import io.aiven.inkless.control_plane.MetadataView;
+
+public class RetentionEnforcer implements Runnable, Closeable {
+    private static final Logger LOGGER = LoggerFactory.getLogger(RetentionEnforcer.class);
+
+    private static final Duration LOG_CONFIG_TTL = Duration.ofMinutes(5);
+
+    private final Time time;
+    private final MetadataView metadataView;
+    private final ControlPlane controlPlane;
+    private final RetentionEnforcementScheduler retentionEnforcementScheduler;
+
+    // TODO consider updating these values reactively instead of caching with TTL (but should be fine for now).
+    private final Cache<TopicPartition, LogConfig> logConfigCache = Caffeine.newBuilder()
+        .expireAfterWrite(LOG_CONFIG_TTL)
+        .build();
+
+    private final RetentionEnforcerMetrics metrics = new RetentionEnforcerMetrics();
+
+    public RetentionEnforcer(final SharedState sharedState) {
+        this(Objects.requireNonNull(sharedState, "sharedState cannot be null").time(),
+            sharedState.metadata(),
+            sharedState.controlPlane(),
+            new RetentionEnforcementScheduler(
+                sharedState.time(),
+                sharedState.metadata(),
+                sharedState.config().retentionEnforcementInterval(),
+                new Random())
+        );
+    }
+
+    // Visible for testing.
+    RetentionEnforcer(final Time time,
+                      final MetadataView metadataView,
+                      final ControlPlane controlPlane,
+                      final RetentionEnforcementScheduler retentionEnforcementScheduler) {
+        this.time = time;
+        this.metadataView = metadataView;
+        this.controlPlane = controlPlane;
+        this.retentionEnforcementScheduler = retentionEnforcementScheduler;
+    }
+
+    @Override
+    public void run() {
+        try {
+            runUnsafe();
+        } catch (final Exception e) {
+            LOGGER.error("Error enforcing retention", e);
+        }
+    }
+
+    private synchronized void runUnsafe() {
+        final List<EnforceRetentionRequest> requests = new ArrayList<>();
+        final List<TopicIdPartition> readyPartitions = retentionEnforcementScheduler.getReadyPartitions();
+        for (final TopicIdPartition partition : readyPartitions) {
+            final LogConfig topicConfig = logConfigCache.get(partition.topicPartition(),
+                tp -> LogConfig.fromProps(metadataView.getDefaultConfig(), metadataView.getTopicConfig(tp.topic())));
+
+            requests.add(new EnforceRetentionRequest(
+                partition.topicId(),
+                partition.partition(),
+                topicConfig.retentionSize,
+                topicConfig.retentionMs
+            ));
+        }
+
+        if (requests.isEmpty()) {
+            return;
+        }
+
+        metrics.recordRetentionEnforcementStarted();
+
+        final Instant start = TimeUtils.durationMeasurementNow(time);
+        final List<EnforceRetentionResponse> responses;
+        try {
+            responses = controlPlane.enforceRetention(requests);
+        } catch (final Exception e) {
+            metrics.recordRetentionEnforcementFinishedWithError();
+            LOGGER.error("Unexpected error when enforcing retention", e);
+            throw new RuntimeException(e);
+        }
+        final Instant ended = TimeUtils.durationMeasurementNow(time);
+        final long durationMs = Duration.between(start, ended).toMillis();
+
+        LOGGER.debug("Enforcing retention for {} partitions took {} ms", requests.size(), durationMs);
+
+        long totalBatchesDeleted = 0;
+        long totalBytesDeleted = 0;
+        for (int i = 0; i < responses.size(); i++) {
+            final TopicIdPartition readyPartition = readyPartitions.get(i);
+            final var request = requests.get(i);
+            final var response = responses.get(i);
+
+            switch (response.errors()) {
+                case NONE -> {
+                    LOGGER.trace("Enforcing retention for {} with retentionBytes={}, retentionMs={} completed successfully. " +
+                            "{} batches and {} bytes deleted, new log start offset: {}",
+                        readyPartition.topicPartition(), request.retentionBytes(), request.retentionMs(),
+                        response.batchesDeleted(), response.bytesDeleted(), response.logStartOffset());
+                    totalBatchesDeleted += response.batchesDeleted();
+                    totalBytesDeleted += response.bytesDeleted();
+                }
+
+                case UNKNOWN_TOPIC_OR_PARTITION ->
+                    // When a topic is deleted, each partition may still be attempted once.
+                    // Use debug logging to not pollute the log with this normal behavior.
+                    LOGGER.debug("Enforcing retention for {} with retentionBytes={}, retentionMs={} completed with error: {}",
+                        readyPartition.topicPartition(), request.retentionBytes(), request.retentionMs(), response.errors());
+
+                default ->
+                    LOGGER.error("Enforcing retention for {} with retentionBytes={}, retentionMs={} completed with error: {}",
+                        readyPartition.topicPartition(), request.retentionBytes(), request.retentionMs(), response.errors());
+            }
+        }
+
+        metrics.recordRetentionEnforcementFinishedSuccessfully(durationMs, totalBatchesDeleted, totalBytesDeleted);
+    }
+
+    @Override
+    public void close() throws IOException {
+        metrics.close();
+    }
+}

--- a/storage/inkless/src/main/java/io/aiven/inkless/delete/RetentionEnforcerMetrics.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/delete/RetentionEnforcerMetrics.java
@@ -1,0 +1,74 @@
+/*
+ * Inkless
+ * Copyright (C) 2025 Aiven OY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.aiven.inkless.delete;
+
+import org.apache.kafka.server.metrics.KafkaMetricsGroup;
+
+import com.yammer.metrics.core.Histogram;
+
+import java.io.Closeable;
+import java.util.Map;
+import java.util.concurrent.atomic.LongAdder;
+
+public class RetentionEnforcerMetrics implements Closeable {
+    static final String RETENTION_ENFORCEMENT_TOTAL_TIME = "RetentionEnforcementTotalTime";
+    static final String RETENTION_ENFORCEMENT_RATE = "RetentionEnforcementRate";
+    static final String RETENTION_ENFORCEMENT_TOTAL_BATCHES_DELETED = "RetentionEnforcementTotalBatchesDeleted";
+    static final String RETENTION_ENFORCEMENT_TOTAL_BYTES_DELETED = "RetentionEnforcementTotalBytesDeleted";
+    static final String RETENTION_ENFORCEMENT_ERROR_RATE = "RetentionEnforcementErrorRate";
+
+    private final KafkaMetricsGroup metricsGroup = new KafkaMetricsGroup(RetentionEnforcer.class);
+    private final Histogram retentionEnforcementTotalTime;
+    private final LongAdder retentionEnforcementRate = new LongAdder();
+    private final LongAdder retentionEnforcementTotalBatchesDeleted = new LongAdder();
+    private final LongAdder retentionEnforcementTotalBytesDeleted = new LongAdder();
+    private final LongAdder retentionEnforcementErrorRate = new LongAdder();
+
+    public RetentionEnforcerMetrics() {
+        retentionEnforcementTotalTime = metricsGroup.newHistogram(RETENTION_ENFORCEMENT_TOTAL_TIME, true, Map.of());
+        metricsGroup.newGauge(RETENTION_ENFORCEMENT_RATE, retentionEnforcementRate::intValue);
+        metricsGroup.newGauge(RETENTION_ENFORCEMENT_TOTAL_BATCHES_DELETED, retentionEnforcementTotalBatchesDeleted::intValue);
+        metricsGroup.newGauge(RETENTION_ENFORCEMENT_TOTAL_BYTES_DELETED, retentionEnforcementTotalBytesDeleted::intValue);
+        metricsGroup.newGauge(RETENTION_ENFORCEMENT_ERROR_RATE, retentionEnforcementErrorRate::intValue);
+    }
+
+    public void recordRetentionEnforcementStarted() {
+        retentionEnforcementRate.increment();
+    }
+
+    public void recordRetentionEnforcementFinishedSuccessfully(final long durationMs,
+                                                               final long totalBatchesDeleted,
+                                                               final long totalBytesDeleted) {
+        retentionEnforcementTotalTime.update(durationMs);
+        retentionEnforcementTotalBatchesDeleted.add(totalBatchesDeleted);
+        retentionEnforcementTotalBytesDeleted.add(totalBytesDeleted);
+    }
+
+    public void recordRetentionEnforcementFinishedWithError() {
+        retentionEnforcementErrorRate.increment();
+    }
+
+    @Override
+    public void close() {
+        metricsGroup.removeMetric(RETENTION_ENFORCEMENT_TOTAL_TIME);
+        metricsGroup.removeMetric(RETENTION_ENFORCEMENT_RATE);
+        metricsGroup.removeMetric(RETENTION_ENFORCEMENT_TOTAL_BATCHES_DELETED);
+        metricsGroup.removeMetric(RETENTION_ENFORCEMENT_TOTAL_BYTES_DELETED);
+        metricsGroup.removeMetric(RETENTION_ENFORCEMENT_ERROR_RATE);
+    }
+}

--- a/storage/inkless/src/main/resources/db/migration/V4__Retention_enforcement.sql
+++ b/storage/inkless/src/main/resources/db/migration/V4__Retention_enforcement.sql
@@ -1,0 +1,133 @@
+-- Copyright (c) 2025 Aiven, Helsinki, Finland. https://aiven.io/
+
+CREATE DOMAIN retention_t AS BIGINT NOT NULL
+CHECK (VALUE >= -1);
+
+CREATE TYPE enforce_retention_request_v1 AS (
+    topic_id topic_id_t,
+    partition partition_t,
+    retention_bytes retention_t,
+    retention_ms retention_t
+);
+
+CREATE TYPE enforce_retention_response_error_v1 AS ENUM (
+    'unknown_topic_or_partition'
+);
+
+CREATE TYPE enforce_retention_response_v1 AS (
+    topic_id topic_id_t,
+    partition partition_t,
+    error enforce_retention_response_error_v1,
+    batches_deleted INT,
+    bytes_deleted BIGINT,
+    log_start_offset offset_nullable_t
+);
+
+CREATE FUNCTION enforce_retention_v1(
+    arg_now TIMESTAMP WITH TIME ZONE,
+    arg_requests enforce_retention_request_v1[]
+)
+RETURNS SETOF enforce_retention_response_v1 LANGUAGE plpgsql VOLATILE AS $$
+DECLARE
+    l_request RECORD;
+    l_log logs%ROWTYPE;
+    l_base_offset_of_first_batch_to_keep offset_nullable_t;
+    l_batches_deleted INT;
+    l_bytes_deleted BIGINT;
+    l_delete_records_response delete_records_response_v1;
+BEGIN
+    FOR l_request IN
+        SELECT *
+        FROM unnest(arg_requests)
+        ORDER BY topic_id, partition  -- ordering is important to prevent deadlocks
+    LOOP
+        SELECT *
+        FROM logs
+        WHERE topic_id = l_request.topic_id
+            AND partition = l_request.partition
+        INTO l_log
+        FOR UPDATE;
+
+        IF NOT FOUND THEN
+            RETURN NEXT (l_request.topic_id, l_request.partition, 'unknown_topic_or_partition', NULL, NULL, NULL)::enforce_retention_response_v1;
+            CONTINUE;
+        END IF;
+
+        l_base_offset_of_first_batch_to_keep = NULL;
+
+        IF l_request.retention_bytes >= 0 OR l_request.retention_ms >= 0 THEN
+            WITH augmented_batches AS (
+                -- For retention by size:
+                --     Associate with each batch the number of bytes that the log would have if this batch and later batches are retained.
+                --     In other words, this is the reverse aggregated size (counted from the end to the beginning).
+                --     An example:
+                --     Batch size | Aggregated | Reverse aggregated |
+                --     (in order) | size       | size               |
+                --              1 |          1 |   10 -  1 + 1 = 10 |
+                --              2 | 1 + 2 =  3 |   10 -  3 + 2 =  9 |
+                --              3 | 3 + 3 =  6 |   10 -  6 + 3 =  7 |
+                --              4 | 6 + 4 = 10 |   10 - 10 + 4 =  4 |
+                --     The reverse aggregated size is equal to what the aggregated size would be if the sorting order is reverse,
+                --     but doing so explicitly might be costly, hence the formula.
+                -- For retention by time:
+                --     Associate with each batch its effective timestamp.
+                SELECT topic_id, partition, last_offset,
+                    base_offset,
+                    l_log.byte_size - SUM(byte_size) OVER (ORDER BY topic_id, partition, last_offset) + byte_size AS reverse_agg_byte_size,
+                    batch_timestamp(timestamp_type, batch_max_timestamp, log_append_timestamp) AS effective_timestamp
+                FROM batches
+                WHERE topic_id = l_request.topic_id
+                    AND partition = l_request.partition
+                ORDER BY topic_id, partition, last_offset
+            )
+            -- Look for the first batch that complies with both retention policies (if they are enabled):
+            -- For size:
+            --    The first batch which being retained with the subsequent batches would make the total log size <= retention_bytes.
+            -- For time:
+            --    The first batch which effective timestamp is greater or equal to the last timestamp to retain.
+            SELECT base_offset
+            FROM augmented_batches
+            WHERE (l_request.retention_bytes < 0 OR reverse_agg_byte_size <= l_request.retention_bytes)
+                AND (l_request.retention_ms < 0 OR effective_timestamp >= (EXTRACT(EPOCH FROM arg_now AT TIME ZONE 'UTC') * 1000)::BIGINT - l_request.retention_ms)
+            ORDER BY topic_id, partition, last_offset
+            LIMIT 1
+            INTO l_base_offset_of_first_batch_to_keep;
+
+            -- No batch satisfy the retention policy == delete everything, i.e. up to HWM.
+            l_base_offset_of_first_batch_to_keep = COALESCE(l_base_offset_of_first_batch_to_keep, l_log.high_watermark);
+        END IF;
+
+        -- Nothing to delete.
+        IF l_base_offset_of_first_batch_to_keep IS NULL THEN
+            RETURN NEXT (l_request.topic_id, l_request.partition, NULL, 0, 0::BIGINT, l_log.log_start_offset)::enforce_retention_response_v1;
+            CONTINUE;
+        END IF;
+
+        SELECT COUNT(*), SUM(byte_size)
+        FROM batches
+        WHERE topic_id = l_request.topic_id
+            AND partition = l_request.partition
+            AND last_offset < l_base_offset_of_first_batch_to_keep
+        INTO l_batches_deleted, l_bytes_deleted;
+
+        SELECT *
+        FROM delete_records_v1(arg_now, array[ROW(l_request.topic_id, l_request.partition, l_base_offset_of_first_batch_to_keep)::delete_records_request_v1])
+        INTO l_delete_records_response;
+
+        -- This should never happen, just fail.
+        IF l_delete_records_response.error IS DISTINCT FROM NULL THEN
+            RAISE 'delete_records_v1 returned unexpected error: %', l_delete_records_response;
+        END IF;
+
+        RETURN NEXT (
+            l_request.topic_id,
+            l_request.partition,
+            NULL::enforce_retention_response_error_v1,
+            COALESCE(l_batches_deleted, 0),
+            COALESCE(l_bytes_deleted, 0),
+            l_delete_records_response.log_start_offset
+        )::enforce_retention_response_v1;
+    END LOOP;
+END;
+$$
+;

--- a/storage/inkless/src/test/java/io/aiven/inkless/control_plane/AbstractControlPlaneTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/control_plane/AbstractControlPlaneTest.java
@@ -23,7 +23,6 @@ import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.record.RecordBatch;
 import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.common.utils.MockTime;
-import org.apache.kafka.common.utils.Time;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -78,7 +77,8 @@ public abstract class AbstractControlPlaneTest {
         "file.merge.lock.period.ms", Long.toString(FILE_MERGE_LOCK_PERIOD.toMillis())
     );
 
-    protected Time time = new MockTime();
+    static final long START_TIME = 10000;
+    protected MockTime time = new MockTime(0, START_TIME, 0);
 
     protected ControlPlane controlPlane;
 
@@ -631,6 +631,363 @@ public abstract class AbstractControlPlaneTest {
         assertThat(controlPlane.getFilesToDelete()).isEmpty();
     }
 
+    @Nested
+    class Retention {
+        private static final String FILE_NAME = "obj1";
+        private static final long BATCH_1_RECORDS = 10;
+        private static final long BATCH_2_RECORDS = 20;
+        private static final long BATCH_3_RECORDS = 30;
+        private static final int BATCH_1_SIZE = 123;
+        private static final int BATCH_2_SIZE = 456;
+        private static final int BATCH_3_SIZE = 789;
+        private static final long BATCH_1_MAX_TIMESTAMP = START_TIME;
+        private static final long BATCH_2_MAX_TIMESTAMP = START_TIME + 10;
+        private static final long BATCH_3_MAX_TIMESTAMP = START_TIME + 30;
+
+        private static final long EXPECTED_HIGH_WATERMARK = BATCH_1_RECORDS + BATCH_2_RECORDS + BATCH_3_RECORDS;
+
+        @Test
+        void nonExistentTopicPartition() {
+            final var responses = controlPlane.enforceRetention(List.of(
+                new EnforceRetentionRequest(
+                    Uuid.ZERO_UUID, 12345, 10, 12)
+            ));
+            assertThat(responses)
+                .map(EnforceRetentionResponse::errors)
+                .containsExactly(Errors.UNKNOWN_TOPIC_OR_PARTITION);
+        }
+
+        @Nested
+        class BySize {
+            @Test
+            void empty() {
+                final var responses = controlPlane.enforceRetention(List.of(
+                    new EnforceRetentionRequest(EXISTING_TOPIC_1_ID, 0, 100, -1)
+                ));
+                assertThat(responses).containsExactly(
+                    EnforceRetentionResponse.success(0, 0, 0)
+                );
+                assertThat(controlPlane.getLogInfo(List.of(new GetLogInfoRequest(EXISTING_TOPIC_1_ID, 0))))
+                    .containsExactly(GetLogInfoResponse.success(0, 0, 0));
+            }
+
+            @Test
+            void deleteNothing() {
+                addBatches();
+                assertThat(getLogStartOffset()).isEqualTo(0L);
+                assertThat(getHighWatermark()).isEqualTo(EXPECTED_HIGH_WATERMARK);
+
+                final var responses = controlPlane.enforceRetention(List.of(
+                    new EnforceRetentionRequest(EXISTING_TOPIC_1_ID, 0, BATCH_1_SIZE + BATCH_2_SIZE + BATCH_3_SIZE, -1)
+                ));
+
+                assertThat(responses)
+                    .containsExactly(EnforceRetentionResponse.success(0, 0, 0));
+                assertThat(getLogStartOffset()).isEqualTo(0);
+                assertThat(getHighWatermark()).isEqualTo(EXPECTED_HIGH_WATERMARK);
+                assertThat(controlPlane.getLogInfo(List.of(new GetLogInfoRequest(EXISTING_TOPIC_1_ID, 0))))
+                    .containsExactly(GetLogInfoResponse.success(0, EXPECTED_HIGH_WATERMARK, BATCH_1_SIZE + BATCH_2_SIZE + BATCH_3_SIZE));
+            }
+
+            @ParameterizedTest
+            @ValueSource(booleans = {true, false})
+            void deleteSome(final boolean deleteMidBatch) {
+                addBatches();
+                assertThat(getLogStartOffset()).isEqualTo(0L);
+                assertThat(getHighWatermark()).isEqualTo(EXPECTED_HIGH_WATERMARK);
+
+                final int retentionBytes = deleteMidBatch ? BATCH_3_SIZE + 1 : BATCH_3_SIZE;
+                final var response = controlPlane.enforceRetention(List.of(
+                    new EnforceRetentionRequest(EXISTING_TOPIC_1_ID, 0, retentionBytes, -1)
+                ));
+
+                final long newLogStartOffset = BATCH_1_RECORDS + BATCH_2_RECORDS;
+                assertThat(response)
+                    .containsExactly(EnforceRetentionResponse.success(2, BATCH_1_SIZE + BATCH_2_SIZE, newLogStartOffset));
+                assertThat(getLogStartOffset()).isEqualTo(newLogStartOffset);
+                assertThat(getHighWatermark()).isEqualTo(EXPECTED_HIGH_WATERMARK);
+                assertThat(controlPlane.getLogInfo(List.of(new GetLogInfoRequest(EXISTING_TOPIC_1_ID, 0))))
+                    .containsExactly(GetLogInfoResponse.success(newLogStartOffset, EXPECTED_HIGH_WATERMARK, BATCH_3_SIZE));
+            }
+
+            @Test
+            void deleteAll() {
+                addBatches();
+                assertThat(getLogStartOffset()).isEqualTo(0L);
+                assertThat(getHighWatermark()).isEqualTo(EXPECTED_HIGH_WATERMARK);
+
+                final var responses = controlPlane.enforceRetention(List.of(
+                    new EnforceRetentionRequest(EXISTING_TOPIC_1_ID, 0, 0, -1)
+                ));
+
+                final long newLogStartOffset = EXPECTED_HIGH_WATERMARK;
+                assertThat(responses)
+                    .containsExactly(EnforceRetentionResponse.success(3, BATCH_1_SIZE + BATCH_2_SIZE + BATCH_3_SIZE, newLogStartOffset));
+                assertThat(getLogStartOffset()).isEqualTo(newLogStartOffset);
+                assertThat(getHighWatermark()).isEqualTo(EXPECTED_HIGH_WATERMARK);
+                assertThat(controlPlane.getLogInfo(List.of(new GetLogInfoRequest(EXISTING_TOPIC_1_ID, 0))))
+                    .containsExactly(GetLogInfoResponse.success(newLogStartOffset, EXPECTED_HIGH_WATERMARK, 0));
+                assertThat(controlPlane.getFilesToDelete()).containsExactly(
+                    new FileToDelete(FILE_NAME, TimeUtils.now(time))
+                );
+            }
+        }
+
+        @Nested
+        class ByTime {
+            @Test
+            void empty() {
+                final var responses = controlPlane.enforceRetention(List.of(
+                    new EnforceRetentionRequest(EXISTING_TOPIC_1_ID, 0, -1, 123456)
+                ));
+                assertThat(responses).containsExactly(EnforceRetentionResponse.success(
+                    0, 0, 0
+                ));
+                assertThat(controlPlane.getLogInfo(List.of(new GetLogInfoRequest(EXISTING_TOPIC_1_ID, 0))))
+                    .containsExactly(GetLogInfoResponse.success(0, 0, 0));
+            }
+
+            @Test
+            void deleteNothing() {
+                addBatches();
+                assertThat(getLogStartOffset()).isEqualTo(0L);
+                assertThat(getHighWatermark()).isEqualTo(EXPECTED_HIGH_WATERMARK);
+
+                time.setCurrentTimeMs(BATCH_3_MAX_TIMESTAMP + 1);
+                final var responses = controlPlane.enforceRetention(List.of(
+                    new EnforceRetentionRequest(EXISTING_TOPIC_1_ID, 0, -1, 1000)
+                ));
+
+                assertThat(responses)
+                    .containsExactly(EnforceRetentionResponse.success(0, 0, 0));
+                assertThat(getLogStartOffset()).isEqualTo(0);
+                assertThat(getHighWatermark()).isEqualTo(EXPECTED_HIGH_WATERMARK);
+                assertThat(controlPlane.getLogInfo(List.of(new GetLogInfoRequest(EXISTING_TOPIC_1_ID, 0))))
+                    .containsExactly(GetLogInfoResponse.success(0, EXPECTED_HIGH_WATERMARK, BATCH_1_SIZE + BATCH_2_SIZE + BATCH_3_SIZE));
+            }
+
+            @Test
+            void deleteSome() {
+                addBatches();
+                assertThat(getLogStartOffset()).isEqualTo(0L);
+                assertThat(getHighWatermark()).isEqualTo(EXPECTED_HIGH_WATERMARK);
+
+                time.setCurrentTimeMs(BATCH_3_MAX_TIMESTAMP);
+                final var responses = controlPlane.enforceRetention(List.of(
+                    new EnforceRetentionRequest(EXISTING_TOPIC_1_ID, 0, -1, BATCH_3_MAX_TIMESTAMP - BATCH_2_MAX_TIMESTAMP)
+                ));
+
+                final long newLogStartOffset = BATCH_1_RECORDS;
+                assertThat(responses)
+                    .containsExactly(EnforceRetentionResponse.success(1, BATCH_1_SIZE, newLogStartOffset));
+                assertThat(getLogStartOffset()).isEqualTo(newLogStartOffset);
+                assertThat(getHighWatermark()).isEqualTo(EXPECTED_HIGH_WATERMARK);
+                assertThat(controlPlane.getLogInfo(List.of(new GetLogInfoRequest(EXISTING_TOPIC_1_ID, 0))))
+                    .containsExactly(GetLogInfoResponse.success(newLogStartOffset, EXPECTED_HIGH_WATERMARK, BATCH_2_SIZE + BATCH_3_SIZE));
+            }
+
+            @Test
+            void deleteAll() {
+                addBatches();
+                assertThat(getLogStartOffset()).isEqualTo(0L);
+                assertThat(getHighWatermark()).isEqualTo(EXPECTED_HIGH_WATERMARK);
+
+                time.setCurrentTimeMs(BATCH_3_MAX_TIMESTAMP + 1);
+                final var responses = controlPlane.enforceRetention(List.of(
+                    new EnforceRetentionRequest(EXISTING_TOPIC_1_ID, 0, -1, 0)
+                ));
+
+                final long newLogStartOffset = EXPECTED_HIGH_WATERMARK;
+                assertThat(responses)
+                    .containsExactly(EnforceRetentionResponse.success(3, BATCH_1_SIZE + BATCH_2_SIZE + BATCH_3_SIZE, newLogStartOffset));
+                assertThat(getLogStartOffset()).isEqualTo(newLogStartOffset);
+                assertThat(getHighWatermark()).isEqualTo(EXPECTED_HIGH_WATERMARK);
+                assertThat(controlPlane.getLogInfo(List.of(new GetLogInfoRequest(EXISTING_TOPIC_1_ID, 0))))
+                    .containsExactly(GetLogInfoResponse.success(newLogStartOffset, EXPECTED_HIGH_WATERMARK, 0));
+                assertThat(controlPlane.getFilesToDelete()).containsExactly(
+                    new FileToDelete(FILE_NAME, TimeUtils.now(time))
+                );
+            }
+
+            @Test
+            void futureTimestamps() {
+                controlPlane.commitFile(FILE_NAME, ObjectFormat.WRITE_AHEAD_MULTI_SEGMENT, BROKER_ID, FILE_SIZE,
+                    List.of(
+                        CommitBatchRequest.of(0, EXISTING_TOPIC_1_ID_PARTITION_0, 1, BATCH_1_SIZE, 0, BATCH_1_RECORDS - 1, START_TIME * 10, TimestampType.CREATE_TIME),
+                        CommitBatchRequest.of(1, EXISTING_TOPIC_1_ID_PARTITION_0, 1, BATCH_2_SIZE, 0, BATCH_2_RECORDS - 1, BATCH_2_MAX_TIMESTAMP, TimestampType.CREATE_TIME),
+                        CommitBatchRequest.of(2, EXISTING_TOPIC_1_ID_PARTITION_0, 1, BATCH_3_SIZE, 0, BATCH_3_RECORDS - 1, BATCH_3_MAX_TIMESTAMP, TimestampType.CREATE_TIME)
+                    ));
+                assertThat(getLogStartOffset()).isEqualTo(0L);
+                assertThat(getHighWatermark()).isEqualTo(EXPECTED_HIGH_WATERMARK);
+
+                final var responses = controlPlane.enforceRetention(List.of(
+                    new EnforceRetentionRequest(EXISTING_TOPIC_1_ID, 0, -1, 0)
+                ));
+
+                assertThat(responses)
+                    .containsExactly(EnforceRetentionResponse.success(0, 0, 0));
+                assertThat(getLogStartOffset()).isEqualTo(0L);
+                assertThat(getHighWatermark()).isEqualTo(EXPECTED_HIGH_WATERMARK);
+                assertThat(controlPlane.getLogInfo(List.of(new GetLogInfoRequest(EXISTING_TOPIC_1_ID, 0))))
+                    .containsExactly(GetLogInfoResponse.success(0, EXPECTED_HIGH_WATERMARK, BATCH_1_SIZE + BATCH_2_SIZE + BATCH_3_SIZE));
+            }
+
+            /**
+             * Test that if we encounter a batch that doesn't breach the policy, we don't look further.
+             */
+            @Test
+            void nonBreachingBatchStopsScanning() {
+                // Timestamps relative to now are:
+                // -10 -9 -8 -1 -7 -6 -5
+                // and we want to delete everything that is older than -4.
+
+                final int batch4Size = 991;
+                final int batch5Size = 992;
+                final int batch6Size = 993;
+                final int batch7Size = 994;
+                final long batch4Records = 40;
+                final long batch5Records = 50;
+                final long batch6Records = 60;
+                final long batch7Records = 70;
+                final long expectedHighWatermark = BATCH_1_RECORDS + BATCH_2_RECORDS + BATCH_3_RECORDS
+                    + batch4Records + batch5Records + batch6Records + batch7Records;
+
+                controlPlane.commitFile(FILE_NAME, ObjectFormat.WRITE_AHEAD_MULTI_SEGMENT, BROKER_ID, FILE_SIZE,
+                    List.of(
+                        CommitBatchRequest.of(0, EXISTING_TOPIC_1_ID_PARTITION_0, 1, BATCH_1_SIZE, 0, BATCH_1_RECORDS - 1, START_TIME - 10, TimestampType.CREATE_TIME),
+                        CommitBatchRequest.of(1, EXISTING_TOPIC_1_ID_PARTITION_0, 1, BATCH_2_SIZE, 0, BATCH_2_RECORDS - 1, START_TIME - 9, TimestampType.CREATE_TIME),
+                        CommitBatchRequest.of(2, EXISTING_TOPIC_1_ID_PARTITION_0, 1, BATCH_3_SIZE, 0, BATCH_3_RECORDS - 1, START_TIME - 8, TimestampType.CREATE_TIME),
+                        CommitBatchRequest.of(2, EXISTING_TOPIC_1_ID_PARTITION_0, 1, batch4Size, 0, batch4Records - 1, START_TIME - 1, TimestampType.CREATE_TIME),
+                        CommitBatchRequest.of(2, EXISTING_TOPIC_1_ID_PARTITION_0, 1, batch5Size, 0, batch5Records - 1, START_TIME - 7, TimestampType.CREATE_TIME),
+                        CommitBatchRequest.of(2, EXISTING_TOPIC_1_ID_PARTITION_0, 1, batch6Size, 0, batch6Records - 1, START_TIME - 6, TimestampType.CREATE_TIME),
+                        CommitBatchRequest.of(2, EXISTING_TOPIC_1_ID_PARTITION_0, 1, batch7Size, 0, batch7Records - 1, START_TIME - 5, TimestampType.CREATE_TIME)
+                    ));
+                assertThat(getLogStartOffset()).isEqualTo(0L);
+                assertThat(getHighWatermark()).isEqualTo(expectedHighWatermark);
+
+                final var responses = controlPlane.enforceRetention(List.of(
+                    new EnforceRetentionRequest(EXISTING_TOPIC_1_ID, 0, -1, 4)
+                ));
+
+                // Only the first 3 batches must be deleted, despite more batches breaching the policy.
+                final long newLogStartOffset = BATCH_1_RECORDS + BATCH_2_RECORDS + BATCH_3_RECORDS;
+                assertThat(responses)
+                    .containsExactly(EnforceRetentionResponse.success(3, BATCH_1_SIZE + BATCH_2_SIZE + BATCH_3_SIZE, newLogStartOffset));
+                assertThat(getLogStartOffset()).isEqualTo(newLogStartOffset);
+                assertThat(getHighWatermark()).isEqualTo(expectedHighWatermark);
+                assertThat(controlPlane.getLogInfo(List.of(new GetLogInfoRequest(EXISTING_TOPIC_1_ID, 0))))
+                    .containsExactly(GetLogInfoResponse.success(newLogStartOffset, expectedHighWatermark, batch4Size + batch5Size + batch6Size + batch7Size));
+            }
+
+            /**
+             * Test that the retention policy works on batches with {@code LOG_APPEND_TIME} timestamp type.
+             */
+            @Test
+            void testAppendTime() {
+                final long batchMaxTimestamp = START_TIME * 100;  // far into the future
+
+                // START_TIME
+                controlPlane.commitFile("obj1", ObjectFormat.WRITE_AHEAD_MULTI_SEGMENT, BROKER_ID, FILE_SIZE,
+                    List.of(
+                        CommitBatchRequest.of(0, EXISTING_TOPIC_1_ID_PARTITION_0, 1, BATCH_1_SIZE, 0, BATCH_1_RECORDS - 1, batchMaxTimestamp, TimestampType.LOG_APPEND_TIME)
+                    ));
+
+                // START_TIME + 1
+                time.setCurrentTimeMs(START_TIME + 1);
+                controlPlane.commitFile("obj2", ObjectFormat.WRITE_AHEAD_MULTI_SEGMENT, BROKER_ID, FILE_SIZE,
+                    List.of(
+                        CommitBatchRequest.of(0, EXISTING_TOPIC_1_ID_PARTITION_0, 1, BATCH_2_SIZE, 0, BATCH_2_RECORDS - 1, batchMaxTimestamp, TimestampType.LOG_APPEND_TIME)
+                    ));
+
+                // START_TIME + 2
+                time.setCurrentTimeMs(START_TIME + 2);
+                controlPlane.commitFile("obj3", ObjectFormat.WRITE_AHEAD_MULTI_SEGMENT, BROKER_ID, FILE_SIZE,
+                    List.of(
+                        CommitBatchRequest.of(0, EXISTING_TOPIC_1_ID_PARTITION_0, 1, BATCH_3_SIZE, 0, BATCH_3_RECORDS - 1, batchMaxTimestamp, TimestampType.LOG_APPEND_TIME)
+                    ));
+                assertThat(getLogStartOffset()).isEqualTo(0L);
+                assertThat(getHighWatermark()).isEqualTo(EXPECTED_HIGH_WATERMARK);
+
+                final var responses = controlPlane.enforceRetention(List.of(
+                    new EnforceRetentionRequest(EXISTING_TOPIC_1_ID, 0, -1, 1)
+                ));
+
+                final long newLogStartOffset = BATCH_1_RECORDS;
+                assertThat(responses)
+                    .containsExactly(EnforceRetentionResponse.success(1, BATCH_1_SIZE, newLogStartOffset));
+                assertThat(getLogStartOffset()).isEqualTo(newLogStartOffset);
+                assertThat(getHighWatermark()).isEqualTo(EXPECTED_HIGH_WATERMARK);
+                assertThat(controlPlane.getLogInfo(List.of(new GetLogInfoRequest(EXISTING_TOPIC_1_ID, 0))))
+                    .containsExactly(GetLogInfoResponse.success(newLogStartOffset, EXPECTED_HIGH_WATERMARK, BATCH_2_SIZE + BATCH_3_SIZE));
+            }
+        }
+
+        /**
+         * Test both retention policies together
+         * and make sure that a batch is deleted if it breaches at least one.
+         */
+        @Test
+        void bothRetentions() {
+            addBatches();
+            assertThat(getLogStartOffset()).isEqualTo(0L);
+            assertThat(getHighWatermark()).isEqualTo(EXPECTED_HIGH_WATERMARK);
+
+            // Time retention deletes only batch 1. Size retention deletes batch 1 and 2.
+            time.setCurrentTimeMs(BATCH_3_MAX_TIMESTAMP);
+            final var responses = controlPlane.enforceRetention(List.of(
+                new EnforceRetentionRequest(EXISTING_TOPIC_1_ID, 0, BATCH_3_SIZE, BATCH_3_MAX_TIMESTAMP - BATCH_2_MAX_TIMESTAMP)
+            ));
+
+            final long newLogStartOffset = BATCH_1_RECORDS + BATCH_2_RECORDS;
+            assertThat(responses)
+                .containsExactly(EnforceRetentionResponse.success(2, BATCH_1_SIZE + BATCH_2_SIZE, newLogStartOffset));
+            assertThat(getLogStartOffset()).isEqualTo(newLogStartOffset);
+            assertThat(getHighWatermark()).isEqualTo(EXPECTED_HIGH_WATERMARK);
+            assertThat(controlPlane.getLogInfo(List.of(new GetLogInfoRequest(EXISTING_TOPIC_1_ID, 0))))
+                .containsExactly(GetLogInfoResponse.success(newLogStartOffset, EXPECTED_HIGH_WATERMARK, BATCH_3_SIZE));
+        }
+
+        @Test
+        void notEnforced() {
+            addBatches();
+            assertThat(getLogStartOffset()).isEqualTo(0L);
+            assertThat(getHighWatermark()).isEqualTo(EXPECTED_HIGH_WATERMARK);
+
+            time.setCurrentTimeMs(BATCH_3_MAX_TIMESTAMP * 10);
+            final var responses = controlPlane.enforceRetention(List.of(
+                new EnforceRetentionRequest(EXISTING_TOPIC_1_ID, 0, -1, -1)
+            ));
+
+            assertThat(responses)
+                .containsExactly(EnforceRetentionResponse.success(0, 0, 0));
+            assertThat(getLogStartOffset()).isEqualTo(0L);
+            assertThat(getHighWatermark()).isEqualTo(EXPECTED_HIGH_WATERMARK);
+            assertThat(controlPlane.getLogInfo(List.of(new GetLogInfoRequest(EXISTING_TOPIC_1_ID, 0))))
+                .containsExactly(GetLogInfoResponse.success(0, EXPECTED_HIGH_WATERMARK, BATCH_1_SIZE + BATCH_2_SIZE + BATCH_3_SIZE));
+        }
+
+        private void addBatches() {
+            controlPlane.commitFile(FILE_NAME, ObjectFormat.WRITE_AHEAD_MULTI_SEGMENT, BROKER_ID, FILE_SIZE,
+                List.of(
+                    CommitBatchRequest.of(0, EXISTING_TOPIC_1_ID_PARTITION_0, 1, BATCH_1_SIZE, 0, BATCH_1_RECORDS - 1, BATCH_1_MAX_TIMESTAMP, TimestampType.CREATE_TIME),
+                    CommitBatchRequest.of(1, EXISTING_TOPIC_1_ID_PARTITION_0, 1, BATCH_2_SIZE, 0, BATCH_2_RECORDS - 1, BATCH_2_MAX_TIMESTAMP, TimestampType.CREATE_TIME),
+                    CommitBatchRequest.of(2, EXISTING_TOPIC_1_ID_PARTITION_0, 1, BATCH_3_SIZE, 0, BATCH_3_RECORDS - 1, BATCH_3_MAX_TIMESTAMP, TimestampType.CREATE_TIME)
+                ));
+        }
+
+        private long getLogStartOffset() {
+            return controlPlane.listOffsets(List.of(
+                new ListOffsetsRequest(EXISTING_TOPIC_1_ID_PARTITION_0, EARLIEST_TIMESTAMP)
+            )).get(0).offset();
+        }
+
+        private long getHighWatermark() {
+            return controlPlane.listOffsets(List.of(
+                new ListOffsetsRequest(EXISTING_TOPIC_1_ID_PARTITION_0, LATEST_TIMESTAMP)
+            )).get(0).offset();
+        }
+    }
+
     @Test
     void deleteFiles() {
         final String objectKey1 = "a1";
@@ -1039,7 +1396,7 @@ public abstract class AbstractControlPlaneTest {
                     List.of(CommitBatchRequest.of(0, EXISTING_TOPIC_1_ID_PARTITION_0, 0, (int) batchSize, 0, 100, 4000, TimestampType.CREATE_TIME)));
 
             // File 4 is the merged file, batches 4 and 5 are in it.
-            final List<FileMergeWorkItem.File> expectedFiles2= List.of(
+            final List<FileMergeWorkItem.File> expectedFiles2 = List.of(
                 new FileMergeWorkItem.File(3L, "obj2", ObjectFormat.WRITE_AHEAD_MULTI_SEGMENT, batchSize,
                     List.of(new BatchInfo(3, "obj2", BatchMetadata.of(EXISTING_TOPIC_1_ID_PARTITION_0, 0, batchSize, 202, 302, committedAt, 3000, TimestampType.CREATE_TIME)))),
                 new FileMergeWorkItem.File(5L, "obj3", ObjectFormat.WRITE_AHEAD_MULTI_SEGMENT, batchSize,

--- a/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/EnforceRetentionJobTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/EnforceRetentionJobTest.java
@@ -1,0 +1,98 @@
+/*
+ * Inkless
+ * Copyright (C) 2025 Aiven OY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.aiven.inkless.control_plane.postgres;
+
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.common.utils.Time;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.List;
+import java.util.Set;
+import java.util.function.Consumer;
+
+import io.aiven.inkless.control_plane.CreateTopicAndPartitionsRequest;
+import io.aiven.inkless.control_plane.EnforceRetentionRequest;
+import io.aiven.inkless.control_plane.EnforceRetentionResponse;
+import io.aiven.inkless.test_utils.InklessPostgreSQLContainer;
+import io.aiven.inkless.test_utils.PostgreSQLTestContainer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The majority of testing is done in AbstractControlPlaneTest. Here we only test some behaviors specific to PG.
+ */
+@Testcontainers
+class EnforceRetentionJobTest {
+    @Container
+    static final InklessPostgreSQLContainer pgContainer = PostgreSQLTestContainer.container();
+
+    static final String TOPIC_0 = "topic0";
+    static final String TOPIC_1 = "topic1";
+    static final Uuid TOPIC_ID_0 = new Uuid(10, 12);
+    static final Uuid TOPIC_ID_1 = new Uuid(555, 333);
+
+    Time time = new MockTime();
+    Consumer<Long> durationCallback = duration -> {};
+
+    @BeforeEach
+    void setUp(final TestInfo testInfo) {
+        pgContainer.createDatabase(testInfo);
+        pgContainer.migrate();
+
+        final Set<CreateTopicAndPartitionsRequest> createTopicAndPartitionsRequests = Set.of(
+            new CreateTopicAndPartitionsRequest(TOPIC_ID_0, TOPIC_0, 100),
+            new CreateTopicAndPartitionsRequest(TOPIC_ID_1, TOPIC_1, 100)
+        );
+        new TopicsAndPartitionsCreateJob(Time.SYSTEM, pgContainer.getJooqCtx(), createTopicAndPartitionsRequests, durationCallback)
+            .run();
+    }
+
+    @AfterEach
+    void tearDown() {
+        pgContainer.tearDown();
+    }
+
+    @Test
+    void forMultiplePartitionsInArbitraryOrder() throws Exception {
+        final EnforceRetentionJob job = new EnforceRetentionJob(time, pgContainer.getJooqCtx(), List.of(
+            new EnforceRetentionRequest(TOPIC_ID_0, 99, 1, 1),
+            new EnforceRetentionRequest(TOPIC_ID_1, 1, 1, 1),
+            new EnforceRetentionRequest(TOPIC_ID_1, 0, 1, 1),
+            new EnforceRetentionRequest(TOPIC_ID_0, 3, 1, 1),
+            new EnforceRetentionRequest(TOPIC_ID_0, 1000, 1, 1),  // non-existent
+            new EnforceRetentionRequest(TOPIC_ID_1, 5, 1, 1),
+            new EnforceRetentionRequest(TOPIC_ID_1, 5, 1, 1)  // duplicate
+        ), durationCallback);
+        assertThat(job.call()).containsExactly(
+            EnforceRetentionResponse.success(0, 0, 0),
+            EnforceRetentionResponse.success(0, 0, 0),
+            EnforceRetentionResponse.success(0, 0, 0),
+            EnforceRetentionResponse.success(0, 0, 0),
+            EnforceRetentionResponse.unknownTopicOrPartition(),
+            EnforceRetentionResponse.success(0, 0, 0),
+            EnforceRetentionResponse.success(0, 0, 0)
+        );
+    }
+}

--- a/storage/inkless/src/test/java/io/aiven/inkless/delete/RetentionEnforcementSchedulerTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/delete/RetentionEnforcementSchedulerTest.java
@@ -1,0 +1,176 @@
+/*
+ * Inkless
+ * Copyright (C) 2025 Aiven OY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.aiven.inkless.delete;
+
+import org.apache.kafka.common.TopicIdPartition;
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.common.utils.Time;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Set;
+import java.util.random.RandomGenerator;
+
+import io.aiven.inkless.control_plane.MetadataView;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.STRICT_STUBS)
+class RetentionEnforcementSchedulerTest {
+    static final Duration ENFORCEMENT_INTERVAL = Duration.ofSeconds(1);
+    static final Long ENFORCEMENT_INTERVAL_MS = ENFORCEMENT_INTERVAL.toMillis();
+
+    static final String TOPIC_0 = "topic0";
+    static final Uuid TOPIC_ID_0 = new Uuid(0, 1);
+    static final TopicIdPartition T0P0 = new TopicIdPartition(TOPIC_ID_0, 0, TOPIC_0);
+    static final TopicIdPartition T0P1 = new TopicIdPartition(TOPIC_ID_0, 1, TOPIC_0);
+
+    Time time = new MockTime();
+    @Mock
+    MetadataView metadataView;
+    @Mock
+    RandomGenerator random;
+
+    @BeforeEach
+    void setUp() {
+        // Make it deterministic. As `bound` is equals to the expected interval * 2, we divide by 2.
+        when(random.nextLong(anyLong())).thenAnswer(inv -> (long) inv.getArguments()[0] / 2);
+    }
+
+    /**
+     * Test that each individual broker must wait longer when the cluster is bigger.
+     */
+    @Test
+    void intervalsDependOnBrokerCount() {
+        final var scheduler = new RetentionEnforcementScheduler(time, metadataView, ENFORCEMENT_INTERVAL, random);
+
+        when(metadataView.getInklessTopicPartitions()).thenReturn(Set.of(T0P0, T0P1));
+        when(metadataView.getBrokerCount()).thenReturn(1);
+
+        // The first run is the initial scheduling.
+        scheduler.getReadyPartitions();
+
+        final Instant expectedNextTime1 = Instant.ofEpochMilli(time.milliseconds() + ENFORCEMENT_INTERVAL_MS);
+        assertThat(scheduler.dumpQueue())
+            .containsExactlyInAnyOrder(
+                new RetentionEnforcementScheduler.TopicIdPartitionWithNextEnforcementTime(T0P0, expectedNextTime1),
+                new RetentionEnforcementScheduler.TopicIdPartitionWithNextEnforcementTime(T0P1, expectedNextTime1)
+            );
+
+        // Add the second broker.
+        when(metadataView.getBrokerCount()).thenReturn(2);
+        // Sleep enough for scheduling to happen.
+        time.sleep(Duration.ofMinutes(10).toMillis());
+
+        assertThat(scheduler.getReadyPartitions()).containsExactlyInAnyOrder(T0P0, T0P1);
+
+        final Instant expectedNextTime2 = Instant.ofEpochMilli(time.milliseconds() + ENFORCEMENT_INTERVAL_MS * 2);
+        assertThat(scheduler.dumpQueue())
+            .containsExactlyInAnyOrder(
+                new RetentionEnforcementScheduler.TopicIdPartitionWithNextEnforcementTime(T0P0, expectedNextTime2),
+                new RetentionEnforcementScheduler.TopicIdPartitionWithNextEnforcementTime(T0P1, expectedNextTime2)
+            );
+
+        // Add the third broker.
+        when(metadataView.getBrokerCount()).thenReturn(3);
+        // Sleep enough for scheduling to happen.
+        time.sleep(Duration.ofMinutes(10).toMillis());
+
+        assertThat(scheduler.getReadyPartitions()).containsExactlyInAnyOrder(T0P0, T0P1);
+
+        final Instant expectedNextTime3 = Instant.ofEpochMilli(time.milliseconds() + ENFORCEMENT_INTERVAL_MS * 3);
+        assertThat(scheduler.dumpQueue())
+            .containsExactlyInAnyOrder(
+                new RetentionEnforcementScheduler.TopicIdPartitionWithNextEnforcementTime(T0P0, expectedNextTime3),
+                new RetentionEnforcementScheduler.TopicIdPartitionWithNextEnforcementTime(T0P1, expectedNextTime3)
+            );
+
+        // Reduce back to the single broker.
+        when(metadataView.getBrokerCount()).thenReturn(1);
+        // Sleep enough for scheduling to happen.
+        time.sleep(Duration.ofMinutes(10).toMillis());
+
+        assertThat(scheduler.getReadyPartitions()).containsExactlyInAnyOrder(T0P0, T0P1);
+
+        final Instant expectedNextTime4 = Instant.ofEpochMilli(time.milliseconds() + ENFORCEMENT_INTERVAL_MS);
+        assertThat(scheduler.dumpQueue())
+            .containsExactlyInAnyOrder(
+                new RetentionEnforcementScheduler.TopicIdPartitionWithNextEnforcementTime(T0P0, expectedNextTime4),
+                new RetentionEnforcementScheduler.TopicIdPartitionWithNextEnforcementTime(T0P1, expectedNextTime4)
+            );
+    }
+
+    @Test
+    void newPartitionsAreScheduled() {
+        final var scheduler = new RetentionEnforcementScheduler(time, metadataView, ENFORCEMENT_INTERVAL, random);
+
+        when(metadataView.getInklessTopicPartitions()).thenReturn(Set.of(T0P0));
+        when(metadataView.getBrokerCount()).thenReturn(1);
+
+        // The first run is the initial scheduling.
+        scheduler.getReadyPartitions();
+
+        // Sleep enough for known partitions to be invalidated.
+        time.sleep(Duration.ofMinutes(10).toMillis());
+        when(metadataView.getInklessTopicPartitions()).thenReturn(Set.of(T0P0, T0P1));
+
+        assertThat(scheduler.getReadyPartitions()).containsExactlyInAnyOrder(T0P0);
+
+        final Instant expectedNextTime = Instant.ofEpochMilli(time.milliseconds() + ENFORCEMENT_INTERVAL_MS);
+        assertThat(scheduler.dumpQueue())
+            .containsExactly(
+                new RetentionEnforcementScheduler.TopicIdPartitionWithNextEnforcementTime(T0P1, expectedNextTime),
+                new RetentionEnforcementScheduler.TopicIdPartitionWithNextEnforcementTime(T0P0, expectedNextTime)
+            );
+    }
+
+    @Test
+    void removedPartitionsAreForgotten() {
+        final var scheduler = new RetentionEnforcementScheduler(time, metadataView, ENFORCEMENT_INTERVAL, random);
+
+        when(metadataView.getInklessTopicPartitions()).thenReturn(Set.of(T0P0, T0P1));
+        when(metadataView.getBrokerCount()).thenReturn(1);
+
+        // The first run is the initial scheduling.
+        scheduler.getReadyPartitions();
+
+        // Sleep enough for known partitions to be invalidated.
+        time.sleep(Duration.ofMinutes(10).toMillis());
+        when(metadataView.getInklessTopicPartitions()).thenReturn(Set.of(T0P1));
+
+        assertThat(scheduler.getReadyPartitions()).containsExactlyInAnyOrder(T0P1);
+        
+        final Instant expectedNextTime = Instant.ofEpochMilli(time.milliseconds() + ENFORCEMENT_INTERVAL_MS);
+        assertThat(scheduler.dumpQueue())
+            .containsExactly(
+                new RetentionEnforcementScheduler.TopicIdPartitionWithNextEnforcementTime(T0P1, expectedNextTime)
+            );
+    }
+}

--- a/storage/inkless/src/test/java/io/aiven/inkless/delete/RetentionEnforcerTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/delete/RetentionEnforcerTest.java
@@ -1,0 +1,121 @@
+/*
+ * Inkless
+ * Copyright (C) 2025 Aiven OY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.aiven.inkless.delete;
+
+import org.apache.kafka.common.TopicIdPartition;
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.common.utils.Time;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import io.aiven.inkless.control_plane.ControlPlane;
+import io.aiven.inkless.control_plane.EnforceRetentionRequest;
+import io.aiven.inkless.control_plane.MetadataView;
+
+import static org.apache.kafka.common.config.TopicConfig.RETENTION_BYTES_CONFIG;
+import static org.apache.kafka.common.config.TopicConfig.RETENTION_MS_CONFIG;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.STRICT_STUBS)
+class RetentionEnforcerTest {
+    static final String TOPIC_0 = "topic0";
+    static final Uuid TOPIC_ID_0 = new Uuid(0, 1);
+    static final TopicIdPartition T0P0 = new TopicIdPartition(TOPIC_ID_0, 0, TOPIC_0);
+
+    Time time = new MockTime();
+    @Mock
+    MetadataView metadataView;
+    @Mock
+    ControlPlane controlPlane;
+    @Mock
+    RetentionEnforcementScheduler retentionEnforcementScheduler;
+
+    @Captor
+    ArgumentCaptor<List<EnforceRetentionRequest>> requestCaptor;
+
+    @Nested
+    class RetentionSettings {
+        @Test
+        void fullDefault() {
+            when(retentionEnforcementScheduler.getReadyPartitions()).thenReturn(List.of(T0P0));
+            when(metadataView.getDefaultConfig()).thenReturn(Map.of());
+            when(metadataView.getTopicConfig(any())).thenReturn(new Properties());
+
+            final var enforcer = new RetentionEnforcer(time, metadataView, controlPlane, retentionEnforcementScheduler);
+            enforcer.run();
+
+            verify(controlPlane).enforceRetention(requestCaptor.capture());
+            assertThat(requestCaptor.getValue()).map(EnforceRetentionRequest::retentionBytes).containsExactly(-1L);
+            assertThat(requestCaptor.getValue()).map(EnforceRetentionRequest::retentionMs).containsExactly(604800000L);
+        }
+
+        @Test
+        void logConfig() {
+            when(retentionEnforcementScheduler.getReadyPartitions()).thenReturn(List.of(T0P0));
+            when(metadataView.getDefaultConfig()).thenReturn(Map.of(
+                RETENTION_BYTES_CONFIG, "123",
+                RETENTION_MS_CONFIG, "567"
+            ));
+            when(metadataView.getTopicConfig(any())).thenReturn(new Properties());
+
+            final var enforcer = new RetentionEnforcer(time, metadataView, controlPlane, retentionEnforcementScheduler);
+            enforcer.run();
+
+            verify(controlPlane).enforceRetention(requestCaptor.capture());
+            assertThat(requestCaptor.getValue()).map(EnforceRetentionRequest::retentionBytes).containsExactly(123L);
+            assertThat(requestCaptor.getValue()).map(EnforceRetentionRequest::retentionMs).containsExactly(567L);
+        }
+
+        @Test
+        void definedForTopic() {
+            when(retentionEnforcementScheduler.getReadyPartitions()).thenReturn(List.of(T0P0));
+            when(metadataView.getDefaultConfig()).thenReturn(Map.of(
+                RETENTION_BYTES_CONFIG, "123",
+                RETENTION_MS_CONFIG, "567"
+            ));
+            final Properties topicConfig = new Properties();
+            topicConfig.put(RETENTION_BYTES_CONFIG, "123000");
+            topicConfig.put(RETENTION_MS_CONFIG, "567000");
+            when(metadataView.getTopicConfig(any())).thenReturn(topicConfig);
+
+            final var enforcer = new RetentionEnforcer(time, metadataView, controlPlane, retentionEnforcementScheduler);
+            enforcer.run();
+
+            verify(controlPlane).enforceRetention(requestCaptor.capture());
+            assertThat(requestCaptor.getValue()).map(EnforceRetentionRequest::retentionBytes).containsExactly(123000L);
+            assertThat(requestCaptor.getValue()).map(EnforceRetentionRequest::retentionMs).containsExactly(567000L);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds retention by time and size (`retention.ms`, `retention.bytes`) to the both control planes and its support on the broker side.

Note to the reviewer: I tried to decompose this into logical separate commits, should be easier to review step-by-step.