### PR TITLE
refactor(inkless): store inkless enabled config on KRaft

### DIFF
--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -344,7 +344,7 @@ class BrokerServer(
        */
       val defaultActionQueue = new DelayedActionQueue
 
-      val inklessMetadataView = new InklessMetadataView(metadataCache, () => logManager.currentDefaultConfig.values().asInstanceOf[util.Map[String, Object]])
+      val inklessMetadataView = new InklessMetadataView(metadataCache, () => config.extractLogConfigMap)
       val inklessSharedState = sharedServer.inklessControlPlane.map { controlPlane =>
         SharedState.initialize(
           time,

--- a/core/src/main/scala/kafka/server/metadata/InklessMetadataView.scala
+++ b/core/src/main/scala/kafka/server/metadata/InklessMetadataView.scala
@@ -19,7 +19,7 @@
 package kafka.server.metadata
 
 import io.aiven.inkless.control_plane.MetadataView
-import org.apache.kafka.common.config.ConfigResource
+import org.apache.kafka.common.config.TopicConfig
 import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.{Node, TopicIdPartition, Uuid}
 
@@ -27,7 +27,6 @@ import java.util.Properties
 import java.util.function.Supplier
 import java.util.stream.{Collectors, IntStream}
 import java.{lang, util}
-
 import scala.jdk.CollectionConverters._
 
 class InklessMetadataView(val metadataCache: KRaftMetadataCache, val defaultConfig: Supplier[util.Map[String, Object]]) extends MetadataView {
@@ -51,11 +50,11 @@ class InklessMetadataView(val metadataCache: KRaftMetadataCache, val defaultConf
   }
 
   override def isInklessTopic(topicName: String): Boolean = {
-    metadataCache.isInklessTopic(topicName, defaultConfig)
+    metadataCache.topicConfig(topicName).getProperty(TopicConfig.INKLESS_ENABLE_CONFIG, "false").toBoolean
   }
 
   override def getTopicConfig(topicName: String): Properties = {
-    metadataCache.config(new ConfigResource(ConfigResource.Type.TOPIC, topicName))
+    metadataCache.topicConfig(topicName)
   }
 
   override def getInklessTopicPartitions: util.Set[TopicIdPartition] = {

--- a/core/src/main/scala/kafka/server/metadata/KRaftMetadataCache.scala
+++ b/core/src/main/scala/kafka/server/metadata/KRaftMetadataCache.scala
@@ -19,7 +19,7 @@ package kafka.server.metadata
 
 import kafka.utils.Logging
 import org.apache.kafka.common._
-import org.apache.kafka.common.config.{ConfigResource, TopicConfig}
+import org.apache.kafka.common.config.ConfigResource
 import org.apache.kafka.common.errors.InvalidTopicException
 import org.apache.kafka.common.internals.Topic
 import org.apache.kafka.common.message.DescribeTopicPartitionsResponseData.{Cursor, DescribeTopicPartitionsResponsePartition, DescribeTopicPartitionsResponseTopic}
@@ -148,7 +148,7 @@ class KRaftMetadataCache(
    * @param topicName                   The name of the topic.
    * @param listenerName                The listener name.
    * @param startIndex                  The smallest index of the partitions to be included in the result.
-   *                                    
+   *
    * @return                            A collection of topic partition metadata and next partition index (-1 means
    *                                    no next partition).
    */
@@ -474,16 +474,6 @@ class KRaftMetadataCache(
       image.features().metadataVersionOrThrow(),
       finalizedFeatures,
       image.highestOffsetAndEpoch().offset)
-  }
-
-  def isInklessTopic(topic: String, defaultConfig: Supplier[util.Map[String, AnyRef]]): Boolean = {
-    val topicConfigs = topicConfig(topic)
-    // avoid instantiating LogConfig as it is expensive
-    val defaultInklessEnable = defaultConfig.get().getOrDefault(TopicConfig.INKLESS_ENABLE_CONFIG, "false").toString.toBoolean
-    val inklessEnabled = if (topicConfigs.containsKey(TopicConfig.INKLESS_ENABLE_CONFIG)) topicConfigs.getProperty(TopicConfig.INKLESS_ENABLE_CONFIG, "false").toBoolean else defaultInklessEnable
-    val isNotInternalTopic = !Topic.isInternal(topic)
-    val isNotClusterMetaTopic = topic != Topic.CLUSTER_METADATA_TOPIC_NAME
-    isNotInternalTopic && isNotClusterMetaTopic && inklessEnabled
   }
 }
 

--- a/core/src/test/scala/kafka/server/metadata/InklessKRaftMetadataCacheTest.java
+++ b/core/src/test/scala/kafka/server/metadata/InklessKRaftMetadataCacheTest.java
@@ -30,10 +30,10 @@ import org.apache.kafka.server.common.KRaftVersion;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Supplier;
+
+import io.aiven.inkless.control_plane.MetadataView;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -41,22 +41,21 @@ class InklessKRaftMetadataCacheTest {
 
     @ParameterizedTest
     @CsvSource({
-        "__consumer_offsets,false,false", "__consumer_offsets,true,false",
-        "__transaction_state,false,false", "__transaction_state,true,false",
-        "__share_group_state,false,false", "__share_group_state,true,false",
-        "__cluster_metadata,false,false", "__cluster_metadata,true,false",
-        "__internal_topic_default,false,false", "__internal_topic_default,true,true",
-        "__internal_topic_enabled,false,true", "__internal_topic_enabled,true,true",
-        "__internal_topic_disabled,false,false", "__internal_topic_disabled,true,false",
-        "regular_topic_default,false,false", "regular_topic_default,true,true",
-        "regular_topic_enabled,false,true", "regular_topic_enabled,true,true",
-        "regular_topic_disabled,false,false", "regular_topic_disabled,true,false",
+        "__consumer_offsets,false",
+        "__transaction_state,false",
+        "__share_group_state,false",
+        "__cluster_metadata,false",
+        "__internal_topic_default,false",
+        "__internal_topic_enabled,true",
+        "__internal_topic_disabled,false",
+        "regular_topic_default,false",
+        "regular_topic_enabled,true",
+        "regular_topic_disabled,false",
     })
-    void isInklessTopic(final String topicName, final boolean defaultInklessEnable, final boolean expectedIsInkless) {
-        Supplier<Map<String, Object>> defaultConfig = () ->
-            defaultInklessEnable ? Collections.singletonMap(TopicConfig.INKLESS_ENABLE_CONFIG, "true") : Collections.emptyMap();
+    void isInklessTopic(final String topicName, final boolean expectedIsInkless) {
         // Given a cache with a couple of inkless topics
         final KRaftMetadataCache cache = new KRaftMetadataCache(1, () -> KRaftVersion.KRAFT_VERSION_0);
+        final MetadataView metadataView = new InklessMetadataView(cache, Map::of);
         final List<ApiMessage> configRecords = List.of(
             new ConfigRecord()
                 .setResourceType(ResourceType.TOPIC.code())
@@ -81,7 +80,7 @@ class InklessKRaftMetadataCacheTest {
         );
         updateCache(cache, configRecords);
         // When checking if a topic is inkless, then the expected result is returned
-        assertEquals(expectedIsInkless, cache.isInklessTopic(topicName, defaultConfig));
+        assertEquals(expectedIsInkless, metadataView.isInklessTopic(topicName));
     }
 
     // Similar to {@link kafka.server.MetadataCacheTest#updateCache}

--- a/core/src/test/scala/kafka/server/metadata/InklessMetadataViewTest.scala
+++ b/core/src/test/scala/kafka/server/metadata/InklessMetadataViewTest.scala
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.{BeforeEach, Test}
 import org.junit.jupiter.api.Assertions._
 import org.mockito.Mockito._
 
-import java.util.{HashMap => JHashMap}
 import java.util.function.Supplier
 import java.util
 
@@ -41,7 +40,7 @@ class InklessMetadataViewTest {
   @Test
   def testGetDefaultConfigFiltersNullValues(): Unit = {
     // Setup a map with some null values
-    val originalConfig = new JHashMap[String, Object]()
+    val originalConfig = new util.HashMap[String, Object]()
     originalConfig.put("key1", "value1")
     originalConfig.put("key2", null)
     originalConfig.put("key3", Integer.valueOf(42))
@@ -66,7 +65,7 @@ class InklessMetadataViewTest {
   @Test
   def testGetDefaultConfigWithNoNullValues(): Unit = {
     // Setup a map with no null values
-    val originalConfig = new JHashMap[String, Object]()
+    val originalConfig = new util.HashMap[String, Object]()
     originalConfig.put("key1", "value1")
     originalConfig.put("key2", "value2")
 
@@ -85,7 +84,7 @@ class InklessMetadataViewTest {
   @Test
   def testGetDefaultConfigWithEmptyMap(): Unit = {
     // Setup an empty map
-    val originalConfig = new JHashMap[String, Object]()
+    val originalConfig = new util.HashMap[String, Object]()
 
     // Configure the mock to return our test map
     when(configSupplier.get()).thenReturn(originalConfig)

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -730,7 +730,7 @@ public class ReplicationControlManager {
         Map<String, String> creationConfigs = translateCreationConfigs(topic.configs());
         Map<Integer, PartitionRegistration> newParts = new HashMap<>();
 
-        boolean inklessEnabled = Boolean.parseBoolean(creationConfigs.getOrDefault(INKLESS_ENABLE_CONFIG, "" + defaultInklessEnable))
+        boolean inklessEnabled = Boolean.parseBoolean(creationConfigs.getOrDefault(INKLESS_ENABLE_CONFIG, String.valueOf(defaultInklessEnable)))
             && !Topic.isInternal(topic.name());
         if (inklessEnabled) {
             if (Math.abs(topic.replicationFactor()) != 1) {
@@ -858,7 +858,7 @@ public class ReplicationControlManager {
         records.add(new ApiMessageAndVersion(new TopicRecord().
             setName(topic.name()).
             setTopicId(topicId), (short) 0));
-        List<ApiMessageAndVersion> validConfigRecords = validConfigRecords(topic, configRecords);
+        List<ApiMessageAndVersion> validConfigRecords = validConfigRecords(topic, configRecords, inklessEnabled);
         // ConfigRecords go after TopicRecord but before PartitionRecord(s).
         records.addAll(validConfigRecords);
         for (Entry<Integer, PartitionRegistration> partEntry : newParts.entrySet()) {
@@ -871,33 +871,38 @@ public class ReplicationControlManager {
         return ApiError.NONE;
     }
 
-    private static List<ApiMessageAndVersion> validConfigRecords(CreatableTopic topic, List<ApiMessageAndVersion> configRecords) {
+    private List<ApiMessageAndVersion> validConfigRecords(CreatableTopic topic, List<ApiMessageAndVersion> configRecords, boolean inklessEnabled) {
         final List<ApiMessageAndVersion> validConfigRecord = new ArrayList<>();
-        boolean inklessSet = false;
+        boolean isInklessEnableDefined = false;
         for (ApiMessageAndVersion configRecord: configRecords) {
             ConfigRecord record;
             try {
                 record = (ConfigRecord) configRecord.message();
             } catch (ClassCastException e) {
+                log.warn("Received unexpected message type {} for config record: {}",
+                    configRecord.message().getClass().getName(), configRecord.message());
                 continue;
             }
-            if (record.name().equals(INKLESS_ENABLE_CONFIG) && Topic.isInternal(topic.name())) {
+            if (record.name().equals(INKLESS_ENABLE_CONFIG)) {
+                // Ensure that inkless enabled config is disabled if it happens to be an internal topic.
                 ApiMessageAndVersion message = new ApiMessageAndVersion(new ConfigRecord()
                     .setName(INKLESS_ENABLE_CONFIG)
-                    .setValue("false")
+                    .setValue(String.valueOf(inklessEnabled))
                     .setResourceName(topic.name())
                     .setResourceType(ResourceType.TOPIC.code()), (short) 0);
                 validConfigRecord.add(message);
 
-                inklessSet = true;
+                isInklessEnableDefined = true;
             } else {
                 validConfigRecord.add(configRecord);
             }
         }
-        if (Topic.isInternal(topic.name()) && !inklessSet) {
+        // Ensure that inkless.enable config is always defined if inkless is enabled.
+        // This allows to quickly check if a topic is inkless or not from the KRaft metadata directly.
+        if (!isInklessEnableDefined && inklessEnabled) {
             validConfigRecord.add(new ApiMessageAndVersion(new ConfigRecord()
                 .setName(INKLESS_ENABLE_CONFIG)
-                .setValue("false")
+                .setValue("true")
                 .setResourceName(topic.name())
                 .setResourceType(ResourceType.TOPIC.code()), (short) 0));
         }

--- a/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
@@ -113,6 +113,7 @@ import org.slf4j.LoggerFactory;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -691,16 +692,90 @@ public class ReplicationControlManagerTest {
         assertEquals(expectedResponse4, result4.response());
     }
 
-    @Test
-    public void testCreateInklessTopic() {
-        ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder().build();
+    @ParameterizedTest
+    @CsvSource({
+        "true,false",
+        "false,false"
+    })
+    public void testNotCreateInklessTopic(boolean logInklessEnableServerConfig, String inklessEnableTopicConfig) {
+        ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder().setDefaultInklessEnable(logInklessEnableServerConfig).build();
         ReplicationControlManager replicationControl = ctx.replicationControl;
         // Given a kafka topic with inkless enabled
         CreateTopicsRequestData request = new CreateTopicsRequestData();
         CreateTopicsRequestData.CreatableTopicConfigCollection creatableTopicConfigs = new CreateTopicsRequestData.CreatableTopicConfigCollection();
-        creatableTopicConfigs.add(new CreateTopicsRequestData.CreatableTopicConfig()
-            .setName(INKLESS_ENABLE_CONFIG)
-            .setValue("true"));
+        if (inklessEnableTopicConfig != null) {
+            creatableTopicConfigs.add(new CreateTopicsRequestData.CreatableTopicConfig()
+                .setName(INKLESS_ENABLE_CONFIG)
+                .setValue(inklessEnableTopicConfig));
+        }
+        request.topics().add(new CreatableTopic().setName("foo").
+            setNumPartitions(-1).setReplicationFactor((short) -1)
+            .setConfigs(creatableTopicConfigs));
+
+        // Given all brokers unfenced
+        ControllerRequestContext requestContext = anonymousContextFor(ApiKeys.CREATE_TOPICS);
+        ctx.registerBrokers(0, 1, 2);
+        ctx.unfenceBrokers(0, 1, 2);
+
+        // When creating a topic with inkless enabled
+        ControllerResult<CreateTopicsResponseData> result =
+            replicationControl.createTopics(requestContext, request, Collections.singleton("foo"));
+        // Then the topic creation should succeed, regardless of the RF
+        CreateTopicsResponseData expectedResponse = new CreateTopicsResponseData();
+        expectedResponse.topics().add(new CreatableTopicResult().setName("foo").
+            setNumPartitions(1).setReplicationFactor((short) 3).
+            setErrorMessage(null).setErrorCode((short) 0).
+            setTopicId(result.response().topics().find("foo").topicId()));
+        assertEquals(expectedResponse, withoutConfigs(result.response()));
+        final List<ConfigRecord> inklessConfigRecords = result.records().stream()
+            .filter(m -> m.message() instanceof ConfigRecord)
+            .map(m -> (ConfigRecord) m.message())
+            .filter(c -> c.name().equals(INKLESS_ENABLE_CONFIG))
+            .toList();
+        assertEquals(1, inklessConfigRecords.size());
+        // Then always inkless is disabled
+        assertTrue(inklessConfigRecords.stream().allMatch(c -> c.value().equals("false")));
+
+        // Given the topic is registered
+        ctx.replay(result.records());
+        assertEquals(new PartitionRegistration.Builder().setReplicas(new int[] {1, 2, 0}).
+                setDirectories(new Uuid[] {
+                    Uuid.fromString("TESTBROKER00001DIRAAAA"),
+                    Uuid.fromString("TESTBROKER00002DIRAAAA"),
+                    Uuid.fromString("TESTBROKER00000DIRAAAA")
+                }).
+                setIsr(new int[] {1, 2, 0}).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).setLeaderEpoch(0).setPartitionEpoch(0).build(),
+            replicationControl.getPartition(
+                ((TopicRecord) result.records().get(0).message()).topicId(), 0));
+
+        // When creating a topic with inkless enabled and already exists
+        ControllerResult<CreateTopicsResponseData> result4 =
+            replicationControl.createTopics(requestContext, request, Collections.singleton("foo"));
+        CreateTopicsResponseData expectedResponse4 = new CreateTopicsResponseData();
+        // Then the topic creation should fail with TOPIC_ALREADY_EXISTS error
+        expectedResponse4.topics().add(new CreatableTopicResult().setName("foo").
+            setErrorCode(Errors.TOPIC_ALREADY_EXISTS.code()).
+            setErrorMessage("Topic 'foo' already exists."));
+        assertEquals(expectedResponse4, result4.response());
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "true,true",
+        "false,true",
+        "true,"
+    })
+    public void testCreateInklessTopic(boolean logInklessEnableServerConfig, String inklessEnableTopicConfig) {
+        ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder().setDefaultInklessEnable(logInklessEnableServerConfig).build();
+        ReplicationControlManager replicationControl = ctx.replicationControl;
+        // Given a kafka topic with inkless enabled
+        CreateTopicsRequestData request = new CreateTopicsRequestData();
+        CreateTopicsRequestData.CreatableTopicConfigCollection creatableTopicConfigs = new CreateTopicsRequestData.CreatableTopicConfigCollection();
+        if (inklessEnableTopicConfig != null) {
+            creatableTopicConfigs.add(new CreateTopicsRequestData.CreatableTopicConfig()
+                .setName(INKLESS_ENABLE_CONFIG)
+                .setValue(inklessEnableTopicConfig));
+        }
         request.topics().add(new CreatableTopic().setName("foo").
             setNumPartitions(-1).setReplicationFactor((short) -1)
             .setConfigs(creatableTopicConfigs));
@@ -746,6 +821,14 @@ public class ReplicationControlManagerTest {
             setErrorMessage(null).setErrorCode((short) 0).
             setTopicId(result3.response().topics().find("foo").topicId()));
         assertEquals(expectedResponse3, withoutConfigs(result3.response()));
+        final List<ConfigRecord> inklessConfigRecords = result3.records().stream()
+            .filter(m -> m.message() instanceof ConfigRecord)
+            .map(m -> (ConfigRecord) m.message())
+            .filter(c -> c.name().equals(INKLESS_ENABLE_CONFIG))
+            .toList();
+        assertEquals(1, inklessConfigRecords.size());
+        // Then always inkless is disabled
+        assertTrue(inklessConfigRecords.stream().allMatch(c -> c.value().equals("true")));
 
         // Given the topic is registered
         ctx.replay(result3.records());
@@ -856,7 +939,7 @@ public class ReplicationControlManagerTest {
             .map(m -> (ConfigRecord) m.message())
             .filter(c -> c.name().equals(INKLESS_ENABLE_CONFIG))
             .toList();
-        assertTrue(inklessConfigRecords.size() == 1);
+        assertEquals(1, inklessConfigRecords.size());
         // Then always inkless is disabled
         assertTrue(inklessConfigRecords.stream().allMatch(c -> c.value().equals("false")));
     }


### PR DESCRIPTION
Server default is constantly used to verify if a topic is inkless or not.
To avoid this repeated work, store always the inkless enabled config on KRaft and rely on this to serve this check.
