### PR TITLE
fix(inkless:ci): regerate jooq classes when not on jdk17

### DIFF
--- a/.github/workflows/inkless.yml
+++ b/.github/workflows/inkless.yml
@@ -97,6 +97,12 @@ jobs:
           gradle-cache-read-only: ${{ inputs.gradle-cache-read-only }}
           gradle-cache-write-only: ${{ inputs.gradle-cache-write-only }}
           develocity-access-key: ${{ secrets.GE_ACCESS_TOKEN }}
+      # JOOQ classes are generated on the previous validate job,
+      # but if generated with JDK 17, there are not warning suppressions for `this-escape` needed after JDK 21.
+      # see https://github.com/jOOQ/jOOQ/issues/15619
+      - name: Regenerate JOOQ classes (needed after JDK 21)
+        if: matrix.java != '17'
+        run: ./gradlew :storage:inkless:generateJooqClasses
       - name: Test
         # Gradle flags
         # --build-cache:  Let Gradle restore the build cache

--- a/.github/workflows/inkless.yml
+++ b/.github/workflows/inkless.yml
@@ -98,7 +98,7 @@ jobs:
           gradle-cache-write-only: ${{ inputs.gradle-cache-write-only }}
           develocity-access-key: ${{ secrets.GE_ACCESS_TOKEN }}
       # JOOQ classes are generated on the previous validate job,
-      # but if generated with JDK 17, there are not warning suppressions for `this-escape` needed after JDK 21.
+      # but if generated with JDK 17, there are no warning suppressions for `this-escape` needed after JDK 21.
       # see https://github.com/jOOQ/jOOQ/issues/15619
       - name: Regenerate JOOQ classes (needed after JDK 21)
         if: matrix.java != '17'


### PR DESCRIPTION
JDK17 is used on validation phase, and artifacts are reused on other jdks phases.
JOOQ classes if <21 they don't contain annotations to avoid `this-escape` compilation errors.

Adding JOOQ regeneration to avoid this.