### PR TITLE
refactor(inkless): initialize round-robin with brokerId

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -125,7 +125,7 @@ class KafkaApis(val requestChannel: RequestChannel,
   val describeTopicPartitionsRequestHandler = new DescribeTopicPartitionsRequestHandler(
     metadataCache, authHelper, config)
 
-  val inklessTopicMetadataTransformer = inklessSharedState.map(s => new InklessTopicMetadataTransformer(s.metadata()))
+  val inklessTopicMetadataTransformer = inklessSharedState.map(s => new InklessTopicMetadataTransformer(brokerId, s.metadata()))
 
   def close(): Unit = {
     aclApis.close()

--- a/storage/inkless/src/main/java/io/aiven/inkless/metadata/InklessTopicMetadataTransformer.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/metadata/InklessTopicMetadataTransformer.java
@@ -35,10 +35,11 @@ import io.aiven.inkless.control_plane.MetadataView;
 public class InklessTopicMetadataTransformer {
     private final MetadataView metadataView;
 
-    private final AtomicInteger roundRobinCounter = new AtomicInteger();
+    private final AtomicInteger roundRobinCounter;
 
-    public InklessTopicMetadataTransformer(final MetadataView metadataView) {
+    public InklessTopicMetadataTransformer(final int brokerId, final MetadataView metadataView) {
         this.metadataView = Objects.requireNonNull(metadataView, "metadataView cannot be null");
+        roundRobinCounter = new AtomicInteger(brokerId);
     }
 
     /**

--- a/storage/inkless/src/test/java/io/aiven/inkless/metadata/InklessTopicMetadataTransformerTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/metadata/InklessTopicMetadataTransformerTest.java
@@ -67,11 +67,11 @@ class InklessTopicMetadataTransformerTest {
 
     @Test
     void nulls() {
-        assertThatThrownBy(() -> new InklessTopicMetadataTransformer(null))
+        assertThatThrownBy(() -> new InklessTopicMetadataTransformer(1, null))
             .isInstanceOf(NullPointerException.class)
             .hasMessage("metadataView cannot be null");
 
-        final var transformer = new InklessTopicMetadataTransformer(metadataView);
+        final var transformer = new InklessTopicMetadataTransformer(1, metadataView);
         assertThatThrownBy(() -> transformer.transformClusterMetadata(LISTENER_NAME, "x", null))
             .isInstanceOf(NullPointerException.class)
             .hasMessage("topicMetadata cannot be null");
@@ -94,7 +94,7 @@ class InklessTopicMetadataTransformerTest {
         @NullSource
         @ValueSource(strings = {"inkless_az=az1", "x=y", ""})
         void clusterMetadata(final String clientId) {
-            final var transformer = new InklessTopicMetadataTransformer(metadataView);
+            final var transformer = new InklessTopicMetadataTransformer(1, metadataView);
 
             final List<MetadataResponseTopic> topicMetadata = List.of();
             transformer.transformClusterMetadata(LISTENER_NAME, clientId, topicMetadata);
@@ -105,7 +105,7 @@ class InklessTopicMetadataTransformerTest {
         @NullSource
         @ValueSource(strings = {"inkless_az=az1", "x=y", ""})
         void describeTopicResponse(final String clientId) {
-            final var transformer = new InklessTopicMetadataTransformer(metadataView);
+            final var transformer = new InklessTopicMetadataTransformer(1, metadataView);
 
             final DescribeTopicPartitionsResponseData describeResponse = new DescribeTopicPartitionsResponseData();
             transformer.transformDescribeTopicResponse(LISTENER_NAME, clientId, describeResponse);
@@ -129,10 +129,10 @@ class InklessTopicMetadataTransformerTest {
 
         @ParameterizedTest
         @CsvSource({
-            "az0,0,2",
-            "az1,1,3",
-            "az_unknown,0,1",
-            ",0,1",
+            "az0,2,0",
+            "az1,3,1",
+            "az_unknown,1,2",
+            ",1,2",
         })
         void clusterMetadata(final String clientAZ, final int expectedLeaderId1, final int expectedLeaderId2) {
             final Supplier<MetadataResponseTopic> inklessTopicMetadata =
@@ -186,7 +186,7 @@ class InklessTopicMetadataTransformerTest {
                 inklessTopicMetadata.get(),
                 classicTopicMetadata.get()
             );
-            final var transformer = new InklessTopicMetadataTransformer(metadataView);
+            final var transformer = new InklessTopicMetadataTransformer(1, metadataView);
 
             transformer.transformClusterMetadata(LISTENER_NAME, "inkless_az=" + clientAZ, topicMetadata);
 
@@ -211,10 +211,10 @@ class InklessTopicMetadataTransformerTest {
 
         @ParameterizedTest
         @CsvSource({
-            "az0,0,2",
-            "az1,1,3",
-            "az_unknown,0,1",
-            ",0,1",
+            "az0,2,0",
+            "az1,3,1",
+            "az_unknown,1,2",
+            ",1,2",
         })
         void describeTopicResponse(final String clientAZ, final int expectedLeaderId1, final int expectedLeaderId2) {
             final Supplier<DescribeTopicPartitionsResponseTopic> inklessTopicMetadata =
@@ -279,7 +279,7 @@ class InklessTopicMetadataTransformerTest {
                         inklessTopicMetadata.get(),
                         classicTopicMetadata.get()
                     ).iterator()));
-            final var transformer = new InklessTopicMetadataTransformer(metadataView);
+            final var transformer = new InklessTopicMetadataTransformer(1, metadataView);
 
             transformer.transformDescribeTopicResponse(LISTENER_NAME, "inkless_az=" + clientAZ, describeResponse);
 
@@ -333,15 +333,15 @@ class InklessTopicMetadataTransformerTest {
                     ));
 
             final List<MetadataResponseTopic> topicMetadata = List.of(inklessTopicMetadata.get());
-            final var transformer = new InklessTopicMetadataTransformer(metadataView);
+            final var transformer = new InklessTopicMetadataTransformer(1, metadataView);
 
             transformer.transformClusterMetadata(LISTENER_NAME, "inkless_az=az0", topicMetadata);
             final var expectedInklessTopicMetadata = inklessTopicMetadata.get();
-            setExpectedLeaderCluster(expectedInklessTopicMetadata.partitions().get(0), 0);
+            setExpectedLeaderCluster(expectedInklessTopicMetadata.partitions().get(0), 1);
             assertThat(topicMetadata.get(0)).isEqualTo(expectedInklessTopicMetadata);
 
             transformer.transformClusterMetadata(LISTENER_NAME, "inkless_az=az0", topicMetadata);
-            setExpectedLeaderCluster(expectedInklessTopicMetadata.partitions().get(0), 1);
+            setExpectedLeaderCluster(expectedInklessTopicMetadata.partitions().get(0), 0);
             assertThat(topicMetadata.get(0)).isEqualTo(expectedInklessTopicMetadata);
         }
 
@@ -368,17 +368,17 @@ class InklessTopicMetadataTransformerTest {
                             ))
                     ).iterator()));
 
-            final var transformer = new InklessTopicMetadataTransformer(metadataView);
+            final var transformer = new InklessTopicMetadataTransformer(1, metadataView);
 
             final DescribeTopicPartitionsResponseData describeResponse = describeResponseSupplier.get();
             transformer.transformDescribeTopicResponse(LISTENER_NAME, "inkless_az=az0", describeResponse);
 
             final var expectedDescribeResponse = describeResponseSupplier.get();
-            setExpectedLeaderDescribeTopicResponse(expectedDescribeResponse.topics().find(TOPIC_INKLESS).partitions().get(0), 0);
+            setExpectedLeaderDescribeTopicResponse(expectedDescribeResponse.topics().find(TOPIC_INKLESS).partitions().get(0), 1);
             assertThat(describeResponse).isEqualTo(expectedDescribeResponse);
 
             transformer.transformDescribeTopicResponse(LISTENER_NAME, "inkless_az=az0", describeResponse);
-            setExpectedLeaderDescribeTopicResponse(expectedDescribeResponse.topics().find(TOPIC_INKLESS).partitions().get(0), 1);
+            setExpectedLeaderDescribeTopicResponse(expectedDescribeResponse.topics().find(TOPIC_INKLESS).partitions().get(0), 0);
             assertThat(describeResponse).isEqualTo(expectedDescribeResponse);
         }
     }
@@ -413,15 +413,15 @@ class InklessTopicMetadataTransformerTest {
                     ));
 
             final List<MetadataResponseTopic> topicMetadata = List.of(inklessTopicMetadata.get());
-            final var transformer = new InklessTopicMetadataTransformer(metadataView);
+            final var transformer = new InklessTopicMetadataTransformer(1, metadataView);
 
             transformer.transformClusterMetadata(LISTENER_NAME, null, topicMetadata);
             final var expectedInklessTopicMetadata = inklessTopicMetadata.get();
-            setExpectedLeaderCluster(expectedInklessTopicMetadata.partitions().get(0), 0);
+            setExpectedLeaderCluster(expectedInklessTopicMetadata.partitions().get(0), 1);
             assertThat(topicMetadata.get(0)).isEqualTo(expectedInklessTopicMetadata);
 
             transformer.transformClusterMetadata(LISTENER_NAME, null, topicMetadata);
-            setExpectedLeaderCluster(expectedInklessTopicMetadata.partitions().get(0), 1);
+            setExpectedLeaderCluster(expectedInklessTopicMetadata.partitions().get(0), 0);
             assertThat(topicMetadata.get(0)).isEqualTo(expectedInklessTopicMetadata);
         }
 
@@ -448,17 +448,17 @@ class InklessTopicMetadataTransformerTest {
                             ))
                     ).iterator()));
 
-            final var transformer = new InklessTopicMetadataTransformer(metadataView);
+            final var transformer = new InklessTopicMetadataTransformer(1, metadataView);
             final DescribeTopicPartitionsResponseData describeResponse = describeResponseSupplier.get();
 
             transformer.transformDescribeTopicResponse(LISTENER_NAME, null, describeResponse);
 
             final var expectedDescribeResponse = describeResponseSupplier.get();
-            setExpectedLeaderDescribeTopicResponse(expectedDescribeResponse.topics().find(TOPIC_INKLESS).partitions().get(0), 0);
+            setExpectedLeaderDescribeTopicResponse(expectedDescribeResponse.topics().find(TOPIC_INKLESS).partitions().get(0), 1);
             assertThat(describeResponse).isEqualTo(expectedDescribeResponse);
 
             transformer.transformDescribeTopicResponse(LISTENER_NAME, null, describeResponse);
-            setExpectedLeaderDescribeTopicResponse(expectedDescribeResponse.topics().find(TOPIC_INKLESS).partitions().get(0), 1);
+            setExpectedLeaderDescribeTopicResponse(expectedDescribeResponse.topics().find(TOPIC_INKLESS).partitions().get(0), 0);
             assertThat(describeResponse).isEqualTo(expectedDescribeResponse);
         }
     }


### PR DESCRIPTION
Inkless Partition leaders are assigned using a round-robin mechanism per request.
This means all topic partitions on the same response will be assigned the same leader based on the client AZ if possible (if available and matching with brokers).

Currently, all round-robin variables are initialized at zero. When many brokers are on the same AZ, this initialization happens to skew the load towards some of the brokers causing uneven load distribution and unpredictable performance depending on the broker serving the requests.

To fix this, the brokerId is being used to initialize the round-robin, so leaders will be spread more evenly.

Distribution of produce requests with current initialization:

<img width="1373" height="610" alt="image" src="https://github.com/user-attachments/assets/d98c4009-72b8-4f98-a9a4-3ab131f83b22" />

Distribution of produce requests with fixed initialization: 

<img width="1378" height="619" alt="image" src="https://github.com/user-attachments/assets/0cb5b5ae-cb56-4238-917a-ee32ac96a865" />
