### PR TITLE
fix broken tests after changes in DelayedFetch

### DIFF
--- a/core/src/main/scala/kafka/server/DelayedFetch.scala
+++ b/core/src/main/scala/kafka/server/DelayedFetch.scala
@@ -170,9 +170,9 @@ class DelayedFetch(
       val fetchOffset = fetchStatus.startOffsetMetadata
       new FindBatchRequest(topicIdPartition, fetchOffset.messageOffset, fetchStatus.fetchInfo.maxBytes)
     }
+    if (requests.isEmpty) { return Some(0) }
 
     val response = replicaManager.findInklessBatches(requests, Int.MaxValue)
-    if (response.isEmpty) { return Some(0) }
     val r = response.get.asScala
     r.foreach { response =>
       response.errors() match {

--- a/core/src/test/scala/integration/kafka/server/DelayedFetchTest.scala
+++ b/core/src/test/scala/integration/kafka/server/DelayedFetchTest.scala
@@ -16,6 +16,8 @@
  */
 package kafka.server
 
+import io.aiven.inkless.control_plane.{BatchInfo, BatchMetadata, FindBatchResponse}
+
 import java.util.{Optional, OptionalLong}
 import scala.collection.Seq
 import kafka.cluster.Partition
@@ -23,7 +25,7 @@ import org.apache.kafka.common.{TopicIdPartition, Uuid}
 import org.apache.kafka.common.errors.{FencedLeaderEpochException, NotLeaderOrFollowerException}
 import org.apache.kafka.common.message.OffsetForLeaderEpochResponseData.EpochEndOffset
 import org.apache.kafka.common.protocol.Errors
-import org.apache.kafka.common.record.MemoryRecords
+import org.apache.kafka.common.record.{MemoryRecords, TimestampType}
 import org.apache.kafka.common.requests.FetchRequest
 import org.apache.kafka.server.LogReadResult
 import org.apache.kafka.server.storage.log.{FetchIsolation, FetchParams, FetchPartitionData}
@@ -34,6 +36,8 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 import org.mockito.ArgumentMatchers.{any, anyInt}
 import org.mockito.Mockito.{mock, when}
+
+import java.util.concurrent.CompletableFuture
 
 class DelayedFetchTest {
   private val maxBytes = 1024
@@ -75,6 +79,8 @@ class DelayedFetchTest {
         fetchOnlyFromLeader = true))
         .thenThrow(new FencedLeaderEpochException("Requested epoch has been fenced"))
     when(replicaManager.isAddingReplica(any(), anyInt())).thenReturn(false)
+    when(replicaManager.fetchParamsWithNewMaxBytes(any(), any())).thenAnswer(_.getArgument(0))
+    when(replicaManager.fetchInklessMessages(any(), any())).thenReturn(CompletableFuture.completedFuture(Seq.empty))
 
     expectReadFromReplica(fetchParams, topicIdPartition, fetchStatus.fetchInfo, Errors.FENCED_LEADER_EPOCH)
 
@@ -116,6 +122,8 @@ class DelayedFetchTest {
       .thenThrow(new NotLeaderOrFollowerException(s"Replica for $topicIdPartition not available"))
     expectReadFromReplica(fetchParams, topicIdPartition, fetchStatus.fetchInfo, Errors.NOT_LEADER_OR_FOLLOWER)
     when(replicaManager.isAddingReplica(any(), anyInt())).thenReturn(false)
+    when(replicaManager.fetchParamsWithNewMaxBytes(any(), any())).thenAnswer(_.getArgument(0))
+    when(replicaManager.fetchInklessMessages(any(), any())).thenReturn(CompletableFuture.completedFuture(Seq.empty))
 
     assertTrue(delayedFetch.tryComplete())
     assertTrue(delayedFetch.isCompleted)
@@ -166,6 +174,8 @@ class DelayedFetchTest {
         .setLeaderEpoch(lastFetchedEpoch.get)
         .setEndOffset(fetchOffset - 1))
     when(replicaManager.isAddingReplica(any(), anyInt())).thenReturn(false)
+    when(replicaManager.fetchParamsWithNewMaxBytes(any(), any())).thenAnswer(_.getArgument(0))
+    when(replicaManager.fetchInklessMessages(any(), any())).thenReturn(CompletableFuture.completedFuture(Seq.empty))
     expectReadFromReplica(fetchParams, topicIdPartition, fetchStatus.fetchInfo, Errors.NONE)
 
     assertTrue(delayedFetch.tryComplete())
@@ -212,6 +222,8 @@ class DelayedFetchTest {
       fetchOnlyFromLeader = true))
       .thenReturn(new LogOffsetSnapshot(0L, endOffsetMetadata, endOffsetMetadata, endOffsetMetadata))
     when(replicaManager.isAddingReplica(any(), anyInt())).thenReturn(false)
+    when(replicaManager.fetchParamsWithNewMaxBytes(any(), any())).thenAnswer(_.getArgument(0))
+    when(replicaManager.fetchInklessMessages(any(), any())).thenReturn(CompletableFuture.completedFuture(Seq.empty))
     expectReadFromReplica(fetchParams, topicIdPartition, fetchStatus.fetchInfo, Errors.NONE)
 
     // 1. When `endOffset` is 0, it refers to the truncation case
@@ -223,6 +235,67 @@ class DelayedFetchTest {
     if (fetchResultOpt.isDefined) {
       assertEquals(Errors.NONE, fetchResultOpt.get.error)
     }
+  }
+
+  @Test
+  def testWithInkless(): Unit = {
+    val classicTopicIdPartition = new TopicIdPartition(Uuid.randomUuid(), 0, "topic")
+    val inklessTopicIdPartition = new TopicIdPartition(Uuid.randomUuid(), 0, "inkless-topic")
+    val classicBytesAvailable = 100
+    val inklessBytesAvailable = 100
+    val minBytes  = classicBytesAvailable + inklessBytesAvailable
+    val fetchOffset = 0L
+    val logStartOffset = 0L
+    val currentLeaderEpoch = Optional.of[Integer](10)
+    val lastFetchedEpoch = Optional.empty[Integer]()
+    val replicaId = 1
+    val inklessBatches = java.util.List.of(
+      new BatchInfo(0L, "object", BatchMetadata.of(inklessTopicIdPartition, 0L, inklessBytesAvailable, 0L, 123L, 1L, 1L, TimestampType.CREATE_TIME))
+    )
+
+    val classicFetchStatus = FetchPartitionStatus(
+      startOffsetMetadata = new LogOffsetMetadata(fetchOffset, 0L, 0),
+      fetchInfo = new FetchRequest.PartitionData(classicTopicIdPartition.topicId, fetchOffset, logStartOffset, maxBytes, currentLeaderEpoch, lastFetchedEpoch))
+    val inklessFetchStatus = FetchPartitionStatus(
+      startOffsetMetadata = new LogOffsetMetadata(fetchOffset),
+      fetchInfo = new FetchRequest.PartitionData(inklessTopicIdPartition.topicId, fetchOffset, logStartOffset, maxBytes, currentLeaderEpoch, lastFetchedEpoch))
+    val fetchParams = buildFollowerFetchParams(replicaId, maxWaitMs = 500, minBytes = minBytes)
+
+    var fetchResultOpt: Option[FetchPartitionData] = None
+    def callback(responses: Seq[(TopicIdPartition, FetchPartitionData)]): Unit = {
+      fetchResultOpt = Some(responses.head._2)
+    }
+
+    val delayedFetch = new DelayedFetch(
+      params = fetchParams,
+      fetchPartitionStatus = Seq(classicTopicIdPartition -> classicFetchStatus, inklessTopicIdPartition -> inklessFetchStatus),
+      replicaManager = replicaManager,
+      isInklessTopic = t => t.equals(inklessTopicIdPartition.topic()),
+      quota = replicaQuota,
+      responseCallback = callback
+    )
+
+    val partition: Partition = mock(classOf[Partition])
+    when(replicaManager.getPartitionOrException(classicTopicIdPartition.topicPartition)).thenReturn(partition)
+    val endOffsetMetadata = new LogOffsetMetadata(500L, 0L, classicBytesAvailable)
+    when(partition.fetchOffsetSnapshot(
+      currentLeaderEpoch,
+      fetchOnlyFromLeader = true))
+      .thenReturn(new LogOffsetSnapshot(0L, endOffsetMetadata, endOffsetMetadata, endOffsetMetadata))
+    when(replicaManager.isAddingReplica(any(), anyInt())).thenReturn(false)
+    when(replicaManager.fetchParamsWithNewMaxBytes(any(), any())).thenAnswer(_.getArgument(0))
+    when(replicaManager.findInklessBatches(any(), any())).thenReturn(Some(java.util.List.of(
+      new FindBatchResponse(Errors.NONE, inklessBatches, 0L, 100L)
+    )))
+    when(replicaManager.fetchInklessMessages(any(), any())).thenReturn(CompletableFuture.completedFuture(Seq.empty))
+    expectReadFromReplica(fetchParams, classicTopicIdPartition, classicFetchStatus.fetchInfo, Errors.NONE)
+
+    assertTrue(delayedFetch.tryComplete())
+    assertTrue(delayedFetch.isCompleted)
+    assertTrue(fetchResultOpt.isDefined)
+
+    val fetchResult = fetchResultOpt.get
+    assertEquals(Errors.NONE, fetchResult.error)
   }
 
   private def buildFollowerFetchParams(


### PR DESCRIPTION
Fix the following tests:

DelayedFetchTest.testDelayedFetchWithMessageOnlyHighWatermark endOffset=0
DelayedFetchTest.testDelayedFetchWithMessageOnlyHighWatermark endOffset=500
DelayedFetchTest.testDivergingEpoch()
DelayedFetchTest.testFetchWithFencedEpoch()
DelayedFetchTest.testNotLeaderOrFollower()
ReplicaManagerQuotasTest.testCompleteInDelayedFetchConsumerFetch()
ReplicaManagerQuotasTest.testCompleteInDelayedFetchWithReplicaThrottling()