### PR TITLE
fix(inkless:docker): use log4j2 to start kafka

### DIFF
--- a/docker/inkless/launch
+++ b/docker/inkless/launch
@@ -67,7 +67,7 @@ export KAFKA_JVM_PERFORMANCE_OPTS="$TEMP_KAFKA_JVM_PERFORMANCE_OPTS"
 export KAFKA_JVM_PERFORMANCE_OPTS="$KAFKA_JVM_PERFORMANCE_OPTS -XX:SharedArchiveFile=/opt/kafka/kafka.jsa"
 
 # Add custom Log4j config
-export KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:/opt/kafka/config/inkless/log4j.properties"
+export KAFKA_LOG4J_OPTS="-Dlog4j2.configurationFile=/opt/kafka/config/inkless/log4j2.yaml"
 
 # Start kafka broker
 exec /opt/kafka/bin/kafka-server-start.sh /opt/kafka/config/server.properties

--- a/docs/inkless/QUICKSTART.md
+++ b/docs/inkless/QUICKSTART.md
@@ -110,7 +110,7 @@ Setup Kafka run configuration on Intellij:
 6. Set the `Working directory` to the root of the project
 7. Set the `Use classpath of module` to `kafka.core.main`
 8. Use Java 17
-9. Set the JVM arguments to `-Dlog4j.configuration=file:config/inkless/log4j2.yaml`
+9. Set the JVM arguments to `-Dlog4j2.configurationFile=./config/inkless/log4j2.yaml`
 
 At this point all should be ready to run the Intellij configuration.
 


### PR DESCRIPTION
Update docker and docs to use log4j2.