### PR TITLE
chore(ci): add inkless version branches to CI nightly

### DIFF
--- a/.github/workflows/inkless-nightly.yml
+++ b/.github/workflows/inkless-nightly.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - 'main'
+      - 'inkless-*'
   # nightly cron job
   schedule:
     - cron: '0 0 * * *'


### PR DESCRIPTION
Include release branches into the CI nightly to run all tests on these.