### PR TITLE
GOV-1307: Fix data loss from empty objects after upload errors, harden against length mismatches

### DIFF
--- a/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/common/ObjectUploader.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/common/ObjectUploader.java
@@ -17,9 +17,7 @@
  */
 package io.aiven.inkless.storage_backend.common;
 
-import java.io.ByteArrayInputStream;
 import java.io.InputStream;
-import java.util.Objects;
 
 import io.aiven.inkless.common.ObjectKey;
 
@@ -35,12 +33,5 @@ public interface ObjectUploader {
      * @throws StorageBackendException if there are errors during the upload.
      */
     void upload(ObjectKey key, InputStream inputStream, long length) throws StorageBackendException;
-
-    default void upload(ObjectKey key, byte[] data) throws StorageBackendException {
-        Objects.requireNonNull(key, "key cannot be null");
-        Objects.requireNonNull(data, "data cannot be null");
-        var inputStream = new ByteArrayInputStream(data);
-        upload(key, inputStream, data.length);
-    }
 
 }

--- a/storage/inkless/src/test/java/io/aiven/inkless/merge/MergeBatchesInputStreamTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/merge/MergeBatchesInputStreamTest.java
@@ -69,17 +69,18 @@ public class MergeBatchesInputStreamTest {
         final Supplier<InputStream> file2InputStreamSupplier = () -> file2InputStream;
         final var file2InputStreamWithPosition = new InputStreamWithPosition(file2InputStreamSupplier, file2Size);
 
-        var mergeBatchesInputStream = new MergeBatchesInputStream.Builder()
+        MergeBatchesInputStream.Builder builder = new MergeBatchesInputStream.Builder()
             .addBatch(new BatchAndStream(batch3Info, file2InputStreamWithPosition))
             .addBatch(new BatchAndStream(batch2Info, file1InputStreamWithPosition))
-            .addBatch(new BatchAndStream(batch1Info, file1InputStreamWithPosition))
-            .build();
+            .addBatch(new BatchAndStream(batch1Info, file1InputStreamWithPosition));
+        var mergeBatchesInputStream = builder.build();
 
-        assertEquals(expectedMergedSize, mergeBatchesInputStream.mergeMetadata().mergedFileSize());
+        assertEquals(expectedMergedSize, builder.mergeMetadata().mergedFileSize());
 
         // Read all batches and write them into an output stream
         var outputStream = new ByteArrayOutputStream(expectedMergedSize);
-        mergeBatchesInputStream.transferTo(outputStream);
+        long transferred = mergeBatchesInputStream.transferTo(outputStream);
+        assertEquals(expectedMergedSize, transferred);
 
         var expected = ByteBuffer.allocate(expectedMergedSize);
         expected.put(batch1Data);

--- a/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/azure/integration/AzureBlobStorageMetricsTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/azure/integration/AzureBlobStorageMetricsTest.java
@@ -32,6 +32,7 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.management.ManagementFactory;
@@ -121,7 +122,7 @@ public class AzureBlobStorageMetricsTest {
 
         final var storage = storage();
 
-        storage.upload(key, data);
+        storage.upload(key, new ByteArrayInputStream(data), data.length);
         try (final InputStream fetch = storage.fetch(key, null)) {
             fetch.readAllBytes();
         }

--- a/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/azure/integration/AzureBlobStorageTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/azure/integration/AzureBlobStorageTest.java
@@ -28,8 +28,11 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
+import java.io.ByteArrayInputStream;
+
 import io.aiven.inkless.common.ByteRange;
 import io.aiven.inkless.storage_backend.common.InvalidRangeException;
+import io.aiven.inkless.storage_backend.common.ObjectUploader;
 import io.aiven.inkless.storage_backend.common.StorageBackendException;
 import io.aiven.inkless.storage_backend.common.fixtures.BaseStorageTest;
 import io.aiven.inkless.storage_backend.common.fixtures.TestUtils;
@@ -66,7 +69,9 @@ abstract class AzureBlobStorageTest extends BaseStorageTest {
         // For some reason, Azure (or only Azurite) considers range 3-5 valid for a 3-byte blob,
         // so the generic test fails.
         final String content = "ABC";
-        storage().upload(TOPIC_PARTITION_SEGMENT_KEY, content.getBytes());
+        ObjectUploader objectUploader = storage();
+        byte[] data = content.getBytes();
+        objectUploader.upload(TOPIC_PARTITION_SEGMENT_KEY, new ByteArrayInputStream(data), data.length);
 
         assertThatThrownBy(() -> storage().fetch(TOPIC_PARTITION_SEGMENT_KEY, new ByteRange(4, 6)))
             .isInstanceOf(InvalidRangeException.class);

--- a/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/gcs/integration/GcsStorageMetricsTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/gcs/integration/GcsStorageMetricsTest.java
@@ -32,6 +32,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.management.ManagementFactory;
@@ -96,7 +97,7 @@ public class GcsStorageMetricsTest {
 
         final ObjectKey key = new TestObjectKey("x");
 
-        storage.upload(key, data);
+        storage.upload(key, new ByteArrayInputStream(data), data.length);
         try (final InputStream fetch = storage.fetch(key, ByteRange.maxRange())) {
             fetch.readAllBytes();
         }

--- a/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/s3/integration/S3ErrorMetricsTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/s3/integration/S3ErrorMetricsTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
+import java.io.ByteArrayInputStream;
 import java.lang.management.ManagementFactory;
 import java.util.Map;
 
@@ -93,9 +94,10 @@ class S3ErrorMetricsTest {
             .willReturn(aResponse().withStatus(statusCode)
                 .withHeader(CONTENT_TYPE, APPLICATION_XML.getMimeType())
                 .withBody(String.format(ERROR_RESPONSE_TEMPLATE, statusCode))));
+        byte[] data = new byte[1];
         final StorageBackendException storageBackendException = catchThrowableOfType(
             StorageBackendException.class,
-            () -> storage.upload(new TestObjectKey("key"), new byte[0]));
+            () -> storage.upload(new TestObjectKey("key"), new ByteArrayInputStream(data), data.length));
         assertThat(storageBackendException.getCause()).isInstanceOf(S3Exception.class);
         final S3Exception s3Exception = (S3Exception) storageBackendException.getCause();
 

--- a/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/s3/integration/S3StorageMetricsTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/s3/integration/S3StorageMetricsTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
+import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.lang.management.ManagementFactory;
 import java.util.Map;
@@ -80,7 +81,7 @@ class S3StorageMetricsTest {
 
         final ObjectKey key = new TestObjectKey("x");
 
-        storage.upload(key, data);
+        storage.upload(key, new ByteArrayInputStream(data), data.length);
         try (final InputStream fetch = storage.fetch(key, ByteRange.maxRange())) {
             fetch.readAllBytes();
         }


### PR DESCRIPTION
The FileUploadJob incorrectly reuses the same InputStream on each upload attempt. This means that the initial upload attempt consumes all of the contents of the InputStream, and it is left empty for subsequent uploads.

If the initial upload attempt fails for whatever reason, subsequent attempts will try to upload an empty object. If that upload succeeds, the broker proceeds to commit batches which have not been written to object storage. This corrupts the state of the cluster. This corruption becomes apparent when the data is fetched, and the object range query cannot be satisfied, because the object is empty.

Instead, re-instantiate the relevant InputStream for each attempt, clearing the state from previous attempts. In addition, implement length checks using the `int length` argument to cross-check the length of the stream/object/coordinates. Finally, improve error messages on invalid range checks to include the object key for faster debugging and mitigation.
