### PR TITLE
Avoid starvation of inkless topics when doing dual topics fetches

### DIFF
--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1914,7 +1914,7 @@ class ReplicaManager(val config: KafkaConfig,
           responseCallback(partitionToFetchPartitionData)
         }
       } else {
-        if (bytesReadable >= params.minBytes || params.maxWaitMs <= 0) {
+        if (inklessFetchInfos.isEmpty && (bytesReadable >= params.minBytes || params.maxWaitMs <= 0)) {
           responseCallback(fetchPartitionData)
         } else {
           delayedResponse(fetchPartitionStatus)


### PR DESCRIPTION
When fetching from both inkless and classic topics, make sure that the DelayedFetch is always created even if the records retrieved for the classic bytes already satisfy the min bytes.