### PR TITLE
feat(inkless): add metrics for client-az hit/miss

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -129,6 +129,7 @@ class KafkaApis(val requestChannel: RequestChannel,
 
   def close(): Unit = {
     aclApis.close()
+    inklessTopicMetadataTransformer.foreach(t => t.close())
     info("Shutdown complete.")
   }
 

--- a/storage/inkless/src/main/java/io/aiven/inkless/metadata/ClientAzAwarenessMetrics.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/metadata/ClientAzAwarenessMetrics.java
@@ -1,0 +1,72 @@
+/*
+ * Inkless
+ * Copyright (C) 2024 - 2025 Aiven OY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.aiven.inkless.metadata;
+
+import org.apache.kafka.server.metrics.KafkaMetricsGroup;
+
+import com.yammer.metrics.core.Meter;
+
+import java.io.Closeable;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+public class ClientAzAwarenessMetrics implements Closeable {
+    private static final String CLIENT_AZ_HIT_RATE = "client-az-hit-rate";
+    private static final String CLIENT_AZ_MISS_RATE = "client-az-miss-rate";
+    private static final String CLIENT_AZ_UNAWARE_RATE = "client-az-unaware-rate";
+
+    private final KafkaMetricsGroup metricsGroup = new KafkaMetricsGroup(ClientAzAwarenessMetrics.class);
+    final Meter clientAzHitRate;
+    final Meter clientAzMissRate;
+    final Map<String, Meter> clientAzHitRatesPerAz;
+    final Meter clientAzUnawareRate;
+
+    public ClientAzAwarenessMetrics() {
+        clientAzUnawareRate = metricsGroup.newMeter(CLIENT_AZ_UNAWARE_RATE, "requests", TimeUnit.SECONDS, Map.of());
+        clientAzMissRate = metricsGroup.newMeter(CLIENT_AZ_MISS_RATE, "requests", TimeUnit.SECONDS, Map.of());
+        clientAzHitRate = metricsGroup.newMeter(CLIENT_AZ_HIT_RATE, "requests", TimeUnit.SECONDS, Map.of());
+        clientAzHitRatesPerAz = new HashMap<>(3);
+    }
+
+    public void recordClientAz(String clientAZ, boolean foundBrokersInClientAZ) {
+        if (clientAZ == null) {
+            clientAzUnawareRate.mark();
+            return;
+        }
+        if (!foundBrokersInClientAZ) {
+            clientAzMissRate.mark();
+            return;
+        }
+        clientAzHitRate.mark();
+        clientAzHitRatesPerAz.computeIfAbsent(clientAZ, az -> metricsGroup.newMeter(
+            CLIENT_AZ_HIT_RATE,
+            "requests",
+            TimeUnit.SECONDS,
+            Map.of("az", clientAZ)
+        )).mark();
+    }
+
+    @Override
+    public void close() {
+        metricsGroup.removeMetric(CLIENT_AZ_HIT_RATE);
+        metricsGroup.removeMetric(CLIENT_AZ_MISS_RATE);
+        metricsGroup.removeMetric(CLIENT_AZ_UNAWARE_RATE);
+        clientAzHitRatesPerAz.keySet().forEach(az -> metricsGroup.removeMetric(CLIENT_AZ_HIT_RATE, Map.of("az", az)));
+    }
+}

--- a/storage/inkless/src/test/java/io/aiven/inkless/metadata/ClientAzAwarenessMetricsTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/metadata/ClientAzAwarenessMetricsTest.java
@@ -1,0 +1,58 @@
+/*
+ * Inkless
+ * Copyright (C) 2024 - 2025 Aiven OY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.aiven.inkless.metadata;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ClientAzAwarenessMetricsTest {
+
+    @Test
+    void testRecordClientAzUnaware() {
+        final ClientAzAwarenessMetrics metrics = new ClientAzAwarenessMetrics();
+        metrics.recordClientAz(null, false);
+        assertEquals(0, metrics.clientAzHitRate.count());
+        assertEquals(0, metrics.clientAzMissRate.count());
+        assertEquals(1, metrics.clientAzUnawareRate.count());
+        metrics.close();
+    }
+
+    @Test
+    void testRecordClientAzMiss() {
+        final ClientAzAwarenessMetrics metrics = new ClientAzAwarenessMetrics();
+        metrics.recordClientAz("us-east-1a", false);
+        assertEquals(0, metrics.clientAzHitRate.count());
+        assertEquals(1, metrics.clientAzMissRate.count());
+        assertEquals(0, metrics.clientAzUnawareRate.count());
+        metrics.close();
+    }
+
+    @Test
+    void testRecordClientAzHit() {
+        final ClientAzAwarenessMetrics metrics = new ClientAzAwarenessMetrics();
+        metrics.recordClientAz("us-east-1a", true);
+        assertEquals(1, metrics.clientAzHitRate.count());
+        assertEquals(0, metrics.clientAzMissRate.count());
+        assertEquals(0, metrics.clientAzUnawareRate.count());
+        assertTrue(metrics.clientAzHitRatesPerAz.containsKey("us-east-1a"));
+        assertEquals(1, metrics.clientAzHitRatesPerAz.get("us-east-1a").count());
+        metrics.close();
+    }
+}


### PR DESCRIPTION
Successfully mapping client-provided AZ to a set of brokers is a key feature to optimize costs for diskless topics.
Adding metrics allows monitoring how much use of this feature is being activated by client configurations, and how balanced are the AZs.
