### PR TITLE
Ensure that inkless fetch  requests always contain the topic id

### DIFF
--- a/storage/inkless/src/main/java/io/aiven/inkless/consume/FindBatchesJob.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/consume/FindBatchesJob.java
@@ -18,17 +18,14 @@
 package io.aiven.inkless.consume;
 
 import org.apache.kafka.common.TopicIdPartition;
-import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.requests.FetchRequest;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.server.storage.log.FetchParams;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.function.Consumer;
 
@@ -36,26 +33,22 @@ import io.aiven.inkless.TimeUtils;
 import io.aiven.inkless.control_plane.ControlPlane;
 import io.aiven.inkless.control_plane.FindBatchRequest;
 import io.aiven.inkless.control_plane.FindBatchResponse;
-import io.aiven.inkless.control_plane.MetadataView;
 
 public class FindBatchesJob implements Callable<Map<TopicIdPartition, FindBatchResponse>> {
 
     private final Time time;
     private final ControlPlane controlPlane;
-    private final MetadataView metadataView;
     private final FetchParams params;
     private final Map<TopicIdPartition, FetchRequest.PartitionData> fetchInfos;
     private final Consumer<Long> durationCallback;
 
     public FindBatchesJob(Time time,
                           ControlPlane controlPlane,
-                          MetadataView metadataView,
                           FetchParams params,
                           Map<TopicIdPartition, FetchRequest.PartitionData> fetchInfos,
                           Consumer<Long> durationCallback) {
         this.time = time;
         this.controlPlane = controlPlane;
-        this.metadataView = metadataView;
         this.params = params;
         this.fetchInfos = fetchInfos;
         this.durationCallback = durationCallback;
@@ -68,21 +61,8 @@ public class FindBatchesJob implements Callable<Map<TopicIdPartition, FindBatchR
 
     private Map<TopicIdPartition, FindBatchResponse> doWork() {
         List<FindBatchRequest> requests = new ArrayList<>();
-        Set<String> topicsWithZeroId = new HashSet<>();
         for (Map.Entry<TopicIdPartition, FetchRequest.PartitionData> fetchInfo : fetchInfos.entrySet()) {
             TopicIdPartition topicIdPartition = fetchInfo.getKey();
-
-            // Older fetch versions (<13) don't have topicId in the request -- backfill it for backward compatibility
-            if (topicIdPartition.topicId() == Uuid.ZERO_UUID) {
-                // if topicId from metadata is zero, then CP will not find it and return proper exception
-                final Uuid topicId = metadataView.getTopicId(topicIdPartition.topic());
-                topicIdPartition = new TopicIdPartition(
-                    topicId,
-                    topicIdPartition.topicPartition()
-                );
-                topicsWithZeroId.add(topicIdPartition.topic());
-            }
-
             requests.add(new FindBatchRequest(topicIdPartition, fetchInfo.getValue().fetchOffset, fetchInfo.getValue().maxBytes));
         }
 
@@ -92,18 +72,7 @@ public class FindBatchesJob implements Callable<Map<TopicIdPartition, FindBatchR
         for (int i = 0; i < requests.size(); i++) {
             FindBatchRequest request = requests.get(i);
             FindBatchResponse response = responses.get(i);
-
-            // Older fetch versions (<13) don't have topicId in the request -- backfill it for backward compatibility
-            TopicIdPartition topicIdPartition = request.topicIdPartition();
-            if (topicsWithZeroId.contains(topicIdPartition.topic())) {
-                // Backfill topicId back to zero for older fetch versions
-                topicIdPartition = new TopicIdPartition(
-                    Uuid.ZERO_UUID,
-                    topicIdPartition.topicPartition()
-                );
-            }
-
-            out.put(topicIdPartition, response);
+            out.put(request.topicIdPartition(), response);
         }
         return out;
     }

--- a/storage/inkless/src/main/java/io/aiven/inkless/consume/Reader.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/consume/Reader.java
@@ -122,7 +122,6 @@ public class Reader implements AutoCloseable {
             new FindBatchesJob(
                 time,
                 controlPlane,
-                metadataView,
                 params,
                 fetchInfos,
                 fetchMetrics::findBatchesFinished

--- a/storage/inkless/src/test/java/io/aiven/inkless/consume/FindBatchesJobTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/consume/FindBatchesJobTest.java
@@ -44,7 +44,6 @@ import io.aiven.inkless.control_plane.BatchMetadata;
 import io.aiven.inkless.control_plane.ControlPlane;
 import io.aiven.inkless.control_plane.FindBatchRequest;
 import io.aiven.inkless.control_plane.FindBatchResponse;
-import io.aiven.inkless.control_plane.MetadataView;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -60,8 +59,6 @@ public class FindBatchesJobTest {
     private ControlPlane controlPlane;
     @Mock
     private FetchParams params;
-    @Mock
-    private MetadataView metadataView;
 
     @Captor
     ArgumentCaptor<List<FindBatchRequest>> requestCaptor;
@@ -84,38 +81,11 @@ public class FindBatchesJobTest {
                 new BatchInfo(1L, OBJECT_KEY_MAIN_PART, BatchMetadata.of(partition0, 0, 10, 0, 0, logAppendTimestamp, maxBatchTimestamp, TimestampType.CREATE_TIME))
             ), logStartOffset, highWatermark)
         );
-        FindBatchesJob job = new FindBatchesJob(time, controlPlane, metadataView, params, fetchInfos, durationMs -> {});
+        FindBatchesJob job = new FindBatchesJob(time, controlPlane, params, fetchInfos, durationMs -> {});
         when(controlPlane.findBatches(requestCaptor.capture(), anyInt())).thenReturn(new ArrayList<>(coordinates.values()));
         Map<TopicIdPartition, FindBatchResponse> result = job.call();
 
         assertThat(result).isEqualTo(coordinates);
     }
 
-    @Test
-    public void findSingleBatchWithoutTopicId() throws Exception {
-        final Uuid noTopicId = Uuid.ZERO_UUID;
-        TopicIdPartition partition0 = new TopicIdPartition(noTopicId, 0, "inkless-topic");
-        Map<TopicIdPartition, FetchRequest.PartitionData> fetchInfos = Map.of(
-            partition0, new FetchRequest.PartitionData(noTopicId, 0, 0, 1000, Optional.empty())
-        );
-        int logStartOffset = 0;
-        long logAppendTimestamp = 10L;
-        long maxBatchTimestamp = 20L;
-        int highWatermark = 1;
-
-        // Simulate the metadata view returning a topic ID for the partition
-        when(metadataView.getTopicId(partition0.topic())).thenReturn(topicId);
-
-        Map<TopicIdPartition, FindBatchResponse> coordinates = Map.of(
-            partition0, FindBatchResponse.success(List.of(
-                new BatchInfo(1L, OBJECT_KEY_MAIN_PART, BatchMetadata.of(partition0, 0, 10, 0, 0, logAppendTimestamp, maxBatchTimestamp, TimestampType.CREATE_TIME))
-            ), logStartOffset, highWatermark)
-        );
-        FindBatchesJob job = new FindBatchesJob(time, controlPlane, metadataView, params, fetchInfos, durationMs -> {});
-        when(controlPlane.findBatches(requestCaptor.capture(), anyInt())).thenReturn(new ArrayList<>(coordinates.values()));
-        Map<TopicIdPartition, FindBatchResponse> result = job.call();
-
-        // Verify that the request was made with the correct topic ID and the result is still with the original partition with no topic ID
-        assertThat(result).isEqualTo(coordinates);
-    }
 }


### PR DESCRIPTION
Fetch requests might not contain the topic id. Retrieve the topic id from KRaft metadata if available