### PR TITLE
feat(inkless): add inkless fetch batching server-side configs

### DIFF
--- a/core/src/main/scala/kafka/server/DelayedFetch.scala
+++ b/core/src/main/scala/kafka/server/DelayedFetch.scala
@@ -56,8 +56,10 @@ class DelayedFetch(
   inklessFetchPartitionStatus: Seq[(TopicIdPartition, FetchPartitionStatus)] = Seq.empty,
   replicaManager: ReplicaManager,
   quota: ReplicaQuota,
-  responseCallback: Seq[(TopicIdPartition, FetchPartitionData)] => Unit
-) extends DelayedOperation(params.maxWaitMs) with Logging {
+  maxWaitMs: Option[Long] = None,
+  minBytes: Option[Int] = None,
+  responseCallback: Seq[(TopicIdPartition, FetchPartitionData)] => Unit,
+) extends DelayedOperation(maxWaitMs.getOrElse(params.maxWaitMs)) with Logging {
 
   override def toString: String = {
     s"DelayedFetch(params=$params" +
@@ -157,7 +159,7 @@ class DelayedFetch(
     }
 
     // Case G
-    if (accumulatedSize >= params.minBytes)
+    if (accumulatedSize >= minBytes.getOrElse(params.minBytes))
       forceComplete()
     else
       false

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -410,6 +410,9 @@ class KafkaConfig private(doLog: Boolean, val props: util.Map[_, _])
   val maxIncrementalFetchSessionCacheSlots = getInt(ServerConfigs.MAX_INCREMENTAL_FETCH_SESSION_CACHE_SLOTS_CONFIG)
   val fetchMaxBytes = getInt(ServerConfigs.FETCH_MAX_BYTES_CONFIG)
 
+  val inklessFetchMinBytes = getInt(ServerConfigs.INKLESS_FETCH_MIN_BYTES_CONFIG)
+  val inklessFetchMaxWaitMs = getInt(ServerConfigs.INKLESS_FETCH_MAX_WAIT_MS_CONFIG)
+
   /** ********* Request Limit Configuration ***********/
   val maxRequestPartitionSizeLimit = getInt(ServerConfigs.MAX_REQUEST_PARTITION_SIZE_LIMIT_CONFIG)
 

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1751,6 +1751,10 @@ class ReplicaManager(val config: KafkaConfig,
 
     val (inklessFetchInfos, classicFetchInfos) = fetchInfos.partition { case (k, _) => isInklessTopic(k.topic()) }
 
+    // Override maxWaitMs and minBytes with lower-bound if there are inkless fetches. Otherwise, leave the consumer-provided values.
+    val maxWaitMs = if (inklessFetchInfos.nonEmpty) Math.max(config.inklessFetchMaxWaitMs.toLong, params.maxWaitMs) else params.maxWaitMs
+    val minBytes = if (inklessFetchInfos.nonEmpty) Math.max(config.inklessFetchMinBytes, params.minBytes) else params.minBytes
+
     if (params.isFromFollower && inklessFetchInfos.nonEmpty) {
       warn("Inkless topics are not supported for follower fetch requests. " +
         s"Request from follower ${params.replicaId} contains inkless topics: ${inklessFetchInfos.map(_._1.topic()).mkString(", ")}")
@@ -1763,13 +1767,18 @@ class ReplicaManager(val config: KafkaConfig,
         case (k, partitionData) =>
           k -> FetchPartitionStatus(new LogOffsetMetadata(partitionData.fetchOffset), partitionData)
       }
+      // If there are inkless fetches, enforce a lower bound on maxWaitMs to ensure that we wait at least as long as the
+      // configured remote fetch max wait time. This is to ensure that we give enough time for the inkless fetches to complete,
+      // and do not overload the control plane with too many requests.
       val delayedFetch = new DelayedFetch(
         params = params,
         classicFetchPartitionStatus = classicFetchPartitionStatus,
         inklessFetchPartitionStatus = inklessFetchPartitionStatus,
         replicaManager = this,
         quota = quota,
-        responseCallback = responseCallback
+        maxWaitMs = Some(maxWaitMs),
+        minBytes = Some(minBytes),
+        responseCallback = responseCallback,
       )
 
       // create a list of (topic, partition) pairs to use as keys for this delayed fetch operation
@@ -1850,7 +1859,7 @@ class ReplicaManager(val config: KafkaConfig,
           val inklessParams = fetchParamsWithNewMaxBytes(params, inklessFetchInfos.size.toFloat / fetchInfos.size.toFloat)
           val inklessResponsesFuture = fetchInklessMessages(inklessParams, inklessFetchInfos)
 
-          val response = inklessResponsesFuture.get(params.maxWaitMs, TimeUnit.MILLISECONDS)
+          val response = inklessResponsesFuture.get(maxWaitMs, TimeUnit.MILLISECONDS)
           response.map { case (tp, data) =>
             val exception: Optional[Throwable] = data.error match {
               case Errors.NONE => Optional.empty()

--- a/server-common/src/main/java/org/apache/kafka/server/config/ServerConfigs.java
+++ b/server-common/src/main/java/org/apache/kafka/server/config/ServerConfigs.java
@@ -101,6 +101,21 @@ public class ServerConfigs {
     public static final int FETCH_MAX_BYTES_DEFAULT = 55 * 1024 * 1024;
     public static final String FETCH_MAX_BYTES_DOC = "The maximum number of bytes we will return for a fetch request. Must be at least 1024.";
 
+    /** ********* Inkless Fetch Batch Configuration ***********/
+    public static final String INKLESS_FETCH_MIN_BYTES_CONFIG = "inkless.fetch.min.bytes";
+    public static final int INKLESS_FETCH_MIN_BYTES_DEFAULT = 1;
+    public static final String INKLESS_FETCH_MIN_BYTES_DOC = "The minimum number of bytes to return for a fetch request. " +
+            "If the number of bytes available is less than this value, the request will wait until more data is available or the maximum wait time is reached. " +
+            "This configuration will override the consumer's <code>fetch.min.bytes</code> setting for inkless fetch requests if the value is greater than the consumer's setting. " +
+            "This is a protective configuration to ensure the operator can control how often to return fetch responses";
+
+    public static final String INKLESS_FETCH_MAX_WAIT_MS_CONFIG = "inkless.fetch.max.wait.ms";
+    public static final int INKLESS_FETCH_MAX_WAIT_MS_DEFAULT = 100;  // Half of the default fetch.max.wait.ms
+    public static final String INKLESS_FETCH_MAX_WAIT_MS_DOC = "The maximum time to wait for a fetch request to be fulfilled. " +
+            "If the request is not fulfilled within this time, it will return an empty response. This is useful for reducing latency in high-throughput scenarios. " +
+            "This configuration will override the consumer's <code>fetch.max.wait.ms</code> setting for inkless fetch requests if the value is less than the consumer's setting. " +
+            "This is a protective configuration to ensure the operator can control how often to return fetch responses";
+
     /** ********* Request Limit Configuration **************/
     public static final String MAX_REQUEST_PARTITION_SIZE_LIMIT_CONFIG = "max.request.partition.size.limit";
     public static final int MAX_REQUEST_PARTITION_SIZE_LIMIT_DEFAULT = 2000;
@@ -144,6 +159,10 @@ public class ServerConfigs {
             /** ********* Fetch Configuration **************/
             .define(MAX_INCREMENTAL_FETCH_SESSION_CACHE_SLOTS_CONFIG, INT, MAX_INCREMENTAL_FETCH_SESSION_CACHE_SLOTS_DEFAULT, atLeast(0), MEDIUM, MAX_INCREMENTAL_FETCH_SESSION_CACHE_SLOTS_DOC)
             .define(FETCH_MAX_BYTES_CONFIG, INT, FETCH_MAX_BYTES_DEFAULT, atLeast(1024), MEDIUM, FETCH_MAX_BYTES_DOC)
+
+            /** ********* Inkless Fetch Batch Configuration ***********/
+            .define(INKLESS_FETCH_MIN_BYTES_CONFIG, INT, INKLESS_FETCH_MIN_BYTES_DEFAULT, atLeast(1), MEDIUM, INKLESS_FETCH_MIN_BYTES_DOC)
+            .define(INKLESS_FETCH_MAX_WAIT_MS_CONFIG, INT, INKLESS_FETCH_MAX_WAIT_MS_DEFAULT, atLeast(0), MEDIUM, INKLESS_FETCH_MAX_WAIT_MS_DOC)
 
             /** ********* Request Limit Configuration ***********/
             .define(MAX_REQUEST_PARTITION_SIZE_LIMIT_CONFIG, INT, MAX_REQUEST_PARTITION_SIZE_LIMIT_DEFAULT, atLeast(1), MEDIUM, MAX_REQUEST_PARTITION_SIZE_LIMIT_DOC)


### PR DESCRIPTION
Introduce fetch.max.wait.ms and fetch.min.bytes for inkless fetch consumer request lower-bound values as a broker-side config to override consumers values if there are smaller.

This should give operators control over how fetch requests are served.