### PR TITLE
feat(inkless): avoid switching from compacted to non-compacted when ClassicTopicRemoteStorageForcePolicy is enabled

### DIFF
--- a/core/src/test/java/kafka/server/InklessConfigsTest.java
+++ b/core/src/test/java/kafka/server/InklessConfigsTest.java
@@ -62,6 +62,7 @@ import io.aiven.inkless.test_utils.S3TestContainer;
 
 import static org.apache.kafka.common.config.TopicConfig.CLEANUP_POLICY_COMPACT;
 import static org.apache.kafka.common.config.TopicConfig.CLEANUP_POLICY_CONFIG;
+import static org.apache.kafka.common.config.TopicConfig.CLEANUP_POLICY_DELETE;
 import static org.apache.kafka.common.config.TopicConfig.DISKLESS_ENABLE_CONFIG;
 import static org.apache.kafka.common.config.TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -332,6 +333,58 @@ public class InklessConfigsTest {
                     Map.of(CLEANUP_POLICY_CONFIG, CLEANUP_POLICY_COMPACT)
                 ));
                 assertEquals("false", getTopicConfig(admin, compactedSchemasTopic).get(REMOTE_LOG_STORAGE_ENABLE_CONFIG));
+            } finally {
+                cluster.close();
+            }
+        }
+
+        @Test
+        void changingCleanupPolicyFromCompactToDeleteRequiresRemoteStorageEnable() throws Exception {
+            final KafkaClusterTestKit cluster = initWithClassicRemoteStorageForceEnabled();
+            final Map<String, Object> clientConfigs = new HashMap<>();
+            clientConfigs.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers());
+
+            try (final Admin admin = AdminClient.create(clientConfigs)) {
+                final String compactedTopic = "compacted-to-delete-rejected";
+                createTopic(admin, compactedTopic, Map.of(
+                    CLEANUP_POLICY_CONFIG, CLEANUP_POLICY_COMPACT,
+                    REMOTE_LOG_STORAGE_ENABLE_CONFIG, "false"
+                ));
+
+                final ExecutionException exception = assertThrows(
+                    ExecutionException.class,
+                    () -> alterTopicConfig(admin, compactedTopic, Map.of(CLEANUP_POLICY_CONFIG, CLEANUP_POLICY_DELETE))
+                );
+                assertEquals(
+                    "It is invalid to change cleanup.policy from compact to delete without enabling remote.storage.enable " +
+                        "when classic.remote.storage.force.enable is enabled.",
+                    exception.getCause().getMessage()
+                );
+            } finally {
+                cluster.close();
+            }
+        }
+
+        @Test
+        void changingCleanupPolicyFromCompactToDeleteWithRemoteStorageEnableIsAllowed() throws Exception {
+            final KafkaClusterTestKit cluster = initWithClassicRemoteStorageForceEnabled();
+            final Map<String, Object> clientConfigs = new HashMap<>();
+            clientConfigs.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers());
+
+            try (final Admin admin = AdminClient.create(clientConfigs)) {
+                final String compactedTopic = "compacted-to-delete-allowed";
+                createTopic(admin, compactedTopic, Map.of(
+                    CLEANUP_POLICY_CONFIG, CLEANUP_POLICY_COMPACT,
+                    REMOTE_LOG_STORAGE_ENABLE_CONFIG, "false"
+                ));
+                alterTopicConfig(admin, compactedTopic, Map.of(
+                    CLEANUP_POLICY_CONFIG, CLEANUP_POLICY_DELETE,
+                    REMOTE_LOG_STORAGE_ENABLE_CONFIG, "true"
+                ));
+
+                final Map<String, String> alteredTopicConfig = getTopicConfig(admin, compactedTopic);
+                assertEquals(CLEANUP_POLICY_DELETE, alteredTopicConfig.get(CLEANUP_POLICY_CONFIG));
+                assertEquals("true", alteredTopicConfig.get(REMOTE_LOG_STORAGE_ENABLE_CONFIG));
             } finally {
                 cluster.close();
             }

--- a/metadata/src/main/java/org/apache/kafka/controller/ClassicTopicRemoteStorageForcePolicy.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ClassicTopicRemoteStorageForcePolicy.java
@@ -70,6 +70,31 @@ final class ClassicTopicRemoteStorageForcePolicy {
         }
     }
 
+    void validateCompactedToDeleteCleanupPolicyTransition(
+        final String topicName,
+        final Map<String, String> targetConfigs,
+        final Map<String, String> existingConfigs
+    ) {
+        if (!enabled
+            || isInternalTopic(topicName)
+            || topicExcludedByRegex(topicName)) {
+            return;
+        }
+        if (!cleanupPolicyContainsCompact(existingConfigs)) {
+            return;
+        }
+        if (!cleanupPolicyIsDeleteOnly(targetConfigs)) {
+            return;
+        }
+        final boolean disklessEnabled = Boolean.parseBoolean(targetConfigs.get(TopicConfig.DISKLESS_ENABLE_CONFIG));
+        final boolean remoteStorageEnabled = Boolean.parseBoolean(targetConfigs.get(TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG));
+        if (!disklessEnabled && !remoteStorageEnabled) {
+            throw new org.apache.kafka.common.errors.InvalidConfigurationException(
+                "It is invalid to change cleanup.policy from compact to delete without enabling remote.storage.enable " +
+                    "when classic.remote.storage.force.enable is enabled.");
+        }
+    }
+
     private boolean shouldForceRemoteStorageEnable(
         final String topicName,
         final boolean disklessEnabled,
@@ -98,6 +123,25 @@ final class ClassicTopicRemoteStorageForcePolicy {
             }
         }
         return false;
+    }
+
+    private boolean cleanupPolicyIsDeleteOnly(final Map<String, String> topicConfigs) {
+        final String cleanupPolicy = topicConfigs.get(TopicConfig.CLEANUP_POLICY_CONFIG);
+        if (cleanupPolicy == null) {
+            return false;
+        }
+        int nonEmptyPolicies = 0;
+        for (String policy : cleanupPolicy.split(",")) {
+            final String trimmedPolicy = policy.trim();
+            if (trimmedPolicy.isEmpty()) {
+                continue;
+            }
+            nonEmptyPolicies++;
+            if (!TopicConfig.CLEANUP_POLICY_DELETE.equals(trimmedPolicy)) {
+                return false;
+            }
+        }
+        return nonEmptyPolicies == 1;
     }
 
     private boolean topicExcludedByRegex(final String topicName) {

--- a/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
@@ -77,6 +77,7 @@ public class ConfigurationControlManager {
     private final Map<String, Object> staticConfig;
     private final ConfigResource currentController;
     private final FeatureControlManager featureControl;
+    private final ClassicTopicRemoteStorageForcePolicy classicTopicRemoteStorageForcePolicy;
 
     static class Builder {
         private LogContext logContext = null;
@@ -88,6 +89,8 @@ public class ConfigurationControlManager {
         private Map<String, Object> staticConfig = Map.of();
         private int nodeId = 0;
         private FeatureControlManager featureControl = null;
+        private boolean classicRemoteStorageForceEnabled = false;
+        private List<String> classicRemoteStorageForceExcludeTopicRegexes = List.of();
 
         Builder setLogContext(LogContext logContext) {
             this.logContext = logContext;
@@ -134,6 +137,16 @@ public class ConfigurationControlManager {
             return this;
         }
 
+        Builder setClassicRemoteStorageForceEnabled(boolean classicRemoteStorageForceEnabled) {
+            this.classicRemoteStorageForceEnabled = classicRemoteStorageForceEnabled;
+            return this;
+        }
+
+        Builder setClassicRemoteStorageForceExcludeTopicRegexes(List<String> classicRemoteStorageForceExcludeTopicRegexes) {
+            this.classicRemoteStorageForceExcludeTopicRegexes = classicRemoteStorageForceExcludeTopicRegexes;
+            return this;
+        }
+
         ConfigurationControlManager build() {
             if (logContext == null) logContext = new LogContext();
             if (snapshotRegistry == null) snapshotRegistry = new SnapshotRegistry(logContext);
@@ -152,7 +165,9 @@ public class ConfigurationControlManager {
                 validator,
                 staticConfig,
                 nodeId,
-                featureControl);
+                featureControl,
+                classicRemoteStorageForceEnabled,
+                classicRemoteStorageForceExcludeTopicRegexes);
         }
     }
 
@@ -164,7 +179,9 @@ public class ConfigurationControlManager {
             ConfigurationValidator validator,
             Map<String, Object> staticConfig,
             int nodeId,
-            FeatureControlManager featureControl
+            FeatureControlManager featureControl,
+            boolean classicRemoteStorageForceEnabled,
+            List<String> classicRemoteStorageForceExcludeTopicRegexes
     ) {
         this.log = logContext.logger(ConfigurationControlManager.class);
         this.snapshotRegistry = snapshotRegistry;
@@ -177,6 +194,10 @@ public class ConfigurationControlManager {
         this.staticConfig = Map.copyOf(staticConfig);
         this.currentController = new ConfigResource(Type.BROKER, Integer.toString(nodeId));
         this.featureControl = featureControl;
+        this.classicTopicRemoteStorageForcePolicy = new ClassicTopicRemoteStorageForcePolicy(
+            classicRemoteStorageForceEnabled,
+            classicRemoteStorageForceExcludeTopicRegexes
+        );
     }
 
     SnapshotRegistry snapshotRegistry() {
@@ -373,6 +394,13 @@ public class ConfigurationControlManager {
             // in the list passed to the policy in order to maintain backwards compatibility
         }
         try {
+            if (configResource.type() == Type.TOPIC) {
+                classicTopicRemoteStorageForcePolicy.validateCompactedToDeleteCleanupPolicyTransition(
+                    configResource.name(),
+                    allConfigs,
+                    existingConfigsMap
+                );
+            }
             validator.validate(configResource, allConfigs, existingConfigsMap);
             if (!newlyCreatedResource) {
                 existenceChecker.accept(configResource);

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -1569,6 +1569,8 @@ public final class QuorumController implements Controller {
             setValidator(configurationValidator).
             setStaticConfig(staticConfig).
             setNodeId(nodeId).
+            setClassicRemoteStorageForceEnabled(classicRemoteStorageForceEnabled).
+            setClassicRemoteStorageForceExcludeTopicRegexes(classicRemoteStorageForceExcludeTopicRegexes).
             setFeatureControl(featureControl).
             build();
         this.producerIdControlManager = new ProducerIdControlManager.Builder().

--- a/metadata/src/test/java/org/apache/kafka/controller/ConfigurationControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ConfigurationControlManagerTest.java
@@ -220,6 +220,34 @@ public class ConfigurationControlManagerTest {
     }
 
     @Test
+    public void testCleanupPolicyCompactToDeleteRejectedWhenClassicRemoteStorageForceEnabled() {
+        ConfigurationControlManager manager = new ConfigurationControlManager.Builder().
+            setFeatureControl(createFeatureControlManager()).
+            setKafkaConfigSchema(SCHEMA).
+            setClassicRemoteStorageForceEnabled(true).
+            build();
+
+        RecordTestUtils.replayAll(manager, List.of(
+            new ApiMessageAndVersion(new ConfigRecord().setResourceType(TOPIC.id()).setResourceName("mytopic")
+                .setName(TopicConfig.CLEANUP_POLICY_CONFIG).setValue(TopicConfig.CLEANUP_POLICY_COMPACT), (short) 0),
+            new ApiMessageAndVersion(new ConfigRecord().setResourceType(TOPIC.id()).setResourceName("mytopic")
+                .setName(TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG).setValue("false"), (short) 0)
+        ));
+
+        ControllerResult<ApiError> result = manager.incrementalAlterConfig(
+            MYTOPIC,
+            Map.of(TopicConfig.CLEANUP_POLICY_CONFIG, entry(SET, TopicConfig.CLEANUP_POLICY_DELETE)),
+            false
+        );
+        assertEquals(Errors.INVALID_CONFIG, result.response().error());
+        assertEquals(
+            "It is invalid to change cleanup.policy from compact to delete without enabling remote.storage.enable " +
+                "when classic.remote.storage.force.enable is enabled.",
+            result.response().message()
+        );
+    }
+
+    @Test
     public void testIncrementalAlterMultipleConfigValues() {
         ConfigurationControlManager manager = new ConfigurationControlManager.Builder().
             setFeatureControl(createFeatureControlManager()).


### PR DESCRIPTION
When `classic.remote.storage.force.enable` is true, it's possible to create topics non-tiered topics with `cleanup.policy=compact` (or `compact,delete`). Once those are created, it should not be possible to change `cleanup.policy` to `delete` without enabling `remote.storage.enable=true`.