### PR TITLE
fix(inkless): Filter out null values from default configs

### DIFF
--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -343,7 +343,7 @@ class BrokerServer(
        */
       val defaultActionQueue = new DelayedActionQueue
 
-      val inklessMetadataView = new InklessMetadataView(metadataCache, () => logManager.currentDefaultConfig.values().asInstanceOf[util.Map[String, AnyRef]])
+      val inklessMetadataView = new InklessMetadataView(metadataCache, () => logManager.currentDefaultConfig.values().asInstanceOf[util.Map[String, Object]])
       val inklessSharedState = sharedServer.inklessControlPlane.map { controlPlane =>
         SharedState.initialize(
           time,

--- a/core/src/main/scala/kafka/server/metadata/InklessMetadataView.scala
+++ b/core/src/main/scala/kafka/server/metadata/InklessMetadataView.scala
@@ -33,12 +33,11 @@ import scala.jdk.CollectionConverters._
 class InklessMetadataView(val metadataCache: KRaftMetadataCache, val defaultConfig: Supplier[util.Map[String, Object]]) extends MetadataView {
   override def getDefaultConfig: util.Map[String, Object] = {
     // Filter out null values as they break LogConfig initialization using Properties.putAll
+    val filtered = new util.HashMap[String, Object]()
     defaultConfig.get().entrySet().asScala
       .filter(_.getValue != null)
-      .foldLeft(new util.HashMap[String, Object]()) { (filtered, entry) =>
-        filtered.put(entry.getKey, entry.getValue)
-        filtered
-      }
+      .foreach(entry => filtered.put(entry.getKey, entry.getValue))
+    filtered
   }
 
   override def getAliveBrokerNodes(listenerName: ListenerName): lang.Iterable[Node] = {

--- a/core/src/main/scala/kafka/server/metadata/InklessMetadataView.scala
+++ b/core/src/main/scala/kafka/server/metadata/InklessMetadataView.scala
@@ -28,9 +28,17 @@ import java.util.function.Supplier
 import java.util.stream.{Collectors, IntStream}
 import java.{lang, util}
 
-class InklessMetadataView(val metadataCache: KRaftMetadataCache, val defaultConfig: Supplier[util.Map[String, AnyRef]]) extends MetadataView {
-  override def getDefaultConfig: util.Map[String, AnyRef] = {
-    defaultConfig.get()
+import scala.jdk.CollectionConverters._
+
+class InklessMetadataView(val metadataCache: KRaftMetadataCache, val defaultConfig: Supplier[util.Map[String, Object]]) extends MetadataView {
+  override def getDefaultConfig: util.Map[String, Object] = {
+    // Filter out null values as they break LogConfig initialization using Properties.putAll
+    defaultConfig.get().entrySet().asScala
+      .filter(_.getValue != null)
+      .foldLeft(new util.HashMap[String, Object]()) { (filtered, entry) =>
+        filtered.put(entry.getKey, entry.getValue)
+        filtered
+      }
   }
 
   override def getAliveBrokerNodes(listenerName: ListenerName): lang.Iterable[Node] = {

--- a/core/src/test/scala/kafka/server/metadata/InklessMetadataViewTest.scala
+++ b/core/src/test/scala/kafka/server/metadata/InklessMetadataViewTest.scala
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Copyright (c) 2024 Aiven, Helsinki, Finland. https://aiven.io/
+
+package kafka.server.metadata
+
+import org.junit.jupiter.api.{BeforeEach, Test}
+import org.junit.jupiter.api.Assertions._
+import org.mockito.Mockito._
+
+import java.util.{HashMap => JHashMap}
+import java.util.function.Supplier
+import java.util
+
+class InklessMetadataViewTest {
+  private var metadataCache: KRaftMetadataCache = _
+  private var configSupplier: Supplier[util.Map[String, Object]] = _
+  private var metadataView: InklessMetadataView = _
+
+  @BeforeEach
+  def setup(): Unit = {
+    metadataCache = mock(classOf[KRaftMetadataCache])
+    configSupplier = mock(classOf[Supplier[util.Map[String, Object]]])
+    metadataView = new InklessMetadataView(metadataCache, configSupplier)
+  }
+
+  @Test
+  def testGetDefaultConfigFiltersNullValues(): Unit = {
+    // Setup a map with some null values
+    val originalConfig = new JHashMap[String, Object]()
+    originalConfig.put("key1", "value1")
+    originalConfig.put("key2", null)
+    originalConfig.put("key3", Integer.valueOf(42))
+    originalConfig.put("key4", null)
+
+    // Configure the mock to return our test map
+    when(configSupplier.get()).thenReturn(originalConfig)
+
+    // Call the method under test
+    val filteredConfig = metadataView.getDefaultConfig
+
+    // Verify null values were filtered out
+    assertEquals(2, filteredConfig.size)
+    assertTrue(filteredConfig.containsKey("key1"))
+    assertEquals("value1", filteredConfig.get("key1"))
+    assertFalse(filteredConfig.containsKey("key2"))
+    assertTrue(filteredConfig.containsKey("key3"))
+    assertEquals(Integer.valueOf(42), filteredConfig.get("key3"))
+    assertFalse(filteredConfig.containsKey("key4"))
+  }
+
+  @Test
+  def testGetDefaultConfigWithNoNullValues(): Unit = {
+    // Setup a map with no null values
+    val originalConfig = new JHashMap[String, Object]()
+    originalConfig.put("key1", "value1")
+    originalConfig.put("key2", "value2")
+
+    // Configure the mock to return our test map
+    when(configSupplier.get()).thenReturn(originalConfig)
+
+    // Call the method under test
+    val filteredConfig = metadataView.getDefaultConfig
+
+    // Verify the filtered map contains all original entries
+    assertEquals(2, filteredConfig.size)
+    assertEquals("value1", filteredConfig.get("key1"))
+    assertEquals("value2", filteredConfig.get("key2"))
+  }
+
+  @Test
+  def testGetDefaultConfigWithEmptyMap(): Unit = {
+    // Setup an empty map
+    val originalConfig = new JHashMap[String, Object]()
+
+    // Configure the mock to return our test map
+    when(configSupplier.get()).thenReturn(originalConfig)
+
+    // Call the method under test
+    val filteredConfig = metadataView.getDefaultConfig
+
+    // Verify the filtered map is empty
+    assertTrue(filteredConfig.isEmpty)
+  }
+}
+


### PR DESCRIPTION
Null values cause the LogConfig initialization using Properties.putAll to fail.
This is now spotted by using the LogConfig on the RetentionEnforcer and the newly added internal config internal.segment.bytes which is null by default, leading to NPE.
