### PR TITLE
refactor(inkless): add fetch fan-out metrics

### DIFF
--- a/storage/inkless/src/main/java/io/aiven/inkless/consume/InklessFetchMetrics.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/consume/InklessFetchMetrics.java
@@ -48,9 +48,9 @@ public class InklessFetchMetrics {
     private static final String FIND_BATCHES_ERROR_RATE = "FindBatchesErrorRate";
     private static final String FILE_FETCH_ERROR_RATE = "FileFetchErrorRate";
     private static final String CACHE_FETCH_ERROR_RATE = "CacheFetchErrorRate";
-    private static final String FETCH_PARTITIONS_PER_FETCH_SIZE = "FetchPartitionsPerFetchSize";
-    private static final String FETCH_BATCHES_PER_FETCH_SIZE = "FetchBatchesPerPartitionSize";
-    private static final String FETCH_OBJECTS_PER_FETCH_SIZE = "FetchObjectsPerFetchSize";
+    private static final String FETCH_PARTITIONS_PER_FETCH_COUNT = "FetchPartitionsPerFetchCount";
+    private static final String FETCH_BATCHES_PER_FETCH_COUNT = "FetchBatchesPerPartitionCount";
+    private static final String FETCH_OBJECTS_PER_FETCH_COUNT = "FetchObjectsPerFetchCount";
 
     private final Time time;
 
@@ -89,9 +89,9 @@ public class InklessFetchMetrics {
         findBatchesErrorRate = metricsGroup.newMeter(FIND_BATCHES_ERROR_RATE, "errors", TimeUnit.SECONDS, Map.of());
         fileFetchErrorRate = metricsGroup.newMeter(FILE_FETCH_ERROR_RATE, "errors", TimeUnit.SECONDS, Map.of());
         cacheFetchErrorRate = metricsGroup.newMeter(CACHE_FETCH_ERROR_RATE, "errors", TimeUnit.SECONDS, Map.of());
-        fetchPartitionSizeHistogram = metricsGroup.newHistogram(FETCH_PARTITIONS_PER_FETCH_SIZE, true, Map.of());
-        fetchBatchesSizeHistogram = metricsGroup.newHistogram(FETCH_BATCHES_PER_FETCH_SIZE, true, Map.of());
-        fetchObjectsSizeHistogram = metricsGroup.newHistogram(FETCH_OBJECTS_PER_FETCH_SIZE, true, Map.of());
+        fetchPartitionSizeHistogram = metricsGroup.newHistogram(FETCH_PARTITIONS_PER_FETCH_COUNT, true, Map.of());
+        fetchBatchesSizeHistogram = metricsGroup.newHistogram(FETCH_BATCHES_PER_FETCH_COUNT, true, Map.of());
+        fetchObjectsSizeHistogram = metricsGroup.newHistogram(FETCH_OBJECTS_PER_FETCH_COUNT, true, Map.of());
     }
 
     public void fetchCompleted(Instant startAt) {
@@ -162,9 +162,9 @@ public class InklessFetchMetrics {
         metricsGroup.removeMetric(FIND_BATCHES_ERROR_RATE);
         metricsGroup.removeMetric(FILE_FETCH_ERROR_RATE);
         metricsGroup.removeMetric(CACHE_FETCH_ERROR_RATE);
-        metricsGroup.removeMetric(FETCH_PARTITIONS_PER_FETCH_SIZE);
-        metricsGroup.removeMetric(FETCH_BATCHES_PER_FETCH_SIZE);
-        metricsGroup.removeMetric(FETCH_OBJECTS_PER_FETCH_SIZE);
+        metricsGroup.removeMetric(FETCH_PARTITIONS_PER_FETCH_COUNT);
+        metricsGroup.removeMetric(FETCH_BATCHES_PER_FETCH_COUNT);
+        metricsGroup.removeMetric(FETCH_OBJECTS_PER_FETCH_COUNT);
     }
 
     public void fetchStarted(int partitionSize) {

--- a/storage/inkless/src/main/java/io/aiven/inkless/consume/Reader.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/consume/Reader.java
@@ -111,7 +111,7 @@ public class Reader implements AutoCloseable {
         final Map<TopicIdPartition, FetchRequest.PartitionData> fetchInfos
     ) {
         final Instant startAt = TimeUtils.durationMeasurementNow(time);
-        fetchMetrics.fetchStarted();
+        fetchMetrics.fetchStarted(fetchInfos.size());
         final var batchCoordinates = CompletableFuture.supplyAsync(
             new FindBatchesJob(
                 time,
@@ -132,11 +132,7 @@ public class Reader implements AutoCloseable {
                         objectFetcher,
                         dataExecutor,
                         coordinates,
-                        fetchMetrics::fetchPlanFinished,
-                        fetchMetrics::cacheQueryFinished,
-                        fetchMetrics::cacheStoreFinished,
-                        fetchMetrics::cacheHit,
-                        fetchMetrics::fetchFileFinished
+                        fetchMetrics
                     ).get()
             )
             .thenCombineAsync(batchCoordinates, (fileExtents, coordinates) ->

--- a/storage/inkless/src/test/java/io/aiven/inkless/consume/FetchPlannerTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/consume/FetchPlannerTest.java
@@ -69,6 +69,8 @@ public class FetchPlannerTest {
     ObjectFetcher fetcher;
     @Mock
     ExecutorService dataExecutor;
+    @Mock
+    InklessFetchMetrics metrics;
 
     ObjectCache cache = new NullCache();
     KeyAlignmentStrategy keyAlignmentStrategy = new FixedBlockAlignment(Integer.MAX_VALUE);
@@ -198,22 +200,18 @@ public class FetchPlannerTest {
         );
     }
 
-    private FetchPlanner fetchPlannerJob(
-            Map<TopicIdPartition, FindBatchResponse> batchCoordinatesFuture
-    ) {
+    private FetchPlanner fetchPlannerJob(Map<TopicIdPartition, FindBatchResponse> batchCoordinatesFuture) {
         return new FetchPlanner(
-                time, FetchPlannerTest.OBJECT_KEY_CREATOR, keyAlignmentStrategy,
-                cache, fetcher, dataExecutor, batchCoordinatesFuture,
-                durationMs -> {}, durationMs -> {}, durationMs -> {}, hitBool -> {}, durationMs -> {}
+            time, FetchPlannerTest.OBJECT_KEY_CREATOR, keyAlignmentStrategy,
+            cache, fetcher, dataExecutor, batchCoordinatesFuture, metrics
         );
     }
 
-    private CacheFetchJob cacheFetchJob(
-            ObjectKey objectKey,
-            ByteRange byteRange
-    ) {
-        return new CacheFetchJob(cache, objectKey, byteRange, time, fetcher,
-                durationMs -> {}, durationMs -> {}, hitBool -> {}, durationMs -> {});
+    private CacheFetchJob cacheFetchJob(         ObjectKey objectKey, ByteRange byteRange) {
+        return new CacheFetchJob(
+            cache, objectKey, byteRange, time, fetcher,
+            durationMs -> {}, durationMs -> {}, hitBool -> {}, durationMs -> {}
+        );
     }
 
     private void assertBatchPlan(Map<TopicIdPartition, FindBatchResponse> coordinates, Set<CacheFetchJob> jobs) {


### PR DESCRIPTION
Consumer fetch requests require a fan-out in number of batches to include to serve them. These batches may be across multiple objects.

Adding histogramns to measure how do these fan-outs look like: partitions per request, batches per partitions, objects per request.
