### PR TITLE
Optimize FindBatchesJob for PostgresControlPlane [INK-45]

### DIFF
--- a/core/src/test/java/kafka/server/InklessClusterTest.java
+++ b/core/src/test/java/kafka/server/InklessClusterTest.java
@@ -150,6 +150,7 @@ public class InklessClusterTest {
         clientConfigs.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
         // by default is latest and nothing would get consumed.
         clientConfigs.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, AutoOffsetResetStrategy.EARLIEST.name());
+        clientConfigs.put(ConsumerConfig.MAX_PARTITION_FETCH_BYTES_CONFIG, "5000000");
         String topicName = "inkless-topic";
         int numRecords = 500;
 

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/PostgresControlPlane.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/PostgresControlPlane.java
@@ -132,7 +132,7 @@ public class PostgresControlPlane extends AbstractControlPlane {
         final FindBatchesJob job = new FindBatchesJob(
             time, jooqCtx,
             requests.toList(), fetchMaxBytes,
-            metrics::onGetLogsCompleted, metrics::onFindBatchesCompleted);
+            metrics::onFindBatchesCompleted);
         return job.call().iterator();
     }
 

--- a/storage/inkless/src/main/resources/db/migration/V7__Find_batches_function.sql
+++ b/storage/inkless/src/main/resources/db/migration/V7__Find_batches_function.sql
@@ -1,0 +1,114 @@
+-- Copyright (c) 2025 Aiven, Helsinki, Finland. https://aiven.io/
+
+CREATE TYPE find_batches_request_v1 AS (
+    topic_id topic_id_t,
+    partition partition_t,
+    starting_offset BIGINT,
+    max_partition_fetch_bytes INT
+);
+
+CREATE TYPE batch_info_v1 AS (
+    batch_id BIGINT,
+    object_key object_key_t,
+    batch_metadata batch_metadata_v1
+);
+
+CREATE TYPE find_batches_response_error_v1 AS ENUM (
+    'offset_out_of_range',
+    'unknown_topic_or_partition'
+);
+
+CREATE TYPE find_batches_response_v1 AS (
+    topic_id topic_id_t,
+    partition partition_t,
+    log_start_offset offset_with_minus_one_t,
+    high_watermark offset_with_minus_one_t,
+    batches batch_info_v1[],
+    error find_batches_response_error_v1
+);
+
+CREATE OR REPLACE FUNCTION find_batches_v1(
+    arg_requests find_batches_request_v1[],
+    fetch_max_bytes INT
+)
+RETURNS SETOF find_batches_response_v1 LANGUAGE sql STABLE AS $$
+    WITH
+        requests AS (
+            SELECT
+                r.topic_id,
+                r.partition,
+                r.starting_offset,
+                r.max_partition_fetch_bytes,
+                r.ordinality AS idx -- for preserving original order
+            FROM unnest(arg_requests) WITH ORDINALITY AS r(topic_id, partition, starting_offset, max_partition_fetch_bytes, ordinality)
+        ),
+        requests_with_log_info AS (
+            SELECT
+                r.idx, r.topic_id, r.partition, r.starting_offset, r.max_partition_fetch_bytes,
+                l.log_start_offset, l.high_watermark, l.topic_name,
+                CASE
+                    WHEN l.topic_id IS NULL THEN 'unknown_topic_or_partition'::find_batches_response_error_v1
+                    WHEN r.starting_offset < 0 OR r.starting_offset > l.high_watermark THEN 'offset_out_of_range'::find_batches_response_error_v1
+                    ELSE NULL
+                END AS error
+            FROM requests r
+            LEFT JOIN logs l ON r.topic_id = l.topic_id AND r.partition = l.partition
+        ),
+        all_batches_with_metadata AS (
+            SELECT
+                r.idx,
+                (
+                    b.batch_id,
+                    f.object_key,
+                    (
+                        b.magic, b.topic_id, r.topic_name, b.partition, b.byte_offset, b.byte_size,
+                        b.base_offset, b.last_offset, b.log_append_timestamp, b.batch_max_timestamp,
+                        b.timestamp_type
+                    )::batch_metadata_v1
+                )::batch_info_v1 AS batch_data,
+                b.byte_size, b.base_offset, r.max_partition_fetch_bytes,
+                ROW_NUMBER() OVER (PARTITION BY r.idx ORDER BY b.base_offset) as rn,
+                SUM(b.byte_size) OVER (PARTITION BY r.idx ORDER BY b.base_offset) as partition_cumulative_bytes
+            FROM requests_with_log_info r
+            JOIN batches b ON r.topic_id = b.topic_id AND r.partition = b.partition
+            JOIN files f ON b.file_id = f.file_id
+            WHERE r.error IS NULL
+                AND b.last_offset >= r.starting_offset
+                AND b.base_offset < r.high_watermark
+        ),
+        per_partition_limited_batches AS (
+            SELECT idx, batch_data, byte_size, base_offset, rn
+            FROM all_batches_with_metadata
+            WHERE rn = 1  -- each partition gets always at least one batch
+                -- include also last batch, even if it overflows max.partition.fetch.bytes
+                OR (partition_cumulative_bytes - byte_size) < max_partition_fetch_bytes
+        ),
+        final_batch_set AS (
+            SELECT idx, batch_data, base_offset, rn
+            FROM (
+                SELECT *, SUM(byte_size) OVER (ORDER BY idx, base_offset) as global_cumulative_bytes
+                FROM per_partition_limited_batches
+            ) AS sized_batches
+            WHERE rn = 1 OR  -- each partition gets always at least one batch
+                -- include also last batch, even if it overflows fetch.max.bytes
+                (global_cumulative_bytes - byte_size) < fetch_max_bytes
+        ),
+        aggregated_batches AS (
+            SELECT
+                idx,
+                array_agg(batch_data ORDER BY base_offset) AS batches
+            FROM final_batch_set
+            GROUP BY idx
+        )
+    SELECT
+        r.topic_id,
+        r.partition,
+        COALESCE(r.log_start_offset, -1),
+        COALESCE(r.high_watermark, -1),
+        CASE WHEN r.error IS NULL THEN COALESCE(ab.batches, '{}'::batch_info_v1[]) ELSE NULL END,
+        r.error
+    FROM requests_with_log_info r
+    LEFT JOIN aggregated_batches ab ON r.idx = ab.idx
+    ORDER BY r.idx;
+$$;
+

--- a/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/FindBatchesJobTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/FindBatchesJobTest.java
@@ -24,14 +24,21 @@ import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
 
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import io.aiven.inkless.common.ObjectFormat;
@@ -54,64 +61,408 @@ class FindBatchesJobTest {
     static final int BROKER_ID = 11;
     static final long FILE_SIZE = 123456;
 
+    static final String OBJECT_KEY = "obj1";
     static final String TOPIC_0 = "topic0";
     static final String TOPIC_1 = "topic1";
+    static final String NON_EXISTENT_TOPIC = "topic1";
     static final Uuid TOPIC_ID_0 = new Uuid(10, 12);
     static final Uuid TOPIC_ID_1 = new Uuid(555, 333);
+    static final Uuid NON_EXISTENT_TOPIC_ID = new Uuid(555, 333);
     static final TopicIdPartition T0P0 = new TopicIdPartition(TOPIC_ID_0, 0, TOPIC_0);
+    static final TopicIdPartition T0P1 = new TopicIdPartition(TOPIC_ID_0, 1, TOPIC_0);
+    static final TopicIdPartition T1P0 = new TopicIdPartition(TOPIC_ID_1, 0, TOPIC_1);
+    static final TopicIdPartition NON_EXISTENT_PARTITION = new TopicIdPartition(TOPIC_ID_0, 2, TOPIC_0);
+    static final TopicIdPartition NON_EXISTENT_TOPIC_ID_PARTITION = new TopicIdPartition(NON_EXISTENT_TOPIC_ID, 2, NON_EXISTENT_TOPIC);
 
     Time time = new MockTime();
 
-    @BeforeEach
-    void setUp(final TestInfo testInfo) {
-        pgContainer.createDatabase(testInfo);
+    @BeforeAll
+    static void initDb() {
+        pgContainer.createDatabase(FindBatchesJobTest.class.getSimpleName());
         pgContainer.migrate();
+    }
+
+    @AfterAll
+    static void tearDownDb() {
+        pgContainer.tearDown();
+    }
+
+    @BeforeEach
+    void setUp() {
+        final var jooqCtx = pgContainer.getJooqCtx();
+
+        jooqCtx.transaction(ctx -> {
+            ctx.dsl().query(
+                """
+                    TRUNCATE TABLE "logs", "batches", "files"
+                    RESTART IDENTITY CASCADE;
+                """
+            ).execute();
+        });
 
         final Set<CreateTopicAndPartitionsRequest> createTopicAndPartitionsRequests = Set.of(
             new CreateTopicAndPartitionsRequest(TOPIC_ID_0, TOPIC_0, 2),
             new CreateTopicAndPartitionsRequest(TOPIC_ID_1, TOPIC_1, 1)
         );
-        new TopicsAndPartitionsCreateJob(Time.SYSTEM, pgContainer.getJooqCtx(), createTopicAndPartitionsRequests, duration -> {}).run();
+        new TopicsAndPartitionsCreateJob(Time.SYSTEM, jooqCtx, createTopicAndPartitionsRequests, duration -> {}).run();
     }
 
-    @AfterEach
-    void tearDown() {
-        pgContainer.tearDown();
+    @Test
+    void topicIdPartitionNotFound() {
+        final FindBatchesJob job = new FindBatchesJob(
+            time, pgContainer.getJooqCtx(),
+            List.of(
+                new FindBatchRequest(NON_EXISTENT_PARTITION, 0, 1000),
+                new FindBatchRequest(NON_EXISTENT_TOPIC_ID_PARTITION, 0, 1000)
+            ),
+            2000,
+            duration -> {});
+        final List<FindBatchResponse> result = job.call();
+
+        assertThat(result).containsExactlyInAnyOrder(
+            new FindBatchResponse(Errors.UNKNOWN_TOPIC_OR_PARTITION, null, -1, -1),
+            new FindBatchResponse(Errors.UNKNOWN_TOPIC_OR_PARTITION, null, -1, -1)
+        );
     }
 
     @Test
     void simpleFind() {
-        final String objectKey1 = "obj1";
+        commitBatches(OBJECT_KEY, List.of(T0P0), 1, 1234, 10);
 
-        final CommitFileJob commitJob = new CommitFileJob(
-            time, pgContainer.getJooqCtx(), objectKey1, ObjectFormat.WRITE_AHEAD_MULTI_SEGMENT, BROKER_ID, FILE_SIZE,
-            List.of(
-                CommitBatchRequest.of(0, T0P0, 0, 1234, 0, 11, 1000, TimestampType.CREATE_TIME)
-            ),
-            duration -> {}
-        );
-        assertThat(commitJob.call()).isNotEmpty();
-
-        final FindBatchesJob job = new FindBatchesJob(
+        final List<FindBatchResponse> result = new FindBatchesJob(
             time, pgContainer.getJooqCtx(),
-            List.of(
-                // This will produce a normal find result with some batches.
-                new FindBatchRequest(new TopicIdPartition(TOPIC_ID_0, 0, TOPIC_0), 0, 1000),
-                // This will be on the border, offset matching HWM, will produce no bathes, but still a successful result.
-                new FindBatchRequest(new TopicIdPartition(TOPIC_ID_0, 1, TOPIC_0), 0, 1000),
-                // This will result in the out-of-range error.
-                new FindBatchRequest(new TopicIdPartition(TOPIC_ID_1, 0, TOPIC_1), 10, 1000)
-            ),
+            List.of(new FindBatchRequest(T0P0, 0, 1500)),
             2000,
-            duration -> {}, duration -> {});
-        final List<FindBatchResponse> result = job.call();
+            duration -> {}
+        ).call();
 
         assertThat(result).containsExactlyInAnyOrder(
             new FindBatchResponse(Errors.NONE, List.of(
-                new BatchInfo(1L, objectKey1, BatchMetadata.of(T0P0, 0, 1234, 0, 11, time.milliseconds(), 1000, TimestampType.CREATE_TIME))
-            ), 0, 12),
+                new BatchInfo(1L, OBJECT_KEY, BatchMetadata.of(T0P0, 0, 1234, 0, 9, time.milliseconds(), time.milliseconds(), TimestampType.CREATE_TIME))
+            ), 0, 10)
+        );
+    }
+
+    @Test
+    void findCornerCases() {
+        commitBatches(OBJECT_KEY, List.of(T0P0), 1, 1234, 10);
+
+        final List<FindBatchResponse> result = new FindBatchesJob(
+            time, pgContainer.getJooqCtx(),
+            List.of(
+                // This will produce a normal find result with some batches, even if the size is > max.partition.fetch.bytes.
+                new FindBatchRequest(T0P0, 0, 1000),
+                // This will be on the border, offset matching HWM, will produce no batches, but still a successful result.
+                new FindBatchRequest(T0P1, 0, 1000),
+                // This will result in the out-of-range error.
+                new FindBatchRequest(T1P0, 10, 1000)
+            ),
+            2000,
+            duration -> {}
+        ).call();
+
+        assertThat(result).containsExactlyInAnyOrder(
+            new FindBatchResponse(Errors.NONE, List.of(
+                new BatchInfo(1L, OBJECT_KEY, BatchMetadata.of(T0P0, 0, 1234, 0, 9, time.milliseconds(), time.milliseconds(), TimestampType.CREATE_TIME))
+            ), 0, 10),
             new FindBatchResponse(Errors.NONE, List.of(), 0, 0),
             new FindBatchResponse(Errors.OFFSET_OUT_OF_RANGE, null, 0, 0)
         );
     }
+
+    @Test
+    void twoRequestsAboutSamePartition() {
+        commitBatches(OBJECT_KEY, List.of(T0P0), 2, 1000, 10);
+
+        final List<FindBatchResponse> result = new FindBatchesJob(
+            time, pgContainer.getJooqCtx(),
+            List.of(
+                // This should return both batches
+                new FindBatchRequest(T0P0, 0, 100000),
+                // This should return only the second batch
+                new FindBatchRequest(T0P0, 13, 100000)
+            ),
+            3000,
+            duration -> {}
+        ).call();
+
+        assertThat(result).containsExactlyInAnyOrder(
+            new FindBatchResponse(Errors.NONE, List.of(
+                new BatchInfo(1L, OBJECT_KEY, BatchMetadata.of(T0P0, 0, 1000, 0, 9, time.milliseconds(), time.milliseconds(), TimestampType.CREATE_TIME)),
+                new BatchInfo(2L, OBJECT_KEY, BatchMetadata.of(T0P0, 1000, 1000, 10, 19, time.milliseconds(), time.milliseconds(), TimestampType.CREATE_TIME))
+            ), 0, 20),
+            new FindBatchResponse(Errors.NONE, List.of(
+                new BatchInfo(2L, OBJECT_KEY, BatchMetadata.of(T0P0, 1000, 1000, 10, 19, time.milliseconds(), time.milliseconds(), TimestampType.CREATE_TIME))
+            ), 0, 20)
+        );
+    }
+
+    @DisplayName("Returns only the first batch when fetch.max.bytes <= first batch size")
+    @ParameterizedTest(name = "fetchMaxBytes = {0}")
+    @ValueSource(ints = {0, 1, 1000})
+    void findWithFetchMaxBytesReturnsFirstBatch(int fetchMaxBytes) {
+        commitBatches(OBJECT_KEY, List.of(T0P0), 2, 1000, 10);
+
+        final List<FindBatchResponse> result = new FindBatchesJob(
+            time, pgContainer.getJooqCtx(),
+            List.of(new FindBatchRequest(T0P0, 0, Integer.MAX_VALUE)),
+            fetchMaxBytes,
+            duration -> {
+            }
+        ).call();
+
+        assertThat(result).containsExactly(
+            new FindBatchResponse(Errors.NONE, List.of(
+                new BatchInfo(1L, OBJECT_KEY, BatchMetadata.of(T0P0, 0, 1000, 0, 9, time.milliseconds(), time.milliseconds(), TimestampType.CREATE_TIME))
+            ), 0, 20)
+        );
+    }
+
+    @DisplayName("Returns both batches when fetch.max.bytes > first batch size")
+    @ParameterizedTest(name = "fetchMaxBytes = {0}")
+    @ValueSource(ints = {1500, 2000, 999999})
+    void findWithFetchMaxBytesReturnsBothBatches(int fetchMaxBytes) {
+        commitBatches(OBJECT_KEY, List.of(T0P0), 2, 1000, 10);
+
+        final List<FindBatchResponse> result = new FindBatchesJob(
+            time, pgContainer.getJooqCtx(),
+            List.of(new FindBatchRequest(T0P0, 0, Integer.MAX_VALUE)),
+            fetchMaxBytes,
+            duration -> {
+            }
+        ).call();
+
+        assertThat(result).containsExactly(
+            new FindBatchResponse(Errors.NONE, List.of(
+                new BatchInfo(1L, OBJECT_KEY, BatchMetadata.of(T0P0, 0, 1000, 0, 9, time.milliseconds(), time.milliseconds(), TimestampType.CREATE_TIME)),
+                new BatchInfo(2L, OBJECT_KEY, BatchMetadata.of(T0P0, 1000, 1000, 10, 19, time.milliseconds(), time.milliseconds(), TimestampType.CREATE_TIME))
+            ), 0, 20)
+        );
+    }
+
+    @DisplayName("Returns only the first batch when max.partition.fetch.bytes <= first batch size")
+    @ParameterizedTest(name = "maxPartitionFetchBytes = {0}")
+    @ValueSource(ints = {0, 1, 1000})
+    void findWithMaxPartitionFetchBytesReturnsFirstBatch(int maxPartitionFetchBytes) {
+        commitBatches(OBJECT_KEY, List.of(T0P0, T0P1), 2, 1000, 10);
+
+        final List<FindBatchResponse> result = new FindBatchesJob(
+            time, pgContainer.getJooqCtx(),
+            List.of(
+                new FindBatchRequest(T0P0, 0, maxPartitionFetchBytes),
+                new FindBatchRequest(T0P1, 0, maxPartitionFetchBytes)
+            ),
+            Integer.MAX_VALUE, duration -> {
+        }
+        ).call();
+
+        assertThat(result).containsExactlyInAnyOrder(
+            new FindBatchResponse(Errors.NONE, List.of(
+                new BatchInfo(1L, OBJECT_KEY, BatchMetadata.of(T0P0, 0, 1000, 0, 9, time.milliseconds(), time.milliseconds(), TimestampType.CREATE_TIME))
+            ), 0, 20),
+            new FindBatchResponse(Errors.NONE, List.of(
+                new BatchInfo(3L, OBJECT_KEY, BatchMetadata.of(T0P1, 2000, 1000, 0, 9, time.milliseconds(), time.milliseconds(), TimestampType.CREATE_TIME))
+            ), 0, 20)
+        );
+    }
+
+    @DisplayName("Returns both batches when max.partition.fetch.bytes > first batch size")
+    @ParameterizedTest(name = "maxPartitionFetchBytes = {0}")
+    @ValueSource(ints = {1500, 2000, 999999})
+    void findWithMaxPartitionFetchBytesReturnsBothBatches(int maxPartitionFetchBytes) {
+        commitBatches(OBJECT_KEY, List.of(T0P0, T0P1), 2, 1000, 10);
+
+        final List<FindBatchResponse> result = new FindBatchesJob(
+            time, pgContainer.getJooqCtx(),
+            List.of(
+                new FindBatchRequest(T0P0, 0, maxPartitionFetchBytes),
+                new FindBatchRequest(T0P1, 0, maxPartitionFetchBytes)
+            ),
+            Integer.MAX_VALUE, duration -> {
+        }
+        ).call();
+
+        assertThat(result).containsExactlyInAnyOrder(
+            new FindBatchResponse(Errors.NONE, List.of(
+                new BatchInfo(1L, OBJECT_KEY, BatchMetadata.of(T0P0, 0, 1000, 0, 9, time.milliseconds(), time.milliseconds(), TimestampType.CREATE_TIME)),
+                new BatchInfo(2L, OBJECT_KEY, BatchMetadata.of(T0P0, 1000, 1000, 10, 19, time.milliseconds(), time.milliseconds(), TimestampType.CREATE_TIME))
+            ), 0, 20),
+            new FindBatchResponse(Errors.NONE, List.of(
+                new BatchInfo(3L, OBJECT_KEY, BatchMetadata.of(T0P1, 2000, 1000, 0, 9, time.milliseconds(), time.milliseconds(), TimestampType.CREATE_TIME)),
+                new BatchInfo(4L, OBJECT_KEY, BatchMetadata.of(T0P1, 3000, 1000, 10, 19, time.milliseconds(), time.milliseconds(), TimestampType.CREATE_TIME))
+            ), 0, 20)
+        );
+    }
+
+    @ParameterizedTest(name = "maxPartitionFetchBytes = {0}, fetchMaxBytes = {1}")
+    @CsvSource({
+        "0, 0",
+        "1, 1",
+        "1000, 1000",
+        "1000, 2000",
+        "1000, 3000",
+        "1000, 2147483647"
+    })
+    void findWithCombinedLimitsReturnsOneBatchPerPartition(int maxPartitionFetchBytes, int fetchMaxBytes) {
+        // max.partition.fetch.bytes limits how many batches per partition, no matter the fetch.max.bytes value
+        commitBatches(OBJECT_KEY, List.of(T0P0, T0P1), 10, 1000, 10);
+
+        final List<FindBatchResponse> result = new FindBatchesJob(
+            time, pgContainer.getJooqCtx(),
+            List.of(
+                new FindBatchRequest(T0P0, 0, maxPartitionFetchBytes),
+                new FindBatchRequest(T0P1, 0, maxPartitionFetchBytes)
+            ),
+            fetchMaxBytes, duration -> {
+        }
+        ).call();
+
+        assertThat(result).containsExactlyInAnyOrder(
+            new FindBatchResponse(Errors.NONE, List.of(
+                new BatchInfo(1L, OBJECT_KEY, BatchMetadata.of(T0P0, 0, 1000, 0, 9, time.milliseconds(), time.milliseconds(), TimestampType.CREATE_TIME))
+            ), 0, 100),
+            new FindBatchResponse(Errors.NONE, List.of(
+                new BatchInfo(11L, OBJECT_KEY, BatchMetadata.of(T0P1, 10000, 1000, 0, 9, time.milliseconds(), time.milliseconds(), TimestampType.CREATE_TIME))
+            ), 0, 100)
+        );
+    }
+
+    @ParameterizedTest(name = "maxPartitionFetchBytes = {0}, fetchMaxBytes = {1}")
+    @CsvSource({
+        "1001, 2000",
+        "1500, 2500",
+        "2000, 3000"
+    })
+    void findWithCombinedLimitsReturnsTwoBatchesForFirstPartitionAndOneBatchForSecondPartition(int maxPartitionFetchBytes, int fetchMaxBytes) {
+        // fetch.max.bytes limits the number of batches for second partition
+        commitBatches(OBJECT_KEY, List.of(T0P0, T0P1), 10, 1000, 10);
+
+        final List<FindBatchResponse> result = new FindBatchesJob(
+            time, pgContainer.getJooqCtx(),
+            List.of(
+                new FindBatchRequest(T0P0, 0, 1001),
+                new FindBatchRequest(T0P1, 0, 1001)
+            ),
+            2000, duration -> {
+        }
+        ).call();
+
+        // With the given limits, we expect both batches for T0P0, but only the first for T0P1 because of the overall fetchMaxBytes limit.
+        assertThat(result).containsExactlyInAnyOrder(
+            new FindBatchResponse(Errors.NONE, List.of(
+                new BatchInfo(1L, OBJECT_KEY, BatchMetadata.of(T0P0, 0, 1000, 0, 9, time.milliseconds(), time.milliseconds(), TimestampType.CREATE_TIME)),
+                new BatchInfo(2L, OBJECT_KEY, BatchMetadata.of(T0P0, 1000, 1000, 10, 19, time.milliseconds(), time.milliseconds(), TimestampType.CREATE_TIME))
+            ), 0, 100),
+            new FindBatchResponse(Errors.NONE, List.of(
+                new BatchInfo(11L, OBJECT_KEY, BatchMetadata.of(T0P1, 10000, 1000, 0, 9, time.milliseconds(), time.milliseconds(), TimestampType.CREATE_TIME))
+            ), 0, 100)
+        );
+    }
+
+    @ParameterizedTest(name = "maxPartitionFetchBytes = {0}, fetchMaxBytes = {1}")
+    @CsvSource({
+        "1001, 4000",
+        "1001, 4500",
+        "1001, 100000",
+        "2000, 4000",
+        "2000, 4500",
+        "2000, 100000",
+    })
+    void findWithCombinedLimitsReturnsTwoBatchesForBothPartitions(int maxPartitionFetchBytes, int fetchMaxBytes) {
+        commitBatches(OBJECT_KEY, List.of(T0P0, T0P1), 10, 1000, 10);
+
+        final List<FindBatchResponse> result = new FindBatchesJob(
+            time, pgContainer.getJooqCtx(),
+            List.of(
+                new FindBatchRequest(T0P0, 0, maxPartitionFetchBytes),
+                new FindBatchRequest(T0P1, 0, maxPartitionFetchBytes)
+            ),
+            fetchMaxBytes, duration -> {
+        }
+        ).call();
+
+        assertThat(result).containsExactlyInAnyOrder(
+            new FindBatchResponse(Errors.NONE, List.of(
+                new BatchInfo(1L, OBJECT_KEY, BatchMetadata.of(T0P0, 0, 1000, 0, 9, time.milliseconds(), time.milliseconds(), TimestampType.CREATE_TIME)),
+                new BatchInfo(2L, OBJECT_KEY, BatchMetadata.of(T0P0, 1000, 1000, 10, 19, time.milliseconds(), time.milliseconds(), TimestampType.CREATE_TIME))
+            ), 0, 100),
+            new FindBatchResponse(Errors.NONE, List.of(
+                new BatchInfo(11L, OBJECT_KEY, BatchMetadata.of(T0P1, 10000, 1000, 0, 9, time.milliseconds(), time.milliseconds(), TimestampType.CREATE_TIME)),
+                new BatchInfo(12L, OBJECT_KEY, BatchMetadata.of(T0P1, 11000, 1000, 10, 19, time.milliseconds(), time.milliseconds(), TimestampType.CREATE_TIME))
+            ), 0, 100)
+        );
+    }
+
+    @ParameterizedTest(name = "maxPartitionFetchBytes = {0}, fetchMaxBytes = {1}")
+    @CsvSource({
+        "3001, 5001",
+        "4000, 6000"
+    })
+    void findWithCombinedLimitsReturnsFourBatchesForFirstPartitionAndTwoForSecondPartition(int maxPartitionFetchBytes, int fetchMaxBytes) {
+        commitBatches(OBJECT_KEY, List.of(T0P0, T0P1), 10, 1000, 10);
+
+        final List<FindBatchResponse> result = new FindBatchesJob(
+            time, pgContainer.getJooqCtx(),
+            List.of(
+                new FindBatchRequest(T0P0, 0, maxPartitionFetchBytes),
+                new FindBatchRequest(T0P1, 0, maxPartitionFetchBytes)
+            ),
+            fetchMaxBytes, duration -> {
+        }
+        ).call();
+
+        assertThat(result).containsExactlyInAnyOrder(
+            new FindBatchResponse(Errors.NONE, List.of(
+                new BatchInfo(1L, OBJECT_KEY, BatchMetadata.of(T0P0, 0, 1000, 0, 9, time.milliseconds(), time.milliseconds(), TimestampType.CREATE_TIME)),
+                new BatchInfo(2L, OBJECT_KEY, BatchMetadata.of(T0P0, 1000, 1000, 10, 19, time.milliseconds(), time.milliseconds(), TimestampType.CREATE_TIME)),
+                new BatchInfo(3L, OBJECT_KEY, BatchMetadata.of(T0P0, 2000, 1000, 20, 29, time.milliseconds(), time.milliseconds(), TimestampType.CREATE_TIME)),
+                new BatchInfo(4L, OBJECT_KEY, BatchMetadata.of(T0P0, 3000, 1000, 30, 39, time.milliseconds(), time.milliseconds(), TimestampType.CREATE_TIME))
+            ), 0, 100),
+            new FindBatchResponse(Errors.NONE, List.of(
+                new BatchInfo(11L, OBJECT_KEY, BatchMetadata.of(T0P1, 10000, 1000, 0, 9, time.milliseconds(), time.milliseconds(), TimestampType.CREATE_TIME)),
+                new BatchInfo(12L, OBJECT_KEY, BatchMetadata.of(T0P1, 11000, 1000, 10, 19, time.milliseconds(), time.milliseconds(), TimestampType.CREATE_TIME))
+            ), 0, 100)
+        );
+    }
+
+    private void commitBatches(
+        final String objectKey,
+        final List<TopicIdPartition> topicPartitions,
+        final int batchesPerPartition,
+        final int batchSize,
+        final int offsetsPerBatch
+    ) {
+        final List<CommitBatchRequest> requests = new ArrayList<>();
+        int fileStartOffset = 0;
+        final Map<TopicIdPartition, Long> kafkaBaseOffsets = new HashMap<>();
+
+        for (final TopicIdPartition partition : topicPartitions) {
+            for (int i = 0; i < batchesPerPartition; i++) {
+                final long baseOffset = kafkaBaseOffsets.getOrDefault(partition, 0L);
+                final long lastOffset = baseOffset + offsetsPerBatch - 1;
+
+                requests.add(CommitBatchRequest.of(
+                    0,
+                    partition,
+                    fileStartOffset,
+                    batchSize,
+                    baseOffset,
+                    lastOffset,
+                    time.milliseconds(),
+                    TimestampType.CREATE_TIME
+                ));
+
+                fileStartOffset += batchSize;
+                kafkaBaseOffsets.put(partition, lastOffset + 1);
+            }
+        }
+
+        final CommitFileJob commitJob = new CommitFileJob(
+            time, pgContainer.getJooqCtx(), objectKey, ObjectFormat.WRITE_AHEAD_MULTI_SEGMENT,
+            BROKER_ID, FILE_SIZE, requests, duration -> {
+        }
+        );
+        assertThat(commitJob.call()).isNotEmpty();
+    }
+
 }


### PR DESCRIPTION
Define a new find_batches_v1 PG function for finding batches from all requested partition.

New implementation of `FindBatchesJob` now also supports limiting by `max.partition.fetch.bytes`.
