### PR TITLE
refactor(inkless): reuse storage metrics instance on cache

### DIFF
--- a/storage/inkless/src/main/java/io/aiven/inkless/cache/BatchCoordinateCacheMetrics.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/cache/BatchCoordinateCacheMetrics.java
@@ -1,3 +1,20 @@
+/*
+ * Inkless
+ * Copyright (C) 2024 - 2025 Aiven OY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package io.aiven.inkless.cache;
 
 import org.apache.kafka.server.metrics.KafkaMetricsGroup;

--- a/storage/inkless/src/main/java/io/aiven/inkless/cache/CaffeineCache.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/cache/CaffeineCache.java
@@ -1,3 +1,20 @@
+/*
+ * Inkless
+ * Copyright (C) 2024 - 2025 Aiven OY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package io.aiven.inkless.cache;
 
 import org.apache.kafka.common.metrics.Metrics;

--- a/storage/inkless/src/main/java/io/aiven/inkless/cache/CaffeineCache.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/cache/CaffeineCache.java
@@ -60,7 +60,7 @@ public final class CaffeineCache implements ObjectCache {
 
     @Override
     public void close() throws IOException {
-        cache.synchronous().cleanUp();
+        // no resources to close
     }
 
     @Override

--- a/storage/inkless/src/main/java/io/aiven/inkless/cache/CaffeineCache.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/cache/CaffeineCache.java
@@ -1,5 +1,7 @@
 package io.aiven.inkless.cache;
 
+import org.apache.kafka.common.metrics.Metrics;
+
 import com.github.benmanes.caffeine.cache.AsyncCache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.stats.CacheStats;
@@ -21,32 +23,33 @@ public final class CaffeineCache implements ObjectCache {
      */
     private final AsyncCache<CacheKey, FileExtent> cache;
 
-    private final CaffeineCacheMetrics metrics;
-
     public CaffeineCache(
         final long maxCacheSize,
         final long lifespanSeconds,
-        final int maxIdleSeconds) {
-        cache = Caffeine.newBuilder()
-                .maximumSize(maxCacheSize)
-                .expireAfterWrite(Duration.ofSeconds(lifespanSeconds))
-                .expireAfterAccess(Duration.ofSeconds(maxIdleSeconds != -1 ? maxIdleSeconds: 180))
-                .recordStats()
-                .buildAsync();
-        metrics = new CaffeineCacheMetrics(cache.synchronous());
+        final int maxIdleSeconds,
+        final Metrics storageMetrics
+    ) {
+        final Caffeine<Object, Object> builder = Caffeine.newBuilder();
+        // size and weight limits
+        builder.maximumSize(maxCacheSize);
+        // expiration policies
+        builder.expireAfterWrite(Duration.ofSeconds(lifespanSeconds));
+        builder.expireAfterAccess(Duration.ofSeconds(maxIdleSeconds != -1 ? maxIdleSeconds : 180));
+        // enable metrics
+        builder.recordStats();
+        cache = builder.buildAsync();
+        new CaffeineCacheMetrics(storageMetrics, cache.synchronous());
     }
 
     @Override
     public void close() throws IOException {
-        metrics.close();
+        cache.synchronous().cleanUp();
     }
 
     @Override
     public FileExtent computeIfAbsent(final CacheKey key, final Function<CacheKey, FileExtent> mappingFunction) {
         final CompletableFuture<FileExtent> future = new CompletableFuture<>();
-        final CompletableFuture<FileExtent> existingFuture = cache.asMap().computeIfAbsent(key, (cacheKey) -> {
-            return future;
-        });
+        final CompletableFuture<FileExtent> existingFuture = cache.asMap().computeIfAbsent(key, (cacheKey) -> future);
         // If existing future is not the same object as created in this function
         // there was a pending cache load and this call is required to join the existing future
         // and discard the created one.

--- a/storage/inkless/src/main/java/io/aiven/inkless/cache/CaffeineCacheMetrics.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/cache/CaffeineCacheMetrics.java
@@ -1,3 +1,20 @@
+/*
+ * Inkless
+ * Copyright (C) 2024 - 2025 Aiven OY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package io.aiven.inkless.cache;
 
 import org.apache.kafka.common.MetricNameTemplate;

--- a/storage/inkless/src/main/java/io/aiven/inkless/cache/CaffeineCacheMetrics.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/cache/CaffeineCacheMetrics.java
@@ -1,27 +1,17 @@
 package io.aiven.inkless.cache;
 
 import org.apache.kafka.common.MetricNameTemplate;
-import org.apache.kafka.common.metrics.JmxReporter;
-import org.apache.kafka.common.metrics.KafkaMetricsContext;
-import org.apache.kafka.common.metrics.MetricConfig;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.Sensor;
-import org.apache.kafka.common.utils.Time;
 
 import com.github.benmanes.caffeine.cache.Cache;
 
-import java.io.Closeable;
-import java.io.IOException;
-import java.util.List;
 import java.util.function.Supplier;
 
 import io.aiven.inkless.common.metrics.MeasurableValue;
 import io.aiven.inkless.common.metrics.SensorProvider;
 
-public final class CaffeineCacheMetrics implements Closeable {
-
-    private final Metrics metrics;
-
+public final class CaffeineCacheMetrics {
     private final Sensor cacheSizeSensor;
     private final Sensor cacheHitCountSensor;
     private final Sensor cacheHitRateSensor;
@@ -30,13 +20,7 @@ public final class CaffeineCacheMetrics implements Closeable {
     private final Sensor cacheAvgLoadPenaltySensor;
     private final Sensor cacheEvictionsSensor;
 
-    public CaffeineCacheMetrics(final Cache<?, ?> cache) {
-        final JmxReporter reporter = new JmxReporter();
-        this.metrics = new Metrics(
-                new MetricConfig(), List.of(reporter), Time.SYSTEM,
-                new KafkaMetricsContext(CaffeineCacheMetricsRegistry.METRIC_CONTEXT)
-        );
-
+    public CaffeineCacheMetrics(final Metrics metrics, final Cache<?, ?> cache) {
         final CaffeineCacheMetricsRegistry metricsRegistry = new CaffeineCacheMetricsRegistry();
         cacheSizeSensor = registerLongSensor(metrics, metricsRegistry.cacheSizeMetricName, CaffeineCacheMetricsRegistry.CACHE_SIZE, cache::estimatedSize);
         cacheHitCountSensor = registerLongSensor(metrics, metricsRegistry.cacheHitCountMetricName, CaffeineCacheMetricsRegistry.CACHE_HIT_COUNT, () -> cache.stats().hitCount());
@@ -62,8 +46,7 @@ public final class CaffeineCacheMetrics implements Closeable {
     @Override
     public String toString() {
         return "CaffeineCacheMetrics{" +
-                "metrics=" + metrics +
-                ", cacheSizeSensor=" + cacheSizeSensor +
+                "cacheSizeSensor=" + cacheSizeSensor +
                 ", cacheHitCountSensor=" + cacheHitCountSensor +
                 ", cacheHitRateSensor=" + cacheHitRateSensor +
                 ", cacheMissCountSensor=" + cacheMissCountSensor +
@@ -71,10 +54,5 @@ public final class CaffeineCacheMetrics implements Closeable {
                 ", cacheAvgLoadPenaltySensor=" + cacheAvgLoadPenaltySensor +
                 ", cacheEvictionsSensor=" + cacheEvictionsSensor +
                 '}';
-    }
-
-    @Override
-    public void close() throws IOException {
-        metrics.close();
     }
 }

--- a/storage/inkless/src/main/java/io/aiven/inkless/cache/CaffeineCacheMetricsRegistry.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/cache/CaffeineCacheMetricsRegistry.java
@@ -20,7 +20,6 @@ package io.aiven.inkless.cache;
 import org.apache.kafka.common.MetricNameTemplate;
 
 public class CaffeineCacheMetricsRegistry {
-    public static final String METRIC_CONTEXT = "io.aiven.inkless.cache.caffeine";
     public static final String METRIC_GROUP = "wal-segment-cache";
 
     public static final String CACHE_SIZE = "size";

--- a/storage/inkless/src/main/java/io/aiven/inkless/cache/IncreasedLogStartOffsetException.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/cache/IncreasedLogStartOffsetException.java
@@ -1,3 +1,20 @@
+/*
+ * Inkless
+ * Copyright (C) 2024 - 2025 Aiven OY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package io.aiven.inkless.cache;
 
 public class IncreasedLogStartOffsetException extends StaleLogFragmentException {

--- a/storage/inkless/src/main/java/io/aiven/inkless/cache/NullBatchCoordinateCache.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/cache/NullBatchCoordinateCache.java
@@ -1,3 +1,20 @@
+/*
+ * Inkless
+ * Copyright (C) 2024 - 2025 Aiven OY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package io.aiven.inkless.cache;
 
 import org.apache.kafka.common.TopicIdPartition;

--- a/storage/inkless/src/main/java/io/aiven/inkless/cache/StaleLogFragmentException.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/cache/StaleLogFragmentException.java
@@ -1,3 +1,20 @@
+/*
+ * Inkless
+ * Copyright (C) 2024 - 2025 Aiven OY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package io.aiven.inkless.cache;
 
 /* When this Exception is raised by a LogFragment, it means that the data contained in the LogFragment

--- a/storage/inkless/src/main/java/io/aiven/inkless/common/SharedState.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/common/SharedState.java
@@ -58,7 +58,8 @@ public final class SharedState implements Closeable {
     private final BatchCoordinateCache batchCoordinateCache;
     private final BrokerTopicStats brokerTopicStats;
     private final Supplier<LogConfig> defaultTopicConfigs;
-    private final Metrics storageMetrics;
+    // Accessible for testing
+    final Metrics storageMetrics;
 
     public SharedState(
         final Time time,

--- a/storage/inkless/src/test/java/io/aiven/inkless/cache/CaffeineCacheMetricsTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/cache/CaffeineCacheMetricsTest.java
@@ -1,0 +1,140 @@
+/*
+ * Inkless
+ * Copyright (C) 2024 - 2025 Aiven OY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.aiven.inkless.cache;
+
+import org.apache.kafka.common.metrics.KafkaMetric;
+import org.apache.kafka.common.metrics.Metrics;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.DOUBLE;
+import static org.awaitility.Awaitility.await;
+
+class CaffeineCacheMetricsTest {
+
+    @Test
+    void testCacheHitMissMetric() {
+        // Given
+        final Metrics metrics = new Metrics();
+        final Cache<String, String> cache = Caffeine.newBuilder()
+            .recordStats()
+            .build();
+        new CaffeineCacheMetrics(metrics, cache);
+        cache.put("key1", "value1");
+
+        // When there is a cache hit
+        var value = cache.getIfPresent("key1"); // hit
+        assertThat(value).isEqualTo("value1");
+
+        // Then
+        assertThat(getMetric(metrics, CaffeineCacheMetricsRegistry.CACHE_HIT_COUNT).metricValue())
+            .asInstanceOf(DOUBLE)
+            .isOne();
+        assertThat(getMetric(metrics, CaffeineCacheMetricsRegistry.CACHE_HIT_RATE).metricValue())
+            .asInstanceOf(DOUBLE)
+            .isOne();
+        assertThat(getMetric(metrics, CaffeineCacheMetricsRegistry.CACHE_MISS_RATE).metricValue())
+            .asInstanceOf(DOUBLE)
+            .isZero();
+
+        // When there is a cache miss
+        value = cache.getIfPresent("key2"); // miss
+        assertThat(value).isNull();
+
+        // Then
+        assertThat(getMetric(metrics, CaffeineCacheMetricsRegistry.CACHE_MISS_COUNT).metricValue())
+            .asInstanceOf(DOUBLE)
+            .isOne();
+        assertThat(getMetric(metrics, CaffeineCacheMetricsRegistry.CACHE_HIT_RATE).metricValue())
+            .asInstanceOf(DOUBLE)
+            .isEqualTo(0.5); // 1 hit, 1 miss
+        assertThat(getMetric(metrics, CaffeineCacheMetricsRegistry.CACHE_MISS_RATE).metricValue())
+            .asInstanceOf(DOUBLE)
+            .isEqualTo(0.5); // 1 hit, 1 miss
+
+        // overall load is zero
+        assertThat(getMetric(metrics, CaffeineCacheMetricsRegistry.CACHE_AVG_LOAD_PENALTY_NANOSECONDS).metricValue())
+            .asInstanceOf(DOUBLE)
+            .isZero();
+    }
+
+    @Test
+    void testCacheSizeAndEviction() {
+        // Given
+        final Metrics metrics = new Metrics();
+        final Cache<String, String> cache = Caffeine.newBuilder()
+            .maximumSize(1)
+            .recordStats()
+            .build();
+        new CaffeineCacheMetrics(metrics, cache);
+
+        // Initially, cache size should be zero
+        assertThat(getMetric(metrics, CaffeineCacheMetricsRegistry.CACHE_SIZE).metricValue())
+            .asInstanceOf(DOUBLE)
+            .isZero();
+
+        // When adding entries to the cache
+        cache.put("key1", "value1");
+        assertThat(getMetric(metrics, CaffeineCacheMetricsRegistry.CACHE_SIZE).metricValue())
+            .asInstanceOf(DOUBLE)
+            .isOne();
+
+        // Adding another entry should evict the first one due to max size of 1
+        cache.put("key2", "value2"); // This should evict key1
+        await().atMost(Duration.ofSeconds(10)).until(() ->
+            // size should eventually come back to 1
+            (double) getMetric(metrics, CaffeineCacheMetricsRegistry.CACHE_SIZE).metricValue() == 1.0
+        );
+        assertThat(getMetric(metrics, CaffeineCacheMetricsRegistry.CACHE_EVICTION_COUNT).metricValue())
+            .asInstanceOf(DOUBLE)
+            .isOne();
+    }
+
+    @Test
+    void testCacheLoadTime() {
+        final Metrics metrics = new Metrics();
+        final Cache<String, String> cache = Caffeine.newBuilder()
+            .recordStats()
+            .build();
+        new CaffeineCacheMetrics(metrics, cache);
+
+        // Simulate cache loads with some computation time
+        cache.get("key1", key -> {
+            try {
+                Thread.sleep(10); // Simulate load time
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            return "value1";
+        });
+
+        assertThat(getMetric(metrics, CaffeineCacheMetricsRegistry.CACHE_AVG_LOAD_PENALTY_NANOSECONDS).metricValue())
+            .asInstanceOf(DOUBLE)
+            .isGreaterThan(0.0);
+    }
+
+    private static KafkaMetric getMetric(Metrics metrics, String metricName) {
+        return metrics.metric(metrics.metricName(metricName, CaffeineCacheMetricsRegistry.METRIC_GROUP));
+    }
+}

--- a/storage/inkless/src/test/java/io/aiven/inkless/common/SharedStateTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/common/SharedStateTest.java
@@ -1,0 +1,108 @@
+/*
+ * Inkless
+ * Copyright (C) 2024 - 2025 Aiven OY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.aiven.inkless.common;
+
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.TopicIdPartition;
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.metrics.JmxReporter;
+import org.apache.kafka.common.metrics.KafkaMetric;
+import org.apache.kafka.common.metrics.MetricsReporter;
+import org.apache.kafka.common.network.ListenerName;
+import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.storage.log.metrics.BrokerTopicStats;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+
+import io.aiven.inkless.config.InklessConfig;
+import io.aiven.inkless.control_plane.InMemoryControlPlane;
+import io.aiven.inkless.control_plane.MetadataView;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SharedStateTest {
+
+    @Test void testStorageMetricName() {
+        // create a shared state instance
+        final MockTime time = new MockTime();
+        final SharedState sharedState = SharedState.initialize(
+            time,
+            1,
+            new InklessConfig(Map.of()),
+            new NoopMetadataView(),
+            new InMemoryControlPlane(time),
+            new BrokerTopicStats(),
+            () -> null
+        );
+        // Ensure that the JMX reporter is registered
+        assertThat(sharedState.storageMetrics.reporters()).hasSize(1);
+        final MetricsReporter metricsReporter = sharedState.storageMetrics.reporters().get(0);
+        assertThat(metricsReporter).isInstanceOf(JmxReporter.class);
+        final JmxReporter jmxReporter = (JmxReporter) metricsReporter;
+
+        // Ensure the proper metric name is built and registered
+        final MetricName metricName = new MetricName("test-metric", "test-group", "desc", Map.of());
+        sharedState.storageMetrics.addMetric(metricName, (config, now) -> 42.0);
+        final KafkaMetric metric = sharedState.storageMetrics.metric(metricName);
+        jmxReporter.init(List.of(metric));
+        jmxReporter.containsMbean("io.aiven.inkless.storage:type=test-group,name=test-metric");
+    }
+
+    private static class NoopMetadataView implements MetadataView {
+        @Override
+        public Map<String, Object> getDefaultConfig() {
+            return Map.of();
+        }
+
+        @Override
+        public Iterable<Node> getAliveBrokerNodes(ListenerName listenerName) {
+            return null;
+        }
+
+        @Override
+        public Integer getBrokerCount() {
+            return 0;
+        }
+
+        @Override
+        public Uuid getTopicId(String topicName) {
+            return null;
+        }
+
+        @Override
+        public boolean isDisklessTopic(String topicName) {
+            return false;
+        }
+
+        @Override
+        public Properties getTopicConfig(String topicName) {
+            return null;
+        }
+
+        @Override
+        public Set<TopicIdPartition> getDisklessTopicPartitions() {
+            return Set.of();
+        }
+    }
+}


### PR DESCRIPTION
Instead of creating yet another metrics instance, reuse the storage metrics instance used by storage layer, as caching is a related module.

This will change the metric name prefix from:
`io.aiven.inkless.cache.caffeine` to `io.aiven.inkless.storage`

Related fixes:
- Add missing headers to cache classes
- Add tests to ensure metric names do not change without notice
