### PR TITLE
feat(inkless): run fetch on fixed thread pools

### DIFF
--- a/storage/inkless/src/main/java/io/aiven/inkless/config/InklessConfig.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/config/InklessConfig.java
@@ -126,6 +126,13 @@ public class InklessConfig extends AbstractConfig {
     // to avoid starting an upload if 8 commits are executing sequentially
     private static final int PRODUCE_UPLOAD_THREAD_POOL_SIZE_DEFAULT = 8;
 
+    public static final String FETCH_DATA_THREAD_POOL_SIZE_CONFIG = "fetch.data.thread.pool.size";
+    public static final String FETCH_DATA_THREAD_POOL_SIZE_DOC = "Thread pool size to concurrently fetch data files from remote storage";
+    private static final int FETCH_DATA_THREAD_POOL_SIZE_DEFAULT = 32;
+
+    public static final String FETCH_METADATA_THREAD_POOL_SIZE_CONFIG = "fetch.metadata.thread.pool.size";
+    public static final String FETCH_METADATA_THREAD_POOL_SIZE_DOC = "Thread pool size to concurrently fetch metadata from batch coordinator";
+    private static final int FETCH_METADATA_THREAD_POOL_SIZE_DEFAULT = 8;
 
     public static ConfigDef configDef() {
         final ConfigDef configDef = new ConfigDef();
@@ -289,6 +296,22 @@ public class InklessConfig extends AbstractConfig {
             ConfigDef.Importance.LOW,
             PRODUCE_UPLOAD_THREAD_POOL_SIZE_DOC
         );
+        configDef.define(
+            FETCH_DATA_THREAD_POOL_SIZE_CONFIG,
+            ConfigDef.Type.INT,
+            FETCH_DATA_THREAD_POOL_SIZE_DEFAULT,
+            ConfigDef.Range.atLeast(1),
+            ConfigDef.Importance.LOW,
+            FETCH_DATA_THREAD_POOL_SIZE_DOC
+        );
+        configDef.define(
+            FETCH_METADATA_THREAD_POOL_SIZE_CONFIG,
+            ConfigDef.Type.INT,
+            FETCH_METADATA_THREAD_POOL_SIZE_DEFAULT,
+            ConfigDef.Range.atLeast(1),
+            ConfigDef.Importance.LOW,
+            FETCH_METADATA_THREAD_POOL_SIZE_DOC
+        );
 
         return configDef;
     }
@@ -383,5 +406,13 @@ public class InklessConfig extends AbstractConfig {
 
     public int produceUploadThreadPoolSize() {
         return getInt(PRODUCE_UPLOAD_THREAD_POOL_SIZE_CONFIG);
+    }
+
+    public int fetchDataThreadPoolSize() {
+        return getInt(FETCH_DATA_THREAD_POOL_SIZE_CONFIG);
+    }
+
+    public int fetchMetadataThreadPoolSize() {
+        return getInt(FETCH_METADATA_THREAD_POOL_SIZE_CONFIG);
     }
 }

--- a/storage/inkless/src/main/java/io/aiven/inkless/consume/FetchHandler.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/consume/FetchHandler.java
@@ -51,7 +51,9 @@ public class FetchHandler implements Closeable {
                 state.cache(),
                 state.controlPlane(),
                 state.config().storage(),
-                state.brokerTopicStats()
+                state.brokerTopicStats(),
+                state.config().fetchMetadataThreadPoolSize(),
+                state.config().fetchDataThreadPoolSize()
             )
         );
     }

--- a/storage/inkless/src/main/java/io/aiven/inkless/consume/FileFetchJob.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/consume/FileFetchJob.java
@@ -69,9 +69,13 @@ public class FileFetchJob implements Callable<FileExtent> {
         return TimeUtils.measureDurationMs(time, this::doWork, durationCallback);
     }
 
-    private FileExtent doWork() throws StorageBackendException, IOException {
-        final ByteBuffer byteBuffer = objectFetcher.readToByteBuffer(objectFetcher.fetch(key, range));
-        return createFileExtent(key, range, byteBuffer);
+    private FileExtent doWork() throws FileFetchException {
+        try {
+            final ByteBuffer byteBuffer = objectFetcher.readToByteBuffer(objectFetcher.fetch(key, range));
+            return createFileExtent(key, range, byteBuffer);
+        } catch (final IOException | StorageBackendException e) {
+            throw new FileFetchException(e);
+        }
     }
 
 

--- a/storage/inkless/src/main/java/io/aiven/inkless/consume/FindBatchesException.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/consume/FindBatchesException.java
@@ -17,7 +17,7 @@
  */
 package io.aiven.inkless.consume;
 
-public class FindBatchesException extends Exception {
+public class FindBatchesException extends RuntimeException {
     public FindBatchesException(Throwable cause) {
         super(cause);
     }

--- a/storage/inkless/src/main/java/io/aiven/inkless/consume/FindBatchesJob.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/consume/FindBatchesJob.java
@@ -26,15 +26,15 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.Callable;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 import io.aiven.inkless.TimeUtils;
 import io.aiven.inkless.control_plane.ControlPlane;
 import io.aiven.inkless.control_plane.FindBatchRequest;
 import io.aiven.inkless.control_plane.FindBatchResponse;
 
-public class FindBatchesJob implements Callable<Map<TopicIdPartition, FindBatchResponse>> {
+public class FindBatchesJob implements Supplier<Map<TopicIdPartition, FindBatchResponse>> {
 
     private final Time time;
     private final ControlPlane controlPlane;
@@ -55,11 +55,11 @@ public class FindBatchesJob implements Callable<Map<TopicIdPartition, FindBatchR
     }
 
     @Override
-    public Map<TopicIdPartition, FindBatchResponse> call() throws Exception {
-        return TimeUtils.measureDurationMs(time, this::doWork, durationCallback);
+    public Map<TopicIdPartition, FindBatchResponse> get() {
+        return TimeUtils.measureDurationMsSupplier(time, this::doWork, durationCallback);
     }
 
-    private Map<TopicIdPartition, FindBatchResponse> doWork() throws Exception {
+    private Map<TopicIdPartition, FindBatchResponse> doWork() {
         try {
             List<FindBatchRequest> requests = new ArrayList<>();
             for (Map.Entry<TopicIdPartition, FetchRequest.PartitionData> fetchInfo : fetchInfos.entrySet()) {

--- a/storage/inkless/src/test/java/io/aiven/inkless/config/InklessConfigTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/config/InklessConfigTest.java
@@ -52,6 +52,8 @@ class InklessConfigTest {
         configs.put("inkless.consume.cache.expiration.lifespan.sec", "200");
         configs.put("inkless.consume.cache.expiration.max.idle.sec", "100");
         configs.put("inkless.produce.upload.thread.pool.size", "16");
+        configs.put("inkless.fetch.data.thread.pool.size", "12");
+        configs.put("inkless.fetch.metadata.thread.pool.size", "14");
         final InklessConfig config = new InklessConfig(new AbstractConfig(new ConfigDef(), configs));
         assertThat(config.controlPlaneClass()).isEqualTo(InMemoryControlPlane.class);
         assertThat(config.controlPlaneConfig()).isEqualTo(Map.of("class", controlPlaneClass));
@@ -69,6 +71,8 @@ class InklessConfigTest {
         assertThat(config.cacheExpirationLifespanSec()).isEqualTo(200);
         assertThat(config.cacheExpirationMaxIdleSec()).isEqualTo(100);
         assertThat(config.produceUploadThreadPoolSize()).isEqualTo(16);
+        assertThat(config.fetchDataThreadPoolSize()).isEqualTo(12);
+        assertThat(config.fetchMetadataThreadPoolSize()).isEqualTo(14);
     }
 
     @Test
@@ -96,6 +100,8 @@ class InklessConfigTest {
         assertThat(config.cacheExpirationLifespanSec()).isEqualTo(60);
         assertThat(config.cacheExpirationMaxIdleSec()).isEqualTo(-1);
         assertThat(config.produceUploadThreadPoolSize()).isEqualTo(8);
+        assertThat(config.fetchDataThreadPoolSize()).isEqualTo(32);
+        assertThat(config.fetchMetadataThreadPoolSize()).isEqualTo(8);
     }
 
     @Test
@@ -117,6 +123,8 @@ class InklessConfigTest {
         configs.put("consume.cache.expiration.lifespan.sec", "200");
         configs.put("consume.cache.expiration.max.idle.sec", "100");
         configs.put("produce.upload.thread.pool.size", "16");
+        configs.put("fetch.data.thread.pool.size", "12");
+        configs.put("fetch.metadata.thread.pool.size", "14");
         final var config = new InklessConfig(
             configs
         );
@@ -136,6 +144,8 @@ class InklessConfigTest {
         assertThat(config.cacheExpirationLifespanSec()).isEqualTo(200);
         assertThat(config.cacheExpirationMaxIdleSec()).isEqualTo(100);
         assertThat(config.produceUploadThreadPoolSize()).isEqualTo(16);
+        assertThat(config.fetchDataThreadPoolSize()).isEqualTo(12);
+        assertThat(config.fetchMetadataThreadPoolSize()).isEqualTo(14);
     }
 
     @Test

--- a/storage/inkless/src/test/java/io/aiven/inkless/consume/FetchCompleterTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/consume/FetchCompleterTest.java
@@ -62,7 +62,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.STRICT_STUBS)
-public class FetchCompleterJobTest {
+public class FetchCompleterTest {
     static final String OBJECT_KEY_PREFIX = "prefix";
     static final ObjectKeyCreator OBJECT_KEY_CREATOR = ObjectKey.creator(OBJECT_KEY_PREFIX, false);
     static final String OBJECT_KEY_A_MAIN_PART = "a";
@@ -75,12 +75,12 @@ public class FetchCompleterJobTest {
 
     @Test
     public void testEmptyFetch() {
-        FetchCompleterJob job = new FetchCompleterJob(
+        FetchCompleter job = new FetchCompleter(
             new MockTime(),
             OBJECT_KEY_CREATOR,
             Collections.emptyMap(),
-            CompletableFuture.completedFuture(Collections.emptyMap()),
-            CompletableFuture.completedFuture(Collections.emptyList()),
+            Collections.emptyMap(),
+            Collections.emptyList(),
             durationMs -> {}
         );
         Map<TopicIdPartition, FetchPartitionData> result = job.get();
@@ -92,12 +92,12 @@ public class FetchCompleterJobTest {
         Map<TopicIdPartition, FetchRequest.PartitionData> fetchInfos = Map.of(
             partition0, new FetchRequest.PartitionData(topicId, 0, 0, 1000, Optional.empty())
         );
-        FetchCompleterJob job = new FetchCompleterJob(
+        FetchCompleter job = new FetchCompleter(
             new MockTime(),
             OBJECT_KEY_CREATOR,
             fetchInfos,
-            CompletableFuture.completedFuture(Collections.emptyMap()),
-            CompletableFuture.completedFuture(Collections.emptyList()),
+            Collections.emptyMap(),
+            Collections.emptyList(),
             durationMs -> {}
         );
         Map<TopicIdPartition, FetchPartitionData> result = job.get();
@@ -115,12 +115,12 @@ public class FetchCompleterJobTest {
         Map<TopicIdPartition, FindBatchResponse> coordinates = Map.of(
             partition0, FindBatchResponse.success(Collections.emptyList(), logStartOffset, highWatermark)
         );
-        FetchCompleterJob job = new FetchCompleterJob(
+        FetchCompleter job = new FetchCompleter(
             new MockTime(),
             OBJECT_KEY_CREATOR,
             fetchInfos,
-            CompletableFuture.completedFuture(coordinates),
-            CompletableFuture.completedFuture(Collections.emptyList()),
+            coordinates,
+            Collections.emptyList(),
             durationMs -> {}
         );
         Map<TopicIdPartition, FetchPartitionData> result = job.get();
@@ -145,12 +145,12 @@ public class FetchCompleterJobTest {
                 new BatchInfo(1L, OBJECT_KEY_A_MAIN_PART, BatchMetadata.of(partition0, 0, 10, 0, 0, logAppendTimestamp, maxBatchTimestamp, TimestampType.CREATE_TIME))
             ), logStartOffset, highWatermark)
         );
-        FetchCompleterJob job = new FetchCompleterJob(
+        FetchCompleter job = new FetchCompleter(
             new MockTime(),
             OBJECT_KEY_CREATOR,
             fetchInfos,
-            CompletableFuture.completedFuture(coordinates),
-            CompletableFuture.completedFuture(Collections.emptyList()),
+            coordinates,
+            Collections.emptyList(),
             durationMs -> {}
         );
         Map<TopicIdPartition, FetchPartitionData> result = job.get();
@@ -178,12 +178,12 @@ public class FetchCompleterJobTest {
         List<Future<FileExtent>> files = Stream.of(
             FileFetchJob.createFileExtent(OBJECT_KEY_A, new ByteRange(0, records.sizeInBytes()), records.buffer())
         ).map(CompletableFuture::completedFuture).collect(Collectors.toList());
-        FetchCompleterJob job = new FetchCompleterJob(
+        FetchCompleter job = new FetchCompleter(
             new MockTime(),
             OBJECT_KEY_CREATOR,
             fetchInfos,
-            CompletableFuture.completedFuture(coordinates),
-            CompletableFuture.completedFuture(files),
+            coordinates,
+            files,
             durationMs -> {}
         );
         Map<TopicIdPartition, FetchPartitionData> result = job.get();
@@ -215,12 +215,12 @@ public class FetchCompleterJobTest {
             FileFetchJob.createFileExtent(OBJECT_KEY_A, new ByteRange(0, records.sizeInBytes()), records.buffer()),
             FileFetchJob.createFileExtent(OBJECT_KEY_B, new ByteRange(0, records.sizeInBytes()), records.buffer())
         ).map(CompletableFuture::completedFuture).collect(Collectors.toList());
-        FetchCompleterJob job = new FetchCompleterJob(
+        FetchCompleter job = new FetchCompleter(
             new MockTime(),
             OBJECT_KEY_CREATOR,
             fetchInfos,
-            CompletableFuture.completedFuture(coordinates),
-            CompletableFuture.completedFuture(files),
+            coordinates,
+            files,
             durationMs -> {}
         );
         Map<TopicIdPartition, FetchPartitionData> result = job.get();
@@ -264,12 +264,12 @@ public class FetchCompleterJobTest {
         }
         List<Future<FileExtent>> files = fileExtents.stream().map(CompletableFuture::completedFuture).collect(Collectors.toList());
 
-        FetchCompleterJob job = new FetchCompleterJob(
+        FetchCompleter job = new FetchCompleter(
             new MockTime(),
             OBJECT_KEY_CREATOR,
             fetchInfos,
-            CompletableFuture.completedFuture(coordinates),
-            CompletableFuture.completedFuture(files),
+            coordinates,
+            files,
             durationMs -> {}
         );
         Map<TopicIdPartition, FetchPartitionData> result = job.get();
@@ -313,12 +313,12 @@ public class FetchCompleterJobTest {
         List<Future<FileExtent>> files = Stream.of(
             FileFetchJob.createFileExtent(OBJECT_KEY_A, new ByteRange(0, totalSize), concatenatedBuffer)
         ).map(CompletableFuture::completedFuture).collect(Collectors.toList());
-        FetchCompleterJob job = new FetchCompleterJob(
+        FetchCompleter job = new FetchCompleter(
             new MockTime(),
             OBJECT_KEY_CREATOR,
             fetchInfos,
-            CompletableFuture.completedFuture(coordinates),
-            CompletableFuture.completedFuture(files),
+            coordinates,
+            files,
             durationMs -> {}
         );
         Map<TopicIdPartition, FetchPartitionData> result = job.get();
@@ -375,12 +375,12 @@ public class FetchCompleterJobTest {
         }
         List<Future<FileExtent>> files = fileExtents.stream().map(CompletableFuture::completedFuture).collect(Collectors.toList());
 
-        FetchCompleterJob job = new FetchCompleterJob(
+        FetchCompleter job = new FetchCompleter(
             new MockTime(),
             OBJECT_KEY_CREATOR,
             fetchInfos,
-            CompletableFuture.completedFuture(coordinates),
-            CompletableFuture.completedFuture(files),
+            coordinates,
+            files,
             durationMs -> {}
         );
         Map<TopicIdPartition, FetchPartitionData> result = job.get();

--- a/storage/inkless/src/test/java/io/aiven/inkless/consume/FindBatchesJobTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/consume/FindBatchesJobTest.java
@@ -68,7 +68,7 @@ public class FindBatchesJobTest {
     TopicIdPartition partition0 = new TopicIdPartition(topicId, 0, "diskless-topic");
 
     @Test
-    public void findSingleBatch() throws Exception {
+    public void findSingleBatch() {
         Map<TopicIdPartition, FetchRequest.PartitionData> fetchInfos = Map.of(
             partition0, new FetchRequest.PartitionData(topicId, 0, 0, 1000, Optional.empty())
         );
@@ -83,7 +83,7 @@ public class FindBatchesJobTest {
         );
         FindBatchesJob job = new FindBatchesJob(time, controlPlane, params, fetchInfos, durationMs -> {});
         when(controlPlane.findBatches(requestCaptor.capture(), anyInt())).thenReturn(new ArrayList<>(coordinates.values()));
-        Map<TopicIdPartition, FindBatchResponse> result = job.call();
+        Map<TopicIdPartition, FindBatchResponse> result = job.get();
 
         assertThat(result).isEqualTo(coordinates);
     }

--- a/storage/inkless/src/test/java/io/aiven/inkless/consume/ReaderTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/consume/ReaderTest.java
@@ -17,22 +17,27 @@
  */
 package io.aiven.inkless.consume;
 
+import org.apache.kafka.common.TopicIdPartition;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.server.storage.log.FetchParams;
+import org.apache.kafka.server.storage.log.FetchPartitionData;
 import org.apache.kafka.storage.log.metrics.BrokerTopicStats;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
 import java.util.Collections;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import io.aiven.inkless.cache.FixedBlockAlignment;
 import io.aiven.inkless.cache.KeyAlignmentStrategy;
@@ -46,9 +51,8 @@ import io.aiven.inkless.storage_backend.common.ObjectFetcher;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.STRICT_STUBS)
@@ -56,18 +60,16 @@ public class ReaderTest {
     private static final ObjectKeyCreator OBJECT_KEY_CREATOR = ObjectKey.creator("", false);
     private static final KeyAlignmentStrategy KEY_ALIGNMENT_STRATEGY = new FixedBlockAlignment(Integer.MAX_VALUE);
     private static final ObjectCache OBJECT_CACHE = new NullCache();
+
+    @Spy
+    private final ExecutorService metadataExecutor = Executors.newSingleThreadExecutor();
+    @Spy
+    private final ExecutorService dataExecutor = Executors.newSingleThreadExecutor();
+
     @Mock
     private ControlPlane controlPlane;
     @Mock
     private ObjectFetcher objectFetcher;
-    @Mock
-    private ExecutorService metadataExecutor;
-    @Mock
-    private ExecutorService fetchPlannerExecutor;
-    @Mock
-    private ExecutorService dataExecutor;
-    @Mock
-    private ExecutorService fetchCompleterExecutor;
     @Mock
     private FetchParams fetchParams;
 
@@ -76,27 +78,21 @@ public class ReaderTest {
 
     @BeforeEach
     public void setup() {
-        reader = new Reader(time, OBJECT_KEY_CREATOR, KEY_ALIGNMENT_STRATEGY, OBJECT_CACHE, controlPlane, objectFetcher, metadataExecutor, fetchPlannerExecutor, dataExecutor, fetchCompleterExecutor, new BrokerTopicStats());
+        reader = new Reader(time, OBJECT_KEY_CREATOR, KEY_ALIGNMENT_STRATEGY, OBJECT_CACHE, controlPlane, objectFetcher, metadataExecutor, dataExecutor, new BrokerTopicStats());
     }
 
     @Test
     public void testReaderEmptyRequests() {
-        when(metadataExecutor.submit(any(FindBatchesJob.class))).thenReturn(CompletableFuture.completedFuture(Collections.emptyMap()));
-        when(fetchPlannerExecutor.submit(any(FetchPlannerJob.class))).thenReturn(CompletableFuture.completedFuture(Collections.emptyList()));
-        doAnswer(invocation -> {
-            invocation.getArgument(0, Runnable.class).run();
-            return null;
-        }).when(fetchCompleterExecutor).execute(any());
-        assertThat(reader.fetch(fetchParams, Collections.emptyMap()))
-                .isCompletedWithValue(Collections.emptyMap());
+        final CompletableFuture<Map<TopicIdPartition, FetchPartitionData>> fetch = reader.fetch(fetchParams, Collections.emptyMap());
+        verify(metadataExecutor, atLeastOnce()).execute(any());
+        verifyNoInteractions(dataExecutor);
+        assertThat(fetch.join()).isEqualTo(Collections.emptyMap());
     }
 
     @Test
     public void testClose() {
         reader.close();
         verify(metadataExecutor, atLeastOnce()).shutdown();
-        verify(metadataExecutor, atLeastOnce()).shutdown();
-        verify(metadataExecutor, atLeastOnce()).shutdown();
-        verify(metadataExecutor, atLeastOnce()).shutdown();
+        verify(dataExecutor, atLeastOnce()).shutdown();
     }
 }


### PR DESCRIPTION
Define fixed thread-pools for fetch data and metadata to define
an upper-bound to consumption related tasks.

Drop executors where there is no IO.
Replace passing futures to compose CompletableFuture instead.

It updates the exception handling to report metrics properly.

The goal is to allow better allocating resources on fetching side.