### PR TITLE
fix(inkless): filter out inkless topics from controller partition metrics

### DIFF
--- a/core/src/main/scala/kafka/server/ControllerServer.scala
+++ b/core/src/main/scala/kafka/server/ControllerServer.scala
@@ -22,7 +22,7 @@ import kafka.raft.KafkaRaftManager
 import kafka.server.QuotaFactory.QuotaManagers
 
 import scala.collection.immutable
-import kafka.server.metadata.{ClientQuotaMetadataManager, DelegationTokenPublisher, DynamicClientQuotaPublisher, DynamicConfigPublisher, DynamicTopicClusterQuotaPublisher, KRaftMetadataCache, KRaftMetadataCachePublisher, ScramPublisher}
+import kafka.server.metadata.{ClientQuotaMetadataManager, DelegationTokenPublisher, DynamicClientQuotaPublisher, DynamicConfigPublisher, DynamicTopicClusterQuotaPublisher, InklessMetadataView, KRaftMetadataCache, KRaftMetadataCachePublisher, ScramPublisher}
 import kafka.utils.{CoreUtils, Logging}
 import org.apache.kafka.common.internals.Plugin
 import org.apache.kafka.common.message.ApiMessageType.ListenerType
@@ -368,10 +368,13 @@ class ControllerServer(
           new DelegationTokenManager(delegationTokenManagerConfigs, tokenCache)
       ))
 
+      // Inkless metadata view needed to filter out inkless topics from offline/leadership metrics
+      val inklessMetadataView = new InklessMetadataView(metadataCache, () => config.extractLogConfigMap)
       // Set up the metrics publisher.
       metadataPublishers.add(new ControllerMetadataMetricsPublisher(
         sharedServer.controllerServerMetrics,
-        sharedServer.metadataPublishingFaultHandler
+        sharedServer.metadataPublishingFaultHandler,
+        t => inklessMetadataView.isInklessTopic(t)
       ))
 
       // Set up the ACL publisher.

--- a/metadata/src/main/java/org/apache/kafka/controller/metrics/ControllerMetadataMetricsPublisher.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/metrics/ControllerMetadataMetricsPublisher.java
@@ -30,6 +30,7 @@ import org.apache.kafka.server.fault.FaultHandler;
 
 import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.function.Function;
 
 
 /**
@@ -44,13 +45,16 @@ public class ControllerMetadataMetricsPublisher implements MetadataPublisher {
     private final ControllerMetadataMetrics metrics;
     private final FaultHandler faultHandler;
     private MetadataImage prevImage = MetadataImage.EMPTY;
+    private Function<String, Boolean> isInklessTopic;
 
     public ControllerMetadataMetricsPublisher(
         ControllerMetadataMetrics metrics,
-        FaultHandler faultHandler
+        FaultHandler faultHandler,
+        Function<String, Boolean> isInklessTopic
     ) {
         this.metrics = metrics;
         this.faultHandler = faultHandler;
+        this.isInklessTopic = isInklessTopic;
     }
 
     @Override
@@ -89,7 +93,7 @@ public class ControllerMetadataMetricsPublisher implements MetadataPublisher {
     }
 
     private void publishDelta(MetadataDelta delta) {
-        ControllerMetricsChanges changes = new ControllerMetricsChanges();
+        ControllerMetricsChanges changes = new ControllerMetricsChanges(isInklessTopic);
         if (delta.clusterDelta() != null) {
             for (Entry<Integer, Optional<BrokerRegistration>> entry :
                     delta.clusterDelta().changedBrokers().entrySet()) {

--- a/metadata/src/main/java/org/apache/kafka/controller/metrics/ControllerMetricsChanges.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/metrics/ControllerMetricsChanges.java
@@ -23,6 +23,7 @@ import org.apache.kafka.metadata.BrokerRegistration;
 import org.apache.kafka.metadata.PartitionRegistration;
 
 import java.util.Map.Entry;
+import java.util.function.Function;
 
 
 /**
@@ -31,6 +32,17 @@ import java.util.Map.Entry;
  */
 @SuppressWarnings("NPathComplexity")
 class ControllerMetricsChanges {
+
+    private Function<String, Boolean> isInklessTopic;
+
+    ControllerMetricsChanges() {
+        this.isInklessTopic = topicName -> false; // Default implementation, can be overridden
+    }
+
+    ControllerMetricsChanges(Function<String, Boolean> isInklessTopic) {
+        this.isInklessTopic = isInklessTopic;
+    }
+
     /**
      * Calculates the change between two boolean values, expressed as an integer.
      */
@@ -118,7 +130,7 @@ class ControllerMetricsChanges {
     }
 
     void handleDeletedTopic(TopicImage deletedTopic) {
-        deletedTopic.partitions().values().forEach(prev -> handlePartitionChange(prev, null));
+        deletedTopic.partitions().values().forEach(prev -> handlePartitionChange(prev, null, isInklessTopic.apply(deletedTopic.name())));
         globalTopicsChange--;
     }
 
@@ -126,21 +138,21 @@ class ControllerMetricsChanges {
         if (prev == null) {
             globalTopicsChange++;
             for (PartitionRegistration nextPartition : topicDelta.partitionChanges().values()) {
-                handlePartitionChange(null, nextPartition);
+                handlePartitionChange(null, nextPartition, isInklessTopic.apply(topicDelta.name()));
             }
         } else {
             for (Entry<Integer, PartitionRegistration> entry : topicDelta.partitionChanges().entrySet()) {
                 int partitionId = entry.getKey();
                 PartitionRegistration prevPartition = prev.partitions().get(partitionId);
                 PartitionRegistration nextPartition = entry.getValue();
-                handlePartitionChange(prevPartition, nextPartition);
+                handlePartitionChange(prevPartition, nextPartition, isInklessTopic.apply(topicDelta.name()));
             }
         }
         topicDelta.partitionToUncleanLeaderElectionCount().forEach((partitionId, count) -> uncleanLeaderElection += count);
         topicDelta.partitionToElrElectionCount().forEach((partitionId, count) -> electionFromElr += count);
     }
 
-    void handlePartitionChange(PartitionRegistration prev, PartitionRegistration next) {
+    void handlePartitionChange(PartitionRegistration prev, PartitionRegistration next, boolean isInkless) {
         boolean wasPresent = false;
         boolean wasOffline = false;
         boolean wasWithoutPreferredLeader = false;
@@ -149,6 +161,11 @@ class ControllerMetricsChanges {
             wasOffline = !prev.hasLeader();
             wasWithoutPreferredLeader = !prev.hasPreferredLeader();
         }
+        if (isInkless) {
+            wasPresent = true;
+            wasOffline = false; // Inkless partitions are always considered online
+            wasWithoutPreferredLeader = false; // Inkless partitions are always considered to have a preferred leader
+        }
         boolean isPresent = false;
         boolean isOffline = false;
         boolean isWithoutPreferredLeader = false;
@@ -156,6 +173,11 @@ class ControllerMetricsChanges {
             isPresent = true;
             isOffline = !next.hasLeader();
             isWithoutPreferredLeader = !next.hasPreferredLeader();
+        }
+        if (isInkless) {
+            isPresent = true;
+            isOffline = false; // Inkless partitions are always considered online
+            isWithoutPreferredLeader = false; // Inkless partitions are always considered to have a preferred leader
         }
         globalPartitionsChange += delta(wasPresent, isPresent);
         offlinePartitionsChange += delta(wasOffline, isOffline);

--- a/metadata/src/test/java/org/apache/kafka/controller/metrics/ControllerMetadataMetricsPublisherTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/metrics/ControllerMetadataMetricsPublisherTest.java
@@ -58,7 +58,7 @@ public class ControllerMetadataMetricsPublisherTest {
         ControllerMetadataMetrics metrics =
                 new ControllerMetadataMetrics(Optional.empty());
         ControllerMetadataMetricsPublisher publisher =
-                new ControllerMetadataMetricsPublisher(metrics, faultHandler);
+                new ControllerMetadataMetricsPublisher(metrics, faultHandler, topicName -> false);
 
         @Override
         public void close() {

--- a/metadata/src/test/java/org/apache/kafka/controller/metrics/ControllerMetricsChangesTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/metrics/ControllerMetricsChangesTest.java
@@ -208,7 +208,7 @@ public class ControllerMetricsChangesTest {
                 setPartitionId(1).
                 setTopicId(FOO_ID).
                 setLeader(1));
-        TOPIC_DELTA2.replay((PartitionRecord) fakePartitionRegistration(NORMAL).
+        TOPIC_DELTA2.replay((PartitionRecord) fakePartitionRegistration(OFFLINE).
                 toRecord(FOO_ID, 5, options).message());
     }
 
@@ -228,8 +228,18 @@ public class ControllerMetricsChangesTest {
         changes.handleTopicChange(TOPIC_DELTA2.image(), TOPIC_DELTA2);
         assertEquals(0, changes.globalTopicsChange());
         assertEquals(1, changes.globalPartitionsChange());
+        assertEquals(1, changes.offlinePartitionsChange());
+        assertEquals(2, changes.partitionsWithoutPreferredLeaderChange());
+    }
+
+    @Test
+    public void testNoPartitionChangesReportedOnInklessTopics() {
+        ControllerMetricsChanges changes = new ControllerMetricsChanges(s -> true);
+        changes.handleTopicChange(TOPIC_DELTA2.image(), TOPIC_DELTA2);
+        assertEquals(0, changes.globalTopicsChange());
+        assertEquals(0, changes.globalPartitionsChange());
         assertEquals(0, changes.offlinePartitionsChange());
-        assertEquals(1, changes.partitionsWithoutPreferredLeaderChange());
+        assertEquals(0, changes.partitionsWithoutPreferredLeaderChange());
     }
 
     @Test


### PR DESCRIPTION
Inkless topic partition metrics like OfflinePartitionCount, leadership changes, etc. are considering Inkless topics.
This change filters them out to avoid reporting them for these topic partitions.
