### PR TITLE
fix(inkless:demo): allow to pass version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ clean:
 DEMO := s3-local
 .PHONY: demo
 demo:
-	$(MAKE) -C docker/examples/docker-compose-files/inkless $(DEMO)
+	$(MAKE) -C docker/examples/docker-compose-files/inkless $(DEMO) KAFKA_VERSION=$(VERSION)
 
 core/build/distributions/kafka_2.13-$(VERSION): core/build/distributions/kafka_2.13-$(VERSION).tgz
 	tar -xf $< -C core/build/distributions

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ build:
 	./gradlew :core:build :storage:inkless:build :metadata:build -x test
 
 core/build/distributions/kafka_2.13-$(VERSION).tgz:
+	echo "Building Kafka distribution with version $(VERSION)"
 	./gradlew releaseTarGz
 
 .PHONY: build_release

--- a/docker/docker_build_test.py
+++ b/docker/docker_build_test.py
@@ -41,6 +41,10 @@ from common import execute, build_docker_image_runner
 import tempfile
 import os
 
+def build_inkless_docker_image(image, tag, image_type):
+    image = f'{image}:{tag}'
+    build_docker_image_runner(f"docker build -f $DOCKER_FILE -t {image} --build-arg kafka_url='' --build-arg kafka_version={tag} --build-arg build_date={date.today()} $DOCKER_DIR", image_type)
+
 def build_docker_image(image, tag, kafka_url, image_type):
     image = f'{image}:{tag}'
     build_docker_image_runner(f"docker build -f $DOCKER_FILE -t {image} --build-arg kafka_url={kafka_url} --build-arg build_date={date.today()} $DOCKER_DIR", image_type)
@@ -79,7 +83,7 @@ if __name__ == '__main__':
             build_docker_image(args.image, args.tag, args.kafka_url, args.image_type)
         else:
             if args.image_type == "inkless":
-                build_docker_image(args.image, args.tag, "", args.image_type)
+                build_inkless_docker_image(args.image, args.tag, args.image_type)
             else:
                 raise ValueError("--kafka-url is a required argument for docker image")
 

--- a/docker/examples/docker-compose-files/inkless/.env
+++ b/docker/examples/docker-compose-files/inkless/.env
@@ -1,0 +1,1 @@
+KAFKA_VERSION=4.1.0-inkless-SNAPSHOT

--- a/docker/examples/docker-compose-files/inkless/Makefile
+++ b/docker/examples/docker-compose-files/inkless/Makefile
@@ -6,7 +6,7 @@ in-memory:
 	$(MAKE) destroy
 
 .PHONY: s3-local
-s3-minio:
+s3-local:
 	$(DOCKER) compose -f docker-compose.yml -f docker-compose.monitoring.yml -f docker-compose.demo.yml -f docker-compose.s3-local.yml up
 	$(MAKE) destroy
 

--- a/docker/examples/docker-compose-files/inkless/Makefile
+++ b/docker/examples/docker-compose-files/inkless/Makefile
@@ -1,5 +1,7 @@
 DOCKER := docker
 
+KAFKA_VERSION ?= 4.1.0-inkless-SNAPSHOT
+
 .PHONY: in-memory
 in-memory:
 	docker compose -f docker-compose.yml -f docker-compose.monitoring.yml -f docker-compose.demo.yml up

--- a/docker/examples/docker-compose-files/inkless/docker-compose.demo.yml
+++ b/docker/examples/docker-compose-files/inkless/docker-compose.demo.yml
@@ -1,6 +1,6 @@
 services:
   create_topic:
-    image: aivenoy/kafka:4.1.0-inkless-SNAPSHOT
+    image: aivenoy/kafka:$KAFKA_VERSION
     restart: "no"
     depends_on:
       broker:

--- a/docker/examples/docker-compose-files/inkless/docker-compose.demo.yml
+++ b/docker/examples/docker-compose-files/inkless/docker-compose.demo.yml
@@ -1,6 +1,6 @@
 services:
   create_topic:
-    image: aivenoy/kafka:$KAFKA_VERSION
+    image: aivenoy/kafka:${KAFKA_VERSION}
     restart: "no"
     depends_on:
       broker:

--- a/docker/examples/docker-compose-files/inkless/docker-compose.yml
+++ b/docker/examples/docker-compose-files/inkless/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   broker: &base-broker
-    image: aivenoy/kafka:$KAFKA_VERSION
+    image: aivenoy/kafka:${KAFKA_VERSION}
     restart: unless-stopped
     ports:
       - "9092:9092"

--- a/docker/examples/docker-compose-files/inkless/docker-compose.yml
+++ b/docker/examples/docker-compose-files/inkless/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   broker: &base-broker
-    image: aivenoy/kafka:4.1.0-inkless-SNAPSHOT
+    image: aivenoy/kafka:$KAFKA_VERSION
     restart: unless-stopped
     ports:
       - "9092:9092"

--- a/docker/inkless/Dockerfile
+++ b/docker/inkless/Dockerfile
@@ -22,9 +22,9 @@ FROM eclipse-temurin:21-jre-alpine AS build-jsa
 
 USER root
 
-ENV KAFKA_VERSION=4.1.0-inkless-SNAPSHOT
+ARG kafka_version
 
-COPY ./resources/distributions/kafka_2.13-$KAFKA_VERSION.tgz /kafka.tgz
+COPY ./resources/distributions/kafka_2.13-$kafka_version.tgz /kafka.tgz
 COPY jsa_launch /etc/kafka/docker/jsa_launch
 
 RUN set -eux ; \
@@ -47,9 +47,9 @@ USER root
 
 ARG build_date
 
-ENV KAFKA_VERSION=4.1.0-inkless-SNAPSHOT
+ARG kafka_version
 
-COPY ./resources/distributions/kafka_2.13-$KAFKA_VERSION.tgz /kafka.tgz
+COPY ./resources/distributions/kafka_2.13-$kafka_version.tgz /kafka.tgz
 
 LABEL org.label-schema.name="kafka" \
       org.label-schema.description="Apache Kafka" \


### PR DESCRIPTION
Set of fixes to inkless demo to allow passing the kafka version to the image.
This is useful when trying to test a specific version (e.g. 4.0.0-inkless).