### PR TITLE
fix(inkless): Use static factory method for HikariMetricsTracker creation

### DIFF
--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/PostgresControlPlane.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/PostgresControlPlane.java
@@ -93,7 +93,7 @@ public class PostgresControlPlane extends AbstractControlPlane {
         config.setJdbcUrl(controlPlaneConfig.connectionString());
         config.setUsername(controlPlaneConfig.username());
         config.setPassword(controlPlaneConfig.password());
-        config.setMetricsTrackerFactory(HikariMetricsTracker::new);
+        config.setMetricsTrackerFactory(HikariMetricsTracker::create);
         config.setTransactionIsolation(IsolationLevel.TRANSACTION_READ_COMMITTED.name());
 
         config.setMaximumPoolSize(controlPlaneConfig.maxConnections());


### PR DESCRIPTION
Necessary to avoid `this-escape` warning.

```
warning: [this-escape] possible 'this' escape before subclass is fully initialized

          activeConnectionsCountSensor = registerSensor(metricsRegistry.activeConnectionsCountMetricName, ACTIVE_CONNECTIONS_COUNT, () -> (long) poolStats.getActiveConnections()); 
```
