### PR TITLE
feat(inkless): add hikari metrics

### DIFF
--- a/storage/inkless/src/main/java/io/aiven/inkless/common/metrics/MeasurableValue.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/common/metrics/MeasurableValue.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2024 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.inkless.common.metrics;
+
+import org.apache.kafka.common.metrics.MetricConfig;
+import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.metrics.stats.Value;
+
+import java.util.function.Supplier;
+
+/**
+ * Implementation of {@link Value} that allows fetching a value from provided {@code Long} {@link Supplier}
+ * to avoid unnecessary calls to {@link Sensor#record()} that under the hood has a synchronized block and affects
+ * performance because of that.
+ */
+public class MeasurableValue extends Value {
+    private final Supplier<Long> value;
+
+    public MeasurableValue(final Supplier<Long> value) {
+        this.value = value;
+    }
+
+    @Override
+    public double measure(final MetricConfig config, final long now) {
+        return value.get();
+    }
+}

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/HikariMetricsRegistry.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/HikariMetricsRegistry.java
@@ -1,0 +1,91 @@
+package io.aiven.inkless.control_plane.postgres;
+
+import org.apache.kafka.common.MetricNameTemplate;
+
+public class HikariMetricsRegistry {
+    public static final String METRIC_CONTEXT = "io.aiven.inkless.control_plane.postgres.connection_pool";
+
+    public static final String ACTIVE_CONNECTIONS_COUNT = "active-connections-count";
+    public static final String TOTAL_CONNECTIONS_COUNT = "total-connections-count";
+    public static final String IDLE_CONNECTIONS_COUNT = "idle-connections-count";
+    public static final String MAX_CONNECTIONS_COUNT = "max-connections-count";
+    public static final String MIN_CONNECTIONS_COUNT = "min-connections-count";
+    public static final String PENDING_THREADS_COUNT = "pending-threads-count";
+    public static final String CONNECTION_ACQUIRED_NANOS = "connection-acquired-nanos";
+    public static final String CONNECTION_ACQUIRED_NANOS_MAX = CONNECTION_ACQUIRED_NANOS + "-max";
+    public static final String CONNECTION_ACQUIRED_NANOS_AVG = CONNECTION_ACQUIRED_NANOS + "-avg";
+    public static final String CONNECTION_USAGE_MILLIS = "connection-usage-millis";
+    public static final String CONNECTION_USAGE_MILLIS_MAX = CONNECTION_USAGE_MILLIS + "-max";
+    public static final String CONNECTION_USAGE_MILLIS_AVG = CONNECTION_USAGE_MILLIS + "-avg";
+    public static final String CONNECTION_TIMEOUT_COUNT = "connection-timeout-count";
+
+    public MetricNameTemplate activeConnectionsCountMetricName;
+    public MetricNameTemplate totalConnectionsCountMetricName;
+    public MetricNameTemplate idleConnectionsCountMetricName;
+    public MetricNameTemplate maxConnectionsCountMetricName;
+    public MetricNameTemplate minConnectionsCountMetricName;
+    public MetricNameTemplate pendingThreadsCountMetricName;
+    public MetricNameTemplate connectionAcquiredNanosAvgMetricName;
+    public MetricNameTemplate connectionAcquiredNanosMaxMetricName;
+    public MetricNameTemplate connectionUsageMillisAvgMetricName;
+    public MetricNameTemplate connectionUsageMillisMaxMetricName;
+    public MetricNameTemplate connectionTimeoutCountMetricName;
+
+    public HikariMetricsRegistry(String poolName) {
+        activeConnectionsCountMetricName = new MetricNameTemplate(
+            ACTIVE_CONNECTIONS_COUNT,
+            poolName,
+            "Number of active connections in the pool"
+        );
+        totalConnectionsCountMetricName = new MetricNameTemplate(
+            TOTAL_CONNECTIONS_COUNT,
+            poolName,
+            "Total number of connections created in the pool"
+        );
+        idleConnectionsCountMetricName = new MetricNameTemplate(
+            IDLE_CONNECTIONS_COUNT,
+            poolName,
+            "Number of idle connections in the pool"
+        );
+        maxConnectionsCountMetricName = new MetricNameTemplate(
+            MAX_CONNECTIONS_COUNT,
+            poolName,
+            "Maximum number of connections allowed in the pool"
+        );
+        minConnectionsCountMetricName = new MetricNameTemplate(
+            MIN_CONNECTIONS_COUNT,
+            poolName,
+            "Minimum number of connections maintained in the pool"
+        );
+        pendingThreadsCountMetricName = new MetricNameTemplate(
+            PENDING_THREADS_COUNT,
+            poolName,
+            "Number of threads waiting for a connection from the pool"
+        );
+        connectionAcquiredNanosAvgMetricName = new MetricNameTemplate(
+            CONNECTION_ACQUIRED_NANOS_AVG,
+            poolName,
+            "Average time spent acquiring connections in nanoseconds"
+        );
+        connectionAcquiredNanosMaxMetricName = new MetricNameTemplate(
+            CONNECTION_ACQUIRED_NANOS_MAX,
+            poolName,
+            "Maximum time spent acquiring a connection in nanoseconds"
+        );
+        connectionUsageMillisAvgMetricName = new MetricNameTemplate(
+            CONNECTION_USAGE_MILLIS_AVG,
+            poolName,
+            "Average time spent using connections in milliseconds"
+        );
+        connectionUsageMillisMaxMetricName = new MetricNameTemplate(
+            CONNECTION_USAGE_MILLIS_MAX,
+            METRIC_CONTEXT,
+            "Maximum time spent using a connection in milliseconds"
+        );
+        connectionTimeoutCountMetricName = new MetricNameTemplate(
+            CONNECTION_TIMEOUT_COUNT,
+            METRIC_CONTEXT,
+            "Number of times a connection acquisition timed out"
+        );
+    }
+}

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/HikariMetricsTracker.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/HikariMetricsTracker.java
@@ -1,0 +1,114 @@
+package io.aiven.inkless.control_plane.postgres;
+
+import com.zaxxer.hikari.metrics.IMetricsTracker;
+import com.zaxxer.hikari.metrics.PoolStats;
+import io.aiven.inkless.common.metrics.SensorProvider;
+import io.aiven.inkless.common.metrics.MeasurableValue;
+import org.apache.kafka.common.MetricNameTemplate;
+import org.apache.kafka.common.metrics.JmxReporter;
+import org.apache.kafka.common.metrics.KafkaMetricsContext;
+import org.apache.kafka.common.metrics.MetricConfig;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.metrics.stats.Avg;
+import org.apache.kafka.common.metrics.stats.Max;
+import org.apache.kafka.common.utils.Time;
+
+import java.util.List;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.function.Supplier;
+
+import static io.aiven.inkless.control_plane.postgres.HikariMetricsRegistry.ACTIVE_CONNECTIONS_COUNT;
+import static io.aiven.inkless.control_plane.postgres.HikariMetricsRegistry.CONNECTION_ACQUIRED_NANOS;
+import static io.aiven.inkless.control_plane.postgres.HikariMetricsRegistry.CONNECTION_TIMEOUT_COUNT;
+import static io.aiven.inkless.control_plane.postgres.HikariMetricsRegistry.CONNECTION_USAGE_MILLIS;
+import static io.aiven.inkless.control_plane.postgres.HikariMetricsRegistry.IDLE_CONNECTIONS_COUNT;
+import static io.aiven.inkless.control_plane.postgres.HikariMetricsRegistry.MAX_CONNECTIONS_COUNT;
+import static io.aiven.inkless.control_plane.postgres.HikariMetricsRegistry.METRIC_CONTEXT;
+import static io.aiven.inkless.control_plane.postgres.HikariMetricsRegistry.MIN_CONNECTIONS_COUNT;
+import static io.aiven.inkless.control_plane.postgres.HikariMetricsRegistry.PENDING_THREADS_COUNT;
+import static io.aiven.inkless.control_plane.postgres.HikariMetricsRegistry.TOTAL_CONNECTIONS_COUNT;
+
+public class HikariMetricsTracker implements IMetricsTracker {
+    private final Metrics metrics;
+    final HikariMetricsRegistry metricsRegistry;
+
+    private final LongAdder connectionTimeoutCount = new LongAdder();
+
+    private final Sensor activeConnectionsCountSensor;
+    private final Sensor totalConnectionsCountSensor;
+    private final Sensor idleConnectionsCountSensor;
+    private final Sensor maxConnectionsCountSensor;
+    private final Sensor minConnectionsCountSensor;
+    private final Sensor pendingThreadsCountSensor;
+    private final Sensor connectionTimeoutCountSensor;
+
+
+    public HikariMetricsTracker(String poolName, PoolStats poolStats) {
+        final JmxReporter reporter = new JmxReporter();
+        this.metrics = new Metrics(
+            new MetricConfig(), List.of(reporter), Time.SYSTEM,
+            new KafkaMetricsContext(METRIC_CONTEXT)
+        );
+
+        metricsRegistry = new HikariMetricsRegistry(poolName);
+        activeConnectionsCountSensor = registerSensor(metricsRegistry.activeConnectionsCountMetricName, ACTIVE_CONNECTIONS_COUNT, () -> (long) poolStats.getActiveConnections());
+        totalConnectionsCountSensor = registerSensor(metricsRegistry.totalConnectionsCountMetricName, TOTAL_CONNECTIONS_COUNT, () -> (long) poolStats.getTotalConnections());
+        idleConnectionsCountSensor = registerSensor(metricsRegistry.idleConnectionsCountMetricName, IDLE_CONNECTIONS_COUNT, () -> (long) poolStats.getIdleConnections());
+        maxConnectionsCountSensor = registerSensor(metricsRegistry.maxConnectionsCountMetricName, MAX_CONNECTIONS_COUNT, () -> (long) poolStats.getMaxConnections());
+        minConnectionsCountSensor = registerSensor(metricsRegistry.minConnectionsCountMetricName, MIN_CONNECTIONS_COUNT, () -> (long) poolStats.getMinConnections());
+        pendingThreadsCountSensor = registerSensor(metricsRegistry.pendingThreadsCountMetricName, PENDING_THREADS_COUNT, () -> (long) poolStats.getPendingThreads());
+
+        connectionTimeoutCountSensor = registerSensor(metricsRegistry.connectionTimeoutCountMetricName, CONNECTION_TIMEOUT_COUNT, connectionTimeoutCount::sum);
+    }
+
+    @Override
+    public void recordConnectionAcquiredNanos(long elapsedAcquiredNanos) {
+        new SensorProvider(metrics, CONNECTION_ACQUIRED_NANOS)
+            .with(metricsRegistry.connectionAcquiredNanosAvgMetricName, new Avg())
+            .with(metricsRegistry.connectionAcquiredNanosMaxMetricName, new Max())
+            .get()
+            .record(elapsedAcquiredNanos);
+    }
+
+    @Override
+    public void recordConnectionUsageMillis(long elapsedBorrowedMillis) {
+        new SensorProvider(metrics, CONNECTION_USAGE_MILLIS)
+            .with(metricsRegistry.connectionUsageMillisAvgMetricName, new Avg())
+            .with(metricsRegistry.connectionUsageMillisMaxMetricName, new Max())
+            .get()
+            .record(elapsedBorrowedMillis);
+    }
+
+    @Override
+    public void recordConnectionTimeout() {
+        connectionTimeoutCount.increment();
+    }
+
+    @Override
+    public void close() {
+        // Implement any cleanup logic if necessary
+    }
+
+    Sensor registerSensor(final MetricNameTemplate metricName, final String sensorName, final Supplier<Long> supplier) {
+        return new SensorProvider(metrics, sensorName)
+            .with(metricName, new MeasurableValue(supplier))
+            .get();
+    }
+
+    @Override
+    public String toString() {
+        return "HikariMetricsTracker{" +
+            "metrics=" + metrics +
+            ", metricsRegistry=" + metricsRegistry +
+            ", connectionTimeoutCount=" + connectionTimeoutCount +
+            ", activeConnectionsCountSensor=" + activeConnectionsCountSensor +
+            ", totalConnectionsCountSensor=" + totalConnectionsCountSensor +
+            ", idleConnectionsCountSensor=" + idleConnectionsCountSensor +
+            ", maxConnectionsCountSensor=" + maxConnectionsCountSensor +
+            ", minConnectionsCountSensor=" + minConnectionsCountSensor +
+            ", pendingThreadsCountSensor=" + pendingThreadsCountSensor +
+            ", connectionTimeoutCountSensor=" + connectionTimeoutCountSensor +
+            '}';
+    }
+}

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/PostgresControlPlane.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/PostgresControlPlane.java
@@ -65,6 +65,7 @@ import io.aiven.inkless.control_plane.MergedFileBatch;
 public class PostgresControlPlane extends AbstractControlPlane {
     private final PostgresControlPlaneMetrics metrics;
 
+
     private HikariDataSource hikariDataSource;
     private DSLContext jooqCtx;
     private PostgresControlPlaneConfig controlPlaneConfig;
@@ -87,10 +88,11 @@ public class PostgresControlPlane extends AbstractControlPlane {
         Migrations.migrate(controlPlaneConfig);
 
         final HikariConfig config = new HikariConfig();
+        config.setPoolName("inkless-control-plane");
         config.setJdbcUrl(controlPlaneConfig.connectionString());
         config.setUsername(controlPlaneConfig.username());
         config.setPassword(controlPlaneConfig.password());
-
+        config.setMetricsTrackerFactory(HikariMetricsTracker::new);
         config.setTransactionIsolation(IsolationLevel.TRANSACTION_READ_COMMITTED.name());
 
         config.setMaximumPoolSize(controlPlaneConfig.maxConnections());


### PR DESCRIPTION
Include a metrics tracker for Hikari using Kafka metrics module.

As Kafka does not have a valid dependency for easier instrumentation, a metric tracker implementation has been included.
