### PR TITLE
chore(inkless:ci): bump test timeout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -230,7 +230,7 @@ jobs:
         uses: ./.github/actions/run-gradle
         with:
           test-task: test
-          timeout-minutes: 180  # 3 hours
+          timeout-minutes: 300  # 5 hours
           test-catalog-path: ${{ steps.load-test-catalog.outputs.download-path }}/combined-test-catalog.txt
           build-scan-artifact-name: build-scan-${{ env.job-variation }}
           run-new-tests: ${{ matrix.run-new }}


### PR DESCRIPTION
Additional tests increase the overall execution time, and require room to complete.
