### PR TITLE
fix(inkless): filter-out inkless topics from controller metrics - part 2

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/metrics/ControllerMetadataMetricsPublisher.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/metrics/ControllerMetadataMetricsPublisher.java
@@ -143,12 +143,15 @@ public class ControllerMetadataMetricsPublisher implements MetadataPublisher {
         int offlinePartitions = 0;
         int partitionsWithoutPreferredLeader = 0;
         for (TopicImage topicImage : newImage.topics().topicsById().values()) {
+            boolean isInkless = isInklessTopic.apply(topicImage.name());
             for (PartitionRegistration partition : topicImage.partitions().values()) {
-                if (!partition.hasLeader()) {
-                    offlinePartitions++;
-                }
-                if (!partition.hasPreferredLeader()) {
-                    partitionsWithoutPreferredLeader++;
+                if (!isInkless) {
+                    if (!partition.hasLeader()) {
+                        offlinePartitions++;
+                    }
+                    if (!partition.hasPreferredLeader()) {
+                        partitionsWithoutPreferredLeader++;
+                    }
                 }
                 totalPartitions++;
             }


### PR DESCRIPTION
The fix for offline partition metrics was missing to filter out topics when publishing metrics on snapshots.