### PR TITLE
storage: change fetch API to return ReadableByteChannel

### DIFF
--- a/storage/inkless/src/main/java/io/aiven/inkless/merge/FileMerger.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/merge/FileMerger.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -151,9 +152,11 @@ public class FileMerger implements Runnable {
                 final var target = workDir.resolve(tmpFileName);
                 paths.add(target);
 
-                try (final var in = storage.fetch(objectKey, null);
-                     final var out = Files.newOutputStream(target)) {
-                    in.transferTo(out);
+                final var in = storage.fetch(objectKey, null);
+                try (final var out = Files.newByteChannel(target, StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE)) {
+                    out.write(storage.readToByteBuffer(in));
+                } catch (Exception e) {
+                    e.printStackTrace();
                 }
 
                 final Supplier<InputStream> inputStream = () -> {

--- a/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/common/ObjectFetcher.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/common/ObjectFetcher.java
@@ -17,11 +17,42 @@
  */
 package io.aiven.inkless.storage_backend.common;
 
-import java.io.InputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.ReadableByteChannel;
+import java.util.ArrayList;
+import java.util.List;
 
 import io.aiven.inkless.common.ByteRange;
 import io.aiven.inkless.common.ObjectKey;
 
 public interface ObjectFetcher {
-    InputStream fetch(ObjectKey key, ByteRange range) throws StorageBackendException;
+
+    /**
+     * Use large enough buffer for reading the blob content to byte buffers to reduce required number
+     * of allocations. Usually default implementations in input streams use 16 KiB buffers. The expectation
+     * of blob sizes from cloud storages are multi-megabyte.
+     */
+    int READ_BUFFER_1MiB = 1024 * 1024;
+
+    ReadableByteChannel fetch(ObjectKey key, ByteRange range) throws StorageBackendException, IOException;
+
+    default ByteBuffer readToByteBuffer(final ReadableByteChannel readableByteChannel) throws IOException {
+        final ByteBuffer byteBuffer;
+        final List<ByteBuffer> buffers = new ArrayList<>(5);
+        int readSize;
+        int totalSize = 0;
+        do {
+            final ByteBuffer tempBuffer = ByteBuffer.allocate(READ_BUFFER_1MiB);
+            readSize = readableByteChannel.read(tempBuffer);
+            if (readSize > 0) {
+                buffers.add(tempBuffer);
+                tempBuffer.flip();
+                totalSize += readSize;
+            }
+        } while (readSize >= 0);
+        byteBuffer = ByteBuffer.allocate(totalSize);
+        buffers.forEach(byteBuffer::put);
+        return byteBuffer.flip();
+    }
 }

--- a/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/gcs/GcsStorage.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/gcs/GcsStorage.java
@@ -31,6 +31,7 @@ import com.groupcdg.pitest.annotations.CoverageIgnore;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.channels.Channels;
+import java.nio.channels.ReadableByteChannel;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -114,10 +115,10 @@ public class GcsStorage implements StorageBackend {
     }
 
     @Override
-    public InputStream fetch(ObjectKey key, ByteRange range) throws StorageBackendException {
+    public ReadableByteChannel fetch(ObjectKey key, ByteRange range) throws StorageBackendException, IOException {
         try {
             if (range != null && range.empty()) {
-                return InputStream.nullInputStream();
+                return Channels.newChannel(InputStream.nullInputStream());
             }
 
             final Blob blob = getBlob(key);
@@ -132,7 +133,7 @@ public class GcsStorage implements StorageBackend {
                 reader.limit(range.endOffset() + 1);
                 reader.seek(range.offset());
             }
-            return Channels.newInputStream(reader);
+            return reader;
         } catch (final IOException e) {
             throw new StorageBackendException("Failed to fetch " + key, e);
         } catch (final BaseServiceException e) {

--- a/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/s3/S3Storage.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/s3/S3Storage.java
@@ -21,6 +21,8 @@ import com.groupcdg.pitest.annotations.CoverageIgnore;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.channels.Channels;
+import java.nio.channels.ReadableByteChannel;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -90,10 +92,10 @@ public class S3Storage implements StorageBackend {
     }
 
     @Override
-    public InputStream fetch(final ObjectKey key, final ByteRange range) throws StorageBackendException {
+    public ReadableByteChannel fetch(final ObjectKey key, final ByteRange range) throws StorageBackendException, IOException {
         try {
             if (range != null && range.empty()) {
-                return InputStream.nullInputStream();
+                return Channels.newChannel(InputStream.nullInputStream());
             }
 
             var builder = GetObjectRequest.builder()
@@ -104,7 +106,7 @@ public class S3Storage implements StorageBackend {
             }
             final GetObjectRequest getRequest = builder
                 .build();
-            return s3Client.getObject(getRequest);
+            return Channels.newChannel(s3Client.getObject(getRequest));
         } catch (final AwsServiceException e) {
             if (e.statusCode() == 404) {
                 throw new KeyNotFoundException(this, key, e);

--- a/storage/inkless/src/test/java/io/aiven/inkless/config/ConfigTestStorageBackend.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/config/ConfigTestStorageBackend.java
@@ -17,7 +17,9 @@
  */
 package io.aiven.inkless.config;
 
+import java.io.IOException;
 import java.io.InputStream;
+import java.nio.channels.ReadableByteChannel;
 import java.util.Map;
 import java.util.Set;
 
@@ -43,7 +45,7 @@ public class ConfigTestStorageBackend implements StorageBackend {
     }
 
     @Override
-    public InputStream fetch(ObjectKey key, ByteRange range) throws StorageBackendException {
+    public ReadableByteChannel fetch(ObjectKey key, ByteRange range) throws StorageBackendException, IOException {
         return null;
     }
 

--- a/storage/inkless/src/test/java/io/aiven/inkless/consume/CacheFetchJobTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/consume/CacheFetchJobTest.java
@@ -27,8 +27,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
-import java.io.ByteArrayInputStream;
 import java.nio.ByteBuffer;
+import java.nio.channels.ReadableByteChannel;
 
 import io.aiven.inkless.cache.MemoryCache;
 import io.aiven.inkless.cache.NullCache;
@@ -40,6 +40,7 @@ import io.aiven.inkless.generated.FileExtent;
 import io.aiven.inkless.storage_backend.common.ObjectFetcher;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
@@ -62,7 +63,10 @@ public class CacheFetchJobTest {
         }
         ByteRange range = new ByteRange(0, size);
         FileExtent expectedFile = FileFetchJob.createFileExtent(objectA, range, ByteBuffer.wrap(array));
-        when(fetcher.fetch(objectA, range)).thenReturn(new ByteArrayInputStream(array));
+
+        final ReadableByteChannel channel = mock(ReadableByteChannel.class);
+        when(fetcher.fetch(objectA, range)).thenReturn(channel);
+        when(fetcher.readToByteBuffer(channel)).thenReturn(ByteBuffer.wrap(array));
 
         ObjectCache cache = new NullCache();
         CacheFetchJob cacheFetchJob = cacheFetchJob(cache, objectA, range);

--- a/storage/inkless/src/test/java/io/aiven/inkless/consume/FileFetchJobTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/consume/FileFetchJobTest.java
@@ -27,8 +27,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
-import java.io.ByteArrayInputStream;
 import java.nio.ByteBuffer;
+import java.nio.channels.ReadableByteChannel;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -42,6 +42,7 @@ import io.aiven.inkless.storage_backend.common.ObjectFetcher;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -70,7 +71,9 @@ public class FileFetchJobTest {
         FileFetchJob job = new FileFetchJob(time, fetcher, objectA, range, durationMs -> { });
         FileExtent expectedFile = FileFetchJob.createFileExtent(objectA, range, ByteBuffer.wrap(array));
 
-        when(fetcher.fetch(objectA, range)).thenReturn(new ByteArrayInputStream(array));
+        final ReadableByteChannel channel = mock(ReadableByteChannel.class);
+        when(fetcher.fetch(objectA, range)).thenReturn(channel);
+        when(fetcher.readToByteBuffer(channel)).thenReturn(ByteBuffer.wrap(array));
         FileExtent actualFile = job.call();
 
         assertThat(actualFile).isEqualTo(expectedFile);

--- a/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/azure/integration/AzureBlobStorageMetricsTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/azure/integration/AzureBlobStorageMetricsTest.java
@@ -34,7 +34,6 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.lang.management.ManagementFactory;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -123,12 +122,8 @@ public class AzureBlobStorageMetricsTest {
         final var storage = storage();
 
         storage.upload(key, new ByteArrayInputStream(data), data.length);
-        try (final InputStream fetch = storage.fetch(key, null)) {
-            fetch.readAllBytes();
-        }
-        try (final InputStream fetch = storage.fetch(key, new ByteRange(0, 1))) {
-            fetch.readAllBytes();
-        }
+        storage.fetch(key, null);
+        storage.fetch(key, new ByteRange(0, 1));
         storage.delete(key);
 
         final ObjectName objectName =

--- a/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/gcs/integration/GcsStorageMetricsTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/gcs/integration/GcsStorageMetricsTest.java
@@ -34,8 +34,8 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.lang.management.ManagementFactory;
+import java.nio.channels.ReadableByteChannel;
 import java.util.Map;
 
 import javax.management.JMException;
@@ -98,11 +98,11 @@ public class GcsStorageMetricsTest {
         final ObjectKey key = new TestObjectKey("x");
 
         storage.upload(key, new ByteArrayInputStream(data), data.length);
-        try (final InputStream fetch = storage.fetch(key, ByteRange.maxRange())) {
-            fetch.readAllBytes();
+        try (final ReadableByteChannel channel = storage.fetch(key, ByteRange.maxRange())) {
+            storage.readToByteBuffer(channel);
         }
-        try (final InputStream fetch = storage.fetch(key, new ByteRange(0, 1))) {
-            fetch.readAllBytes();
+        try (final ReadableByteChannel channel = storage.fetch(key, new ByteRange(0, 1))) {
+            storage.readToByteBuffer(channel);
         }
         storage.delete(key);
 

--- a/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/in_memory/InMemoryStorageTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/in_memory/InMemoryStorageTest.java
@@ -20,7 +20,8 @@ package io.aiven.inkless.storage_backend.in_memory;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
-import java.io.InputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.Set;
 
 import io.aiven.inkless.common.ByteRange;
@@ -66,27 +67,27 @@ class InMemoryStorageTest {
     }
 
     @Test
-    void uploadAndFetch() throws StorageBackendException {
+    void uploadAndFetch() throws StorageBackendException, IOException {
         final InMemoryStorage storage = new InMemoryStorage();
         final byte[] data = new byte[10];
         storage.upload(OBJECT_KEY, new ByteArrayInputStream(data), data.length);
 
-        final InputStream fetch = storage.fetch(OBJECT_KEY, ByteRange.maxRange());
+        final ByteBuffer fetch = storage.readToByteBuffer(storage.fetch(OBJECT_KEY, ByteRange.maxRange()));
 
-        assertThat(fetch).hasBinaryContent(data);
+        assertThat(fetch.array()).isEqualTo(data);
     }
 
     @Test
-    void fetchRanged() throws StorageBackendException {
+    void fetchRanged() throws StorageBackendException, IOException {
         final InMemoryStorage storage = new InMemoryStorage();
         final byte[] data = new byte[]{0, 1, 2, 3, 4, 5, 6, 7};
         storage.upload(OBJECT_KEY, new ByteArrayInputStream(data), data.length);
 
-        final InputStream fetch1 = storage.fetch(OBJECT_KEY, new ByteRange(1, 2));
-        assertThat(fetch1).hasBinaryContent(new byte[]{1, 2});
+        final ByteBuffer fetch1 = storage.readToByteBuffer(storage.fetch(OBJECT_KEY, new ByteRange(1, 2)));
+        assertThat(fetch1.array()).isEqualTo(new byte[]{1, 2});
 
-        final InputStream fetch2 = storage.fetch(OBJECT_KEY, new ByteRange(1, 100));
-        assertThat(fetch2).hasBinaryContent(new byte[]{1, 2, 3, 4, 5, 6, 7});
+        final ByteBuffer fetch2 = storage.readToByteBuffer(storage.fetch(OBJECT_KEY, new ByteRange(1, 100)));
+        assertThat(fetch2.array()).isEqualTo(new byte[]{1, 2, 3, 4, 5, 6, 7});
     }
 
     @Test
@@ -101,13 +102,13 @@ class InMemoryStorageTest {
     }
 
     @Test
-    void delete() throws StorageBackendException {
+    void delete() throws StorageBackendException, IOException {
         final InMemoryStorage storage = new InMemoryStorage();
         final byte[] data = new byte[]{0, 1, 2, 3, 4, 5, 6, 7};
         storage.upload(OBJECT_KEY, new ByteArrayInputStream(data), data.length);
 
-        final InputStream fetch = storage.fetch(OBJECT_KEY, new ByteRange(1, 2));
-        assertThat(fetch).hasBinaryContent(new byte[]{1, 2});
+        final ByteBuffer fetch = storage.readToByteBuffer(storage.fetch(OBJECT_KEY, new ByteRange(1, 2)));
+        assertThat(fetch.array()).isEqualTo(new byte[]{1, 2});
 
         storage.delete(OBJECT_KEY);
 
@@ -116,13 +117,13 @@ class InMemoryStorageTest {
     }
 
     @Test
-    void deleteMany() throws StorageBackendException {
+    void deleteMany() throws StorageBackendException, IOException {
         final InMemoryStorage storage = new InMemoryStorage();
         final byte[] data = new byte[]{0, 1, 2, 3, 4, 5, 6, 7};
         storage.upload(OBJECT_KEY, new ByteArrayInputStream(data), data.length);
 
-        final InputStream fetch = storage.fetch(OBJECT_KEY, new ByteRange(1, 2));
-        assertThat(fetch).hasBinaryContent(new byte[]{1, 2});
+        final ByteBuffer fetch = storage.readToByteBuffer(storage.fetch(OBJECT_KEY, new ByteRange(1, 2)));
+        assertThat(fetch.array()).isEqualTo(new byte[]{1, 2});
 
         storage.delete(Set.of(OBJECT_KEY, PlainObjectKey.create("un", "related")));
 

--- a/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/s3/integration/S3StorageMetricsTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/s3/integration/S3StorageMetricsTest.java
@@ -25,7 +25,6 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.io.ByteArrayInputStream;
-import java.io.InputStream;
 import java.lang.management.ManagementFactory;
 import java.util.Map;
 import java.util.Set;
@@ -82,12 +81,8 @@ class S3StorageMetricsTest {
         final ObjectKey key = new TestObjectKey("x");
 
         storage.upload(key, new ByteArrayInputStream(data), data.length);
-        try (final InputStream fetch = storage.fetch(key, ByteRange.maxRange())) {
-            fetch.readAllBytes();
-        }
-        try (final InputStream fetch = storage.fetch(key, new ByteRange(0, 1))) {
-            fetch.readAllBytes();
-        }
+        storage.fetch(key, ByteRange.maxRange());
+        storage.fetch(key, new ByteRange(0, 1));
         storage.delete(key);
         storage.delete(Set.of(key));
 


### PR DESCRIPTION
This allows to allocate ByteBuffers and reduce amount of byte array copying.
Tested with GCS client.

Pre:
<img width="971" height="462" alt="image" src="https://github.com/user-attachments/assets/4c66a087-2845-4a2c-81cd-20966a5d3aa5" />

Post:
<img width="530" height="294" alt="image" src="https://github.com/user-attachments/assets/f397049d-ef3a-46f2-8120-5796430a0d8c" />
