### PR TITLE
fix(inkless:ci): regenerate jooq classes with jdk23 on kafka ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,7 +127,10 @@ jobs:
       - name: Setup Gradle
         uses: ./.github/actions/setup-gradle
         with:
-          java-version: 23
+          # Inkless: Downgrading to 17 as jooq classes are generated (or cached) with this-escape
+          # and can't find how to overcome this issue. Leaving it at JDK17 for the checks,
+          # as both JDKs 17 and 23 are tested in the next phase
+          java-version: 17
           gradle-cache-read-only: ${{ !inputs.is-trunk }}
           gradle-cache-write-only: ${{ inputs.is-trunk }}
           develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
@@ -215,6 +218,12 @@ jobs:
         with:
           name: combined-test-catalog
 
+      # JOOQ classes are generated on the previous validate job,
+      # but if generated with JDK 17, there are no warning suppressions for `this-escape` needed after JDK 21.
+      # see https://github.com/jOOQ/jOOQ/issues/15619
+      - name: Regenerate JOOQ classes (needed after JDK 21)
+        if: matrix.java != '17'
+        run: ./gradlew :storage:inkless:generateJooqClasses
       - name: JUnit Tests
         id: junit-test
         uses: ./.github/actions/run-gradle

--- a/build.gradle
+++ b/build.gradle
@@ -265,7 +265,7 @@ if (repo != null) {
   rat {
     dependsOn subprojects.collect {
       it.tasks.matching {
-        it.name == "processMessages" || it.name == "processTestMessages"
+        it.name == "processMessages" || it.name == "processTestMessages" || it.name == "generateJooqClasses"
       }
     }
 


### PR DESCRIPTION
Had to downgrade the checks JDK to 17, as it is for some reason always generating (or using cached) classes with this-escape.

I tried different workarounds but will just leave it as a comment for now, as the tests _are_ running on both JDKs 17 and 23.
