### PR TITLE
feat(inkless): add error rate metrics for file committer

### DIFF
--- a/storage/inkless/src/main/java/io/aiven/inkless/produce/FileCommitJob.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/produce/FileCommitJob.java
@@ -115,8 +115,8 @@ class FileCommitJob implements Supplier<List<CommitBatchResponse>> {
                 throw e;
             }
         } else {
-            LOGGER.error("Upload failed: {}", result.uploadError.getMessage());
-            throw new RuntimeException("File not uploaded", result.uploadError);
+            // no need to log here, it was already logged in waitForUpload
+            throw new FileUploadException(result.uploadError);
         }
     }
 

--- a/storage/inkless/src/main/java/io/aiven/inkless/produce/FileCommitter.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/produce/FileCommitter.java
@@ -21,6 +21,9 @@ import org.apache.kafka.common.utils.Time;
 
 import com.groupcdg.pitest.annotations.DoNotMutate;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.Closeable;
 import java.io.IOException;
 import java.time.Duration;
@@ -52,6 +55,8 @@ import io.aiven.inkless.storage_backend.common.StorageBackend;
  * <p>It uploads files concurrently, but commits them to the control plan sequentially.
  */
 class FileCommitter implements Closeable {
+    private static final Logger LOGGER = LoggerFactory.getLogger(FileCommitter.class);
+
     private final FileCommitterMetrics metrics;
 
     private final Lock lock = new ReentrantLock();
@@ -177,9 +182,19 @@ class FileCommitter implements Closeable {
                         .whenComplete((result, error) -> {
                             totalFilesInProgress.addAndGet(-1);
                             totalBytesInProgress.addAndGet(-file.size());
-                            metrics.fileFinished(file.start(), uploadAndCommitStart);
+                            if (error != null) {
+                                // at this point the commit has failed and need to check whether it failed on upload or commit
+                                LOGGER.error("Failed to commit diskless file {}", file, error);
+                                if (error.getCause() instanceof FileUploadException) {
+                                    metrics.fileUploadFailed();
+                                } else {
+                                    metrics.fileCommitFailed();
+                                }
+                            } else {
+                                // only mark as finished if everything succeeded
+                                metrics.fileFinished(file.start(), uploadAndCommitStart);
+                            }
                         });
-
 
                 final CacheStoreJob cacheStoreJob = new CacheStoreJob(
                         time,
@@ -195,8 +210,10 @@ class FileCommitter implements Closeable {
                 final AppendCompleter completerJob = new AppendCompleter(file);
                 if (commitBatchResponses != null) {
                     completerJob.finishCommitSuccessfully(commitBatchResponses);
+                    metrics.writeCompleted();
                 } else {
                     completerJob.finishCommitWithError();
+                    metrics.writeFailed();
                 }
             });
         } finally {

--- a/storage/inkless/src/main/java/io/aiven/inkless/produce/FileCommitterMetrics.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/produce/FileCommitterMetrics.java
@@ -22,6 +22,7 @@ import org.apache.kafka.server.metrics.KafkaMetricsGroup;
 
 import com.groupcdg.pitest.annotations.CoverageIgnore;
 import com.yammer.metrics.core.Histogram;
+import com.yammer.metrics.core.Meter;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -29,7 +30,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.atomic.LongAdder;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
 import io.aiven.inkless.TimeUtils;
@@ -40,15 +41,19 @@ class FileCommitterMetrics implements Closeable {
     private static final String FILE_UPLOAD_AND_COMMIT_TIME = "FileUploadAndCommitTime";
     private static final String FILE_UPLOAD_TIME = "FileUploadTime";
     private static final String FILE_UPLOAD_RATE = "FileUploadRate";
+    private static final String FILE_UPLOAD_ERROR_RATE = "FileUploadErrorRate";
     private static final String FILE_COMMIT_WAIT_TIME = "FileCommitWaitTime";
     private static final String FILE_COMMIT_TIME = "FileCommitTime";
     private static final String FILE_COMMIT_RATE = "FileCommitRate";
+    private static final String FILE_COMMIT_ERROR_RATE = "FileCommitErrorRate";
     private static final String CACHE_STORE_TIME = "CacheStoreTime";
     private static final String COMMIT_QUEUE_FILES = "CommitQueueFiles";
     private static final String COMMIT_QUEUE_BYTES = "CommitQueueBytes";
     private static final String FILE_SIZE = "FileSize";
     private static final String BATCHES_COUNT = "BatchesCount";
     private static final String BATCHES_COMMIT_RATE = "BatchesCommitRate";
+    private static final String WRITE_RATE = "WriteRate";
+    private static final String WRITE_ERROR_RATE = "WriteErrorRate";
 
     private final Time time;
 
@@ -61,23 +66,31 @@ class FileCommitterMetrics implements Closeable {
     private final Histogram fileSizeHistogram;
     private final Histogram batchesCountHistogram;
     private final Histogram cacheStoreTimeHistogram;
-    private final LongAdder fileUploadRate = new LongAdder();
-    private final LongAdder fileCommitRate = new LongAdder();
-    private final LongAdder batchesCommitRate = new LongAdder();
+    private final Meter fileUploadRate;
+    private final Meter fileUploadErrorRate;
+    private final Meter fileCommitRate;
+    private final Meter fileCommitErrorRate;
+    private final Meter batchesCommitRate;
+    private final Meter writeRate;
+    private final Meter writeErrorRate;
 
     FileCommitterMetrics(final Time time) {
         this.time = Objects.requireNonNull(time, "time cannot be null");
         fileTotalLifeTimeHistogram = metricsGroup.newHistogram(FILE_TOTAL_LIFE_TIME, true, Map.of());
         fileUploadAndCommitTimeHistogram = metricsGroup.newHistogram(FILE_UPLOAD_AND_COMMIT_TIME, true, Map.of());
         fileUploadTimeHistogram = metricsGroup.newHistogram(FILE_UPLOAD_TIME, true, Map.of());
-        metricsGroup.newGauge(FILE_UPLOAD_RATE, fileUploadRate::intValue);
+        fileUploadRate = metricsGroup.newMeter(FILE_UPLOAD_RATE, "uploads", TimeUnit.SECONDS, Map.of());
+        fileUploadErrorRate = metricsGroup.newMeter(FILE_UPLOAD_ERROR_RATE, "errors", TimeUnit.SECONDS, Map.of());
         fileCommitTimeHistogram = metricsGroup.newHistogram(FILE_COMMIT_TIME, true, Map.of());
         fileCommitWaitTimeHistogram = metricsGroup.newHistogram(FILE_COMMIT_WAIT_TIME, true, Map.of());
-        metricsGroup.newGauge(FILE_COMMIT_RATE, fileCommitRate::intValue);
-        metricsGroup.newGauge(BATCHES_COMMIT_RATE, batchesCommitRate::intValue);
+        fileCommitRate = metricsGroup.newMeter(FILE_COMMIT_RATE, "commits", TimeUnit.SECONDS, Map.of());
+        fileCommitErrorRate = metricsGroup.newMeter(FILE_COMMIT_ERROR_RATE, "errors", TimeUnit.SECONDS, Map.of());
+        batchesCommitRate = metricsGroup.newMeter(BATCHES_COMMIT_RATE, "batches", TimeUnit.SECONDS, Map.of());
         fileSizeHistogram = metricsGroup.newHistogram(FILE_SIZE, true, Map.of());
         batchesCountHistogram = metricsGroup.newHistogram(BATCHES_COUNT, true, Map.of());
         cacheStoreTimeHistogram = metricsGroup.newHistogram(CACHE_STORE_TIME, true, Map.of());
+        writeRate = metricsGroup.newMeter(WRITE_RATE, "writes", TimeUnit.SECONDS, Map.of());
+        writeErrorRate = metricsGroup.newMeter(WRITE_ERROR_RATE, "errors", TimeUnit.SECONDS, Map.of());
     }
 
     void initTotalFilesInProgressMetric(final Supplier<Integer> supplier) {
@@ -94,17 +107,25 @@ class FileCommitterMetrics implements Closeable {
 
     void batchesAdded(final int size) {
         batchesCountHistogram.update(size);
-        batchesCommitRate.add(size);
+        batchesCommitRate.mark(size);
     }
 
     void fileUploadFinished(final long durationMs) {
         fileUploadTimeHistogram.update(durationMs);
-        fileUploadRate.increment();
+        fileUploadRate.mark();
+    }
+
+    void fileUploadFailed() {
+        fileUploadErrorRate.mark();
     }
 
     void fileCommitFinished(final long durationMs) {
         fileCommitTimeHistogram.update(durationMs);
-        fileCommitRate.increment();
+        fileCommitRate.mark();
+    }
+
+    void fileCommitFailed() {
+        fileCommitErrorRate.mark();
     }
 
     void fileCommitWaitFinished(final long durationMs) {
@@ -115,6 +136,14 @@ class FileCommitterMetrics implements Closeable {
         final Instant now = TimeUtils.durationMeasurementNow(time);
         fileTotalLifeTimeHistogram.update(Duration.between(fileStart, now).toMillis());
         fileUploadAndCommitTimeHistogram.update(Duration.between(uploadAndCommitStart, now).toMillis());
+    }
+
+    void writeCompleted() {
+        writeRate.mark();
+    }
+
+    void writeFailed() {
+        writeErrorRate.mark();
     }
 
     void cacheStoreFinished(final long durationMs) {
@@ -129,12 +158,16 @@ class FileCommitterMetrics implements Closeable {
         metricsGroup.removeMetric(FILE_UPLOAD_AND_COMMIT_TIME);
         metricsGroup.removeMetric(FILE_UPLOAD_TIME);
         metricsGroup.removeMetric(FILE_UPLOAD_RATE);
+        metricsGroup.removeMetric(FILE_UPLOAD_ERROR_RATE);
         metricsGroup.removeMetric(FILE_COMMIT_TIME);
         metricsGroup.removeMetric(FILE_COMMIT_RATE);
+        metricsGroup.removeMetric(FILE_COMMIT_ERROR_RATE);
         metricsGroup.removeMetric(FILE_SIZE);
         metricsGroup.removeMetric(FILE_COMMIT_WAIT_TIME);
         metricsGroup.removeMetric(CACHE_STORE_TIME);
         metricsGroup.removeMetric(BATCHES_COUNT);
         metricsGroup.removeMetric(BATCHES_COMMIT_RATE);
+        metricsGroup.removeMetric(WRITE_RATE);
+        metricsGroup.removeMetric(WRITE_ERROR_RATE);
     }
 }

--- a/storage/inkless/src/main/java/io/aiven/inkless/produce/FileUploadException.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/produce/FileUploadException.java
@@ -1,0 +1,24 @@
+/*
+ * Inkless
+ * Copyright (C) 2024 - 2025 Aiven OY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.aiven.inkless.produce;
+
+public class FileUploadException extends RuntimeException {
+    public FileUploadException(final Throwable cause) {
+        super(cause);
+    }
+}


### PR DESCRIPTION
Identify errors by accumulating occurance of failed writes vs writes completed; and introduce specific rates for uploads (remote storage based), and commits (batch coordinator based) errors.

Also, use Meter as other Metrics instrumentations instead of Gauge.