### PR TITLE
Create docs/inkless/topic_configs.rst

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2481,6 +2481,19 @@ project(':storage:inkless') {
     }
   }
 
+  task genInklessTopicConfigDoc(type: JavaExec) {
+    classpath = project(':storage:inkless').sourceSets.main.runtimeClasspath
+    mainClass = 'io.aiven.inkless.doc.TopicConfigsDocs'
+
+    // Define the outputs formally
+    outputs.file("$rootDir/docs/inkless/topic_configs.rst")
+
+    // Set up the output in the execution phase, not configuration, and avoid removing on clean
+    doFirst {
+      standardOutput = new File("$rootDir/docs/inkless/topic_configs.rst").newOutputStream()
+    }
+  }
+
   tasks {
     generateJooqClasses {
       withContainer {
@@ -2589,6 +2602,7 @@ project(':storage:inkless') {
 
   tasks.named('build') {
     dependsOn tasks.named('genInklessConfigDoc')
+    dependsOn tasks.named('genInklessTopicConfigDoc')
   }
 }
 

--- a/clients/src/main/java/org/apache/kafka/common/config/TopicConfig.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/TopicConfig.java
@@ -231,5 +231,5 @@ public class TopicConfig {
 
     public static final String INKLESS_ENABLE_CONFIG = "inkless.enable";
     public static final String INKLESS_ENABLE_DOC = "To enable inkless mode for a topic, set this configuration as true. " +
-        "You can not disable this config once it is enabled.";
+            "You can not disable this config once it is enabled. If not set, defaults to server level config log.inkless.enable.";
 }

--- a/docs/inkless/README.md
+++ b/docs/inkless/README.md
@@ -12,4 +12,6 @@ For a Frequently Asked Questions formatted documentation, see [FAQ](FAQ.md)
 
 For configuration references, see [Configs](configs.rst)
 
+For a Topic Config documentation, see [Topic Configs](topic_configs.rst)
+
 Inkless is not supposed to be a long-term fork. We don't accept patches. The code is open exclusively for information purposes. We actively work on contributing these changes to Apache Kafka, see [KIP-1150: Diskless Topics](https://cwiki.apache.org/confluence/display/KAFKA/KIP-1150%3A+Diskless+Topics).

--- a/docs/inkless/topic_configs.rst
+++ b/docs/inkless/topic_configs.rst
@@ -1,0 +1,13 @@
+Inkless Topic Configurations
+============================
+
+This document describes the topic-level configurations for Inkless.
+
+``inkless.enable``
+  To enable inkless mode for a topic, set this configuration as true. You can not disable this config once it is enabled. If not set, defaults to server level config log.inkless.enable.
+
+  * Type: boolean
+  * Default: false
+  * Importance: high
+
+

--- a/storage/inkless/src/main/java/io/aiven/inkless/doc/TopicConfigsDocs.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/doc/TopicConfigsDocs.java
@@ -1,0 +1,54 @@
+/*
+ * Inkless
+ * Copyright (C) 2024 - 2025 Aiven OY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.aiven.inkless.doc;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.TopicConfig;
+
+/**
+ * Class to generate documentation for Inkless topic-level configurations.
+ */
+public class TopicConfigsDocs {
+    /**
+     * Returns a ConfigDef with all Inkless topic-level configurations.
+     */
+    public static ConfigDef configDef() {
+        final ConfigDef configDef = new ConfigDef();
+
+        configDef.define(
+                TopicConfig.INKLESS_ENABLE_CONFIG,
+                ConfigDef.Type.BOOLEAN,
+                false,
+                ConfigDef.Importance.HIGH,
+                TopicConfig.INKLESS_ENABLE_DOC
+        );
+
+        return configDef;
+    }
+
+    public static void main(String[] args) {
+        System.out.println("Inkless Topic Configurations");
+        System.out.println("============================");
+        System.out.println();
+        System.out.println("This document describes the topic-level configurations for Inkless.");
+        System.out.println();
+
+        final ConfigDef configDef = TopicConfigsDocs.configDef();
+        System.out.println(configDef.toEnrichedRst());
+    }
+}


### PR DESCRIPTION
Add a new class TopicConfigsDocs to document Inkless topic-level configurations.

Add genInklessTopicConfigDoc Gradle task and make build depend on it.

Note: in order to add now Inkless-specific topic configs, the config needs to be manually added in TopicConfigsDocs.

Also note, the server level default key is manually specified in the inkless.enable topic config key documentation. It's not very straightforward to automatically create that. The rst-file generator doesn't seem to support that right now. The HTML creator would likely work, if LogConfigDef was used instead of ConfigDef.