### PR TITLE
feat(inkless): add persistent storage for infinispan

### DIFF
--- a/core/src/main/scala/kafka/log/LogManager.scala
+++ b/core/src/main/scala/kafka/log/LogManager.scala
@@ -17,6 +17,8 @@
 
 package kafka.log
 
+import io.aiven.inkless.cache.ObjectCache
+
 import java.lang.{Long => JLong}
 import java.io.{File, IOException}
 import java.nio.file.{Files, NoSuchFileException}
@@ -41,7 +43,7 @@ import org.apache.kafka.metadata.properties.{MetaProperties, MetaPropertiesEnsem
 import java.util.{Collections, Optional, OptionalLong, Properties}
 import org.apache.kafka.server.metrics.KafkaMetricsGroup
 import org.apache.kafka.server.util.{FileLock, Scheduler}
-import org.apache.kafka.storage.internals.log.{CleanerConfig, LogCleaner, LogConfig, LogDirFailureChannel, LogManager => JLogManager, LogOffsetsListener, ProducerStateManagerConfig, RemoteIndexCache, UnifiedLog}
+import org.apache.kafka.storage.internals.log.{CleanerConfig, LogCleaner, LogConfig, LogDirFailureChannel, LogOffsetsListener, ProducerStateManagerConfig, RemoteIndexCache, UnifiedLog, LogManager => JLogManager}
 import org.apache.kafka.storage.internals.checkpoint.{CleanShutdownFileHandler, OffsetCheckpointFile}
 import org.apache.kafka.storage.log.metrics.BrokerTopicStats
 
@@ -461,6 +463,8 @@ class LogManager(logDirs: Seq[File],
             // Ignore remote-log-index-cache directory as that is index cache maintained by tiered storage subsystem
             // but not any topic-partition dir.
             !logDir.getName.equals(RemoteIndexCache.DIR_NAME) &&
+            // Ignore inkless-cache directory as that is a cache maintained by the inkless subsystem
+            !logDir.getName.equals(ObjectCache.INKLESS_CACHE_DIR_NAME) &&
             UnifiedLog.parseTopicPartitionName(logDir).topic != KafkaRaftServer.MetadataTopic)
         numTotalLogs += logsToLoad.length
         numRemainingLogs.put(logDirAbsolutePath, logsToLoad.length)

--- a/core/src/main/scala/kafka/log/LogManager.scala
+++ b/core/src/main/scala/kafka/log/LogManager.scala
@@ -17,7 +17,7 @@
 
 package kafka.log
 
-import io.aiven.inkless.cache.ObjectCache
+import io.aiven.inkless.cache.InfinispanCache
 
 import java.lang.{Long => JLong}
 import java.io.{File, IOException}
@@ -43,7 +43,7 @@ import org.apache.kafka.metadata.properties.{MetaProperties, MetaPropertiesEnsem
 import java.util.{Collections, Optional, OptionalLong, Properties}
 import org.apache.kafka.server.metrics.KafkaMetricsGroup
 import org.apache.kafka.server.util.{FileLock, Scheduler}
-import org.apache.kafka.storage.internals.log.{CleanerConfig, LogCleaner, LogConfig, LogDirFailureChannel, LogOffsetsListener, ProducerStateManagerConfig, RemoteIndexCache, UnifiedLog, LogManager => JLogManager}
+import org.apache.kafka.storage.internals.log.{CleanerConfig, LogCleaner, LogConfig, LogDirFailureChannel, LogManager => JLogManager, LogOffsetsListener, ProducerStateManagerConfig, RemoteIndexCache, UnifiedLog}
 import org.apache.kafka.storage.internals.checkpoint.{CleanShutdownFileHandler, OffsetCheckpointFile}
 import org.apache.kafka.storage.log.metrics.BrokerTopicStats
 
@@ -464,7 +464,7 @@ class LogManager(logDirs: Seq[File],
             // but not any topic-partition dir.
             !logDir.getName.equals(RemoteIndexCache.DIR_NAME) &&
             // Ignore inkless-cache directory as that is a cache maintained by the inkless subsystem
-            !logDir.getName.equals(ObjectCache.INKLESS_CACHE_DIR_NAME) &&
+            !logDir.getName.equals(InfinispanCache.DIR_NAME) &&
             UnifiedLog.parseTopicPartitionName(logDir).topic != KafkaRaftServer.MetadataTopic)
         numTotalLogs += logsToLoad.length
         numRemainingLogs.put(logDirAbsolutePath, logsToLoad.length)

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -60,6 +60,7 @@ import org.apache.kafka.server.transaction.AddPartitionsToTxnManager
 import org.apache.kafka.storage.internals.log.LogDirFailureChannel
 import org.apache.kafka.storage.log.metrics.BrokerTopicStats
 
+import java.nio.file.Path
 import java.time.Duration
 import java.util
 import java.util.Optional
@@ -354,6 +355,7 @@ class BrokerServer(
           inklessMetadataView,
           controlPlane,
           brokerTopicStats,
+          Path.of(config.logDirs().get(0)),
           () => logManager.currentDefaultConfig
         )
       }

--- a/storage/inkless/src/main/java/io/aiven/inkless/cache/InfinispanCache.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/cache/InfinispanCache.java
@@ -17,6 +17,7 @@
  */
 package io.aiven.inkless.cache;
 
+import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.utils.ExponentialBackoff;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Timer;
@@ -32,6 +33,8 @@ import org.infinispan.manager.DefaultCacheManager;
 import org.infinispan.stats.Stats;
 
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
 
 import io.aiven.inkless.generated.CacheKey;
@@ -51,43 +54,90 @@ public class InfinispanCache implements ObjectCache {
 
     private InfinispanCacheMetrics metrics;
 
-    public static InfinispanCache build(Time time, String clusterId, String rack, long maxCacheSize) {
-        final InfinispanCache infinispanCache = new InfinispanCache(time, clusterId, rack, maxCacheSize);
+    public static InfinispanCache build(
+        Time time,
+        String clusterId,
+        String rack,
+        long maxCacheSize,
+        Path basePath,
+        boolean isPersistent,
+        long lifespanSeconds,
+        int maxIdleSeconds
+    ) {
+        final InfinispanCache infinispanCache = new InfinispanCache(time, clusterId, rack, maxCacheSize, basePath, isPersistent, lifespanSeconds, maxIdleSeconds);
         infinispanCache.initializeMetrics();
         return infinispanCache;
     }
 
-    private InfinispanCache(Time time, String clusterId, String rack, long maxCacheSize) {
+    public InfinispanCache(
+        Time time,
+        String clusterId,
+        String rack,
+        long maxCacheSize,
+        Path basePath,
+        boolean isPersistent,
+        long lifespanSeconds,
+        int maxIdleSeconds
+    ) {
         this.time = time;
         this.maxCacheSize = maxCacheSize;
         GlobalConfigurationBuilder globalConfig = GlobalConfigurationBuilder.defaultClusteredBuilder();
+        final String clusterName = clusterName(clusterId, rack);
         globalConfig.transport()
-            .clusterName(clusterName(clusterId, rack))
+            .clusterName(clusterName)
             .addProperty("configurationFile", "jgroups-udp.xml"); // Set bind port to 0
         globalConfig.serialization()
-                .addContextInitializers()
-                .marshaller(new KafkaMarshaller())
-                .allowList().addClasses(CacheKey.class, FileExtent.class);
-        cacheManager = new DefaultCacheManager(globalConfig.build());
+            .addContextInitializers()
+            .marshaller(new KafkaMarshaller())
+            .allowList().addClasses(CacheKey.class, FileExtent.class);
+        this.cacheManager = new DefaultCacheManager(globalConfig.build());
         ConfigurationBuilder config = new ConfigurationBuilder();
         config.statistics().enable();
         config.clustering()
-            .cacheMode(CacheMode.DIST_SYNC)
-            .memory()
+            .cacheMode(CacheMode.DIST_SYNC);
+        config.memory()
             .storage(StorageType.HEAP)
             .maxCount(maxCacheSize)
             .whenFull(EvictionStrategy.REMOVE);
-        cache = cacheManager.administration()
-                .withFlags(CacheContainerAdmin.AdminFlag.VOLATILE)
-                .getOrCreateCache("fileExtents", config.build());
-        backoff = new ExponentialBackoff(1, CACHE_WRITE_BACKOFF_EXP_BASE, CACHE_WRITE_BACKOFF_EXP_BASE, CACHE_WRITE_BACKOFF_JITTER);
+        if (isPersistent) {
+            // Prepare the cache directory within a known location. Index and data directories are created within this directory.
+            final Path cacheBasePath = cachePersistenceDir(basePath);
+            config.persistence()
+                .passivation(true)
+                .addSoftIndexFileStore()
+                .shared(false)
+                .purgeOnStartup(true)
+                .dataLocation(cacheBasePath.resolve("data").toAbsolutePath().toString())
+                .indexLocation(cacheBasePath.resolve("index").toAbsolutePath().toString());
+            // There is not explicit way to define how much space the cache can use on disk,
+            // there are only two proxies: lifespan (fixed time to keep an entry)
+            // and maxIdle (how long to keep it without being accessed).
+            // Lifespan is the only that can guarantee that the cache will not grow indefinitely.
+            // To estimate the maximum disk usage use maximum buffer size and number of uploading threads.
+            // e.g. 6MB buffer size * 10 threads = 60MB maximum disk usage per sec.
+            // 5 minutes lifespan = 60MB * 300 seconds = 18GB maximum disk usage.
+            // Lifespan is enforced, but maxIdle can be disabled (it is by default).
+            config.expiration()
+                // maximum time an entry can live in the cache (fixed)
+                .lifespan(lifespanSeconds, TimeUnit.SECONDS)
+                // maximum time an entry is idle (not accessed) before it is evicted
+                // entries expire based on either lifespan or maxIdle, whichever happens first
+                // when disabled and only lifespan is used
+                .maxIdle(maxIdleSeconds, TimeUnit.SECONDS)
+                // how often the cache checks for expired entries
+                .wakeUpInterval(5, TimeUnit.SECONDS);
+        }
+        this.cache = cacheManager.administration()
+            .withFlags(CacheContainerAdmin.AdminFlag.VOLATILE)
+            .getOrCreateCache("fileExtents", config.build());
+        this.backoff = new ExponentialBackoff(1, CACHE_WRITE_BACKOFF_EXP_BASE, CACHE_WRITE_BACKOFF_EXP_BASE, CACHE_WRITE_BACKOFF_JITTER);
     }
 
     private void initializeMetrics() {
         this.metrics = new InfinispanCacheMetrics(this);
     }
 
-    private static String clusterName(String clusterId, String rack) {
+    static String clusterName(String clusterId, String rack) {
         // To avoid cross-rack traffic, include rack in the cluster name
         // Clusters with different names don't share data or storage
         return "inkless-" + clusterId + (rack != null ? "-" + rack : "" );
@@ -119,7 +169,7 @@ public class InfinispanCache implements ObjectCache {
 
     @Override
     public void put(CacheKey key, FileExtent value) {
-        cache.put(key, value, 1L, TimeUnit.MINUTES);
+        cache.put(key, value);
     }
 
     @Override
@@ -146,4 +196,21 @@ public class InfinispanCache implements ObjectCache {
     public Stats metrics() {
         return cache.getAdvancedCache().getStats();
     }
+
+    static Path cachePersistenceDir(Path baseDir) {
+        final Path p = baseDir.resolve(INKLESS_CACHE_DIR_NAME);
+        if (!Files.exists(p)) {
+            try {
+                return Files.createDirectories(p);
+            } catch (IOException e) {
+                throw new ConfigException("Failed to create cache directories", e);
+            }
+        } else if (!Files.isDirectory(p)) {
+            throw new ConfigException("Cache persistence directory is not a directory: " + p);
+        } else if (!Files.isWritable(p)) {
+            throw new ConfigException("Cache persistence directory is not writable: " + p);
+        }
+        return p;
+    }
+
 }

--- a/storage/inkless/src/main/java/io/aiven/inkless/cache/InfinispanCache.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/cache/InfinispanCache.java
@@ -41,6 +41,7 @@ import io.aiven.inkless.generated.CacheKey;
 import io.aiven.inkless.generated.FileExtent;
 
 public class InfinispanCache implements ObjectCache {
+    public static final String DIR_NAME = "inkless-cache";
 
     // Length of time the object is "leased" to the caller if not already present in the map
     private static final int CACHE_WRITE_LOCK_TIMEOUT_MS = 10000;
@@ -198,7 +199,7 @@ public class InfinispanCache implements ObjectCache {
     }
 
     static Path cachePersistenceDir(Path baseDir) {
-        final Path p = baseDir.resolve(INKLESS_CACHE_DIR_NAME);
+        final Path p = baseDir.resolve(DIR_NAME);
         if (!Files.exists(p)) {
             try {
                 return Files.createDirectories(p);

--- a/storage/inkless/src/main/java/io/aiven/inkless/cache/ObjectCache.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/cache/ObjectCache.java
@@ -25,4 +25,5 @@ import io.aiven.inkless.generated.CacheKey;
 import io.aiven.inkless.generated.FileExtent;
 
 public interface ObjectCache extends Cache<CacheKey, FileExtent>, Closeable {
+    String INKLESS_CACHE_DIR_NAME = "inkless-cache";
 }

--- a/storage/inkless/src/main/java/io/aiven/inkless/cache/ObjectCache.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/cache/ObjectCache.java
@@ -25,5 +25,4 @@ import io.aiven.inkless.generated.CacheKey;
 import io.aiven.inkless.generated.FileExtent;
 
 public interface ObjectCache extends Cache<CacheKey, FileExtent>, Closeable {
-    String INKLESS_CACHE_DIR_NAME = "inkless-cache";
 }

--- a/storage/inkless/src/main/java/io/aiven/inkless/common/SharedState.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/common/SharedState.java
@@ -77,8 +77,8 @@ public record SharedState(
                 config.cacheMaxCount(),
                 logDir,
                 config.isCachePersistenceEnabled(),
-                config.cachePersistenceLifespanSec(),
-                config.cachePersistenceMaxIdleSec()
+                config.cacheExpirationLifespanSec(),
+                config.cacheExpirationMaxIdleSec()
             ),
             brokerTopicStats,
             defaultTopicConfigs

--- a/storage/inkless/src/main/java/io/aiven/inkless/common/SharedState.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/common/SharedState.java
@@ -23,6 +23,7 @@ import org.apache.kafka.storage.log.metrics.BrokerTopicStats;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.function.Supplier;
 
 import io.aiven.inkless.cache.FixedBlockAlignment;
@@ -57,6 +58,7 @@ public record SharedState(
         MetadataView metadata,
         ControlPlane controlPlane,
         BrokerTopicStats brokerTopicStats,
+        Path logDir,
         Supplier<LogConfig> defaultTopicConfigs
     ) {
         return new SharedState(
@@ -68,7 +70,16 @@ public record SharedState(
             config.storage(),
             ObjectKey.creator(config.objectKeyPrefix(), config.objectKeyLogPrefixMasked()),
             new FixedBlockAlignment(config.fetchCacheBlockBytes()),
-            InfinispanCache.build(time, clusterId, rack, config.cacheMaxCount()),
+            InfinispanCache.build(
+                time,
+                clusterId,
+                rack,
+                config.cacheMaxCount(),
+                logDir,
+                config.isCachePersistenceEnabled(),
+                config.cachePersistenceLifespanSec(),
+                config.cachePersistenceMaxIdleSec()
+            ),
             brokerTopicStats,
             defaultTopicConfigs
         );

--- a/storage/inkless/src/main/java/io/aiven/inkless/config/InklessConfig.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/config/InklessConfig.java
@@ -78,8 +78,23 @@ public class InklessConfig extends AbstractConfig {
     private static final int CONSUME_CACHE_BLOCK_BYTES_DEFAULT = 16 * 1024 * 1024;  // 16 MiB
 
     public static final String CONSUME_CACHE_MAX_COUNT_CONFIG = CONSUME_PREFIX + "cache.max.count";
-    private static final String CONSUME_CACHE_MAX_COUNT_DOC = "The maximum number of objects to cache in memory.";
+    private static final String CONSUME_CACHE_MAX_COUNT_DOC = "The maximum number of objects to cache in memory. " +
+        "If the cache exceeds this limit, and the cache persistence is enabled, " +
+        "the least recently used objects will be persisted to disk and removed from memory.";
     private static final int CONSUME_CACHE_MAX_COUNT_DEFAULT = 1000;
+
+    public static final String CONSUME_CACHE_PERSISTENCE_ENABLE_CONFIG = CONSUME_PREFIX + "cache.persistence.enable";
+    private static final String CONSUME_CACHE_PERSISTENCE_ENABLE_DOC = "Enable cache persistence to disk. " +
+        "If this is not set, the cache will not be persisted to disk. " +
+        "If this is set, the cache will be persisted to disk when it exceeds the maximum count limit.";
+
+    public static final String CONSUME_CACHE_PERSISTENCE_LIFESPAN_SEC_CONFIG = CONSUME_PREFIX + "cache.persistence.lifespan.sec";
+    private static final String CONSUME_CACHE_PERSISTENCE_LIFESPAN_SEC_DOC = "The lifespan in seconds of a cache entry before it will be removed from all storages.";
+    private static final int CONSUME_CACHE_PERSISTENCE_LIFESPAN_SEC_DEFAULT = 60; // Defaults to 1 minute
+
+    public static final String CONSUME_CACHE_PERSISTENCE_MAX_IDLE_SEC_CONFIG = CONSUME_PREFIX + "cache.persistence.max.idle.sec";
+    private static final String CONSUME_CACHE_PERSISTENCE_MAX_IDLE_SEC_DOC = "The maximum idle time in seconds before a cache entry will be removed from all storages.";
+    private static final int CONSUME_CACHE_PERSISTENCE_MAX_IDLE_SEC_DEFAULT = -1;
 
     public static final String RETENTION_ENFORCEMENT_INTERVAL_MS_CONFIG = "retention.enforcement.interval.ms";
     private static final String RETENTION_ENFORCEMENT_INTERVAL_MS_DOC = "The interval with which to enforce retention policies on a partition. " +
@@ -243,6 +258,29 @@ public class InklessConfig extends AbstractConfig {
             CONSUME_CACHE_MAX_COUNT_DOC
         );
         configDef.define(
+            CONSUME_CACHE_PERSISTENCE_ENABLE_CONFIG,
+            ConfigDef.Type.BOOLEAN,
+            false,
+            ConfigDef.Importance.LOW,
+            CONSUME_CACHE_PERSISTENCE_ENABLE_DOC
+        );
+        configDef.define(
+            CONSUME_CACHE_PERSISTENCE_LIFESPAN_SEC_CONFIG,
+            ConfigDef.Type.INT,
+            CONSUME_CACHE_PERSISTENCE_LIFESPAN_SEC_DEFAULT,
+            ConfigDef.Range.atLeast(10), // As it checks every 5 seconds
+            ConfigDef.Importance.LOW,
+            CONSUME_CACHE_PERSISTENCE_LIFESPAN_SEC_DOC
+        );
+        configDef.define(
+            CONSUME_CACHE_PERSISTENCE_MAX_IDLE_SEC_CONFIG,
+            ConfigDef.Type.INT,
+            CONSUME_CACHE_PERSISTENCE_MAX_IDLE_SEC_DEFAULT,
+            ConfigDef.Range.atLeast(-1), // As it checks every 5 seconds
+            ConfigDef.Importance.LOW,
+            CONSUME_CACHE_PERSISTENCE_MAX_IDLE_SEC_DOC
+        );
+        configDef.define(
             PRODUCE_UPLOAD_THREAD_POOL_SIZE_CONFIG,
             ConfigDef.Type.INT,
             PRODUCE_UPLOAD_THREAD_POOL_SIZE_DEFAULT,
@@ -328,6 +366,18 @@ public class InklessConfig extends AbstractConfig {
 
     public Long cacheMaxCount() {
         return getLong(CONSUME_CACHE_MAX_COUNT_CONFIG);
+    }
+
+    public boolean isCachePersistenceEnabled() {
+        return getBoolean(CONSUME_CACHE_PERSISTENCE_ENABLE_CONFIG);
+    }
+
+    public int cachePersistenceLifespanSec() {
+        return getInt(CONSUME_CACHE_PERSISTENCE_LIFESPAN_SEC_CONFIG);
+    }
+
+    public int cachePersistenceMaxIdleSec() {
+        return getInt(CONSUME_CACHE_PERSISTENCE_MAX_IDLE_SEC_CONFIG);
     }
 
     public int produceUploadThreadPoolSize() {

--- a/storage/inkless/src/main/java/io/aiven/inkless/config/InklessConfig.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/config/InklessConfig.java
@@ -88,13 +88,14 @@ public class InklessConfig extends AbstractConfig {
         "If this is not set, the cache will not be persisted to disk. " +
         "If this is set, the cache will be persisted to disk when it exceeds the maximum count limit.";
 
-    public static final String CONSUME_CACHE_PERSISTENCE_LIFESPAN_SEC_CONFIG = CONSUME_PREFIX + "cache.persistence.lifespan.sec";
-    private static final String CONSUME_CACHE_PERSISTENCE_LIFESPAN_SEC_DOC = "The lifespan in seconds of a cache entry before it will be removed from all storages.";
-    private static final int CONSUME_CACHE_PERSISTENCE_LIFESPAN_SEC_DEFAULT = 60; // Defaults to 1 minute
+    public static final String CONSUME_CACHE_EXPIRATION_LIFESPAN_SEC_CONFIG = CONSUME_PREFIX + "cache.expiration.lifespan.sec";
+    private static final String CONSUME_CACHE_EXPIRATION_LIFESPAN_SEC_DOC = "The lifespan in seconds of a cache entry before it will be removed from all storages.";
+    private static final int CONSUME_CACHE_EXPIRATION_LIFESPAN_SEC_DEFAULT = 60; // Defaults to 1 minute
 
-    public static final String CONSUME_CACHE_PERSISTENCE_MAX_IDLE_SEC_CONFIG = CONSUME_PREFIX + "cache.persistence.max.idle.sec";
-    private static final String CONSUME_CACHE_PERSISTENCE_MAX_IDLE_SEC_DOC = "The maximum idle time in seconds before a cache entry will be removed from all storages.";
-    private static final int CONSUME_CACHE_PERSISTENCE_MAX_IDLE_SEC_DEFAULT = -1;
+    public static final String CONSUME_CACHE_EXPIRATION_MAX_IDLE_SEC_CONFIG = CONSUME_PREFIX + "cache.expiration.max.idle.sec";
+    private static final String CONSUME_CACHE_EXPIRATION_MAX_IDLE_SEC_DOC = "The maximum idle time in seconds before a cache entry will be removed from all storages. " +
+        "-1 means disabled, and entries will not be removed based on idle time.";
+    private static final int CONSUME_CACHE_EXPIRATION_MAX_IDLE_SEC_DEFAULT = -1; // Disabled by default
 
     public static final String RETENTION_ENFORCEMENT_INTERVAL_MS_CONFIG = "retention.enforcement.interval.ms";
     private static final String RETENTION_ENFORCEMENT_INTERVAL_MS_DOC = "The interval with which to enforce retention policies on a partition. " +
@@ -265,20 +266,20 @@ public class InklessConfig extends AbstractConfig {
             CONSUME_CACHE_PERSISTENCE_ENABLE_DOC
         );
         configDef.define(
-            CONSUME_CACHE_PERSISTENCE_LIFESPAN_SEC_CONFIG,
+            CONSUME_CACHE_EXPIRATION_LIFESPAN_SEC_CONFIG,
             ConfigDef.Type.INT,
-            CONSUME_CACHE_PERSISTENCE_LIFESPAN_SEC_DEFAULT,
+            CONSUME_CACHE_EXPIRATION_LIFESPAN_SEC_DEFAULT,
             ConfigDef.Range.atLeast(10), // As it checks every 5 seconds
             ConfigDef.Importance.LOW,
-            CONSUME_CACHE_PERSISTENCE_LIFESPAN_SEC_DOC
+            CONSUME_CACHE_EXPIRATION_LIFESPAN_SEC_DOC
         );
         configDef.define(
-            CONSUME_CACHE_PERSISTENCE_MAX_IDLE_SEC_CONFIG,
+            CONSUME_CACHE_EXPIRATION_MAX_IDLE_SEC_CONFIG,
             ConfigDef.Type.INT,
-            CONSUME_CACHE_PERSISTENCE_MAX_IDLE_SEC_DEFAULT,
+            CONSUME_CACHE_EXPIRATION_MAX_IDLE_SEC_DEFAULT,
             ConfigDef.Range.atLeast(-1), // As it checks every 5 seconds
             ConfigDef.Importance.LOW,
-            CONSUME_CACHE_PERSISTENCE_MAX_IDLE_SEC_DOC
+            CONSUME_CACHE_EXPIRATION_MAX_IDLE_SEC_DOC
         );
         configDef.define(
             PRODUCE_UPLOAD_THREAD_POOL_SIZE_CONFIG,
@@ -372,12 +373,12 @@ public class InklessConfig extends AbstractConfig {
         return getBoolean(CONSUME_CACHE_PERSISTENCE_ENABLE_CONFIG);
     }
 
-    public int cachePersistenceLifespanSec() {
-        return getInt(CONSUME_CACHE_PERSISTENCE_LIFESPAN_SEC_CONFIG);
+    public int cacheExpirationLifespanSec() {
+        return getInt(CONSUME_CACHE_EXPIRATION_LIFESPAN_SEC_CONFIG);
     }
 
-    public int cachePersistenceMaxIdleSec() {
-        return getInt(CONSUME_CACHE_PERSISTENCE_MAX_IDLE_SEC_CONFIG);
+    public int cacheExpirationMaxIdleSec() {
+        return getInt(CONSUME_CACHE_EXPIRATION_MAX_IDLE_SEC_CONFIG);
     }
 
     public int produceUploadThreadPoolSize() {

--- a/storage/inkless/src/main/java/io/aiven/inkless/config/InklessConfig.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/config/InklessConfig.java
@@ -269,7 +269,7 @@ public class InklessConfig extends AbstractConfig {
             CONSUME_CACHE_EXPIRATION_LIFESPAN_SEC_CONFIG,
             ConfigDef.Type.INT,
             CONSUME_CACHE_EXPIRATION_LIFESPAN_SEC_DEFAULT,
-            ConfigDef.Range.atLeast(10), // As it checks every 5 seconds
+            ConfigDef.Range.atLeast(10), // As it checks every 5 seconds, and the object lock timeout is 10 secs.
             ConfigDef.Importance.LOW,
             CONSUME_CACHE_EXPIRATION_LIFESPAN_SEC_DOC
         );
@@ -277,7 +277,7 @@ public class InklessConfig extends AbstractConfig {
             CONSUME_CACHE_EXPIRATION_MAX_IDLE_SEC_CONFIG,
             ConfigDef.Type.INT,
             CONSUME_CACHE_EXPIRATION_MAX_IDLE_SEC_DEFAULT,
-            ConfigDef.Range.atLeast(-1), // As it checks every 5 seconds
+            ConfigDef.Range.atLeast(-1),
             ConfigDef.Importance.LOW,
             CONSUME_CACHE_EXPIRATION_MAX_IDLE_SEC_DOC
         );

--- a/storage/inkless/src/test/java/io/aiven/inkless/cache/InfinispanCacheTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/cache/InfinispanCacheTest.java
@@ -1,0 +1,144 @@
+package io.aiven.inkless.cache;
+
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.common.utils.Time;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
+
+import static io.aiven.inkless.cache.ObjectCache.INKLESS_CACHE_DIR_NAME;
+import static org.junit.jupiter.api.Assertions.*;
+
+class InfinispanCacheTest {
+
+    final Time time = new MockTime();
+
+    @TempDir
+    Path baseDir;
+
+    @Test
+    void testCacheCreationWithBasicConfig() throws IOException {
+        InfinispanCache cache = new InfinispanCache(
+            time,
+            "test-cluster",
+            "rack1",
+            1000L,
+            baseDir,
+            false,
+            300L,
+            60
+        );
+
+        assertNotNull(cache);
+        assertEquals(0, cache.size());
+        cache.close();
+    }
+
+    @Test
+    void testCacheCreationWithPersistentConfig() throws IOException {
+        InfinispanCache cache = new InfinispanCache(
+            time,
+            "test-cluster",
+            "rack1",
+            1000L,
+            baseDir,
+            true,
+            300L,
+            60
+        );
+
+        assertNotNull(cache);
+        assertEquals(0, cache.size());
+
+        // Verify cache directories are created
+        Path cacheDir = baseDir.resolve(INKLESS_CACHE_DIR_NAME);
+        assertTrue(Files.exists(cacheDir));
+        assertTrue(Files.isDirectory(cacheDir));
+
+        cache.close();
+    }
+
+    @Test
+    void testCachePersistenceDirCreation() {
+        Path result = InfinispanCache.cachePersistenceDir(baseDir);
+
+        assertNotNull(result);
+        assertTrue(Files.exists(result));
+        assertTrue(Files.isDirectory(result));
+        assertEquals(baseDir.resolve(INKLESS_CACHE_DIR_NAME), result);
+    }
+
+    @Test
+    void testCachePersistenceDirAlreadyExists() throws IOException {
+        Path cacheDir = baseDir.resolve(INKLESS_CACHE_DIR_NAME);
+        Files.createDirectories(cacheDir);
+
+        Path result = InfinispanCache.cachePersistenceDir(baseDir);
+
+        assertEquals(cacheDir, result);
+        assertTrue(Files.exists(result));
+        assertTrue(Files.isDirectory(result));
+    }
+
+    @Test
+    void testCachePersistenceDirNotDirectory() throws IOException {
+        Path notADir = baseDir.resolve(INKLESS_CACHE_DIR_NAME);
+        Files.createFile(notADir);
+
+        ConfigException exception = assertThrows(ConfigException.class, () -> InfinispanCache.cachePersistenceDir(baseDir));
+
+        assertTrue(exception.getMessage().contains("Cache persistence directory is not a directory"));
+    }
+
+    @Test
+    void testCachePersistenceDirNotWritable() throws IOException {
+        Path cacheDir = baseDir.resolve(INKLESS_CACHE_DIR_NAME);
+        Files.createDirectories(cacheDir);
+
+        // Make directory non-writable (Unix/Linux only)
+        try {
+            Files.setPosixFilePermissions(cacheDir, PosixFilePermissions.fromString("r-xr-xr-x"));
+
+            ConfigException exception = assertThrows(ConfigException.class, () -> {
+                InfinispanCache.cachePersistenceDir(baseDir);
+            });
+
+            assertTrue(exception.getMessage().contains("Cache persistence directory is not writable"));
+        } catch (UnsupportedOperationException e) {
+            // Skip this test on non-POSIX systems (like Windows)
+            System.out.println("Skipping writable test on non-POSIX system");
+        }
+    }
+
+    @Test
+    void testClusterNameGeneration() {
+        // Test with rack
+        assertEquals("inkless-cluster1-rack1", InfinispanCache.clusterName("cluster1", "rack1"));
+
+        // Test without rack
+        assertEquals("inkless-cluster1", InfinispanCache.clusterName("cluster1", null));
+    }
+
+    @Test
+    void testCacheMetricsInitialization() throws IOException {
+        InfinispanCache cache = new InfinispanCache(
+            time,
+            "test-cluster",
+            "rack1",
+            1000L,
+            baseDir,
+            false,
+            300L,
+            60
+        );
+
+        assertNotNull(cache.metrics());
+        cache.close();
+    }
+}

--- a/storage/inkless/src/test/java/io/aiven/inkless/cache/InfinispanCacheTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/cache/InfinispanCacheTest.java
@@ -12,7 +12,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermissions;
 
-import static io.aiven.inkless.cache.ObjectCache.INKLESS_CACHE_DIR_NAME;
 import static org.junit.jupiter.api.Assertions.*;
 
 class InfinispanCacheTest {
@@ -57,7 +56,7 @@ class InfinispanCacheTest {
         assertEquals(0, cache.size());
 
         // Verify cache directories are created
-        Path cacheDir = baseDir.resolve(INKLESS_CACHE_DIR_NAME);
+        Path cacheDir = baseDir.resolve("inkless-cache");
         assertTrue(Files.exists(cacheDir));
         assertTrue(Files.isDirectory(cacheDir));
 
@@ -71,12 +70,12 @@ class InfinispanCacheTest {
         assertNotNull(result);
         assertTrue(Files.exists(result));
         assertTrue(Files.isDirectory(result));
-        assertEquals(baseDir.resolve(INKLESS_CACHE_DIR_NAME), result);
+        assertEquals(baseDir.resolve("inkless-cache"), result);
     }
 
     @Test
     void testCachePersistenceDirAlreadyExists() throws IOException {
-        Path cacheDir = baseDir.resolve(INKLESS_CACHE_DIR_NAME);
+        Path cacheDir = baseDir.resolve("inkless-cache");
         Files.createDirectories(cacheDir);
 
         Path result = InfinispanCache.cachePersistenceDir(baseDir);
@@ -88,7 +87,7 @@ class InfinispanCacheTest {
 
     @Test
     void testCachePersistenceDirNotDirectory() throws IOException {
-        Path notADir = baseDir.resolve(INKLESS_CACHE_DIR_NAME);
+        Path notADir = baseDir.resolve("inkless-cache");
         Files.createFile(notADir);
 
         ConfigException exception = assertThrows(ConfigException.class, () -> InfinispanCache.cachePersistenceDir(baseDir));
@@ -98,7 +97,7 @@ class InfinispanCacheTest {
 
     @Test
     void testCachePersistenceDirNotWritable() throws IOException {
-        Path cacheDir = baseDir.resolve(INKLESS_CACHE_DIR_NAME);
+        Path cacheDir = baseDir.resolve("inkless-cache");
         Files.createDirectories(cacheDir);
 
         // Make directory non-writable (Unix/Linux only)

--- a/storage/inkless/src/test/java/io/aiven/inkless/config/InklessConfigTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/config/InklessConfigTest.java
@@ -49,8 +49,8 @@ class InklessConfigTest {
         configs.put("inkless.file.merger.interval.ms", "100");
         configs.put("inkless.consume.cache.max.count", "100");
         configs.put("inkless.consume.cache.persistence.enable", "true");
-        configs.put("inkless.consume.cache.persistence.lifespan.sec", "200");
-        configs.put("inkless.consume.cache.persistence.max.idle.sec", "100");
+        configs.put("inkless.consume.cache.expiration.lifespan.sec", "200");
+        configs.put("inkless.consume.cache.expiration.max.idle.sec", "100");
         configs.put("inkless.produce.upload.thread.pool.size", "16");
         final InklessConfig config = new InklessConfig(new AbstractConfig(new ConfigDef(), configs));
         assertThat(config.controlPlaneClass()).isEqualTo(InMemoryControlPlane.class);
@@ -66,8 +66,8 @@ class InklessConfigTest {
         assertThat(config.fileMergerInterval()).isEqualTo(Duration.ofMillis(100));
         assertThat(config.cacheMaxCount()).isEqualTo(100);
         assertThat(config.isCachePersistenceEnabled()).isTrue();
-        assertThat(config.cachePersistenceLifespanSec()).isEqualTo(200);
-        assertThat(config.cachePersistenceMaxIdleSec()).isEqualTo(100);
+        assertThat(config.cacheExpirationLifespanSec()).isEqualTo(200);
+        assertThat(config.cacheExpirationMaxIdleSec()).isEqualTo(100);
         assertThat(config.produceUploadThreadPoolSize()).isEqualTo(16);
     }
 
@@ -93,8 +93,8 @@ class InklessConfigTest {
         assertThat(config.fileMergerInterval()).isEqualTo(Duration.ofMinutes(1));
         assertThat(config.cacheMaxCount()).isEqualTo(1000);
         assertThat(config.isCachePersistenceEnabled()).isFalse();
-        assertThat(config.cachePersistenceLifespanSec()).isEqualTo(60);
-        assertThat(config.cachePersistenceMaxIdleSec()).isEqualTo(-1);
+        assertThat(config.cacheExpirationLifespanSec()).isEqualTo(60);
+        assertThat(config.cacheExpirationMaxIdleSec()).isEqualTo(-1);
         assertThat(config.produceUploadThreadPoolSize()).isEqualTo(8);
     }
 
@@ -114,8 +114,8 @@ class InklessConfigTest {
         configs.put("file.merger.interval.ms", "100");
         configs.put("consume.cache.max.count", "100");
         configs.put("consume.cache.persistence.enable", "true");
-        configs.put("consume.cache.persistence.lifespan.sec", "200");
-        configs.put("consume.cache.persistence.max.idle.sec", "100");
+        configs.put("consume.cache.expiration.lifespan.sec", "200");
+        configs.put("consume.cache.expiration.max.idle.sec", "100");
         configs.put("produce.upload.thread.pool.size", "16");
         final var config = new InklessConfig(
             configs
@@ -133,8 +133,8 @@ class InklessConfigTest {
         assertThat(config.fileMergerInterval()).isEqualTo(Duration.ofMillis(100));
         assertThat(config.cacheMaxCount()).isEqualTo(100);
         assertThat(config.isCachePersistenceEnabled()).isTrue();
-        assertThat(config.cachePersistenceLifespanSec()).isEqualTo(200);
-        assertThat(config.cachePersistenceMaxIdleSec()).isEqualTo(100);
+        assertThat(config.cacheExpirationLifespanSec()).isEqualTo(200);
+        assertThat(config.cacheExpirationMaxIdleSec()).isEqualTo(100);
         assertThat(config.produceUploadThreadPoolSize()).isEqualTo(16);
     }
 

--- a/storage/inkless/src/test/java/io/aiven/inkless/config/InklessConfigTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/config/InklessConfigTest.java
@@ -48,6 +48,9 @@ class InklessConfigTest {
         configs.put("inkless.file.cleaner.retention.period.ms", "200");
         configs.put("inkless.file.merger.interval.ms", "100");
         configs.put("inkless.consume.cache.max.count", "100");
+        configs.put("inkless.consume.cache.persistence.enable", "true");
+        configs.put("inkless.consume.cache.persistence.lifespan.sec", "200");
+        configs.put("inkless.consume.cache.persistence.max.idle.sec", "100");
         configs.put("inkless.produce.upload.thread.pool.size", "16");
         final InklessConfig config = new InklessConfig(new AbstractConfig(new ConfigDef(), configs));
         assertThat(config.controlPlaneClass()).isEqualTo(InMemoryControlPlane.class);
@@ -62,6 +65,9 @@ class InklessConfigTest {
         assertThat(config.fileCleanerRetentionPeriod()).isEqualTo(Duration.ofMillis(200));
         assertThat(config.fileMergerInterval()).isEqualTo(Duration.ofMillis(100));
         assertThat(config.cacheMaxCount()).isEqualTo(100);
+        assertThat(config.isCachePersistenceEnabled()).isTrue();
+        assertThat(config.cachePersistenceLifespanSec()).isEqualTo(200);
+        assertThat(config.cachePersistenceMaxIdleSec()).isEqualTo(100);
         assertThat(config.produceUploadThreadPoolSize()).isEqualTo(16);
     }
 
@@ -86,6 +92,9 @@ class InklessConfigTest {
         assertThat(config.fileCleanerRetentionPeriod()).isEqualTo(Duration.ofMinutes(1));
         assertThat(config.fileMergerInterval()).isEqualTo(Duration.ofMinutes(1));
         assertThat(config.cacheMaxCount()).isEqualTo(1000);
+        assertThat(config.isCachePersistenceEnabled()).isFalse();
+        assertThat(config.cachePersistenceLifespanSec()).isEqualTo(60);
+        assertThat(config.cachePersistenceMaxIdleSec()).isEqualTo(-1);
         assertThat(config.produceUploadThreadPoolSize()).isEqualTo(8);
     }
 
@@ -104,6 +113,9 @@ class InklessConfigTest {
         configs.put("file.cleaner.retention.period.ms", "200");
         configs.put("file.merger.interval.ms", "100");
         configs.put("consume.cache.max.count", "100");
+        configs.put("consume.cache.persistence.enable", "true");
+        configs.put("consume.cache.persistence.lifespan.sec", "200");
+        configs.put("consume.cache.persistence.max.idle.sec", "100");
         configs.put("produce.upload.thread.pool.size", "16");
         final var config = new InklessConfig(
             configs
@@ -120,6 +132,9 @@ class InklessConfigTest {
         assertThat(config.fileCleanerRetentionPeriod()).isEqualTo(Duration.ofMillis(200));
         assertThat(config.fileMergerInterval()).isEqualTo(Duration.ofMillis(100));
         assertThat(config.cacheMaxCount()).isEqualTo(100);
+        assertThat(config.isCachePersistenceEnabled()).isTrue();
+        assertThat(config.cachePersistenceLifespanSec()).isEqualTo(200);
+        assertThat(config.cachePersistenceMaxIdleSec()).isEqualTo(100);
         assertThat(config.produceUploadThreadPoolSize()).isEqualTo(16);
     }
 

--- a/storage/inkless/src/test/java/io/aiven/inkless/delete/FileCleanerIntegrationTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/delete/FileCleanerIntegrationTest.java
@@ -41,6 +41,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
@@ -51,6 +52,7 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -133,6 +135,8 @@ class FileCleanerIntegrationTest {
     MetadataView metadataView;
     @Mock
     Supplier<LogConfig> defaultTopicConfigs;
+    @TempDir
+    Path logDir;
 
     ControlPlane controlPlane;
     SharedState sharedState;
@@ -175,7 +179,7 @@ class FileCleanerIntegrationTest {
         final InklessConfig inklessConfig = new InklessConfig(config);
 
         sharedState = SharedState.initialize(time, "cluster-id", "az1", BROKER_ID, inklessConfig,
-            metadataView, controlPlane, new BrokerTopicStats(), defaultTopicConfigs);
+            metadataView, controlPlane, new BrokerTopicStats(), logDir, defaultTopicConfigs);
     }
 
     @AfterEach

--- a/storage/inkless/src/test/java/io/aiven/inkless/merge/FileMergerIntegrationTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/merge/FileMergerIntegrationTest.java
@@ -39,6 +39,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
@@ -154,6 +155,8 @@ class FileMergerIntegrationTest {
 
     ControlPlane controlPlane;
     SharedState sharedState;
+    @TempDir
+    Path logDir;
 
     @BeforeEach
     void setup() {
@@ -197,7 +200,7 @@ class FileMergerIntegrationTest {
         final InklessConfig inklessConfig = new InklessConfig(config);
 
         sharedState = SharedState.initialize(time, "cluster-id", "az1", BROKER_ID, inklessConfig,
-            metadataView, controlPlane, new BrokerTopicStats(), defaultTopicConfigs);
+            metadataView, controlPlane, new BrokerTopicStats(), logDir, defaultTopicConfigs);
 
         createTopics(controlPlane);
 

--- a/storage/inkless/src/test/java/io/aiven/inkless/merge/FileMergerMockedTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/merge/FileMergerMockedTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -108,6 +109,8 @@ class FileMergerMockedTest {
     ArgumentCaptor<ObjectKey> objectKeyCaptor;
     @Captor
     ArgumentCaptor<Long> sleepCaptor;
+    @TempDir
+    Path logDir;
 
     SharedState sharedState;
 
@@ -118,7 +121,7 @@ class FileMergerMockedTest {
         when(inklessConfig.cacheMaxCount()).thenReturn(10000L);
 
         sharedState = SharedState.initialize(time, "cluster-id", "rack", BROKER_ID, inklessConfig, mock(MetadataView.class), controlPlane,
-            mock(BrokerTopicStats.class), mock(Supplier.class));
+            mock(BrokerTopicStats.class), logDir, mock(Supplier.class));
     }
 
     @AfterEach


### PR DESCRIPTION
Enable Infinispan passivation feature that permits to use local disk as a second tier for cache entries.
By default, it reuses the log directory, so there is no need to create another volume and reuses the same storage as classic kafka. It adds a couple of knobs: lifespan and maxIdle to be used as a proxy on the amount of space cache entries could use.
