### PR TITLE
refactor(inkless): add a batches per partition limit configuration

### DIFF
--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1721,7 +1721,7 @@ class ReplicaManager(val config: KafkaConfig,
 
   def findDisklessBatches(requests: Seq[FindBatchRequest], maxBytes: Int): Option[util.List[FindBatchResponse]] = {
     inklessSharedState.map { sharedState =>
-      sharedState.controlPlane().findBatches(requests.asJava, maxBytes)
+      sharedState.controlPlane().findBatches(requests.asJava, maxBytes, sharedState.config().maxBatchesPerPartitionToFind())
     }
   }
 

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -6628,7 +6628,7 @@ class ReplicaManagerTest {
       when(findBatchResponse.estimatedByteSize(fetchOffset)).thenReturn(RECORDS.sizeInBytes())
       when(findBatchResponse.errors()).thenReturn(Errors.NONE)
       val cp = mock(classOf[ControlPlane])
-      when(cp.findBatches(any(), any())).thenReturn(util.List.of(findBatchResponse, findBatchResponse))
+      when(cp.findBatches(any(), any(), any())).thenReturn(util.List.of(findBatchResponse, findBatchResponse))
 
       // Prepare the FetchHandler response to be called when the forceComplete method is invoked.
       val disklessResponse = Map(
@@ -6693,7 +6693,7 @@ class ReplicaManagerTest {
       when(findBatchResponse.estimatedByteSize(fetchOffset)).thenReturn(RECORDS.sizeInBytes())
       when(findBatchResponse.errors()).thenReturn(Errors.NONE)
       val cp = mock(classOf[ControlPlane])
-      when(cp.findBatches(any(), any())).thenReturn(util.List.of(findBatchResponse))
+      when(cp.findBatches(any(), any(), any())).thenReturn(util.List.of(findBatchResponse))
 
       // Prepare the FetchHandler response to be called when the forceComplete method is invoked.
       val disklessResponse = Map(disklessTopicPartition ->
@@ -6751,7 +6751,7 @@ class ReplicaManagerTest {
       when(findBatchResponse.estimatedByteSize(fetchOffset)).thenReturn(RECORDS.sizeInBytes()) // first half of the bytes available from diskless
       when(findBatchResponse.errors()).thenReturn(Errors.NONE)
       val cp = mock(classOf[ControlPlane])
-      when(cp.findBatches(any(), any())).thenReturn(util.List.of(findBatchResponse))
+      when(cp.findBatches(any(), any(), any())).thenReturn(util.List.of(findBatchResponse))
 
       // Prepare the FetchHandler response to be called when the forceComplete method is invoked.
       val disklessResponse = Map(disklessTopicPartition ->
@@ -6831,7 +6831,7 @@ class ReplicaManagerTest {
       when(findBatchResponse.estimatedByteSize(fetchOffset)).thenReturn(RECORDS.sizeInBytes()) // first half of the bytes available from diskless
       when(findBatchResponse.errors()).thenReturn(Errors.NONE)
       val cp = mock(classOf[ControlPlane])
-      when(cp.findBatches(any(), any())).thenReturn(util.List.of(findBatchResponse))
+      when(cp.findBatches(any(), any(), any())).thenReturn(util.List.of(findBatchResponse))
 
       // Prepare the FetchHandler response to be called when the forceComplete method is invoked.
       val disklessResponse = Map(disklessTopicPartition ->
@@ -6911,7 +6911,7 @@ class ReplicaManagerTest {
       when(findBatchResponse.estimatedByteSize(fetchOffset)).thenReturn(RECORDS.sizeInBytes())
       when(findBatchResponse.errors()).thenReturn(Errors.NONE)
       val cp = mock(classOf[ControlPlane])
-      when(cp.findBatches(any(), any())).thenReturn(util.List.of(findBatchResponse))
+      when(cp.findBatches(any(), any(), any())).thenReturn(util.List.of(findBatchResponse))
 
       // Prepare the FetchHandler response to be called when the forceComplete method is invoked.
       val disklessResponse = Map(disklessTopicPartition ->
@@ -6974,7 +6974,7 @@ class ReplicaManagerTest {
       when(findBatchResponse.estimatedByteSize(fetchOffset)).thenReturn(minBytes - 10L)
       when(findBatchResponse.errors()).thenReturn(Errors.NONE)
       val cp = mock(classOf[ControlPlane])
-      when(cp.findBatches(any(), any())).thenReturn(util.List.of(findBatchResponse))
+      when(cp.findBatches(any(), any(), any())).thenReturn(util.List.of(findBatchResponse))
 
       // Prepare the FetchHandler response to be called when the forceComplete method is invoked.
       val disklessResponse = Map(disklessTopicPartition ->
@@ -7049,7 +7049,7 @@ class ReplicaManagerTest {
 
       // Prepare the FindBatchResponse to be returned by the ControlPlane when it tries to complete the delayed fetch.
       val cp = mock(classOf[ControlPlane])
-      when(cp.findBatches(any(), any())).thenThrow(new ControlPlaneException("Error in control plane"))
+      when(cp.findBatches(any(), any(), any())).thenThrow(new ControlPlaneException("Error in control plane"))
 
       // Prepare the FetchHandler response to be called when the forceComplete method is invoked.
       val disklessResponse = Map(disklessTopicPartition ->

--- a/storage/inkless/src/main/java/io/aiven/inkless/config/InklessConfig.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/config/InklessConfig.java
@@ -134,6 +134,12 @@ public class InklessConfig extends AbstractConfig {
     public static final String FETCH_METADATA_THREAD_POOL_SIZE_DOC = "Thread pool size to concurrently fetch metadata from batch coordinator";
     private static final int FETCH_METADATA_THREAD_POOL_SIZE_DEFAULT = 8;
 
+    public static final String FETCH_FIND_BATCHES_MAX_BATCHES_PER_PARTITION_CONFIG = "fetch.find.batches.max.per.partition";
+    public static final String FETCH_FIND_BATCHES_MAX_BATCHES_PER_PARTITION_DOC = "The maximum number of batches to find per partition when processing a fetch request. "
+        + "A value of 0 means all available batches are fetched. "
+        + "This is primarily intended for environments where the batches fan-out on fetch requests can overload the control plane back-end.";
+    private static final int FETCH_FIND_BATCHES_MAX_BATCHES_PER_PARTITION_DEFAULT = 0;
+
     public static ConfigDef configDef() {
         final ConfigDef configDef = new ConfigDef();
 
@@ -312,6 +318,14 @@ public class InklessConfig extends AbstractConfig {
             ConfigDef.Importance.LOW,
             FETCH_METADATA_THREAD_POOL_SIZE_DOC
         );
+        configDef.define(
+            FETCH_FIND_BATCHES_MAX_BATCHES_PER_PARTITION_CONFIG,
+            ConfigDef.Type.INT,
+            FETCH_FIND_BATCHES_MAX_BATCHES_PER_PARTITION_DEFAULT,
+            ConfigDef.Range.atLeast(0),
+            ConfigDef.Importance.LOW,
+            FETCH_FIND_BATCHES_MAX_BATCHES_PER_PARTITION_DOC
+        );
 
         return configDef;
     }
@@ -414,5 +428,9 @@ public class InklessConfig extends AbstractConfig {
 
     public int fetchMetadataThreadPoolSize() {
         return getInt(FETCH_METADATA_THREAD_POOL_SIZE_CONFIG);
+    }
+
+    public int maxBatchesPerPartitionToFind() {
+        return getInt(FETCH_FIND_BATCHES_MAX_BATCHES_PER_PARTITION_CONFIG);
     }
 }

--- a/storage/inkless/src/main/java/io/aiven/inkless/consume/FetchHandler.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/consume/FetchHandler.java
@@ -53,7 +53,8 @@ public class FetchHandler implements Closeable {
                 state.config().storage(),
                 state.brokerTopicStats(),
                 state.config().fetchMetadataThreadPoolSize(),
-                state.config().fetchDataThreadPoolSize()
+                state.config().fetchDataThreadPoolSize(),
+                state.config().maxBatchesPerPartitionToFind()
             )
         );
     }

--- a/storage/inkless/src/main/java/io/aiven/inkless/consume/FindBatchesJob.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/consume/FindBatchesJob.java
@@ -40,17 +40,20 @@ public class FindBatchesJob implements Supplier<Map<TopicIdPartition, FindBatchR
     private final ControlPlane controlPlane;
     private final FetchParams params;
     private final Map<TopicIdPartition, FetchRequest.PartitionData> fetchInfos;
+    private final int maxBatchesPerPartition;
     private final Consumer<Long> durationCallback;
 
     public FindBatchesJob(Time time,
                           ControlPlane controlPlane,
                           FetchParams params,
                           Map<TopicIdPartition, FetchRequest.PartitionData> fetchInfos,
+                          int maxBatchesPerPartition,
                           Consumer<Long> durationCallback) {
         this.time = time;
         this.controlPlane = controlPlane;
         this.params = params;
         this.fetchInfos = fetchInfos;
+        this.maxBatchesPerPartition = maxBatchesPerPartition;
         this.durationCallback = durationCallback;
     }
 
@@ -67,7 +70,7 @@ public class FindBatchesJob implements Supplier<Map<TopicIdPartition, FindBatchR
                 requests.add(new FindBatchRequest(topicIdPartition, fetchInfo.getValue().fetchOffset, fetchInfo.getValue().maxBytes));
             }
 
-            List<FindBatchResponse> responses = controlPlane.findBatches(requests, params.maxBytes);
+            List<FindBatchResponse> responses = controlPlane.findBatches(requests, params.maxBytes, maxBatchesPerPartition);
 
             Map<TopicIdPartition, FindBatchResponse> out = new HashMap<>();
             for (int i = 0; i < requests.size(); i++) {

--- a/storage/inkless/src/main/java/io/aiven/inkless/consume/Reader.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/consume/Reader.java
@@ -54,6 +54,7 @@ public class Reader implements AutoCloseable {
     private final ObjectCache cache;
     private final ControlPlane controlPlane;
     private final ObjectFetcher objectFetcher;
+    private final int maxBatchesPerPartitionToFind;
     private final ExecutorService metadataExecutor;
     private final ExecutorService dataExecutor;
     private final InklessFetchMetrics fetchMetrics;
@@ -68,7 +69,8 @@ public class Reader implements AutoCloseable {
         ObjectFetcher objectFetcher,
         BrokerTopicStats brokerTopicStats,
         int fetchMetadataThreadPoolSize,
-        int fetchDataThreadPoolSize
+        int fetchDataThreadPoolSize,
+        int maxBatchesPerPartitionToFind
     ) {
         this(
             time,
@@ -77,6 +79,7 @@ public class Reader implements AutoCloseable {
             cache,
             controlPlane,
             objectFetcher,
+            maxBatchesPerPartitionToFind,
             Executors.newFixedThreadPool(fetchMetadataThreadPoolSize, new InklessThreadFactory("inkless-fetch-metadata-", false)),
             Executors.newFixedThreadPool(fetchDataThreadPoolSize, new InklessThreadFactory("inkless-fetch-data-", false)),
             brokerTopicStats
@@ -90,6 +93,7 @@ public class Reader implements AutoCloseable {
         ObjectCache cache,
         ControlPlane controlPlane,
         ObjectFetcher objectFetcher,
+        int maxBatchesPerPartitionToFind,
         ExecutorService metadataExecutor,
         ExecutorService dataExecutor,
         BrokerTopicStats brokerTopicStats
@@ -100,6 +104,7 @@ public class Reader implements AutoCloseable {
         this.cache = cache;
         this.controlPlane = controlPlane;
         this.objectFetcher = objectFetcher;
+        this.maxBatchesPerPartitionToFind = maxBatchesPerPartitionToFind;
         this.metadataExecutor = metadataExecutor;
         this.dataExecutor = dataExecutor;
         this.fetchMetrics = new InklessFetchMetrics(time);
@@ -118,6 +123,7 @@ public class Reader implements AutoCloseable {
                 controlPlane,
                 params,
                 fetchInfos,
+                maxBatchesPerPartitionToFind,
                 fetchMetrics::findBatchesFinished
             ),
             metadataExecutor

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/AbstractControlPlane.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/AbstractControlPlane.java
@@ -84,7 +84,8 @@ public abstract class AbstractControlPlane implements ControlPlane {
     @Override
     public List<FindBatchResponse> findBatches(
         final List<FindBatchRequest> findBatchRequests,
-        final int fetchMaxBytes
+        final int fetchMaxBytes,
+        final int maxBatchesPerPartition
     ) {
         final SplitMapper<FindBatchRequest, FindBatchResponse> splitMapper = new SplitMapper<>(
             findBatchRequests, findBatchRequest -> true
@@ -96,14 +97,15 @@ public abstract class AbstractControlPlane implements ControlPlane {
         );
 
         // Process those partitions that are present in the metadata.
-        splitMapper.setTrueOut(findBatchesForExistingPartitions(splitMapper.getTrueIn(), fetchMaxBytes));
+        splitMapper.setTrueOut(findBatchesForExistingPartitions(splitMapper.getTrueIn(), fetchMaxBytes, maxBatchesPerPartition));
 
         return splitMapper.getOut();
     }
 
     protected abstract Iterator<FindBatchResponse> findBatchesForExistingPartitions(
         final Stream<FindBatchRequest> requests,
-        final int fetchMaxBytes
+        final int fetchMaxBytes,
+        final int maxBatchesPerPartition
     );
 
     @Override

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/ControlPlane.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/ControlPlane.java
@@ -39,8 +39,10 @@ public interface ControlPlane extends Closeable, Configurable {
             List<CommitBatchRequest> batches);
 
     List<FindBatchResponse> findBatches(
-            List<FindBatchRequest> findBatchRequests,
-            int fetchMaxBytes);
+        List<FindBatchRequest> findBatchRequests,
+        int fetchMaxBytes,
+        int maxBatchesPerPartition
+    );
 
     void createTopicAndPartitions(Set<CreateTopicAndPartitionsRequest> requests);
 

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/InMemoryControlPlane.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/InMemoryControlPlane.java
@@ -206,7 +206,9 @@ public class InMemoryControlPlane extends AbstractControlPlane {
     @Override
     protected Iterator<FindBatchResponse> findBatchesForExistingPartitions(
         final Stream<FindBatchRequest> requests,
-        final int fetchMaxBytes
+        final int fetchMaxBytes,
+        // ignored for in-memory implementation
+        final int maxBatchesPerPartition
     ) {
         return requests
             .map(request -> findBatchesForExistingPartition(request, fetchMaxBytes))

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/FindBatchesJob.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/FindBatchesJob.java
@@ -38,24 +38,27 @@ import io.aiven.inkless.control_plane.ControlPlaneException;
 import io.aiven.inkless.control_plane.FindBatchRequest;
 import io.aiven.inkless.control_plane.FindBatchResponse;
 
-import static org.jooq.generated.Tables.FIND_BATCHES_V1;
+import static org.jooq.generated.Tables.FIND_BATCHES_V2;
 
 class FindBatchesJob implements Callable<List<FindBatchResponse>> {
     private final Time time;
     private final DSLContext jooqCtx;
     private final List<FindBatchRequest> requests;
     private final int fetchMaxBytes;
+    private final int maxBatchesPerPartition;
     private final Consumer<Long> durationCallback;
 
     FindBatchesJob(final Time time,
                    final DSLContext jooqCtx,
                    final List<FindBatchRequest> requests,
                    final int fetchMaxBytes,
+                   final int maxBatchesPerPartition,
                    final Consumer<Long> durationCallback) {
         this.time = time;
         this.jooqCtx = jooqCtx;
         this.requests = requests;
         this.fetchMaxBytes = fetchMaxBytes;
+        this.maxBatchesPerPartition = maxBatchesPerPartition;
         this.durationCallback = durationCallback;
     }
 
@@ -87,7 +90,7 @@ class FindBatchesJob implements Callable<List<FindBatchResponse>> {
                     FindBatchesResponseV1.HIGH_WATERMARK,
                     FindBatchesResponseV1.BATCHES,
                     FindBatchesResponseV1.ERROR
-                ).from(FIND_BATCHES_V1.call(dbRequests, fetchMaxBytes))
+                ).from(FIND_BATCHES_V2.call(dbRequests, fetchMaxBytes, maxBatchesPerPartition))
                     .fetchInto(FindBatchesResponseV1Record.class);
 
                 if (dbResponses.size() != requests.size()) {

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/PostgresControlPlane.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/PostgresControlPlane.java
@@ -130,11 +130,12 @@ public class PostgresControlPlane extends AbstractControlPlane {
     @Override
     protected Iterator<FindBatchResponse> findBatchesForExistingPartitions(
         final Stream<FindBatchRequest> requests,
-        final int fetchMaxBytes
+        final int fetchMaxBytes,
+        final int maxBatchesPerPartition
     ) {
         final FindBatchesJob job = new FindBatchesJob(
             time, jooqCtx,
-            requests.toList(), fetchMaxBytes,
+            requests.toList(), fetchMaxBytes, maxBatchesPerPartition,
             metrics::onFindBatchesCompleted);
         return job.call().iterator();
     }

--- a/storage/inkless/src/main/resources/db/migration/V8__Find_batches_function_with_limit.sql
+++ b/storage/inkless/src/main/resources/db/migration/V8__Find_batches_function_with_limit.sql
@@ -1,0 +1,88 @@
+-- Copyright (c) 2025 Aiven, Helsinki, Finland. https://aiven.io/
+CREATE OR REPLACE FUNCTION find_batches_v2(
+    arg_requests find_batches_request_v1[],
+    fetch_max_bytes INT,
+    max_batches_per_partition INT DEFAULT 0
+)
+RETURNS SETOF find_batches_response_v1 LANGUAGE sql STABLE AS $$
+    WITH
+        requests AS (
+            SELECT
+                r.topic_id,
+                r.partition,
+                r.starting_offset,
+                r.max_partition_fetch_bytes,
+                r.ordinality AS idx -- for preserving original order
+            FROM unnest(arg_requests) WITH ORDINALITY AS r(topic_id, partition, starting_offset, max_partition_fetch_bytes, ordinality)
+        ),
+        requests_with_log_info AS (
+            SELECT
+                r.idx, r.topic_id, r.partition, r.starting_offset, r.max_partition_fetch_bytes,
+                l.log_start_offset, l.high_watermark, l.topic_name,
+                CASE
+                    WHEN l.topic_id IS NULL THEN 'unknown_topic_or_partition'::find_batches_response_error_v1
+                    WHEN r.starting_offset < 0 OR r.starting_offset > l.high_watermark THEN 'offset_out_of_range'::find_batches_response_error_v1
+                    ELSE NULL
+                END AS error
+            FROM requests r
+            LEFT JOIN logs l ON r.topic_id = l.topic_id AND r.partition = l.partition
+        ),
+        all_batches_with_metadata AS (
+            SELECT
+                r.idx,
+                (
+                    b.batch_id,
+                    f.object_key,
+                    (
+                        b.magic, b.topic_id, r.topic_name, b.partition, b.byte_offset, b.byte_size,
+                        b.base_offset, b.last_offset, b.log_append_timestamp, b.batch_max_timestamp,
+                        b.timestamp_type
+                    )::batch_metadata_v1
+                )::batch_info_v1 AS batch_data,
+                b.byte_size, b.base_offset, r.max_partition_fetch_bytes,
+                ROW_NUMBER() OVER (PARTITION BY r.idx ORDER BY b.base_offset) as rn,
+                SUM(b.byte_size) OVER (PARTITION BY r.idx ORDER BY b.base_offset) as partition_cumulative_bytes
+            FROM requests_with_log_info r
+            JOIN batches b ON r.topic_id = b.topic_id AND r.partition = b.partition
+            JOIN files f ON b.file_id = f.file_id
+            WHERE r.error IS NULL
+                AND b.last_offset >= r.starting_offset
+                AND b.base_offset < r.high_watermark
+        ),
+        per_partition_limited_batches AS (
+            SELECT idx, batch_data, byte_size, base_offset, rn
+            FROM all_batches_with_metadata
+            WHERE (rn = 1  -- each partition gets always at least one batch
+                -- include also last batch, even if it overflows max.partition.fetch.bytes
+                OR (partition_cumulative_bytes - byte_size) < max_partition_fetch_bytes
+                ) AND (max_batches_per_partition = 0 OR rn <= max_batches_per_partition)
+        ),
+        final_batch_set AS (
+            SELECT idx, batch_data, base_offset, rn
+            FROM (
+                SELECT *, SUM(byte_size) OVER (ORDER BY idx, base_offset) as global_cumulative_bytes
+                FROM per_partition_limited_batches
+            ) AS sized_batches
+            WHERE rn = 1 OR  -- each partition gets always at least one batch
+                -- include also last batch, even if it overflows fetch.max.bytes
+                (global_cumulative_bytes - byte_size) < fetch_max_bytes
+        ),
+        aggregated_batches AS (
+            SELECT
+                idx,
+                array_agg(batch_data ORDER BY base_offset) AS batches
+            FROM final_batch_set
+            GROUP BY idx
+        )
+    SELECT
+        r.topic_id,
+        r.partition,
+        COALESCE(r.log_start_offset, -1),
+        COALESCE(r.high_watermark, -1),
+        CASE WHEN r.error IS NULL THEN COALESCE(ab.batches, '{}'::batch_info_v1[]) ELSE NULL END,
+        r.error
+    FROM requests_with_log_info r
+    LEFT JOIN aggregated_batches ab ON r.idx = ab.idx
+    ORDER BY r.idx;
+$$;
+

--- a/storage/inkless/src/test/java/io/aiven/inkless/consume/FindBatchesJobTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/consume/FindBatchesJobTest.java
@@ -54,6 +54,7 @@ import static org.mockito.Mockito.when;
 public class FindBatchesJobTest {
 
     private final Time time = new MockTime();
+    private final int maxBatchesPerPartition = 0;
 
     @Mock
     private ControlPlane controlPlane;
@@ -81,8 +82,8 @@ public class FindBatchesJobTest {
                 new BatchInfo(1L, OBJECT_KEY_MAIN_PART, BatchMetadata.of(partition0, 0, 10, 0, 0, logAppendTimestamp, maxBatchTimestamp, TimestampType.CREATE_TIME))
             ), logStartOffset, highWatermark)
         );
-        FindBatchesJob job = new FindBatchesJob(time, controlPlane, params, fetchInfos, durationMs -> {});
-        when(controlPlane.findBatches(requestCaptor.capture(), anyInt())).thenReturn(new ArrayList<>(coordinates.values()));
+        FindBatchesJob job = new FindBatchesJob(time, controlPlane, params, fetchInfos, maxBatchesPerPartition, durationMs -> {});
+        when(controlPlane.findBatches(requestCaptor.capture(), anyInt(), anyInt())).thenReturn(new ArrayList<>(coordinates.values()));
         Map<TopicIdPartition, FindBatchResponse> result = job.get();
 
         assertThat(result).isEqualTo(coordinates);

--- a/storage/inkless/src/test/java/io/aiven/inkless/consume/ReaderTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/consume/ReaderTest.java
@@ -78,7 +78,7 @@ public class ReaderTest {
 
     @BeforeEach
     public void setup() {
-        reader = new Reader(time, OBJECT_KEY_CREATOR, KEY_ALIGNMENT_STRATEGY, OBJECT_CACHE, controlPlane, objectFetcher, metadataExecutor, dataExecutor, new BrokerTopicStats());
+        reader = new Reader(time, OBJECT_KEY_CREATOR, KEY_ALIGNMENT_STRATEGY, OBJECT_CACHE, controlPlane, objectFetcher, 0, metadataExecutor, dataExecutor, new BrokerTopicStats());
     }
 
     @Test

--- a/storage/inkless/src/test/java/io/aiven/inkless/control_plane/AbstractControlPlaneTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/control_plane/AbstractControlPlaneTest.java
@@ -174,7 +174,8 @@ public abstract class AbstractControlPlaneTest {
                 new FindBatchRequest(EXISTING_TOPIC_1_ID_PARTITION_0, 11, Integer.MAX_VALUE),
                 new FindBatchRequest(new TopicIdPartition(EXISTING_TOPIC_1_ID, EXISTING_TOPIC_1_PARTITIONS + 1, EXISTING_TOPIC_1) , 11, Integer.MAX_VALUE),
                 new FindBatchRequest(new TopicIdPartition(Uuid.ONE_UUID, 0, NONEXISTENT_TOPIC), 11, Integer.MAX_VALUE)
-            ), Integer.MAX_VALUE);
+            ), Integer.MAX_VALUE, 0
+        );
         assertThat(findResponse).containsExactly(
             new FindBatchResponse(
                 Errors.NONE,
@@ -203,7 +204,9 @@ public abstract class AbstractControlPlaneTest {
 
         for (int offset = 0; offset < numberOfRecordsInBatch1; offset++) {
             final List<FindBatchResponse> findResponse = controlPlane.findBatches(
-                List.of(new FindBatchRequest(EXISTING_TOPIC_1_ID_PARTITION_0, offset, Integer.MAX_VALUE)), Integer.MAX_VALUE);
+                List.of(new FindBatchRequest(EXISTING_TOPIC_1_ID_PARTITION_0, offset, Integer.MAX_VALUE)),
+                Integer.MAX_VALUE, 0
+            );
             assertThat(findResponse).containsExactly(
                 new FindBatchResponse(Errors.NONE, List.of(
                     new BatchInfo(1L, objectKey1, BatchMetadata.of(EXISTING_TOPIC_1_ID_PARTITION_0, 1, 10, 0, numberOfRecordsInBatch1 - 1, expectedLogAppendTime, 1000, TimestampType.CREATE_TIME)),
@@ -213,7 +216,9 @@ public abstract class AbstractControlPlaneTest {
         }
         for (int offset = numberOfRecordsInBatch1; offset < numberOfRecordsInBatch1 + numberOfRecordsInBatch2; offset++) {
             final List<FindBatchResponse> findResponse = controlPlane.findBatches(
-                List.of(new FindBatchRequest(EXISTING_TOPIC_1_ID_PARTITION_0, offset, Integer.MAX_VALUE)), Integer.MAX_VALUE);
+                List.of(new FindBatchRequest(EXISTING_TOPIC_1_ID_PARTITION_0, offset, Integer.MAX_VALUE)),
+                Integer.MAX_VALUE, 0
+            );
             assertThat(findResponse).containsExactly(
                 new FindBatchResponse(Errors.NONE, List.of(
                     new BatchInfo(2L, objectKey2, BatchMetadata.of(EXISTING_TOPIC_1_ID_PARTITION_0, 100, 10, numberOfRecordsInBatch1, lastOffset, expectedLogAppendTime, 2000, TimestampType.CREATE_TIME))
@@ -235,7 +240,8 @@ public abstract class AbstractControlPlaneTest {
 
         final List<FindBatchResponse> findResponse = controlPlane.findBatches(
             List.of(new FindBatchRequest(EXISTING_TOPIC_1_ID_PARTITION_0, 10, Integer.MAX_VALUE)),
-            Integer.MAX_VALUE);
+            Integer.MAX_VALUE, 0
+        );
         assertThat(findResponse).containsExactly(
             new FindBatchResponse(Errors.NONE, List.of(), 0, 10)
         );
@@ -254,7 +260,8 @@ public abstract class AbstractControlPlaneTest {
 
         final List<FindBatchResponse> findResponse = controlPlane.findBatches(
             List.of(new FindBatchRequest(EXISTING_TOPIC_1_ID_PARTITION_0, 11, Integer.MAX_VALUE)),
-            Integer.MAX_VALUE);
+            Integer.MAX_VALUE, 0
+        );
         assertThat(findResponse).containsExactly(
             new FindBatchResponse(Errors.OFFSET_OUT_OF_RANGE, null, 0, 10)
         );
@@ -273,7 +280,8 @@ public abstract class AbstractControlPlaneTest {
 
         final List<FindBatchResponse> findResponse = controlPlane.findBatches(
             List.of(new FindBatchRequest(EXISTING_TOPIC_1_ID_PARTITION_0, -1, Integer.MAX_VALUE)),
-            Integer.MAX_VALUE);
+            Integer.MAX_VALUE, 0
+        );
         assertThat(findResponse).containsExactly(
             new FindBatchResponse(Errors.OFFSET_OUT_OF_RANGE, null, 0, 10)
         );
@@ -283,7 +291,8 @@ public abstract class AbstractControlPlaneTest {
     void findBeforeCommit() {
         final List<FindBatchResponse> findResponse = controlPlane.findBatches(
             List.of(new FindBatchRequest(EXISTING_TOPIC_1_ID_PARTITION_0, 11, Integer.MAX_VALUE)),
-            Integer.MAX_VALUE);
+            Integer.MAX_VALUE, 0
+        );
         assertThat(findResponse).containsExactly(
             new FindBatchResponse(Errors.OFFSET_OUT_OF_RANGE, null, 0, 0)
         );
@@ -324,7 +333,8 @@ public abstract class AbstractControlPlaneTest {
             ));
 
         final List<FindBatchRequest> findBatchRequests = List.of(new FindBatchRequest(new TopicIdPartition(newTopic1Id, 0, newTopic1Name), 0, Integer.MAX_VALUE));
-        final List<FindBatchResponse> findBatchResponsesBeforeDelete = controlPlane.findBatches(findBatchRequests, Integer.MAX_VALUE);
+        final List<FindBatchResponse> findBatchResponsesBeforeDelete = controlPlane.findBatches(findBatchRequests, Integer.MAX_VALUE, 0
+        );
 
         // Create new topic and partitions for the existing one.
         controlPlane.createTopicAndPartitions(Set.of(
@@ -343,7 +353,8 @@ public abstract class AbstractControlPlaneTest {
             GetLogInfoResponse.success(0, 0, 0)
         );
 
-        final List<FindBatchResponse> findBatchResponsesAfterDelete = controlPlane.findBatches(findBatchRequests, Integer.MAX_VALUE);
+        final List<FindBatchResponse> findBatchResponsesAfterDelete = controlPlane.findBatches(findBatchRequests, Integer.MAX_VALUE, 0
+        );
         assertThat(findBatchResponsesBeforeDelete).isEqualTo(findBatchResponsesAfterDelete);
 
         // Nothing happens as this is idempotent
@@ -363,7 +374,8 @@ public abstract class AbstractControlPlaneTest {
             GetLogInfoResponse.success(0, 0, 0)
         );
 
-        final List<FindBatchResponse> findBatchResponsesAfterDelete2 = controlPlane.findBatches(findBatchRequests, Integer.MAX_VALUE);
+        final List<FindBatchResponse> findBatchResponsesAfterDelete2 = controlPlane.findBatches(findBatchRequests, Integer.MAX_VALUE, 0
+        );
         assertThat(findBatchResponsesAfterDelete2).isEqualTo(findBatchResponsesAfterDelete);
     }
 
@@ -385,7 +397,8 @@ public abstract class AbstractControlPlaneTest {
             ));
 
         final List<FindBatchRequest> findBatchRequests = List.of(new FindBatchRequest(EXISTING_TOPIC_2_ID_PARTITION_0, 0, Integer.MAX_VALUE));
-        final List<FindBatchResponse> findBatchResponsesBeforeDelete = controlPlane.findBatches(findBatchRequests, Integer.MAX_VALUE);
+        final List<FindBatchResponse> findBatchResponsesBeforeDelete = controlPlane.findBatches(findBatchRequests, Integer.MAX_VALUE, 0
+        );
 
         time.sleep(1001);  // advance time
         controlPlane.deleteTopics(Set.of(EXISTING_TOPIC_1_ID, Uuid.ONE_UUID));
@@ -395,7 +408,8 @@ public abstract class AbstractControlPlaneTest {
             new FileToDelete(objectKey1, TimeUtils.now(time))
         );
 
-        final List<FindBatchResponse> findBatchResponsesAfterDelete = controlPlane.findBatches(findBatchRequests, Integer.MAX_VALUE);
+        final List<FindBatchResponse> findBatchResponsesAfterDelete = controlPlane.findBatches(findBatchRequests, Integer.MAX_VALUE, 0
+        );
         assertThat(findBatchResponsesAfterDelete).isEqualTo(findBatchResponsesBeforeDelete);
 
         // Nothing happens as it's idempotent.
@@ -422,7 +436,9 @@ public abstract class AbstractControlPlaneTest {
             .containsExactly(GetLogInfoResponse.success(0, 10, FILE_SIZE));
 
         final List<FindBatchResponse> findResponseBeforeDelete = controlPlane.findBatches(
-            List.of(new FindBatchRequest(EXISTING_TOPIC_1_ID_PARTITION_0, 0, Integer.MAX_VALUE)), Integer.MAX_VALUE);
+            List.of(new FindBatchRequest(EXISTING_TOPIC_1_ID_PARTITION_0, 0, Integer.MAX_VALUE)),
+            Integer.MAX_VALUE, 0
+        );
 
         final List<DeleteRecordsResponse> deleteRecordsResponses = controlPlane.deleteRecords(List.of(
             new DeleteRecordsRequest(EXISTING_TOPIC_1_ID_PARTITION_0, 3),
@@ -434,7 +450,9 @@ public abstract class AbstractControlPlaneTest {
         );
 
         final List<FindBatchResponse> findResponse = controlPlane.findBatches(
-            List.of(new FindBatchRequest(EXISTING_TOPIC_1_ID_PARTITION_0, 0, Integer.MAX_VALUE)), Integer.MAX_VALUE);
+            List.of(new FindBatchRequest(EXISTING_TOPIC_1_ID_PARTITION_0, 0, Integer.MAX_VALUE)),
+            Integer.MAX_VALUE, 0
+        );
 
         assertThat(findResponse).containsExactly(
             new FindBatchResponse(Errors.NONE, findResponseBeforeDelete.get(0).batches(), 3, 10)
@@ -478,7 +496,9 @@ public abstract class AbstractControlPlaneTest {
             .containsExactly(GetLogInfoResponse.success(0, 30, FILE_SIZE * 3));
 
         final List<FindBatchResponse> findResponseBeforeDelete = controlPlane.findBatches(
-            List.of(new FindBatchRequest(EXISTING_TOPIC_1_ID_PARTITION_0, 0, Integer.MAX_VALUE)), Integer.MAX_VALUE);
+            List.of(new FindBatchRequest(EXISTING_TOPIC_1_ID_PARTITION_0, 0, Integer.MAX_VALUE)),
+            Integer.MAX_VALUE, 0
+        );
 
         final List<DeleteRecordsResponse> deleteRecordsResponses = controlPlane.deleteRecords(List.of(
             new DeleteRecordsRequest(EXISTING_TOPIC_1_ID_PARTITION_0, 19),
@@ -490,7 +510,9 @@ public abstract class AbstractControlPlaneTest {
         );
 
         final List<FindBatchResponse> findResponse = controlPlane.findBatches(
-            List.of(new FindBatchRequest(EXISTING_TOPIC_1_ID_PARTITION_0, 0, Integer.MAX_VALUE)), Integer.MAX_VALUE);
+            List.of(new FindBatchRequest(EXISTING_TOPIC_1_ID_PARTITION_0, 0, Integer.MAX_VALUE)),
+            Integer.MAX_VALUE, 0
+        );
 
         assertThat(findResponse).containsExactly(
             new FindBatchResponse(Errors.NONE, List.of(
@@ -519,7 +541,9 @@ public abstract class AbstractControlPlaneTest {
             .containsExactly(GetLogInfoResponse.success(0, 10, FILE_SIZE));
 
         final List<FindBatchResponse> findResponseBeforeDelete = controlPlane.findBatches(
-            List.of(new FindBatchRequest(EXISTING_TOPIC_1_ID_PARTITION_0, 0, Integer.MAX_VALUE)), Integer.MAX_VALUE);
+            List.of(new FindBatchRequest(EXISTING_TOPIC_1_ID_PARTITION_0, 0, Integer.MAX_VALUE)),
+            Integer.MAX_VALUE, 0
+        );
 
         final List<DeleteRecordsResponse> deleteRecordsResponses = controlPlane.deleteRecords(List.of(
             new DeleteRecordsRequest(EXISTING_TOPIC_1_ID_PARTITION_0, 0),
@@ -531,7 +555,9 @@ public abstract class AbstractControlPlaneTest {
         );
 
         final List<FindBatchResponse> findResponse = controlPlane.findBatches(
-            List.of(new FindBatchRequest(EXISTING_TOPIC_1_ID_PARTITION_0, 0, Integer.MAX_VALUE)), Integer.MAX_VALUE);
+            List.of(new FindBatchRequest(EXISTING_TOPIC_1_ID_PARTITION_0, 0, Integer.MAX_VALUE)),
+            Integer.MAX_VALUE, 0
+        );
         assertThat(findResponse).isEqualTo(findResponseBeforeDelete);
 
         assertThat(controlPlane.getFilesToDelete()).isEmpty();
@@ -560,7 +586,9 @@ public abstract class AbstractControlPlaneTest {
         );
 
         final List<FindBatchResponse> findResponse = controlPlane.findBatches(
-            List.of(new FindBatchRequest(EXISTING_TOPIC_1_ID_PARTITION_0, 0, Integer.MAX_VALUE)), Integer.MAX_VALUE);
+            List.of(new FindBatchRequest(EXISTING_TOPIC_1_ID_PARTITION_0, 0, Integer.MAX_VALUE)),
+            Integer.MAX_VALUE, 0
+        );
         assertThat(findResponse).containsExactly(
             new FindBatchResponse(Errors.NONE, List.of(), 10, 10)
         );
@@ -583,7 +611,9 @@ public abstract class AbstractControlPlaneTest {
         );
 
         final List<FindBatchResponse> findResponseBeforeDelete = controlPlane.findBatches(
-            List.of(new FindBatchRequest(EXISTING_TOPIC_1_ID_PARTITION_0, 0, Integer.MAX_VALUE)), Integer.MAX_VALUE);
+            List.of(new FindBatchRequest(EXISTING_TOPIC_1_ID_PARTITION_0, 0, Integer.MAX_VALUE)),
+            Integer.MAX_VALUE, 0
+        );
 
         final List<DeleteRecordsResponse> deleteRecordsResponses = controlPlane.deleteRecords(List.of(
             new DeleteRecordsRequest(EXISTING_TOPIC_1_ID_PARTITION_0, deleteOffset)
@@ -593,7 +623,9 @@ public abstract class AbstractControlPlaneTest {
         );
 
         final List<FindBatchResponse> findResponse = controlPlane.findBatches(
-            List.of(new FindBatchRequest(EXISTING_TOPIC_1_ID_PARTITION_0, 0, Integer.MAX_VALUE)), Integer.MAX_VALUE);
+            List.of(new FindBatchRequest(EXISTING_TOPIC_1_ID_PARTITION_0, 0, Integer.MAX_VALUE)),
+            Integer.MAX_VALUE, 0
+        );
         assertThat(findResponse).isEqualTo(findResponseBeforeDelete);
 
         assertThat(controlPlane.getFilesToDelete()).isEmpty();
@@ -617,7 +649,9 @@ public abstract class AbstractControlPlaneTest {
         );
 
         final List<FindBatchResponse> findResponseBeforeDelete = controlPlane.findBatches(
-            List.of(new FindBatchRequest(EXISTING_TOPIC_1_ID_PARTITION_1, 0, Integer.MAX_VALUE)), Integer.MAX_VALUE);
+            List.of(new FindBatchRequest(EXISTING_TOPIC_1_ID_PARTITION_1, 0, Integer.MAX_VALUE)),
+            Integer.MAX_VALUE, 0
+        );
 
         final List<DeleteRecordsResponse> deleteRecordsResponses = controlPlane.deleteRecords(List.of(
             new DeleteRecordsRequest(EXISTING_TOPIC_1_ID_PARTITION_0, 10)
@@ -625,7 +659,9 @@ public abstract class AbstractControlPlaneTest {
         assertThat(deleteRecordsResponses).containsExactly(DeleteRecordsResponse.success(10));
 
         final List<FindBatchResponse> findResponse = controlPlane.findBatches(
-            List.of(new FindBatchRequest(EXISTING_TOPIC_1_ID_PARTITION_1, 0, Integer.MAX_VALUE)), Integer.MAX_VALUE);
+            List.of(new FindBatchRequest(EXISTING_TOPIC_1_ID_PARTITION_1, 0, Integer.MAX_VALUE)),
+            Integer.MAX_VALUE, 0
+        );
         assertThat(findResponse).isEqualTo(findResponseBeforeDelete);
 
         assertThat(controlPlane.getFilesToDelete()).isEmpty();
@@ -1506,7 +1542,8 @@ public abstract class AbstractControlPlaneTest {
 
         final List<FindBatchResponse> findResponse = controlPlane.findBatches(
             List.of(new FindBatchRequest(EXISTING_TOPIC_1_ID_PARTITION_0, 0, Integer.MAX_VALUE)),
-            Integer.MAX_VALUE);
+            Integer.MAX_VALUE, 0
+        );
         assertThat(findResponse).containsExactly(
             new FindBatchResponse(
                 Errors.NONE,
@@ -1815,7 +1852,8 @@ public abstract class AbstractControlPlaneTest {
                 List.of(
                     new FindBatchRequest(EXISTING_TOPIC_1_ID_PARTITION_0, 0, Integer.MAX_VALUE),
                     new FindBatchRequest(EXISTING_TOPIC_1_ID_PARTITION_1, 0, Integer.MAX_VALUE)
-                ), Integer.MAX_VALUE);
+                ), Integer.MAX_VALUE, 0
+            );
             assertThat(findBatchResult).containsExactly(
                 FindBatchResponse.success(List.of(
                     new BatchInfo(6L, "obj_merged", BatchMetadata.of(EXISTING_TOPIC_1_ID_PARTITION_0, 0L, file1Batch1Size, 0L, 100L, committedAt, 1000L, TimestampType.CREATE_TIME)),
@@ -1900,7 +1938,8 @@ public abstract class AbstractControlPlaneTest {
                 List.of(
                     new FindBatchRequest(EXISTING_TOPIC_1_ID_PARTITION_0, 0, Integer.MAX_VALUE),
                     new FindBatchRequest(EXISTING_TOPIC_2_ID_PARTITION_0, 0, Integer.MAX_VALUE)
-                ), Integer.MAX_VALUE);
+                ), Integer.MAX_VALUE, 0
+            );
             assertThat(findBatchResult).containsExactly(
                 FindBatchResponse.unknownTopicOrPartition(),
                 FindBatchResponse.success(List.of(
@@ -1948,7 +1987,9 @@ public abstract class AbstractControlPlaneTest {
             ));
 
             final var findBatchResult = controlPlane.findBatches(
-                List.of(new FindBatchRequest(EXISTING_TOPIC_1_ID_PARTITION_0, 0, Integer.MAX_VALUE)), Integer.MAX_VALUE);
+                List.of(new FindBatchRequest(EXISTING_TOPIC_1_ID_PARTITION_0, 0, Integer.MAX_VALUE)),
+                Integer.MAX_VALUE, 0
+            );
             assertThat(findBatchResult).containsExactly(
                 FindBatchResponse.success(List.of(
                     new BatchInfo(3L, "obj_merged", BatchMetadata.of(EXISTING_TOPIC_1_ID_PARTITION_0, fileSize, fileSize, 100L, 200L, committedAt, 2000L, TimestampType.LOG_APPEND_TIME))
@@ -1996,7 +2037,9 @@ public abstract class AbstractControlPlaneTest {
             ));
 
             final var findBatchResult = controlPlane.findBatches(
-                List.of(new FindBatchRequest(EXISTING_TOPIC_1_ID_PARTITION_0, 0, Integer.MAX_VALUE)), Integer.MAX_VALUE);
+                List.of(new FindBatchRequest(EXISTING_TOPIC_1_ID_PARTITION_0, 0, Integer.MAX_VALUE)),
+                Integer.MAX_VALUE, 0
+            );
             assertThat(findBatchResult).containsExactly(FindBatchResponse.unknownTopicOrPartition());
 
             // Since the new merged file doesn't host any live batch, it should end up in files-to-delete as well.

--- a/storage/inkless/src/test/java/io/aiven/inkless/delete/FileCleanerIntegrationTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/delete/FileCleanerIntegrationTest.java
@@ -259,7 +259,7 @@ class FileCleanerIntegrationTest {
         final List<FindBatchRequest> findBatchRequests = ALL_TOPIC_ID_PARTITIONS.stream()
             .map(tidp -> new FindBatchRequest(tidp, 0, Integer.MAX_VALUE))
             .toList();
-        final List<FindBatchResponse> findBatchResponses = controlPlane.findBatches(findBatchRequests, Integer.MAX_VALUE);
+        final List<FindBatchResponse> findBatchResponses = controlPlane.findBatches(findBatchRequests, Integer.MAX_VALUE, 0);
 
         final Map<TopicIdPartition, Long> result = new HashMap<>();
         for (int i = 0; i < findBatchResponses.size(); i++) {

--- a/storage/inkless/src/test/java/io/aiven/inkless/merge/FileMergerIntegrationTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/merge/FileMergerIntegrationTest.java
@@ -278,7 +278,7 @@ class FileMergerIntegrationTest {
         final List<FindBatchRequest> findBatchRequests = ALL_TOPIC_ID_PARTITIONS.stream()
             .map(tidp -> new FindBatchRequest(tidp, 0, Integer.MAX_VALUE))
             .toList();
-        final List<FindBatchResponse> findBatchResponses = controlPlane.findBatches(findBatchRequests, Integer.MAX_VALUE);
+        final List<FindBatchResponse> findBatchResponses = controlPlane.findBatches(findBatchRequests, Integer.MAX_VALUE, 0);
 
         final Map<TopicIdPartition, Long> result = new HashMap<>();
         for (int i = 0; i < findBatchResponses.size(); i++) {


### PR DESCRIPTION
Introduce another fetch-side configuration to control how many batches to return per partition when serving a single request.

This configuration is pass down to the Control-plane back-end implementation.
PostgreSQL control-plane implementation will use this to limit the number of batches per partition at the DB function level.

Most changes are aligning tests to the new configuration. I've highlighted the main changes to help with the review.
