### PR TITLE
fix(inkless:sync): improve branch consistency check and add cherry-pick sync guide

### DIFF
--- a/inkless-sync/CHERRY-PICK-SESSION-TEMPLATE.md
+++ b/inkless-sync/CHERRY-PICK-SESSION-TEMPLATE.md
@@ -1,0 +1,110 @@
+# Cherry-pick Session: [BRANCH]
+
+## Session Info
+- **Date**: [YYYY-MM-DD]
+- **Source**: origin/main
+- **Target**: [inkless-X.Y]
+- **Base**: [commit hash] ([base description, e.g., "Merge tag '4.0.2' into inkless-4.0"])
+- **Status**: [In Progress | Blocked | Complete]
+
+---
+
+## Commits to Cherry-pick
+
+List commits in main branch order (oldest first). Exclude commits not applicable to the release branch (e.g., version bumps).
+
+| # | Hash | PR | Subject | Status |
+|---|------|-----|---------|--------|
+| 1 | | # | | Pending |
+
+---
+
+## Conflict Resolution Log
+
+Document every conflict resolution. This is critical for reproducibility and future reference.
+
+### Template per commit:
+
+```
+### #NNN - [commit subject]
+
+**File**: `path/to/file`
+- **Conflict**: [describe what conflicted]
+- **Resolution**: [what was done]
+- **Reason**: [why this resolution is correct for the release branch]
+```
+
+---
+
+## Compilation Errors
+
+Track compilation errors found after cherry-picks and their fixes.
+
+| # | File:Line | Error | Cherry-pick | Fix | Status |
+|---|-----------|-------|-------------|-----|--------|
+| | | | #NNN | | |
+
+---
+
+## Verification
+
+### Build
+```bash
+make build
+```
+- [ ] Build passes
+
+### Tests
+```bash
+make test
+```
+- [ ] Tests pass
+
+### Checklist
+- [ ] All cherry-picks applied
+- [ ] All conflicts documented
+- [ ] Compilation verified after each cherry-pick
+- [ ] Full build passes
+- [ ] Full tests pass
+
+---
+
+## Summary
+
+### Results
+| Result | Count |
+|--------|-------|
+| Successfully cherry-picked | |
+| Cherry-picked with conflicts | |
+| Skipped (not applicable) | |
+| Failed | |
+
+### Key Conflict Patterns
+
+Document recurring patterns for future sessions:
+
+| Pattern | Files | Resolution |
+|---------|-------|------------|
+| TopicPartition vs TopicIdPartition | produce path files | Keep release branch type, use TopicIdEnricher |
+| Missing feature (e.g., share coordinator) | BrokerMetadataPublisher, etc. | Skip feature blocks |
+| Interface method replacement | MetadataView.java, etc. | Keep existing + add new |
+| Pool.forEach vs foreachEntry | ReplicaManager.scala | Use `foreachEntry` on 4.0 |
+| Readable vs ByteBuffer (parse methods) | AbstractRequest, AbstractResponse | Use ByteBuffer + ByteBufferAccessor |
+| createTestTopic missing Uuid param | ReplicationControlManagerTest | Add Uuid.randomUuid() as first arg |
+| Enum expansion (ApiKeys, etc.) | ApiKeys.java, AbstractRequest/Response | Add only inkless entry, skip main-only features |
+| Cross-module dependency | ConfigurationControlManager | Inline constants from inaccessible modules |
+| Java records not available | ReplicationControlManager | Use static final class instead |
+| PartitionListener package | InitDisklessLogManager | Use kafka.cluster on 4.0 |
+
+### Deferred Commits
+
+Commits that could not be cherry-picked and the reason:
+
+| PR | Reason | Blocked By |
+|----|--------|------------|
+| | | |
+
+---
+
+## Notes
+[Any additional observations or learnings from this session]

--- a/inkless-sync/CHERRY-PICK-SYNC-GUIDE.md
+++ b/inkless-sync/CHERRY-PICK-SYNC-GUIDE.md
@@ -1,0 +1,329 @@
+# Cherry-pick Sync Guide
+
+This guide explains how to cherry-pick inkless-specific commits from `main` to release branches (e.g., `inkless-4.0`, `inkless-4.1`).
+
+## Overview
+
+Unlike [Release Sync](RELEASE-SYNC-GUIDE.md) (which merges upstream Apache Kafka patches), cherry-pick sync propagates **inkless feature commits** from `main` to release branches. This is needed because inkless features land on `main` first, and must be backported to active release branches.
+
+### When to Use
+
+- After new inkless features or fixes are merged to `main`
+- Before cutting a new inkless release from a release branch
+- Periodically to keep release branches up to date with inkless development
+
+## Quick Start
+
+### Check What's Missing
+
+```bash
+./inkless-sync/branch-consistency.sh inkless-4.0 --missing
+```
+
+### Preview Cherry-picks
+
+```bash
+./inkless-sync/cherry-pick-to-release.sh inkless-4.0 --dry-run
+```
+
+### Execute Cherry-picks
+
+```bash
+./inkless-sync/cherry-pick-to-release.sh inkless-4.0
+```
+
+## Workflow
+
+### Step 1: Discovery
+
+Run the consistency check to see which commits are missing:
+
+```bash
+./inkless-sync/branch-consistency.sh inkless-4.0 --missing
+```
+
+This uses `--first-parent` on main to identify commits landed directly via PR (squash-merged), excluding upstream content brought in via merge commits. Commits are matched to the release branch by PR number (`(#NNN)` pattern).
+
+To also see old commits that were intentionally skipped:
+
+```bash
+./inkless-sync/branch-consistency.sh inkless-4.0 --missing --all
+```
+
+### Step 2: Create Session File
+
+Track progress in a session file:
+
+```bash
+mkdir -p .inkless-sync
+cp inkless-sync/CHERRY-PICK-SESSION-TEMPLATE.md \
+   .inkless-sync/CHERRY-PICK-SESSION-$(date +%Y-%m-%d).md
+```
+
+### Step 3: Review Commits
+
+Before cherry-picking, review the list of commits. Consider:
+
+- **Ordering**: Commits should be applied oldest-first (main branch order). The script handles this automatically when using `branch-consistency.sh` output.
+- **Dependencies**: Some commits depend on earlier ones. Check PR descriptions for prerequisite PRs.
+- **Exclusions**: Skip commits that are not applicable to the release branch (e.g., version bumps like `MINOR: update Kafka version variables`).
+
+### Step 4: Cherry-pick
+
+#### Interactive Mode (Recommended)
+
+```bash
+./inkless-sync/cherry-pick-to-release.sh inkless-4.0
+```
+
+The script prompts before each commit. Options: `Y`(proceed), `n`(skip), `s`(skip), `q`(quit).
+
+#### Non-interactive Mode
+
+```bash
+./inkless-sync/cherry-pick-to-release.sh inkless-4.0 --no-interactive
+```
+
+Stops on first conflict. Resolve manually, then `git cherry-pick --continue` and re-run the script.
+
+#### Specific Commits
+
+```bash
+./inkless-sync/cherry-pick-to-release.sh inkless-4.0 abc123 def456
+```
+
+When providing specific commits, they are applied in the order given (not reversed).
+
+### Step 5: Resolve Conflicts
+
+When a cherry-pick has conflicts, resolve them following the patterns in [Conflict Resolution Patterns](#conflict-resolution-patterns) below.
+
+**After resolving each conflict:**
+
+1. Compile to verify: `./gradlew :storage:inkless:compileJava :core:compileScala`
+2. Document the resolution in the session file
+3. If compilation requires additional fixes, amend the cherry-pick commit with the fixes
+
+### Step 6: Compile After Each Cherry-pick
+
+After each successful cherry-pick (with or without conflict resolution):
+
+```bash
+# Core inkless modules (fast check)
+./gradlew :storage:inkless:compileJava :core:compileScala
+
+# If the commit touches tests
+./gradlew :storage:inkless:compileTestJava :core:compileTestScala
+
+# If the commit touches metadata, clients, or other modules
+./gradlew :metadata:compileJava :clients:compileJava
+```
+
+Fix any compilation errors before proceeding to the next commit. Commit fixes as amendments to the cherry-pick (if the cherry-pick introduced the broken code) or as separate `sync(compile):` commits.
+
+**Important**: Commits touching `clients/` (e.g., `ApiKeys.java`, `AbstractRequest.java`) or `metadata/` (e.g., `ReplicationControlManager.java`) need their respective modules compiled — not just `:core` and `:storage:inkless`.
+
+### Step 7: Periodic Full Compilation
+
+After every 5-10 cherry-picks, run a full project compilation to catch cross-module issues early:
+
+```bash
+./gradlew compileJava compileScala compileTestJava compileTestScala
+```
+
+This catches issues like cross-module dependency problems (e.g., `metadata` module importing from `server` module) that per-module checks miss.
+
+### Step 8: Verify Build
+
+After all cherry-picks are complete:
+
+```bash
+make build
+make test
+```
+
+### Step 9: Archive Session
+
+```bash
+mv .inkless-sync/CHERRY-PICK-SESSION-*.md inkless-sync/sessions/
+```
+
+## Conflict Resolution Patterns
+
+Cherry-pick conflicts differ from merge conflicts because they arise from **divergence between main and the release branch**, not from upstream changes.
+
+### Common Divergence Points
+
+| Area | main | Release (4.0) | Resolution Pattern |
+|------|------|---------------|-------------------|
+| Partition types | `TopicIdPartition` throughout produce path | `TopicPartition` + `TopicIdEnricher` | Keep release branch's type, adapt cherry-pick logic |
+| Share coordinator | Present (Kafka 4.2+ feature) | Absent | Skip share coordinator blocks |
+| KRaft/ZK compat | KRaft-only (ZK removed) | ZK compatibility code still present | Keep both where needed |
+| `DynamicThreadPool` | Moved to separate class | Still exists as object in `DynamicBrokerConfig` | Keep existing + add new code |
+| `Pool` class | `forEach` method | `foreachEntry` method | Use `foreachEntry` on 4.0 |
+| `KRaftMetadataCache.getTopicName()` | Returns `java.util.Optional[String]` | Returns `Option[String]` | Use `Some(name)` not `Optional.of(name)` |
+| `KRaftMetadataCache.getAliveBrokerNodes()` | Returns `java.util.List[Node]` | Returns `Seq[Node]` | Add `.asJava` when implementing Java interfaces |
+| `config.logDirs` | Returns `java.util.List[String]` | Returns `Seq[String]` | No `.asScala` needed on 4.0 |
+| `FeatureControlManager` | `metadataVersionOrThrow()` | `metadataVersion()` | Use `metadataVersion()` on 4.0 |
+| `AbstractRequest/Response.parse` | Uses `Readable` parameter | Uses `ByteBuffer` + `ByteBufferAccessor` | Adapt parse methods to `ByteBuffer` on 4.0 |
+| `BrokerMetadataPublisher` ctor | Takes `ShareCoordinator`, `SharePartitionManager` | Takes `Option[ShareCoordinator]`, no `SharePartitionManager` | Wrap in `Some()`, drop `SharePartitionManager` |
+| `Partition.makeLeader/makeFollower` | Takes `PartitionRegistration` | Takes `LeaderAndIsrRequest.PartitionState` | Convert via `toLeaderAndIsrPartitionState()` |
+| `PartitionListener` | Package `org.apache.kafka.server.partition` | Package `kafka.cluster` | Use `kafka.cluster.PartitionListener` on 4.0 |
+| `UnifiedLog.producerStateManager` | Method call `producerStateManager()` | Field access `producerStateManager` (Scala val) | Drop parens on 4.0 |
+| Java records | Used on main (e.g., `record IneligibleReplica`) | Not available (Java 11) | Use static final class with explicit fields |
+| `createTestTopic` (tests) | `createTestTopic(name, ...)` | `createTestTopic(Uuid.randomUuid(), name, ...)` | Add `Uuid.randomUuid()` as first arg |
+| `ApiKeys` enum | Includes STREAMS_GROUP, SHARE_GROUP_OFFSETS, etc. | Fewer entries (no STREAMS_GROUP_*, no *_SHARE_GROUP_OFFSETS) | Add only INIT_DISKLESS_LOG, don't carry main-only entries |
+
+### Resolution by File Type
+
+#### Pure Inkless Files (`storage/inkless/**`)
+
+Usually apply cleanly. If not, the conflict is typically in:
+- **Import changes**: Accept the cherry-pick's imports, remove any that don't exist on the release branch
+- **API differences**: Adapt to the release branch's API surface
+
+#### Core Kafka Files (`core/src/main/scala/**`)
+
+These are the most conflict-prone. Common patterns:
+
+**Imports**: Cherry-pick may add imports for classes that don't exist on the release branch or are in different packages.
+- Check if the imported class exists: `git log --oneline --all -- '**/ClassName.java'`
+- If it doesn't exist, skip the import and adapt the code
+
+**Constructor parameters**: Cherry-pick may reference constructor params or methods that differ.
+- Compare the class signature on main vs release branch
+- Adapt the cherry-pick to use the release branch's API
+
+**Feature blocks**: Cherry-pick may include code for features not present on the release branch (e.g., share coordinator).
+- Skip the entire feature block
+- Keep only the inkless-specific additions
+
+#### Interface/API Files (`MetadataView.java`, etc.)
+
+Cherry-pick may replace methods that are still in use on the release branch.
+- **Keep existing methods** that other code still calls
+- **Add new methods** from the cherry-pick as additions, not replacements
+- Verify no callers are broken: `grep -r "methodName" --include="*.java" --include="*.scala"`
+
+#### Test Files
+
+- Accept cherry-pick's test changes when they simplify test setup
+- Verify test constructors match the production code on the release branch
+- If a test references a class/constructor that doesn't exist on the release branch, adapt it
+
+### TopicPartition vs TopicIdPartition Pattern
+
+This is the most frequent conflict source between main and 4.0. On main, the produce path uses `TopicIdPartition` directly. On 4.0, it uses `TopicPartition` with `TopicIdEnricher` to add the topic ID.
+
+**When cherry-picking produce path changes:**
+1. Keep the release branch's `TopicPartition`-based signatures
+2. Use `TopicIdEnricher.enrich(metadata, entriesPerPartition)` to convert when needed
+3. Pass `entriesPerPartitionEnriched.keySet()` (which is `Set<TopicIdPartition>`) to methods that need topic IDs
+
+**Example adaptation** (AppendHandler on 4.0):
+```java
+// main version: handle() receives Map<TopicIdPartition, MemoryRecords> directly
+// 4.0 version: handle() receives Map<TopicPartition, MemoryRecords>, enriches internally
+public CompletableFuture<...> handle(Map<TopicPartition, MemoryRecords> entriesPerPartition, ...) {
+    // Enrich with topic IDs (4.0-specific step)
+    Map<TopicIdPartition, MemoryRecords> entriesPerPartitionEnriched =
+        TopicIdEnricher.enrich(metadata, entriesPerPartition);
+    // Now use entriesPerPartitionEnriched for methods that need TopicIdPartition
+    return writer.write(entriesPerPartitionEnriched,
+        getLogConfigs(entriesPerPartitionEnriched.keySet()), requestLocal);
+}
+```
+
+## Commit Convention
+
+Cherry-picked commits retain their original message. When additional fixes are needed:
+
+| Prefix | Use |
+|--------|-----|
+| `sync(compile):` | Fixing compilation errors after cherry-pick |
+| `sync(test):` | Fixing test compilation/failures after cherry-pick |
+
+Alternatively, amend the cherry-pick commit with the fixes if they are small and directly related.
+
+## Troubleshooting
+
+### "Commit not found"
+
+The commit hash may have been rebased on main. Use the PR number to find the current hash:
+
+```bash
+git log --oneline origin/main --grep="(#NNN)"
+```
+
+### Cherry-pick Applies But Doesn't Compile
+
+This is expected when main and the release branch have diverged significantly. Common causes:
+- Missing imports (class in different package or doesn't exist on release branch)
+- Method signature differences
+- Type mismatches (TopicPartition vs TopicIdPartition)
+- Cross-module dependency (e.g., `ServerConfigs` is in `server` module, not accessible from `metadata` module on 4.0)
+- Java version differences (main uses records, 4.0 uses Java 11 classes)
+- Scala/Java API surface differences (`ByteBuffer` vs `Readable`, `Option` vs `Optional`)
+
+Fix compilation errors, then either amend the cherry-pick or create a separate `sync(compile):` commit.
+
+**Concrete examples from inkless-4.0 sync (2026-03):**
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `forEach` not a member of `Pool` | 4.0 uses `foreachEntry` | Change to `foreachEntry` |
+| `metadataVersionOrThrow()` not found | 4.0 uses `metadataVersion()` | Drop `OrThrow` |
+| `ByteBuffer` cannot convert to `Readable` | `InitDisklessLogRequest.parse` written for main's API | Change to `ByteBuffer` + `ByteBufferAccessor` |
+| `ServerConfigs` not found in metadata module | `metadata` module can't depend on `server` on 4.0 | Inline the constant values |
+| `PartitionListener` not found | Different package on 4.0 (`kafka.cluster` vs `org.apache.kafka.server.partition`) | Fix import |
+| `producerStateManager()` not a member | Scala val on 4.0, not a method | Remove parens |
+| `String cannot be converted to Uuid` | `createTestTopic` takes `Uuid` first on 4.0 | Add `Uuid.randomUuid()` |
+
+### Too Many Conflicts
+
+If a commit has extensive conflicts, consider:
+1. Cherry-picking the commit's changes manually (read the PR diff on GitHub)
+2. Skipping the commit if it's not critical for the release branch
+3. Creating a release-branch-specific implementation
+
+### Knowing When to Stop
+
+Not all commits can be cleanly cherry-picked. **Defer a commit** when it:
+- Introduces code that depends on APIs fundamentally different between main and 4.0 (e.g., `org.apache.kafka.server.partition.PartitionListener` on main vs `kafka.cluster.PartitionListener` on 4.0, with different method signatures or lifecycles)
+- Requires cross-module dependency changes (e.g., `metadata` module importing from `server` module)
+- Needs multiple deep adaptations across different subsystems simultaneously
+
+**Strategy**: Cherry-pick in batches. Compile after each batch. If a commit breaks compilation and the fix is non-trivial, reset to the last good state and defer the problematic commit. Record it in the session file with the reason for deferral, so the next session can pick it up with a focused effort.
+
+## AI-Assisted Cherry-pick Sync
+
+For AI-assisted sessions, use this prompt:
+
+```
+I need to cherry-pick inkless commits from main to a release branch.
+
+## Context
+- Target branch: inkless-4.0 (or inkless-4.1, etc.)
+- Source: origin/main
+
+## Steps
+
+1. Run `./inkless-sync/branch-consistency.sh inkless-4.0 --missing` to find missing commits
+2. Create session file from inkless-sync/CHERRY-PICK-SESSION-TEMPLATE.md
+3. Present each commit for approval before cherry-picking
+4. Resolve conflicts following inkless-sync/CHERRY-PICK-SYNC-GUIDE.md
+5. Compile after each cherry-pick: `./gradlew :storage:inkless:compileJava :core:compileScala`
+6. Document all conflict resolutions in the session file
+7. Run full build and tests after all cherry-picks
+
+Reference files:
+- inkless-sync/CHERRY-PICK-SYNC-GUIDE.md
+- inkless-sync/CHERRY-PICK-SESSION-TEMPLATE.md
+- inkless-sync/CONFLICT-RESOLUTION-STRATEGY.md
+```
+
+## Related Documentation
+
+- [Branch Consistency Check](README.md#branch-consistency-check) - Finding missing commits
+- [Conflict Resolution Strategy](CONFLICT-RESOLUTION-STRATEGY.md) - General conflict patterns
+- [Release Sync Guide](RELEASE-SYNC-GUIDE.md) - Upstream patch sync (different workflow)

--- a/inkless-sync/CHERRY-PICK-SYNC-GUIDE.md
+++ b/inkless-sync/CHERRY-PICK-SYNC-GUIDE.md
@@ -1,6 +1,6 @@
 # Cherry-pick Sync Guide
 
-This guide explains how to cherry-pick inkless-specific commits from `main` to release branches (e.g., `inkless-4.0`, `inkless-4.1`).
+This guide explains how to cherry-pick inkless-specific commits from `main` to release branches (e.g., `inkless-4.1`, `inkless-4.2`).
 
 ## Overview
 
@@ -17,19 +17,19 @@ Unlike [Release Sync](RELEASE-SYNC-GUIDE.md) (which merges upstream Apache Kafka
 ### Check What's Missing
 
 ```bash
-./inkless-sync/branch-consistency.sh inkless-4.0 --missing
+./inkless-sync/branch-consistency.sh inkless-4.1 --missing
 ```
 
 ### Preview Cherry-picks
 
 ```bash
-./inkless-sync/cherry-pick-to-release.sh inkless-4.0 --dry-run
+./inkless-sync/cherry-pick-to-release.sh inkless-4.1 --dry-run
 ```
 
 ### Execute Cherry-picks
 
 ```bash
-./inkless-sync/cherry-pick-to-release.sh inkless-4.0
+./inkless-sync/cherry-pick-to-release.sh inkless-4.1
 ```
 
 ## Workflow
@@ -39,7 +39,7 @@ Unlike [Release Sync](RELEASE-SYNC-GUIDE.md) (which merges upstream Apache Kafka
 Run the consistency check to see which commits are missing:
 
 ```bash
-./inkless-sync/branch-consistency.sh inkless-4.0 --missing
+./inkless-sync/branch-consistency.sh inkless-4.1 --missing
 ```
 
 This uses `--first-parent` on main to identify commits landed directly via PR (squash-merged), excluding upstream content brought in via merge commits. Commits are matched to the release branch by PR number (`(#NNN)` pattern).
@@ -47,7 +47,7 @@ This uses `--first-parent` on main to identify commits landed directly via PR (s
 To also see old commits that were intentionally skipped:
 
 ```bash
-./inkless-sync/branch-consistency.sh inkless-4.0 --missing --all
+./inkless-sync/branch-consistency.sh inkless-4.1 --missing --all
 ```
 
 ### Step 2: Create Session File
@@ -73,7 +73,7 @@ Before cherry-picking, review the list of commits. Consider:
 #### Interactive Mode (Recommended)
 
 ```bash
-./inkless-sync/cherry-pick-to-release.sh inkless-4.0
+./inkless-sync/cherry-pick-to-release.sh inkless-4.1
 ```
 
 The script prompts before each commit. Options: `Y`(proceed), `n`(skip), `s`(skip), `q`(quit).
@@ -81,7 +81,7 @@ The script prompts before each commit. Options: `Y`(proceed), `n`(skip), `s`(ski
 #### Non-interactive Mode
 
 ```bash
-./inkless-sync/cherry-pick-to-release.sh inkless-4.0 --no-interactive
+./inkless-sync/cherry-pick-to-release.sh inkless-4.1 --no-interactive
 ```
 
 Stops on first conflict. Resolve manually, then `git cherry-pick --continue` and re-run the script.
@@ -89,7 +89,7 @@ Stops on first conflict. Resolve manually, then `git cherry-pick --continue` and
 #### Specific Commits
 
 ```bash
-./inkless-sync/cherry-pick-to-release.sh inkless-4.0 abc123 def456
+./inkless-sync/cherry-pick-to-release.sh inkless-4.1 abc123 def456
 ```
 
 When providing specific commits, they are applied in the order given (not reversed).
@@ -154,31 +154,32 @@ Cherry-pick conflicts differ from merge conflicts because they arise from **dive
 
 ### Common Divergence Points
 
-| Area | main | Release (4.0) | Resolution Pattern |
-|------|------|---------------|-------------------|
-| Partition types | `TopicIdPartition` throughout produce path | `TopicPartition` + `TopicIdEnricher` | Keep release branch's type, adapt cherry-pick logic |
-| Share coordinator | Present (Kafka 4.2+ feature) | Absent | Skip share coordinator blocks |
-| KRaft/ZK compat | KRaft-only (ZK removed) | ZK compatibility code still present | Keep both where needed |
-| `DynamicThreadPool` | Moved to separate class | Still exists as object in `DynamicBrokerConfig` | Keep existing + add new code |
-| `Pool` class | `forEach` method | `foreachEntry` method | Use `foreachEntry` on 4.0 |
-| `KRaftMetadataCache.getTopicName()` | Returns `java.util.Optional[String]` | Returns `Option[String]` | Use `Some(name)` not `Optional.of(name)` |
-| `KRaftMetadataCache.getAliveBrokerNodes()` | Returns `java.util.List[Node]` | Returns `Seq[Node]` | Add `.asJava` when implementing Java interfaces |
-| `config.logDirs` | Returns `java.util.List[String]` | Returns `Seq[String]` | No `.asScala` needed on 4.0 |
-| `FeatureControlManager` | `metadataVersionOrThrow()` | `metadataVersion()` | Use `metadataVersion()` on 4.0 |
-| `AbstractRequest/Response.parse` | Uses `Readable` parameter | Uses `ByteBuffer` + `ByteBufferAccessor` | Adapt parse methods to `ByteBuffer` on 4.0 |
-| `BrokerMetadataPublisher` ctor | Takes `ShareCoordinator`, `SharePartitionManager` | Takes `Option[ShareCoordinator]`, no `SharePartitionManager` | Wrap in `Some()`, drop `SharePartitionManager` |
-| `Partition.makeLeader/makeFollower` | Takes `PartitionRegistration` | Takes `LeaderAndIsrRequest.PartitionState` | Convert via `toLeaderAndIsrPartitionState()` |
-| `PartitionListener` | Package `org.apache.kafka.server.partition` | Package `kafka.cluster` | Use `kafka.cluster.PartitionListener` on 4.0 |
-| `UnifiedLog.producerStateManager` | Method call `producerStateManager()` | Field access `producerStateManager` (Scala val) | Drop parens on 4.0 |
-| Java records | Used on main (e.g., `record IneligibleReplica`) | Not available (Java 11) | Use static final class with explicit fields |
-| `createTestTopic` (tests) | `createTestTopic(name, ...)` | `createTestTopic(Uuid.randomUuid(), name, ...)` | Add `Uuid.randomUuid()` as first arg |
-| `ApiKeys` enum | Includes STREAMS_GROUP, SHARE_GROUP_OFFSETS, etc. | Fewer entries (no STREAMS_GROUP_*, no *_SHARE_GROUP_OFFSETS) | Add only INIT_DISKLESS_LOG, don't carry main-only entries |
+The following are examples of API divergences encountered during cherry-pick syncs. As release branches progress, some entries may no longer apply — verify against your target branch.
+
+| Area                                       | main                                              | Release branch                                               | Resolution Pattern                                        | Affected versions |
+| ------------------------------------------ | ------------------------------------------------- | ------------------------------------------------------------ | --------------------------------------------------------- | ----------------- |
+| Partition types                            | `TopicIdPartition` throughout produce path        | `TopicPartition` + `TopicIdEnricher`                         | Keep release branch's type, adapt cherry-pick logic       | 4.0, 4.1          |
+| Share coordinator                          | Present (Kafka 4.2+ feature)                      | Absent                                                       | Skip share coordinator blocks                             | 4.0, 4.1          |
+| KRaft/ZK compat                            | KRaft-only (ZK removed)                           | ZK compatibility code present                                | Keep both where needed                                    | 4.0 only          |
+| `DynamicThreadPool`                        | Moved to separate class                           | Object in `DynamicBrokerConfig`                              | Keep existing + add new code                              | 4.0               |
+| `Pool` class                               | `forEach` method                                  | `foreachEntry` method                                        | Use whichever method exists                               | 4.0               |
+| `KRaftMetadataCache.getTopicName()`        | Returns `java.util.Optional[String]`              | Returns `Option[String]`                                     | Use `Some(name)` not `Optional.of(name)`                  | 4.0               |
+| `KRaftMetadataCache.getAliveBrokerNodes()` | Returns `java.util.List[Node]`                    | Returns `Seq[Node]`                                          | Add `.asJava` when implementing Java interfaces           | 4.0               |
+| `FeatureControlManager`                    | `metadataVersionOrThrow()`                        | `metadataVersion()`                                          | Check which method exists                                 | 4.0               |
+| `AbstractRequest/Response.parse`           | Uses `Readable` parameter                         | Uses `ByteBuffer` + `ByteBufferAccessor`                     | Adapt parse methods to match                              | 4.0               |
+| `BrokerMetadataPublisher` ctor             | Takes `ShareCoordinator`, `SharePartitionManager` | Takes `Option[ShareCoordinator]`, no `SharePartitionManager` | Wrap in `Some()`, drop `SharePartitionManager`            | 4.0, 4.1          |
+| `Partition.makeLeader/makeFollower`        | Takes `PartitionRegistration`                     | Takes `LeaderAndIsrRequest.PartitionState`                   | Convert via `toLeaderAndIsrPartitionState()`              | 4.0               |
+| `PartitionListener`                        | Package `org.apache.kafka.server.partition`       | Package `kafka.cluster`                                      | Use the package that exists on target                     | 4.0               |
+| `UnifiedLog.producerStateManager`          | Method call `producerStateManager()`              | Field access (Scala val)                                     | Drop parens if it's a val                                 | 4.0               |
+| Java records                               | Used (e.g., `record IneligibleReplica`)           | Not available (Java 11)                                      | Use static final class with explicit fields               | 4.0 only          |
+| `ApiKeys` enum                             | Includes STREAMS_GROUP, SHARE_GROUP_OFFSETS, etc. | Fewer entries                                                | Add only INIT_DISKLESS_LOG, don't carry main-only entries | 4.0, 4.1          |
 
 ### Resolution by File Type
 
 #### Pure Inkless Files (`storage/inkless/**`)
 
 Usually apply cleanly. If not, the conflict is typically in:
+
 - **Import changes**: Accept the cherry-pick's imports, remove any that don't exist on the release branch
 - **API differences**: Adapt to the release branch's API surface
 
@@ -187,20 +188,24 @@ Usually apply cleanly. If not, the conflict is typically in:
 These are the most conflict-prone. Common patterns:
 
 **Imports**: Cherry-pick may add imports for classes that don't exist on the release branch or are in different packages.
+
 - Check if the imported class exists: `git log --oneline --all -- '**/ClassName.java'`
 - If it doesn't exist, skip the import and adapt the code
 
 **Constructor parameters**: Cherry-pick may reference constructor params or methods that differ.
+
 - Compare the class signature on main vs release branch
 - Adapt the cherry-pick to use the release branch's API
 
 **Feature blocks**: Cherry-pick may include code for features not present on the release branch (e.g., share coordinator).
+
 - Skip the entire feature block
 - Keep only the inkless-specific additions
 
 #### Interface/API Files (`MetadataView.java`, etc.)
 
 Cherry-pick may replace methods that are still in use on the release branch.
+
 - **Keep existing methods** that other code still calls
 - **Add new methods** from the cherry-pick as additions, not replacements
 - Verify no callers are broken: `grep -r "methodName" --include="*.java" --include="*.scala"`
@@ -213,19 +218,21 @@ Cherry-pick may replace methods that are still in use on the release branch.
 
 ### TopicPartition vs TopicIdPartition Pattern
 
-This is the most frequent conflict source between main and 4.0. On main, the produce path uses `TopicIdPartition` directly. On 4.0, it uses `TopicPartition` with `TopicIdEnricher` to add the topic ID.
+This is a frequent conflict source when the release branch still uses `TopicPartition` in the produce path while main has moved to `TopicIdPartition`. If the release branch uses `TopicIdEnricher`, follow this pattern:
 
 **When cherry-picking produce path changes:**
+
 1. Keep the release branch's `TopicPartition`-based signatures
 2. Use `TopicIdEnricher.enrich(metadata, entriesPerPartition)` to convert when needed
 3. Pass `entriesPerPartitionEnriched.keySet()` (which is `Set<TopicIdPartition>`) to methods that need topic IDs
 
-**Example adaptation** (AppendHandler on 4.0):
+**Example adaptation** (AppendHandler):
+
 ```java
 // main version: handle() receives Map<TopicIdPartition, MemoryRecords> directly
-// 4.0 version: handle() receives Map<TopicPartition, MemoryRecords>, enriches internally
+// release branch: handle() receives Map<TopicPartition, MemoryRecords>, enriches internally
 public CompletableFuture<...> handle(Map<TopicPartition, MemoryRecords> entriesPerPartition, ...) {
-    // Enrich with topic IDs (4.0-specific step)
+    // Enrich with topic IDs (release-branch-specific step)
     Map<TopicIdPartition, MemoryRecords> entriesPerPartitionEnriched =
         TopicIdEnricher.enrich(metadata, entriesPerPartition);
     // Now use entriesPerPartitionEnriched for methods that need TopicIdPartition
@@ -238,10 +245,10 @@ public CompletableFuture<...> handle(Map<TopicPartition, MemoryRecords> entriesP
 
 Cherry-picked commits retain their original message. When additional fixes are needed:
 
-| Prefix | Use |
-|--------|-----|
-| `sync(compile):` | Fixing compilation errors after cherry-pick |
-| `sync(test):` | Fixing test compilation/failures after cherry-pick |
+| Prefix           | Use                                                |
+| ---------------- | -------------------------------------------------- |
+| `sync(compile):` | Fixing compilation errors after cherry-pick        |
+| `sync(test):`    | Fixing test compilation/failures after cherry-pick |
 
 Alternatively, amend the cherry-pick commit with the fixes if they are small and directly related.
 
@@ -258,30 +265,32 @@ git log --oneline origin/main --grep="(#NNN)"
 ### Cherry-pick Applies But Doesn't Compile
 
 This is expected when main and the release branch have diverged significantly. Common causes:
+
 - Missing imports (class in different package or doesn't exist on release branch)
 - Method signature differences
 - Type mismatches (TopicPartition vs TopicIdPartition)
-- Cross-module dependency (e.g., `ServerConfigs` is in `server` module, not accessible from `metadata` module on 4.0)
-- Java version differences (main uses records, 4.0 uses Java 11 classes)
+- Cross-module dependency (e.g., `ServerConfigs` is in `server` module, not accessible from `metadata` module on release branch)
+- Java version differences (main may use newer Java features not available on the release branch)
 - Scala/Java API surface differences (`ByteBuffer` vs `Readable`, `Option` vs `Optional`)
 
 Fix compilation errors, then either amend the cherry-pick or create a separate `sync(compile):` commit.
 
-**Concrete examples from inkless-4.0 sync (2026-03):**
+**Concrete examples from inkless-4.1 sync:**
 
-| Error | Cause | Fix |
-|-------|-------|-----|
-| `forEach` not a member of `Pool` | 4.0 uses `foreachEntry` | Change to `foreachEntry` |
-| `metadataVersionOrThrow()` not found | 4.0 uses `metadataVersion()` | Drop `OrThrow` |
-| `ByteBuffer` cannot convert to `Readable` | `InitDisklessLogRequest.parse` written for main's API | Change to `ByteBuffer` + `ByteBufferAccessor` |
-| `ServerConfigs` not found in metadata module | `metadata` module can't depend on `server` on 4.0 | Inline the constant values |
-| `PartitionListener` not found | Different package on 4.0 (`kafka.cluster` vs `org.apache.kafka.server.partition`) | Fix import |
-| `producerStateManager()` not a member | Scala val on 4.0, not a method | Remove parens |
-| `String cannot be converted to Uuid` | `createTestTopic` takes `Uuid` first on 4.0 | Add `Uuid.randomUuid()` |
+| Error                                        | Cause                                                                                        | Fix                                           |
+| -------------------------------------------- | -------------------------------------------------------------------------------------------- | --------------------------------------------- |
+| `forEach` not a member of `Pool`             | Release branch uses `foreachEntry`                                                           | Change to `foreachEntry`                      |
+| `metadataVersionOrThrow()` not found         | Release branch uses `metadataVersion()`                                                      | Drop `OrThrow`                                |
+| `ByteBuffer` cannot convert to `Readable`    | `InitDisklessLogRequest.parse` written for main's API                                        | Change to `ByteBuffer` + `ByteBufferAccessor` |
+| `ServerConfigs` not found in metadata module | `metadata` module can't depend on `server` on release branch                                 | Inline the constant values                    |
+| `PartitionListener` not found                | Different package on release branch (`kafka.cluster` vs `org.apache.kafka.server.partition`) | Fix import                                    |
+| `producerStateManager()` not a member        | Scala val on release branch, not a method                                                    | Remove parens                                 |
+| `String cannot be converted to Uuid`         | `createTestTopic` takes `Uuid` first on release branch                                       | Add `Uuid.randomUuid()`                       |
 
 ### Too Many Conflicts
 
 If a commit has extensive conflicts, consider:
+
 1. Cherry-picking the commit's changes manually (read the PR diff on GitHub)
 2. Skipping the commit if it's not critical for the release branch
 3. Creating a release-branch-specific implementation
@@ -289,7 +298,8 @@ If a commit has extensive conflicts, consider:
 ### Knowing When to Stop
 
 Not all commits can be cleanly cherry-picked. **Defer a commit** when it:
-- Introduces code that depends on APIs fundamentally different between main and 4.0 (e.g., `org.apache.kafka.server.partition.PartitionListener` on main vs `kafka.cluster.PartitionListener` on 4.0, with different method signatures or lifecycles)
+
+- Introduces code that depends on APIs fundamentally different between main and the release branch (e.g., `org.apache.kafka.server.partition.PartitionListener` on main vs `kafka.cluster.PartitionListener` on release branch, with different method signatures or lifecycles)
 - Requires cross-module dependency changes (e.g., `metadata` module importing from `server` module)
 - Needs multiple deep adaptations across different subsystems simultaneously
 
@@ -303,12 +313,12 @@ For AI-assisted sessions, use this prompt:
 I need to cherry-pick inkless commits from main to a release branch.
 
 ## Context
-- Target branch: inkless-4.0 (or inkless-4.1, etc.)
+- Target branch: inkless-4.1 (or inkless-4.2, etc.)
 - Source: origin/main
 
 ## Steps
 
-1. Run `./inkless-sync/branch-consistency.sh inkless-4.0 --missing` to find missing commits
+1. Run `./inkless-sync/branch-consistency.sh inkless-4.1 --missing` to find missing commits
 2. Create session file from inkless-sync/CHERRY-PICK-SESSION-TEMPLATE.md
 3. Present each commit for approval before cherry-picking
 4. Resolve conflicts following inkless-sync/CHERRY-PICK-SYNC-GUIDE.md

--- a/inkless-sync/CONFLICT-RESOLUTION-STRATEGY.md
+++ b/inkless-sync/CONFLICT-RESOLUTION-STRATEGY.md
@@ -174,6 +174,91 @@ After each sync, these files typically need inkless additions re-applied:
    - Constructor: split `classicFetchPartitionStatus`/`disklessFetchPartitionStatus`
    - Methods: `tryCompleteDiskless`
 
+## Cherry-pick Sync Conflicts
+
+Cherry-picking inkless commits from main to release branches produces a distinct class of conflicts caused by **divergence between main and the release branch**, rather than upstream changes.
+
+### Category 6: Type Divergence (TopicPartition vs TopicIdPartition)
+**Strategy: Keep release branch's type, adapt cherry-pick logic**
+
+On main, the produce path uses `TopicIdPartition` directly. On release branches (4.0, 4.1), it uses `TopicPartition` with `TopicIdEnricher` to convert.
+
+**Resolution**:
+1. Keep the release branch's `TopicPartition`-based method signatures
+2. Use `TopicIdEnricher.enrich()` where topic IDs are needed
+3. Pass enriched `Set<TopicIdPartition>` to internal methods that require it
+
+### Category 7: Missing Features on Release Branch
+**Strategy: Skip feature blocks that don't exist on the release branch**
+
+Cherry-picks from main may include code for features not present on the release branch (e.g., share coordinator on 4.0, KRaft-only APIs).
+
+**Resolution**:
+1. Identify blocks related to the missing feature
+2. Skip those blocks entirely during conflict resolution
+3. Keep only the inkless-specific additions
+
+### Category 8: Interface/API Expansion
+**Strategy: Add new methods, don't replace existing ones**
+
+Cherry-picks may replace interface methods that are still called by existing code on the release branch.
+
+**Resolution**:
+1. Keep ALL existing methods that have callers on the release branch
+2. Add new methods from the cherry-pick as additions
+3. Verify no callers are broken: `grep -r "methodName" --include="*.java" --include="*.scala"`
+
+### Category 9: Class/Object Coexistence
+**Strategy: Keep both when main split or moved code that still exists on the release branch**
+
+Cherry-picks may assume code was refactored (e.g., `DynamicThreadPool` moved to separate class on main but still exists as object on 4.0).
+
+**Resolution**:
+1. Keep the existing class/object on the release branch
+2. Add the new class/code from the cherry-pick alongside it
+
+### Category 10: Cross-Module Dependency
+**Strategy: Inline constants or restructure to avoid the dependency**
+
+Cherry-picks from main may introduce imports that cross module boundaries differently than on the release branch. For example, `metadata` module importing `ServerConfigs` from `server` module works on main but not on 4.0.
+
+**Resolution**:
+1. Identify the constant or class being referenced
+2. If it's a simple constant (string, boolean), inline the value directly
+3. If it's a class, check if an equivalent exists in an accessible module
+4. Document the inlining so it can be revisited when module structure changes
+
+### Category 11: Enum/Switch Expansion
+**Strategy: Add only the new inkless entry, skip entries from features not on the release branch**
+
+Cherry-picks that add new entries to enums or switch statements (e.g., `ApiKeys`, `AbstractRequest.parseRequest`, `AbstractResponse.parseResponse`) may carry additional entries from features not present on the release branch.
+
+**Resolution**:
+1. Keep all existing entries from HEAD (the release branch)
+2. Add ONLY the new inkless entry (e.g., `INIT_DISKLESS_LOG`)
+3. Drop entries for features not on the release branch (e.g., `STREAMS_GROUP_HEARTBEAT`, `DESCRIBE_SHARE_GROUP_OFFSETS` on 4.0)
+4. Ensure parameter types match the release branch (e.g., `ByteBuffer` not `Readable`)
+
+### Category 12: Java Language Feature Divergence
+**Strategy: Downgrade to the release branch's Java version features**
+
+Main may use newer Java features (records, sealed classes, pattern matching) that don't exist on the release branch's Java version.
+
+**Resolution**:
+1. Replace `record` declarations with `static final class` + explicit fields/constructor
+2. Replace `sealed` interfaces with regular interfaces
+3. Replace pattern matching switches with if/else chains
+4. Keep the same logic and field names for minimal divergence
+
+### Cherry-pick Conflict Tracking
+
+Use `.inkless-sync/CHERRY-PICK-SESSION-*.md` files to track:
+- Each commit's conflict details
+- Resolution decisions and reasoning
+- Compilation errors and fixes
+
+See [CHERRY-PICK-SYNC-GUIDE.md](CHERRY-PICK-SYNC-GUIDE.md) for the full workflow and session template.
+
 ## Guiding Principles
 
 ### Principle 1: Minimize Future Conflicts

--- a/inkless-sync/README.md
+++ b/inkless-sync/README.md
@@ -14,6 +14,7 @@ The sync process follows the [Versioning Strategy](../docs/inkless/VERSIONING-ST
 Start a sync session with Claude Code using the appropriate prompt:
 - **Main Sync** → [MAIN-SYNC-PROMPT.md](MAIN-SYNC-PROMPT.md) — weekly/biweekly sync with Apache Kafka trunk
 - **Release Sync** → [RELEASE-SYNC-PROMPT.md](RELEASE-SYNC-PROMPT.md) — sync release branches with upstream patches
+- **Cherry-pick Sync** → [CHERRY-PICK-SYNC-GUIDE.md](CHERRY-PICK-SYNC-GUIDE.md) — backport inkless features from main to release branches
 
 Context for the agent:
 - Scripts are in `inkless-sync/`
@@ -32,17 +33,19 @@ Context for the agent:
 | `create-release-branch.sh` | Create new inkless release branches |
 | `cherry-pick-to-release.sh` | Cherry-pick inkless commits to release branches |
 
-## Two Types of Sync
+## Three Types of Sync
 
 | Type | Branch | Script | Use Case |
 |------|--------|--------|----------|
 | **Main Sync** | `main` | `main-sync.sh` | Weekly/biweekly sync with Apache Kafka trunk |
 | **Release Sync** | `inkless-4.0`, etc. | `release-sync.sh` | Sync release branches with upstream patch releases |
+| **Cherry-pick Sync** | `inkless-4.0`, etc. | `cherry-pick-to-release.sh` | Backport inkless features from main to release branches |
 
 ### When to Use Each
 
 - **Main Sync**: Regular development sync to keep up with Apache Kafka trunk
 - **Release Sync**: When Apache releases a patch (e.g., 4.0.1) and we need to incorporate fixes into our release branch
+- **Cherry-pick Sync**: When inkless features land on main and need to be backported to active release branches
 
 ## Quick Start
 
@@ -138,6 +141,8 @@ After creating the branch, sync with upstream to set the release version:
 ./inkless-sync/cherry-pick-to-release.sh inkless-4.0 abc123 def456
 ```
 
+For detailed cherry-pick workflow, conflict resolution patterns, and session tracking, see [CHERRY-PICK-SYNC-GUIDE.md](CHERRY-PICK-SYNC-GUIDE.md).
+
 ## How It Works (Main Sync)
 
 ### Phase 1: Preparation
@@ -177,6 +182,8 @@ inkless-sync/
 ├── README.md                     # This file
 ├── RELEASE-SYNC-GUIDE.md         # Release sync documentation
 ├── RELEASE-SYNC-PROMPT.md        # AI prompt for release syncs
+├── CHERRY-PICK-SYNC-GUIDE.md    # Cherry-pick sync documentation
+├── CHERRY-PICK-SESSION-TEMPLATE.md  # Session template for cherry-pick syncs
 ├── CONFLICT-RESOLUTION-STRATEGY.md     # Conflict resolution guidance
 ├── MAIN-SYNC-PROMPT.md                 # AI prompt for main branch syncs
 ├── MAIN-SYNC-SESSION-TEMPLATE.md       # Session template for main syncs
@@ -305,5 +312,6 @@ The structured commit approach makes it easy to:
 - [Versioning Strategy](../docs/inkless/VERSIONING-STRATEGY.md)
 - [Inkless README](../docs/inkless/README.md)
 - [Release Sync Guide](RELEASE-SYNC-GUIDE.md)
+- [Cherry-pick Sync Guide](CHERRY-PICK-SYNC-GUIDE.md)
 - [Conflict Resolution Strategy](CONFLICT-RESOLUTION-STRATEGY.md)
 - [Main Sync Prompt](MAIN-SYNC-PROMPT.md)

--- a/inkless-sync/branch-consistency.sh
+++ b/inkless-sync/branch-consistency.sh
@@ -88,40 +88,25 @@ parse_args() {
     RELEASE_BRANCH="${positional[0]}"
 }
 
-# Check if commit is inkless-specific (not a sync/merge commit)
-# Only considers commits that:
-# 1. Have a PR number (squash-merged PRs)
-# 2. Mention inkless/diskless
-# 3. Are not merge or sync commits
-is_inkless_commit() {
+# Check if commit should be excluded from cherry-pick consideration.
+# With --first-parent, we only see commits directly landed on main (PRs),
+# so we only need to exclude sync fix-up commits and non-PR commits.
+is_excluded_commit() {
     local commit_msg="$1"
 
-    # MUST have a PR number - this filters out merge conflict resolution commits
-    # PR merges have pattern (#XXX)
+    # Must have a PR number — squash-merged PRs have pattern (#XXX).
+    # Commits without PR numbers are manual fixes that can't be reliably
+    # matched against the release branch.
     if [[ ! "$commit_msg" =~ \(#[0-9]+\) ]]; then
-        return 1
+        return 0
     fi
 
-    # Exclude merge commits
-    if [[ "$commit_msg" =~ ^[Mm]erge ]]; then
-        return 1
-    fi
-
-    # Exclude sync-specific commits (these are main-trunk sync related)
+    # Exclude sync-specific commits (main-trunk sync related)
     if [[ "$commit_msg" =~ ^(sync\(|fix\(sync\)|docs\(sync\)|refactor\(sync\)) ]]; then
-        return 1
-    fi
-
-    # Include commits that mention inkless or diskless
-    if [[ "$commit_msg" =~ (inkless|diskless|Inkless|Diskless) ]]; then
         return 0
     fi
 
-    # Include commits with inkless-related prefixes
-    if [[ "$commit_msg" =~ ^(feat|fix|refactor|chore|docs|test)\((inkless|diskless|storage:inkless|metadata:diskless) ]]; then
-        return 0
-    fi
-
+    # Not excluded
     return 1
 }
 
@@ -179,7 +164,10 @@ check_consistency() {
     echo "Branch diverged at: $diverge_desc"
     echo ""
 
-    # First, get all inkless commits on main since divergence
+    # Get all inkless commits on main since divergence.
+    # --first-parent only walks the main branch lineage, so upstream commits
+    # brought in via merge are excluded. Only PRs landed directly on main
+    # (and sync fix-ups) appear. We then filter out sync fix-ups.
     info "Scanning main branch for inkless commits..."
 
     local inkless_commits_file
@@ -189,10 +177,10 @@ check_consistency() {
 
     while IFS= read -r line; do
         local msg="${line#* }"
-        if is_inkless_commit "$msg"; then
+        if ! is_excluded_commit "$msg"; then
             echo "$line" >> "$inkless_commits_file"
         fi
-    done < <(git log --oneline --no-merges "$diverge_point..origin/main")
+    done < <(git log --first-parent --no-merges --oneline "$diverge_point..origin/main")
 
     local inkless_count
     inkless_count=$(wc -l < "$inkless_commits_file" | tr -d ' ')

--- a/inkless-sync/cherry-pick-to-release.sh
+++ b/inkless-sync/cherry-pick-to-release.sh
@@ -229,8 +229,11 @@ main() {
     # Get commits to cherry-pick
     local commits=()
 
+    local reverse_order=true
+
     if [[ ${#SPECIFIC_COMMITS[@]} -gt 0 ]]; then
         commits=("${SPECIFIC_COMMITS[@]}")
+        reverse_order=false  # User-provided order is respected as-is
         echo "Specific commits provided: ${#commits[@]}"
     else
         info "Finding missing commits using branch-consistency..."
@@ -248,10 +251,24 @@ main() {
         return
     fi
 
+    # Build ordered list for display and execution
+    local ordered=()
+    if [[ "$reverse_order" == "true" ]]; then
+        for ((i=${#commits[@]}-1; i>=0; i--)); do
+            ordered+=("${commits[$i]}")
+        done
+    else
+        ordered=("${commits[@]}")
+    fi
+
     echo ""
-    echo "## Commits to cherry-pick"
+    if [[ "$reverse_order" == "true" ]]; then
+        echo "## Commits to cherry-pick (oldest first)"
+    else
+        echo "## Commits to cherry-pick (provided order)"
+    fi
     echo ""
-    for commit in "${commits[@]}"; do
+    for commit in "${ordered[@]}"; do
         local msg
         msg=$(git log --format="%s" -1 "$commit" 2>/dev/null || echo "unknown")
         local applicable="✓"
@@ -288,7 +305,7 @@ main() {
     local skip_count=0
     local fail_count=0
 
-    for commit in "${commits[@]}"; do
+    for commit in "${ordered[@]}"; do
         if ! is_applicable_commit "$commit"; then
             echo ""
             echo "Skipping merge resolution commit: $commit"


### PR DESCRIPTION
- Fix `branch-consistency.sh` to use `--first-parent` when listing main commits, so upstream merge-commit content is excluded from the missing-commits report.
- Add comprehensive cherry-pick sync documentation covering the workflow, conflict resolution patterns, and session tracking for backporting inkless commits from main to release branches (e.g., inkless-4.0).