### PR TITLE
fix(controller): skip AlterConfigPolicy validation for newly created resources

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
@@ -369,7 +369,14 @@ public class ConfigurationControlManager {
             if (!newlyCreatedResource) {
                 existenceChecker.accept(configResource);
             }
-            alterConfigPolicy.ifPresent(policy -> policy.validate(new RequestMetadata(configResource, alteredConfigsForAlterConfigPolicyCheck)));
+            // When a resource is being created (e.g. topic creation), we may generate ConfigRecords
+            // before the resource is fully visible to other controller components. In that flow, we
+            // intentionally do not apply AlterConfigPolicy validation to the CreateTopics payload
+            // (ZooKeeper mode historically only applied CreateTopicPolicy during topic creation).
+            if (!newlyCreatedResource) {
+                alterConfigPolicy.ifPresent(policy ->
+                    policy.validate(new RequestMetadata(configResource, alteredConfigsForAlterConfigPolicyCheck)));
+            }
         } catch (ConfigException e) {
             return new ApiError(INVALID_CONFIG, e.getMessage());
         } catch (Throwable e) {


### PR DESCRIPTION
We keep the flow in `createTopics` that calls `configurationControl.incrementalAlterConfig` because that's responsible for building the `ConfigRecord`s which are appended to the controller metadata. So instead we just skip calling the policy validation if it's a creation request.