### PR TITLE
Fix deadlock in delete_records_v1 [INK-260]

### DIFF
--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/FunctionResultProcessor.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/FunctionResultProcessor.java
@@ -1,0 +1,73 @@
+/*
+ * Inkless
+ * Copyright (C) 2025 Aiven OY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.aiven.inkless.control_plane.postgres;
+
+import org.apache.kafka.common.TopicIdPartition;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+class FunctionResultProcessor {
+    /**
+     * Map the result of a Postgres function to a list of responses.
+     *
+     * <p>A Postgres function may reorder requests in safe locking order. This function restores the order defined by the order of requests,
+     * matching by topic-partition.
+     * Technically there may be multiple requests for one partition, this function handles this situation.
+     * @param requests The original requests.
+     * @param functionResult The result of the Postgres function.
+     * @param requestToKey The mapper from a request to a {@code TopicIdPartition} key.
+     * @param recordToKey The mapper from a Postgres record to a {@code TopicIdPartition} key.
+     * @param responseMapper The function that maps from a Postgres record and a request to the final response.
+     */
+    static <Request, FunctionResultRecord, Response> List<Response> processWithMappingOrder(
+        final List<Request> requests,
+        final List<FunctionResultRecord> functionResult,
+        final Function<Request, TopicIdPartition> requestToKey,
+        final Function<FunctionResultRecord, TopicIdPartition> recordToKey,
+        final BiFunction<Request, FunctionResultRecord, Response> responseMapper
+    ) {
+        if (functionResult.size() != requests.size()) {
+            throw new RuntimeException(String.format("Expected %d items, returned %d", requests.size(), functionResult.size()));
+        }
+
+        // Account for potential multiple requests for one partition.
+        final Map<TopicIdPartition, List<FunctionResultRecord>> resultMap = new HashMap<>();
+        for (var record : functionResult) {
+            resultMap
+                .computeIfAbsent(recordToKey.apply(record), k -> new ArrayList<>())
+                .add(record);
+        }
+
+        final List<Response> responses = new ArrayList<>();
+        for (final var request : requests) {
+            final TopicIdPartition key = requestToKey.apply(request);
+            final var records = resultMap.get(key);
+            if (records == null || records.isEmpty()) {
+                throw new RuntimeException("No result found for request: " + request);
+            }
+            final var record = records.remove(0);
+            responses.add(responseMapper.apply(request, record));
+        }
+        return responses;
+    }
+}

--- a/storage/inkless/src/main/resources/db/migration/V5__Fix_deadlock_in_delete_records_v1.sql
+++ b/storage/inkless/src/main/resources/db/migration/V5__Fix_deadlock_in_delete_records_v1.sql
@@ -1,0 +1,90 @@
+-- Copyright (c) 2025 Aiven, Helsinki, Finland. https://aiven.io/
+
+CREATE OR REPLACE FUNCTION delete_records_v1(
+    arg_now TIMESTAMP WITH TIME ZONE,
+    arg_requests delete_records_request_v1[]
+)
+RETURNS SETOF delete_records_response_v1 LANGUAGE plpgsql VOLATILE AS $$
+DECLARE
+    l_request RECORD;
+    l_log RECORD;
+    l_converted_offset BIGINT = -1;
+    l_deleted_bytes BIGINT;
+BEGIN
+
+    DROP TABLE IF EXISTS affected_files;
+    CREATE TEMPORARY TABLE affected_files (
+        file_id BIGINT PRIMARY KEY
+    )
+    ON COMMIT DROP;
+
+    FOR l_request IN
+        SELECT *
+        FROM unnest(arg_requests)
+        ORDER BY topic_id, partition  -- ordering is important to prevent deadlocks
+    LOOP
+        SELECT *
+        FROM logs
+        WHERE topic_id = l_request.topic_id
+            AND partition = l_request.partition
+        FOR UPDATE
+        INTO l_log;
+
+        IF NOT FOUND THEN
+            RETURN NEXT (l_request.topic_id, l_request.partition, 'unknown_topic_or_partition', NULL)::delete_records_response_v1;
+            CONTINUE;
+        END IF;
+
+        l_converted_offset = CASE
+            -- -1 = org.apache.kafka.common.requests.DeleteRecordsRequest.HIGH_WATERMARK
+            WHEN l_request.offset = -1 THEN l_log.high_watermark
+            ELSE l_request.offset
+        END;
+
+        IF l_converted_offset < 0 OR l_converted_offset > l_log.high_watermark THEN
+            RETURN NEXT (l_request.topic_id, l_request.partition, 'offset_out_of_range', NULL)::delete_records_response_v1;
+            CONTINUE;
+        END IF;
+
+        l_converted_offset = GREATEST(l_converted_offset, l_log.log_start_offset);
+
+        -- Delete the affected batches.
+        WITH deleted_batches AS (
+           DELETE FROM batches
+           WHERE topic_id = l_log.topic_id
+               AND partition = l_log.partition
+               AND last_offset < l_converted_offset
+           RETURNING file_id, byte_size
+        ),
+        -- Remember what files were affected.
+        _1 AS (
+            INSERT INTO affected_files (file_id)
+            SELECT DISTINCT file_id
+            FROM deleted_batches
+            ON CONFLICT DO NOTHING  -- ignore duplicates
+        )
+        SELECT COALESCE(SUM(byte_size), 0)
+        FROM deleted_batches
+        INTO l_deleted_bytes;
+
+        UPDATE logs
+        SET log_start_offset = l_converted_offset,
+            byte_size = byte_size - l_deleted_bytes
+        WHERE topic_id = l_log.topic_id
+            AND partition = l_log.partition;
+
+        RETURN NEXT (l_request.topic_id, l_request.partition, NULL, l_converted_offset)::delete_records_response_v1;
+    END LOOP;
+
+    -- Out of the affected files, select those that are now empty (i.e. no batch refers to them)
+    -- and mark them for deletion.
+    PERFORM mark_file_to_delete_v1(arg_now, file_id)
+    FROM (
+        SELECT DISTINCT af.file_id
+        FROM affected_files AS af
+            LEFT JOIN batches AS b ON af.file_id = b.file_id
+        WHERE b.batch_id IS NULL
+    );
+END;
+$$
+;


### PR DESCRIPTION
The function did the deadlock-preventing ordering on a wrong query.

The job test was enhanced to check different request orders work correctly.

`EnforceRetentionJob` already had the code for processing results of such a PG function, which was generalized to serve both.
