### PR TITLE
feat(inkless): Init diskless log on Control Plane

### DIFF
--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -366,9 +366,10 @@ class BrokerServer(
         retryTimeoutMs = 60000
       )
       initDisklessLogChannelManager.start()
-      maybeInitDisklessLogManager = sharedServer.inklessControlPlane.map { _ =>
+      maybeInitDisklessLogManager = sharedServer.inklessControlPlane.map { controlPlane =>
         new InitDisklessLogManager(
           controllerChannelManager = initDisklessLogChannelManager,
+          controlPlane = controlPlane,
           scheduler = kafkaScheduler,
           brokerId = config.brokerId,
           brokerEpochSupplier = () => lifecycleManager.brokerEpoch

--- a/core/src/main/scala/kafka/server/InitDisklessLogBatchQueue.scala
+++ b/core/src/main/scala/kafka/server/InitDisklessLogBatchQueue.scala
@@ -237,8 +237,10 @@ abstract class RetriableInitDisklessLogBatchQueue[S <: InitDisklessLogState](
     }
   }
 
-  private def completeAndRemovePromise(tp: TopicPartition, accepted: Boolean): Unit = {
-    Option(resultPromiseByTp.remove(tp)).foreach(_.trySuccess(accepted))
+  private def completeAndRemovePromise(tp: TopicPartition, accepted: Boolean): Unit = withQueueLock {
+    if (!queuedByTp.containsKey(tp)) {
+      Option(resultPromiseByTp.remove(tp)).foreach(_.trySuccess(accepted))
+    }
   }
 
   private def computeRetryDelayMs(): Long = {

--- a/core/src/main/scala/kafka/server/InitDisklessLogBatchQueue.scala
+++ b/core/src/main/scala/kafka/server/InitDisklessLogBatchQueue.scala
@@ -114,8 +114,11 @@ abstract class RetriableInitDisklessLogBatchQueue[S <: InitDisklessLogState](
   }
 
   def remove(tp: TopicPartition): Unit = {
-    withQueueLock { queuedByTp.remove(tp) }
-    completeAndRemovePromise(tp, accepted = false)
+    val promise = withQueueLock {
+      queuedByTp.remove(tp)
+      Option(resultPromiseByTp.remove(tp))
+    }
+    promise.foreach(_.trySuccess(false))
   }
   
   private def task(): Unit = {

--- a/core/src/main/scala/kafka/server/InitDisklessLogBatchQueue.scala
+++ b/core/src/main/scala/kafka/server/InitDisklessLogBatchQueue.scala
@@ -67,7 +67,7 @@ abstract class RetriableInitDisklessLogBatchQueue[S <: InitDisklessLogState](
 
   private case class Attempt(state: S, attemptNumber: Int)
   private var queuedByTp = new java.util.LinkedHashMap[TopicPartition, Attempt]()
-  private val resultPromiseByTp = new java.util.HashMap[TopicPartition, Promise[Boolean]]()
+  private val resultPromiseByTp = new java.util.concurrent.ConcurrentHashMap[TopicPartition, Promise[Boolean]]()
   private val retryBackoff = new ExponentialBackoff(retryPeriodMs, 2, maxRetryTimeMs, 0.0)
   
   private sealed trait TaskStatus
@@ -101,43 +101,21 @@ abstract class RetriableInitDisklessLogBatchQueue[S <: InitDisklessLogState](
   def enqueue(tp: TopicPartition, state: S): Future[Boolean] = {
     val promise = withQueueLock {
       val currentPromise = resultPromiseByTp.computeIfAbsent(tp, _ => Promise[Boolean]())
-      val duplicateQueued = Option(queuedByTp.get(tp)).exists(existing => existing.state == state)
-      if (duplicateQueued) {
-        taskStatus match {
-          case TaskScheduled(scheduledTask) =>
-            // Reschedule when receiving a duplicate so it's immediately sent
-            scheduledTask.cancel(false)
-            scheduleNewTask(lingerMs)
-          case _ =>
-        }
-        currentPromise
-      } else {
-        val preservedAttemptNumber = Option(queuedByTp.get(tp)).map(_.attemptNumber).getOrElse(0)
-        // Keep retry progression for already queued partitions, but always refresh the state payload.
-        queuedByTp.put(tp, Attempt(state, attemptNumber = preservedAttemptNumber))
-
-        taskStatus match {
-          case NoTask =>
-            // Schedule a new run, allowing linger for additional ready partitions.
-            scheduleNewTask(lingerMs)
-          case TaskScheduled(scheduledTask) =>
-            // Re-schedule using linger so newly ready partitions can batch together.
-            scheduledTask.cancel(false)
-            scheduleNewTask(lingerMs)
-          case TaskRunning =>
-            // A task is in-flight. Newly queued work is already in queuedByTp
-            // and will be picked up by finishTask.
-        }
-        currentPromise
+      val existing = Option(queuedByTp.get(tp))
+      val isDuplicate = existing.exists(_.state == state)
+      if (!isDuplicate) {
+        val attemptNum = existing.map(_.attemptNumber).getOrElse(0)
+        queuedByTp.put(tp, Attempt(state, attemptNumber = attemptNum))
       }
+      maybeScheduleOrReschedule(lingerMs)
+      currentPromise
     }
-    
     promise.future
   }
 
-  def remove(tp: TopicPartition): Unit = withQueueLock {
-    queuedByTp.remove(tp)
-    Option(resultPromiseByTp.remove(tp)).foreach(_.trySuccess(false))
+  def remove(tp: TopicPartition): Unit = {
+    withQueueLock { queuedByTp.remove(tp) }
+    completeAndRemovePromise(tp, accepted = false)
   }
   
   private def task(): Unit = {
@@ -222,12 +200,22 @@ abstract class RetriableInitDisklessLogBatchQueue[S <: InitDisklessLogState](
   }
 
   private def finishTask(): Unit = withQueueLock {
-    if (queuedByTp.isEmpty) {
-      taskStatus = NoTask
-    } else {
+    taskStatus = NoTask
+    if (!queuedByTp.isEmpty) {
       val hasFreshAttempts = queuedByTp.values().asScala.exists(_.attemptNumber == 0)
       val delayMs = if (hasFreshAttempts) lingerMs else computeRetryDelayMs()
-      scheduleNewTask(delayMs)
+      maybeScheduleOrReschedule(delayMs)
+    }
+  }
+
+  private def maybeScheduleOrReschedule(delayMs: Long): Unit = {
+    taskStatus match {
+      case NoTask =>
+        scheduleNewTask(delayMs)
+      case TaskScheduled(scheduledTask) =>
+        scheduledTask.cancel(false)
+        scheduleNewTask(delayMs)
+      case TaskRunning =>
     }
   }
 
@@ -246,7 +234,7 @@ abstract class RetriableInitDisklessLogBatchQueue[S <: InitDisklessLogState](
     }
   }
 
-  private def completeAndRemovePromise(tp: TopicPartition, accepted: Boolean): Unit = withQueueLock {
+  private def completeAndRemovePromise(tp: TopicPartition, accepted: Boolean): Unit = {
     Option(resultPromiseByTp.remove(tp)).foreach(_.trySuccess(accepted))
   }
 

--- a/core/src/main/scala/kafka/server/InitDisklessLogBatchQueue.scala
+++ b/core/src/main/scala/kafka/server/InitDisklessLogBatchQueue.scala
@@ -17,11 +17,13 @@
 package kafka.server
 
 import kafka.server.InitDisklessLogBatchQueue.ParsedResponse
+import io.aiven.inkless.control_plane.ControlPlane
 import kafka.utils.Logging
 import org.apache.kafka.clients.ClientResponse
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.message.InitDisklessLogResponseData
 import org.apache.kafka.common.requests.{InitDisklessLogRequest, InitDisklessLogResponse}
+import org.apache.kafka.common.utils.ExponentialBackoff
 import org.apache.kafka.server.common.{ControllerRequestCompletionHandler, NodeToControllerChannelManager}
 import org.apache.kafka.server.util.Scheduler
 
@@ -66,6 +68,7 @@ abstract class RetriableInitDisklessLogBatchQueue[S <: InitDisklessLogState](
   private case class Attempt(state: S, attemptNumber: Int)
   private var queuedByTp = new java.util.LinkedHashMap[TopicPartition, Attempt]()
   private val resultPromiseByTp = new java.util.HashMap[TopicPartition, Promise[Boolean]]()
+  private val retryBackoff = new ExponentialBackoff(retryPeriodMs, 2, maxRetryTimeMs, 0.0)
   
   private sealed trait TaskStatus
   private case object NoTask extends TaskStatus
@@ -97,24 +100,36 @@ abstract class RetriableInitDisklessLogBatchQueue[S <: InitDisklessLogState](
 
   def enqueue(tp: TopicPartition, state: S): Future[Boolean] = {
     val promise = withQueueLock {
-      val preservedAttemptNumber = Option(queuedByTp.get(tp)).map(_.attemptNumber).getOrElse(0)
-      // Keep retry progression for already queued partitions, but always refresh the state payload.
-      queuedByTp.put(tp, Attempt(state, attemptNumber = preservedAttemptNumber))
       val currentPromise = resultPromiseByTp.computeIfAbsent(tp, _ => Promise[Boolean]())
-      
-      taskStatus match {
-        case NoTask =>
-          // Schedule a new run, allowing linger for additional ready partitions.
-          scheduleNewTask(lingerMs)
-        case TaskScheduled(scheduledTask) =>
-          // Re-schedule using linger so newly ready partitions can batch together.
-          scheduledTask.cancel(false)
-          scheduleNewTask(lingerMs)
-        case TaskRunning =>
-          // A task is in-flight. Newly queued work is already in queuedByTp
-          // and will be picked up by finishTask.
+      val duplicateQueued = Option(queuedByTp.get(tp)).exists(existing => existing.state == state)
+      if (duplicateQueued) {
+        taskStatus match {
+          case TaskScheduled(scheduledTask) =>
+            // Reschedule when receiving a duplicate so it's immediately sent
+            scheduledTask.cancel(false)
+            scheduleNewTask(lingerMs)
+          case _ =>
+        }
+        currentPromise
+      } else {
+        val preservedAttemptNumber = Option(queuedByTp.get(tp)).map(_.attemptNumber).getOrElse(0)
+        // Keep retry progression for already queued partitions, but always refresh the state payload.
+        queuedByTp.put(tp, Attempt(state, attemptNumber = preservedAttemptNumber))
+
+        taskStatus match {
+          case NoTask =>
+            // Schedule a new run, allowing linger for additional ready partitions.
+            scheduleNewTask(lingerMs)
+          case TaskScheduled(scheduledTask) =>
+            // Re-schedule using linger so newly ready partitions can batch together.
+            scheduledTask.cancel(false)
+            scheduleNewTask(lingerMs)
+          case TaskRunning =>
+            // A task is in-flight. Newly queued work is already in queuedByTp
+            // and will be picked up by finishTask.
+        }
+        currentPromise
       }
-      currentPromise
     }
     
     promise.future
@@ -237,22 +252,9 @@ abstract class RetriableInitDisklessLogBatchQueue[S <: InitDisklessLogState](
 
   private def computeRetryDelayMs(): Long = {
     val maxAttemptNumber = queuedByTp.values().asScala.map(_.attemptNumber).maxOption.getOrElse(0)
-    if (maxAttemptNumber <= 0) {
-      retryPeriodMs
-    } else {
-      // First retry waits retryPeriodMs, then doubles exponentially up to maxRetryTimeMs.
-      var delay = retryPeriodMs
-      var exponent = maxAttemptNumber - 1
-      while (exponent > 0 && delay < maxRetryTimeMs) {
-        if (delay >= (maxRetryTimeMs + 1L) / 2L) {
-          delay = maxRetryTimeMs
-        } else {
-          delay = delay * 2L
-        }
-        exponent -= 1
-      }
-      Math.min(delay, maxRetryTimeMs)
-    }
+    // First retry waits retryPeriodMs, then doubles exponentially up to maxRetryTimeMs.
+    val attempts = Math.max(maxAttemptNumber - 1, 0)
+    retryBackoff.backoff(attempts)
   }
 
 }
@@ -317,3 +319,47 @@ class SendingToControllerBatchQueue(
     }
   }
 }
+
+class AwaitingMetadataBatchQueue(
+  controlPlane: ControlPlane,
+  scheduler: Scheduler,
+  brokerId: Int,
+  brokerEpochSupplier: () => Long,
+  lingerMs: Long,
+  retryPeriodMs: Long,
+  maxRetryTimeMs: Long
+) extends RetriableInitDisklessLogBatchQueue[AwaitingMetadata](
+  scheduler = scheduler,
+  brokerId = brokerId,
+  brokerEpochSupplier = brokerEpochSupplier,
+  lingerMs = lingerMs,
+  retryPeriodMs = retryPeriodMs,
+  maxRetryTimeMs = maxRetryTimeMs
+) {
+  logIdent = s"[AwaitingMetadataBatchQueue] "
+
+  override protected def shouldSend(state: AwaitingMetadata): Boolean = {
+    if (state.metadataPayload.isDefined) {
+      true
+    } else {
+      state.warn(s"Skipping InitDisklessLog control-plane request because metadata payload is missing for ${state.tp}")
+      false
+    }
+  }
+
+  override protected def sendBatch(
+    states: Iterable[AwaitingMetadata],
+    brokerId: Int,
+    brokerEpoch: Long,
+    onBatchComplete: Either[String, Iterable[ParsedResponse]] => Unit
+  ): Unit = {
+    AwaitingMetadata.sendBatch(
+      states = states,
+      destination = controlPlane,
+      brokerId = brokerId,
+      brokerEpoch = brokerEpoch,
+      onBatchComplete = onBatchComplete
+    )
+  }
+}
+

--- a/core/src/main/scala/kafka/server/InitDisklessLogManager.scala
+++ b/core/src/main/scala/kafka/server/InitDisklessLogManager.scala
@@ -60,7 +60,7 @@ class InitDisklessLogManager(
     scheduler = scheduler,
     brokerId = brokerId,
     brokerEpochSupplier = brokerEpochSupplier,
-    lingerMs = 0L,
+    lingerMs = lingerMs,
     retryPeriodMs = retryPeriodMs,
     maxRetryTimeMs = maxRetryTimeMs
   )

--- a/core/src/main/scala/kafka/server/InitDisklessLogManager.scala
+++ b/core/src/main/scala/kafka/server/InitDisklessLogManager.scala
@@ -16,6 +16,7 @@
  */
 package kafka.server
 
+import io.aiven.inkless.control_plane.{ControlPlane, InitDisklessLogProducerState => CpProducerState}
 import kafka.cluster.Partition
 import kafka.utils.Logging
 import org.apache.kafka.common.{TopicPartition, Uuid}
@@ -28,6 +29,7 @@ import scala.jdk.CollectionConverters._
 
 class InitDisklessLogManager(
   controllerChannelManager: NodeToControllerChannelManager,
+  controlPlane: ControlPlane,
   scheduler: Scheduler,
   brokerId: Int,
   brokerEpochSupplier: () => Long
@@ -53,13 +55,49 @@ class InitDisklessLogManager(
     retryPeriodMs = retryPeriodMs,
     maxRetryTimeMs = maxRetryTimeMs
   )
+  private val awaitingMetadataQueue = new AwaitingMetadataBatchQueue(
+    controlPlane = controlPlane,
+    scheduler = scheduler,
+    brokerId = brokerId,
+    brokerEpochSupplier = brokerEpochSupplier,
+    lingerMs = 0L,
+    retryPeriodMs = retryPeriodMs,
+    maxRetryTimeMs = maxRetryTimeMs
+  )
 
   private[server] def getTrackedPartitions: Set[TopicPartition] = tracked.keySet().asScala.toSet
 
   private[server] def getInitState(tp: TopicPartition): Option[InitDisklessLogState] = Option(tracked.get(tp))
 
   /**
-   * Register a sealed partition for migration. If HW already
+   * Handles already-applied diskless init metadata for a partition.
+   * This keeps/moves the partition to AwaitingMetadata and triggers a prompt
+   * control-plane init send, since metadata is committed and visible.
+   */
+  def initOnControlPlane(
+    partition: Partition,
+    topicId: Uuid,
+    topicName: String,
+    disklessStartOffset: Long,
+    producerStates: java.util.List[CpProducerState]
+  ): Unit = {
+    if (disklessStartOffset < 0) {
+      warn(s"Received negative disklessStartOffset ($disklessStartOffset) for $topicName:${partition.topicPartition}, skipping control-plane init")
+      return
+    }
+
+    val tp = partition.topicPartition
+    val payload = DisklessInitMetadata(topicName, disklessStartOffset, producerStates)
+    val newState = AwaitingMetadata(partition, topicId, Some(payload))
+    if (tracked.putIfAbsent(tp, newState) != null) {
+      tracked.computeIfPresent(tp, (_, _) => newState)
+    }
+    enqueueAwaitingMetadata(tp, newState)
+  }
+
+  /**
+   * Register a sealed partition for migration. Registers this manager as a
+   * PartitionListener to receive HW advancement notifications. If HW already
    * equals LEO, immediately marks the partition ready and schedules a batch
    * send. Otherwise, waits for HW advancement notifications.
    */
@@ -81,6 +119,7 @@ class InitDisklessLogManager(
         enqueueSendingToController(tp, sendingToController)
         sendingToController
       case awaitingMetadata: AwaitingMetadata => awaitingMetadata
+      case done: Done => done
       case _: Failed => null
     })
 
@@ -120,13 +159,30 @@ class InitDisklessLogManager(
     }(ExecutionContext.parasitic)
   }
 
+  private def enqueueAwaitingMetadata(tp: TopicPartition, state: AwaitingMetadata): Unit = {
+    awaitingMetadataQueue.enqueue(tp, state).foreach { accepted =>
+      if (accepted) {
+        tracked.computeIfPresent(tp, (_, initDisklessLogState) =>
+          initDisklessLogState match {
+            case awaitingMetadata: AwaitingMetadata => awaitingMetadata.onSuccess
+            case other => other
+          }
+        )
+        tracked.remove(tp)
+      } else {
+        tracked.remove(tp)
+      }
+    }(ExecutionContext.parasitic)
+  }
+
   /**
    * Remove a partition from tracking (e.g., when leadership is lost).
    */
   def removePartition(tp: TopicPartition): Unit = {
     if (tracked.remove(tp) != null) {
       sendingToControllerQueue.remove(tp)
-      info(s"Removed partition $tp from diskless init log tracking")
+      awaitingMetadataQueue.remove(tp)
+      info(s"Removed partition $tp from diskless init tracking")
     }
   }
 }

--- a/core/src/main/scala/kafka/server/InitDisklessLogState.scala
+++ b/core/src/main/scala/kafka/server/InitDisklessLogState.scala
@@ -16,6 +16,7 @@
  */
 package kafka.server
 
+import io.aiven.inkless.control_plane.{ControlPlane, InitDisklessLogProducerState => CpProducerState, InitDisklessLogRequest => CpInitRequest, InitDisklessLogResponse => CpInitResponse}
 import kafka.cluster.Partition
 import kafka.server.InitDisklessLogBatchQueue.ParsedResponse
 import kafka.utils.Logging
@@ -33,6 +34,12 @@ sealed trait InitDisklessLogState extends Logging {
   val topicId: Uuid
   val tp: TopicPartition = partition.topicPartition
 }
+
+final case class DisklessInitMetadata(
+  topicName: String,
+  disklessStartOffset: Long,
+  producerStates: util.List[CpProducerState]
+)
 
 final case class Failed(partition: Partition, topicId: Uuid) extends WaitingForReplicationOutcome
 
@@ -108,7 +115,7 @@ final case class SendingToController(
 
   def onSuccess: AwaitingMetadata = {
     info(s"Request successful. Advancing to AwaitingMetadata.")
-    AwaitingMetadata(partition, topicId)
+    AwaitingMetadata(partition, topicId, metadataPayload = None)
   }
 }
 
@@ -197,8 +204,102 @@ object SendingToController {
 /** Controller accepted the request; waiting for the PartitionChangeRecord with disklessStartOffset to propagate. */
 final case class AwaitingMetadata(
   partition: Partition,
-  topicId: Uuid
+  topicId: Uuid,
+  metadataPayload: Option[DisklessInitMetadata] = None
 ) extends InitDisklessLogState {
   logIdent = s"[InitDisklessLog->AwaitingMetadata $tp] "
 
-}   
+  def onSuccess: Done = {
+    info(s"Metadata application successful. Advancing to Done.")
+    Done(partition, topicId)
+  }
+}
+
+/** Terminal state used for observability once metadata init succeeds. */
+final case class Done(
+  partition: Partition,
+  topicId: Uuid
+) extends InitDisklessLogState {
+  logIdent = s"[InitDisklessLog->Done $tp] "
+}
+
+object AwaitingMetadata {
+
+  def sendBatch(
+    states: Iterable[AwaitingMetadata],
+    destination: ControlPlane,
+    brokerId: Int,
+    brokerEpoch: Long,
+    onBatchComplete: Either[String, Iterable[ParsedResponse]] => Unit
+  ): Unit = {
+    def retriable(state: AwaitingMetadata): ParsedResponse =
+      ParsedResponse(state.topicId, state.tp.partition(), Errors.NOT_CONTROLLER, InitDisklessLogBatchQueue.RetriableFailure)
+
+    // Keep stable ordering to align final outcomes with input states.
+    val stateSeq = states.toSeq
+    // Retry outcomes computed locally (without a control-plane round-trip), keyed by input index.
+    val retryOutcomeByIndex = scala.collection.mutable.Map[Int, ParsedResponse]()
+    // Batched control-plane requests for states that are ready to be applied.
+    val requests = new util.ArrayList[CpInitRequest]()
+
+    // Validate each state and either precompute a retry outcome or queue a batched request.
+    stateSeq.zipWithIndex.foreach { case (state, index) =>
+      state.metadataPayload match {
+        case None =>
+          state.warn(s"Missing metadata payload for ${state.tp} while awaiting metadata; scheduling retry")
+          retryOutcomeByIndex += index -> retriable(state)
+        case Some(metadata) =>
+          state.partition.log match {
+            case None =>
+              state.warn(s"Partition ${state.tp} has no log while applying diskless metadata, scheduling retry")
+              retryOutcomeByIndex += index -> retriable(state)
+            case Some(log) =>
+              requests.add(new CpInitRequest(
+                state.topicId,
+                metadata.topicName,
+                state.tp.partition(),
+                log.logStartOffset,
+                metadata.disklessStartOffset,
+                metadata.producerStates
+              ))
+          }
+      }
+    }
+
+    // Issue one Control Plane call for the whole batch (if any requests exist).
+    val responseResult: Either[Throwable, Seq[CpInitResponse]] =
+      if (requests.isEmpty) Right(Seq.empty)
+      else {
+        try Right(Option(destination.initDisklessLog(requests)).map(_.asScala.toSeq).getOrElse(Seq.empty))
+        catch {
+          case t: Throwable => Left(t)
+        }
+      }
+
+    // Rebuild outcomes in original order.
+    val responseIterator = responseResult.getOrElse(Seq.empty).iterator
+    val outcomes = stateSeq.zipWithIndex.map { case (state, index) =>
+      retryOutcomeByIndex.getOrElse(index, {
+        responseResult match {
+          case Left(t) =>
+            // If the single batched call fails, retry all.
+            state.warn(s"Control-plane InitDisklessLog for ${state.tp} failed, scheduling retry", t)
+            retriable(state)
+          case Right(_) =>
+            (if (responseIterator.hasNext) Some(responseIterator.next()) else None) match {
+              case Some(r) if r.error() == Errors.NONE || r.error() == Errors.INVALID_REQUEST =>
+                ParsedResponse(state.topicId, state.tp.partition(), r.error(), InitDisklessLogBatchQueue.Success)
+              case Some(r) =>
+                ParsedResponse(state.topicId, state.tp.partition(), r.error(), InitDisklessLogBatchQueue.RetriableFailure)
+              case None =>
+                // Missing response entry is treated as retriable to avoid dropping work.
+                state.warn(s"Control-plane InitDisklessLog response missing for ${state.tp}, scheduling retry")
+                retriable(state)
+            }
+        }
+      })
+    }
+
+    onBatchComplete(Right(outcomes))
+  }
+}

--- a/core/src/main/scala/kafka/server/InitDisklessLogState.scala
+++ b/core/src/main/scala/kafka/server/InitDisklessLogState.scala
@@ -215,7 +215,7 @@ final case class AwaitingMetadata(
   }
 }
 
-/** Terminal state used for observability once metadata init succeeds. */
+/** Terminal state once metadata init succeeds. */
 final case class Done(
   partition: Partition,
   topicId: Uuid
@@ -287,6 +287,7 @@ object AwaitingMetadata {
             retriable(state)
           case Right(_) =>
             (if (responseIterator.hasNext) Some(responseIterator.next()) else None) match {
+              // INVALID_REQUEST = partition already initialized (idempotent success)
               case Some(r) if r.error() == Errors.NONE || r.error() == Errors.INVALID_REQUEST =>
                 ParsedResponse(state.topicId, state.tp.partition(), r.error(), InitDisklessLogBatchQueue.Success)
               case Some(r) =>

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -19,7 +19,7 @@ package kafka.server
 import com.yammer.metrics.core.Meter
 import io.aiven.inkless.common.SharedState
 import io.aiven.inkless.consume.{FetchHandler, FetchOffsetHandler}
-import io.aiven.inkless.control_plane.{BatchInfo, FindBatchRequest, FindBatchResponse}
+import io.aiven.inkless.control_plane.{BatchInfo, FindBatchRequest, FindBatchResponse, InitDisklessLogProducerState}
 import io.aiven.inkless.delete.{DeleteRecordsInterceptor, FileCleaner, RetentionEnforcer}
 import io.aiven.inkless.merge.FileMerger
 import io.aiven.inkless.produce.AppendHandler
@@ -2818,6 +2818,57 @@ class ReplicaManager(val config: KafkaConfig,
       if (metadataVersion.isDirectoryAssignmentSupported) {
         // We only want to update the directoryIds if DirectoryAssignment is supported!
         localChanges.directoryIds.forEach(maybeUpdateTopicAssignment)
+      }
+    }
+
+    initDisklessLogOnControlPlane(delta)
+  }
+
+  private def initDisklessLogOnControlPlane(delta: TopicsDelta): Unit = {
+    initDisklessLogManager.foreach { manager =>
+      delta.changedTopics().forEach { (topicId, topicDelta) =>
+        val topicName = topicDelta.name()
+        topicDelta.partitionChanges().forEach { (partitionId, partitionRegistration) =>
+          val previousPartition = Option(delta.image().getTopic(topicId)).flatMap { topicImage =>
+            Option(topicImage.partitions().get(partitionId))
+          }
+          val shouldInitOnControlPlane = previousPartition.exists { previous =>
+            previous.disklessStartOffset == PartitionRegistration.NO_DISKLESS_START_OFFSET &&
+              partitionRegistration.disklessStartOffset >= 0
+          }
+
+          val tp = new TopicPartition(topicName, partitionId)
+          if (shouldInitOnControlPlane) {
+            onlinePartition(tp) match {
+              case Some(partition) if partition.isLeader =>
+                val producerStates = partitionRegistration.disklessProducerStates.asScala.map { producerState =>
+                  new InitDisklessLogProducerState(
+                    producerState.producerId(),
+                    producerState.producerEpoch(),
+                    producerState.baseSequence(),
+                    producerState.lastSequence(),
+                    producerState.assignedOffset(),
+                    producerState.batchMaxTimestamp()
+                  )
+                }.asJava
+                manager.initOnControlPlane(
+                  partition = partition,
+                  topicId = topicId,
+                  topicName = topicName,
+                  disklessStartOffset = partitionRegistration.disklessStartOffset,
+                  producerStates = producerStates
+                )
+              case Some(_) =>
+                stateChangeLogger.info(
+                  s"Skipping diskless init on control plane for $tp because the partition is not a local leader."
+                )
+              case None =>
+                stateChangeLogger.info(
+                  s"Skipping diskless init on control plane for $tp because the partition is not online locally."
+                )
+            }
+          }
+        }
       }
     }
   }

--- a/core/src/test/java/kafka/server/InklessTopicTypeSwitcherClusterTest.java
+++ b/core/src/test/java/kafka/server/InklessTopicTypeSwitcherClusterTest.java
@@ -1,0 +1,389 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.server;
+
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AlterConfigOp;
+import org.apache.kafka.clients.admin.ConfigEntry;
+import org.apache.kafka.clients.admin.CreateTopicsResult;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.config.ConfigResource;
+import org.apache.kafka.common.config.TopicConfig;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.test.KafkaClusterTestKit;
+import org.apache.kafka.common.test.TestKitNodes;
+import org.apache.kafka.coordinator.group.GroupCoordinatorConfig;
+import org.apache.kafka.server.config.ReplicationConfigs;
+import org.apache.kafka.server.config.ServerConfigs;
+import org.apache.kafka.server.log.remote.storage.RemoteLogManagerConfig;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.aiven.inkless.config.InklessConfig;
+import io.aiven.inkless.control_plane.postgres.PostgresControlPlane;
+import io.aiven.inkless.control_plane.postgres.PostgresControlPlaneConfig;
+import io.aiven.inkless.storage_backend.s3.S3Storage;
+import io.aiven.inkless.storage_backend.s3.S3StorageConfig;
+import io.aiven.inkless.test_utils.InklessPostgreSQLContainer;
+import io.aiven.inkless.test_utils.MinioContainer;
+import io.aiven.inkless.test_utils.PostgreSQLTestContainer;
+import io.aiven.inkless.test_utils.S3TestContainer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Testcontainers
+public class InklessTopicTypeSwitcherClusterTest {
+    @Container
+    protected static InklessPostgreSQLContainer pgContainer = PostgreSQLTestContainer.container();
+    @Container
+    protected static MinioContainer s3Container = S3TestContainer.minio();
+
+    private static final Logger log = LoggerFactory.getLogger(InklessTopicTypeSwitcherClusterTest.class);
+    private static final int NUM_PARTITIONS = 3;
+    private static final int MAX_PRODUCE_RETRIES = 6;
+    private static final int PRODUCE_RETRY_BACKOFF_MS = 250;
+    private static final Duration PRODUCE_SEND_TIMEOUT = Duration.ofSeconds(5);
+
+    private KafkaClusterTestKit cluster;
+
+    @BeforeEach
+    public void setup(final TestInfo testInfo) throws Exception {
+        log.warn("[stage=setup] Initializing containers and 3-broker cluster");
+        s3Container.createBucket(testInfo);
+        pgContainer.createDatabase(testInfo);
+
+        final Map<Integer, Map<String, String>> perServerProps = Map.of(
+            0, Map.of(ServerConfigs.BROKER_RACK_CONFIG, "az1"),
+            1, Map.of(ServerConfigs.BROKER_RACK_CONFIG, "az2"),
+            2, Map.of(ServerConfigs.BROKER_RACK_CONFIG, "az3")
+        );
+
+        final TestKitNodes nodes = new TestKitNodes.Builder()
+            .setCombined(true)
+            .setNumBrokerNodes(3)
+            .setNumControllerNodes(1)
+            .setPerServerProperties(perServerProps)
+            .build();
+
+        cluster = new KafkaClusterTestKit.Builder(nodes)
+            .setConfigProp(GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, "1")
+            .setConfigProp(ServerConfigs.DISKLESS_STORAGE_SYSTEM_ENABLE_CONFIG, "true")
+            .setConfigProp(ServerConfigs.DISKLESS_MANAGED_REPLICAS_ENABLE_CONFIG, "true")
+            .setConfigProp(ServerConfigs.DISKLESS_ALLOW_FROM_CLASSIC_ENABLE_CONFIG, "true")
+            .setConfigProp(RemoteLogManagerConfig.REMOTE_LOG_STORAGE_SYSTEM_ENABLE_PROP, "true")
+            .setConfigProp(RemoteLogManagerConfig.REMOTE_STORAGE_MANAGER_CLASS_NAME_PROP, "org.apache.kafka.server.log.remote.storage.NoOpRemoteStorageManager")
+            .setConfigProp(RemoteLogManagerConfig.REMOTE_LOG_METADATA_MANAGER_CLASS_NAME_PROP, "org.apache.kafka.server.log.remote.storage.NoOpRemoteLogMetadataManager")
+            .setConfigProp(ReplicationConfigs.DEFAULT_REPLICATION_FACTOR_CONFIG, "3")
+            .setConfigProp(InklessConfig.PREFIX + InklessConfig.CONTROL_PLANE_CLASS_CONFIG, PostgresControlPlane.class.getName())
+            .setConfigProp(InklessConfig.PREFIX + InklessConfig.CONTROL_PLANE_PREFIX + PostgresControlPlaneConfig.CONNECTION_STRING_CONFIG, pgContainer.getJdbcUrl())
+            .setConfigProp(InklessConfig.PREFIX + InklessConfig.CONTROL_PLANE_PREFIX + PostgresControlPlaneConfig.USERNAME_CONFIG, PostgreSQLTestContainer.USERNAME)
+            .setConfigProp(InklessConfig.PREFIX + InklessConfig.CONTROL_PLANE_PREFIX + PostgresControlPlaneConfig.PASSWORD_CONFIG, PostgreSQLTestContainer.PASSWORD)
+            .setConfigProp(InklessConfig.PREFIX + InklessConfig.STORAGE_BACKEND_CLASS_CONFIG, S3Storage.class.getName())
+            .setConfigProp(InklessConfig.PREFIX + InklessConfig.STORAGE_PREFIX + S3StorageConfig.S3_BUCKET_NAME_CONFIG, s3Container.getBucketName())
+            .setConfigProp(InklessConfig.PREFIX + InklessConfig.STORAGE_PREFIX + S3StorageConfig.S3_REGION_CONFIG, s3Container.getRegion())
+            .setConfigProp(InklessConfig.PREFIX + InklessConfig.STORAGE_PREFIX + S3StorageConfig.S3_ENDPOINT_URL_CONFIG, s3Container.getEndpoint())
+            .setConfigProp(InklessConfig.PREFIX + InklessConfig.STORAGE_PREFIX + S3StorageConfig.S3_PATH_STYLE_ENABLED_CONFIG, "true")
+            .setConfigProp(InklessConfig.PREFIX + InklessConfig.STORAGE_PREFIX + S3StorageConfig.AWS_ACCESS_KEY_ID_CONFIG, s3Container.getAccessKey())
+            .setConfigProp(InklessConfig.PREFIX + InklessConfig.STORAGE_PREFIX + S3StorageConfig.AWS_SECRET_ACCESS_KEY_CONFIG, s3Container.getSecretKey())
+            .build();
+
+        cluster.format();
+        cluster.startup();
+        cluster.waitForReadyBrokers();
+        log.warn("[stage=setup] Cluster is ready. bootstrapServers={}", cluster.bootstrapServers());
+    }
+
+    @AfterEach
+    public void teardown() throws Exception {
+        log.warn("[stage=teardown] Closing cluster");
+        cluster.close();
+    }
+
+    @Test
+    public void migrateClassicTopicToDiskless() throws Exception {
+        final String topicSuffix = UUID.randomUUID().toString().substring(0, 8);
+        final String disklessTopic = "diskless-" + topicSuffix;
+        final String classicTopic = "classic-" + topicSuffix;
+        final String classicToDisklessTopic = "classic-to-diskless-" + topicSuffix;
+        final List<String> topics = List.of(disklessTopic, classicTopic, classicToDisklessTopic);
+        final Map<String, Integer> producedCounts = new HashMap<>();
+        producedCounts.put(disklessTopic, 0);
+        producedCounts.put(classicTopic, 0);
+        producedCounts.put(classicToDisklessTopic, 0);
+
+        final Map<String, Object> adminConfigs = baseClientConfigs();
+        final Map<String, Object> producerConfigs = producerConfigs();
+        log.warn("[stage=test-start] topics: diskless={}, classic={}, migrating={}", disklessTopic, classicTopic, classicToDisklessTopic);
+
+        try (Admin admin = AdminClient.create(adminConfigs)) {
+            final NewTopic diskless = new NewTopic(disklessTopic, NUM_PARTITIONS, (short) -1)
+                .configs(Map.of(TopicConfig.DISKLESS_ENABLE_CONFIG, "true"));
+            final NewTopic classic = new NewTopic(classicTopic, NUM_PARTITIONS, (short) 3)
+                .configs(Map.of(TopicConfig.DISKLESS_ENABLE_CONFIG, "false"));
+            final NewTopic classicToDiskless = new NewTopic(classicToDisklessTopic, NUM_PARTITIONS, (short) 3)
+                .configs(Map.of(TopicConfig.DISKLESS_ENABLE_CONFIG, "false"));
+
+            final CreateTopicsResult createTopics = admin.createTopics(List.of(diskless, classic, classicToDiskless));
+            createTopics.all().get(30, TimeUnit.SECONDS);
+            log.warn("[stage=topics-created] Created all topics");
+
+            assertEquals("true", getTopicConfig(admin, disklessTopic).get(TopicConfig.DISKLESS_ENABLE_CONFIG));
+            assertEquals("false", getTopicConfig(admin, classicTopic).get(TopicConfig.DISKLESS_ENABLE_CONFIG));
+            assertEquals("false", getTopicConfig(admin, classicToDisklessTopic).get(TopicConfig.DISKLESS_ENABLE_CONFIG));
+
+            final AtomicBoolean keepProducing = new AtomicBoolean(true);
+            final AtomicReference<Throwable> producerFailure = new AtomicReference<>(null);
+            final CountDownLatch producerStarted = new CountDownLatch(1);
+
+            final Thread producerThread = new Thread(() -> {
+                try (Producer<byte[], byte[]> producer = new KafkaProducer<>(producerConfigs)) {
+                    log.warn("[stage=pre-migration-produce] Producing baseline records to all topics");
+                    produceRounds(producer, topics, producedCounts, 12, true);
+                    producerStarted.countDown();
+
+                    log.warn("[stage=during-migration-produce] Continuing produces during migration");
+                    while (keepProducing.get()) {
+                        produceRounds(producer, topics, producedCounts, 1, false);
+                    }
+                } catch (Throwable t) {
+                    producerFailure.set(t);
+                    producerStarted.countDown();
+                }
+            }, "migration-producer-thread");
+
+            producerThread.start();
+            assertTrue(producerStarted.await(30, TimeUnit.SECONDS), "Producer thread did not finish baseline production in time");
+
+            try {
+                log.warn("[stage=migration-start] Enabling diskless for topic={}", classicToDisklessTopic);
+                alterTopicConfig(admin, classicToDisklessTopic, Map.of(TopicConfig.DISKLESS_ENABLE_CONFIG, "true"));
+
+                log.warn("[stage=await-migration] Waiting for diskless.enable=true on topic={}", classicToDisklessTopic);
+                waitForTopicDisklessValue(admin, classicToDisklessTopic, "true");
+            } finally {
+                keepProducing.set(false);
+                producerThread.join(TimeUnit.SECONDS.toMillis(60));
+            }
+
+            assertTrue(!producerThread.isAlive(), "Producer thread did not stop in time");
+            if (producerFailure.get() != null) {
+                throw new RuntimeException("Producer thread failed", producerFailure.get());
+            }
+
+            assertEquals("true", getTopicConfig(admin, disklessTopic).get(TopicConfig.DISKLESS_ENABLE_CONFIG));
+            assertEquals("false", getTopicConfig(admin, classicTopic).get(TopicConfig.DISKLESS_ENABLE_CONFIG));
+            assertEquals("true", getTopicConfig(admin, classicToDisklessTopic).get(TopicConfig.DISKLESS_ENABLE_CONFIG));
+            log.warn("[stage=post-migration-validated] Topic configurations and placement checks passed");
+        }
+
+        log.warn("[stage=consume-verify] Produced counts before consume verification={}", producedCounts);
+        consumeAndAssertTopicCounts(baseConsumerConfigs(), topics, producedCounts);
+    }
+
+    private Map<String, Object> baseClientConfigs() {
+        final Map<String, Object> configs = new HashMap<>();
+        configs.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers());
+        configs.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
+        configs.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
+        configs.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
+        configs.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
+        return configs;
+    }
+
+    private Map<String, Object> producerConfigs() {
+        final Map<String, Object> configs = baseClientConfigs();
+        configs.put(ProducerConfig.ACKS_CONFIG, "all");
+        configs.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, "true");
+        configs.put(ProducerConfig.RETRIES_CONFIG, Integer.toString(Integer.MAX_VALUE));
+        configs.put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, "5");
+        return configs;
+    }
+
+    private Map<String, Object> baseConsumerConfigs() {
+        final Map<String, Object> configs = baseClientConfigs();
+        configs.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        configs.put(ConsumerConfig.GROUP_ID_CONFIG, "it-group-" + UUID.randomUUID());
+        return configs;
+    }
+
+    private void produceRounds(final Producer<byte[], byte[]> producer,
+                               final List<String> topics,
+                               final Map<String, Integer> producedCounts,
+                               final int rounds,
+                               final boolean failOnExhaustedRetries) throws Exception {
+        log.warn("[stage=produce-rounds] rounds={}, failOnExhaustedRetries={}, topics={}",
+            rounds, failOnExhaustedRetries, topics);
+        for (int i = 0; i < rounds; i++) {
+            for (String topic : topics) {
+                final int partition = i % NUM_PARTITIONS;
+                final byte[] value = (topic + "-value-" + i).getBytes(StandardCharsets.UTF_8);
+                final boolean sent = sendWithRetry(producer, new ProducerRecord<>(topic, partition, null, value));
+                if (!sent && failOnExhaustedRetries) {
+                    throw new RuntimeException("Exhausted producer retries for topic " + topic);
+                }
+                if (sent) {
+                    producedCounts.compute(topic, (k, v) -> v == null ? 1 : v + 1);
+                }
+            }
+        }
+        producer.flush();
+        log.warn("[stage=produce-rounds] completed rounds={}, currentProducedCounts={}", rounds, producedCounts);
+    }
+
+    private boolean sendWithRetry(final Producer<byte[], byte[]> producer,
+                                  final ProducerRecord<byte[], byte[]> record) throws Exception {
+        Exception latest = null;
+        for (int attempt = 1; attempt <= MAX_PRODUCE_RETRIES; attempt++) {
+            try {
+                producer.send(record).get(PRODUCE_SEND_TIMEOUT.toSeconds(), TimeUnit.SECONDS);
+                return true;
+            } catch (Exception e) {
+                latest = e;
+                log.warn("Producer send failed for topic={}, partition={}, attempt={}/{}",
+                    record.topic(), record.partition(), attempt, MAX_PRODUCE_RETRIES, e);
+                Thread.sleep(PRODUCE_RETRY_BACKOFF_MS);
+            }
+        }
+        log.warn("Exhausted producer retries for topic={}, partition={}", record.topic(), record.partition(), latest);
+        return false;
+    }
+
+    private void consumeAndAssertTopicCounts(final Map<String, Object> consumerConfigs,
+                                             final List<String> topics,
+                                             final Map<String, Integer> expectedCounts) {
+        final Map<String, Integer> consumedCounts = new HashMap<>();
+        topics.forEach(topic -> consumedCounts.put(topic, 0));
+        log.warn("[stage=consume-start] topics={}, expectedCounts={}", topics, expectedCounts);
+
+        try (Consumer<byte[], byte[]> consumer = new KafkaConsumer<>(consumerConfigs)) {
+            consumer.subscribe(topics);
+            final long deadline = System.currentTimeMillis() + Duration.ofSeconds(90).toMillis();
+
+            while (System.currentTimeMillis() < deadline) {
+                final ConsumerRecords<byte[], byte[]> records = consumer.poll(Duration.ofSeconds(1));
+                for (ConsumerRecord<byte[], byte[]> record : records) {
+                    consumedCounts.compute(record.topic(), (k, v) -> v == null ? 1 : v + 1);
+                }
+
+                if (hasReachedExpected(consumedCounts, expectedCounts, topics)) {
+                    break;
+                }
+            }
+        }
+        log.warn("[stage=consume-end] consumedCounts={}", consumedCounts);
+
+        for (String topic : topics) {
+            final int expected = expectedCounts.getOrDefault(topic, 0);
+            final int actual = consumedCounts.getOrDefault(topic, 0);
+            if (expected > 0) {
+                assertTrue(actual >= expected,
+                    "Expected to consume at least " + expected + " record(s) from topic "
+                        + topic + " after producing to it, but consumed " + actual);
+            }
+        }
+    }
+
+    private boolean hasReachedExpected(final Map<String, Integer> consumedCounts,
+                                       final Map<String, Integer> expectedCounts,
+                                       final List<String> topics) {
+        for (String topic : topics) {
+            if (consumedCounts.getOrDefault(topic, 0) < expectedCounts.getOrDefault(topic, 0)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private void waitForTopicDisklessValue(final Admin admin,
+                                           final String topic,
+                                           final String expectedValue) throws Exception {
+        final long deadline = System.currentTimeMillis() + Duration.ofSeconds(60).toMillis();
+        while (System.currentTimeMillis() < deadline) {
+            final String disklessValue = getTopicConfig(admin, topic).get(TopicConfig.DISKLESS_ENABLE_CONFIG);
+            if (expectedValue.equals(disklessValue)) {
+                return;
+            }
+            Thread.sleep(500);
+        }
+        assertEquals(expectedValue, getTopicConfig(admin, topic).get(TopicConfig.DISKLESS_ENABLE_CONFIG));
+    }
+
+    private void alterTopicConfig(final Admin admin,
+                                  final String topic,
+                                  final Map<String, String> newConfigs) throws Exception {
+        final ConfigResource topicResource = new ConfigResource(ConfigResource.Type.TOPIC, topic);
+        final Collection<AlterConfigOp> operations = newConfigs.entrySet().stream()
+            .map(entry -> new AlterConfigOp(new ConfigEntry(entry.getKey(), entry.getValue()), AlterConfigOp.OpType.SET))
+            .toList();
+        admin.incrementalAlterConfigs(Map.of(topicResource, operations)).all().get(20, TimeUnit.SECONDS);
+    }
+
+    private Map<String, String> getTopicConfig(final Admin admin, final String topic) throws Exception {
+        int maxRetries = 5;
+        long retryDelayMs = 1000;
+        for (int attempt = 1; attempt <= maxRetries; attempt++) {
+            try {
+                final ConfigResource topicResource = new ConfigResource(ConfigResource.Type.TOPIC, topic);
+                final var configsResult = admin.describeConfigs(Collections.singletonList(topicResource));
+                final var allConfigs = configsResult.all().get(10, TimeUnit.SECONDS);
+                final Map<String, String> topicConfigs = new HashMap<>();
+                allConfigs.get(topicResource).entries().forEach(entry -> topicConfigs.put(entry.name(), entry.value()));
+                return topicConfigs;
+            } catch (ExecutionException e) {
+                if (attempt == maxRetries) {
+                    throw e;
+                }
+                Thread.sleep(retryDelayMs);
+            }
+        }
+        throw new IllegalStateException("Exited retry loop unexpectedly.");
+    }
+}

--- a/core/src/test/scala/unit/kafka/server/InitDisklessLogManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/InitDisklessLogManagerTest.scala
@@ -16,6 +16,7 @@
  */
 package kafka.server
 
+import io.aiven.inkless.control_plane.{ControlPlane, InitDisklessLogProducerState => CpProducerState, InitDisklessLogResponse => CpInitResponse}
 import kafka.cluster.Partition
 import org.apache.kafka.clients.ClientResponse
 import org.apache.kafka.common.{TopicPartition, Uuid}
@@ -47,6 +48,7 @@ class InitDisklessLogManagerTest {
   private val tp0 = new TopicPartition("test-topic", 0)
 
   private var channelManager: MockInitDisklessLogChannelManager = _
+  private var controlPlane: ControlPlane = _
   private var mockTime: MockTime = _
   private var scheduler: MockScheduler = _
   private var manager: InitDisklessLogManager = _
@@ -55,11 +57,13 @@ class InitDisklessLogManagerTest {
   @BeforeEach
   def setUp(): Unit = {
     channelManager = new MockInitDisklessLogChannelManager()
+    controlPlane = mock(classOf[ControlPlane])
     mockTime = new MockTime()
     scheduler = new MockScheduler(mockTime)
     listenersByTp = mutable.Map.empty
     manager = new InitDisklessLogManager(
       controllerChannelManager = channelManager,
+      controlPlane = controlPlane,
       scheduler = scheduler,
       brokerId = brokerId,
       brokerEpochSupplier = () => brokerEpoch
@@ -912,6 +916,94 @@ class InitDisklessLogManagerTest {
             .setErrorCode(error.code())
         ))
     ))
+  }
+
+  @Test
+  def testMetadataAppliedCallsControlPlaneAndRemovesTracking(): Unit = {
+    val partition = mockPartition(hw = 100, leo = 100)
+    when(controlPlane.initDisklessLog(any())).thenReturn(util.List.of(CpInitResponse.success()))
+
+    manager.initOnControlPlane(
+      partition = partition,
+      topicId = topicId,
+      topicName = tp0.topic(),
+      disklessStartOffset = 100L,
+      producerStates = util.List.of(new CpProducerState(1L, 0.toShort, 0, 1, 100L, 1000L))
+    )
+
+    scheduler.tick()
+
+    verify(controlPlane).initDisklessLog(any())
+    assertTrue(manager.getTrackedPartitions.isEmpty)
+  }
+
+  @Test
+  def testMetadataAppliedAlreadyInitializedIsTerminalSuccess(): Unit = {
+    val partition = mockPartition(hw = 100, leo = 100)
+    when(controlPlane.initDisklessLog(any())).thenReturn(util.List.of(CpInitResponse.alreadyInitialized()))
+
+    manager.initOnControlPlane(
+      partition = partition,
+      topicId = topicId,
+      topicName = tp0.topic(),
+      disklessStartOffset = 100L,
+      producerStates = util.List.of()
+    )
+
+    scheduler.tick()
+
+    verify(controlPlane).initDisklessLog(any())
+    assertTrue(manager.getTrackedPartitions.isEmpty)
+  }
+
+  @Test
+  def testMetadataAppliedRetriableErrorSchedulesRetry(): Unit = {
+    val partition = mockPartition(hw = 100, leo = 100)
+    when(controlPlane.initDisklessLog(any()))
+      .thenReturn(util.List.of(new CpInitResponse(Errors.NOT_CONTROLLER)))
+      .thenReturn(util.List.of(CpInitResponse.success()))
+
+    manager.initOnControlPlane(
+      partition = partition,
+      topicId = topicId,
+      topicName = tp0.topic(),
+      disklessStartOffset = 100L,
+      producerStates = util.List.of()
+    )
+
+    scheduler.tick()
+    assertState[AwaitingMetadata](tp0)
+    verify(controlPlane, times(1)).initDisklessLog(any())
+
+    fireRetry()
+    verify(controlPlane, times(2)).initDisklessLog(any())
+    assertTrue(manager.getTrackedPartitions.isEmpty)
+  }
+
+  @Test
+  def testMetadataAppliedRepeatedCallbackIsIdempotent(): Unit = {
+    val partition = mockPartition(hw = 100, leo = 100)
+    when(controlPlane.initDisklessLog(any())).thenReturn(util.List.of(CpInitResponse.success()))
+
+    manager.initOnControlPlane(
+      partition = partition,
+      topicId = topicId,
+      topicName = tp0.topic(),
+      disklessStartOffset = 100L,
+      producerStates = util.List.of()
+    )
+    manager.initOnControlPlane(
+      partition = partition,
+      topicId = topicId,
+      topicName = tp0.topic(),
+      disklessStartOffset = 100L,
+      producerStates = util.List.of()
+    )
+
+    scheduler.tick()
+
+    verify(controlPlane, atLeastOnce()).initDisklessLog(any())
+    assertTrue(manager.getTrackedPartitions.isEmpty)
   }
 }
 

--- a/core/src/test/scala/unit/kafka/server/InitDisklessLogManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/InitDisklessLogManagerTest.scala
@@ -931,7 +931,7 @@ class InitDisklessLogManagerTest {
       producerStates = util.List.of(new CpProducerState(1L, 0.toShort, 0, 1, 100L, 1000L))
     )
 
-    scheduler.tick()
+    fireLinger()
 
     verify(controlPlane).initDisklessLog(any())
     assertTrue(manager.getTrackedPartitions.isEmpty)
@@ -950,7 +950,7 @@ class InitDisklessLogManagerTest {
       producerStates = util.List.of()
     )
 
-    scheduler.tick()
+    fireLinger()
 
     verify(controlPlane).initDisklessLog(any())
     assertTrue(manager.getTrackedPartitions.isEmpty)
@@ -971,7 +971,7 @@ class InitDisklessLogManagerTest {
       producerStates = util.List.of()
     )
 
-    scheduler.tick()
+    fireLinger()
     assertState[AwaitingMetadata](tp0)
     verify(controlPlane, times(1)).initDisklessLog(any())
 
@@ -981,7 +981,7 @@ class InitDisklessLogManagerTest {
   }
 
   @Test
-  def testMetadataAppliedRepeatedCallbackIsIdempotent(): Unit = {
+  def testMetadataAppliedRepeatedCallbacksAreDeduplicated(): Unit = {
     val partition = mockPartition(hw = 100, leo = 100)
     when(controlPlane.initDisklessLog(any())).thenReturn(util.List.of(CpInitResponse.success()))
 
@@ -1000,9 +1000,9 @@ class InitDisklessLogManagerTest {
       producerStates = util.List.of()
     )
 
-    scheduler.tick()
+    fireLinger()
 
-    verify(controlPlane, atLeastOnce()).initDisklessLog(any())
+    verify(controlPlane, times(1)).initDisklessLog(any())
     assertTrue(manager.getTrackedPartitions.isEmpty)
   }
 }

--- a/core/src/test/scala/unit/kafka/server/metadata/InitDisklessLogFlowTest.scala
+++ b/core/src/test/scala/unit/kafka/server/metadata/InitDisklessLogFlowTest.scala
@@ -120,6 +120,7 @@ class InitDisklessLogFlowTest {
       pcrDelta.replay(pcr)
       val pcrImage = withClusterBrokers(pcrDelta.apply(MetadataProvenance.EMPTY))
       ctx.metadataPublisher.onMetadataUpdate(pcrDelta, pcrImage, metadataManifest())
+      ctx.time.sleep(ctx.initDisklessLogManager.lingerMs)
       ctx.scheduler.tick()
 
       // Final check: metadata-triggered control-plane init executed.
@@ -605,6 +606,7 @@ class InitDisklessLogFlowTest {
       val pcrImage = withClusterBrokers(pcrDelta.apply(MetadataProvenance.EMPTY))
       ctx.metadataPublisher.onMetadataUpdate(pcrDelta, pcrImage, metadataManifest())
 
+      ctx.time.sleep(ctx.initDisklessLogManager.lingerMs)
       ctx.scheduler.tick()
 
       verify(ctx.controlPlane, times(1)).initDisklessLog(any())
@@ -674,6 +676,8 @@ class InitDisklessLogFlowTest {
       broker0Ctx.metadataPublisher.onMetadataUpdate(pcrDelta, pcrImage, metadataManifest())
       broker1Ctx.metadataPublisher.onMetadataUpdate(pcrDelta, pcrImage, metadataManifest())
 
+      broker0Ctx.time.sleep(broker0Ctx.initDisklessLogManager.lingerMs)
+      broker1Ctx.time.sleep(broker1Ctx.initDisklessLogManager.lingerMs)
       broker0Ctx.scheduler.tick()
       broker1Ctx.scheduler.tick()
 

--- a/core/src/test/scala/unit/kafka/server/metadata/InitDisklessLogFlowTest.scala
+++ b/core/src/test/scala/unit/kafka/server/metadata/InitDisklessLogFlowTest.scala
@@ -17,10 +17,11 @@
 
 package kafka.server.metadata
 
+import io.aiven.inkless.control_plane.{ControlPlane, InitDisklessLogResponse => CpInitResponse}
 import kafka.coordinator.transaction.TransactionCoordinator
 import kafka.log.LogManager
 import kafka.server.QuotaFactory.QuotaManagers
-import kafka.server.{HostedPartition, InitDisklessLogManager, InitDisklessLogState, MockInitDisklessLogChannelManager, ReplicaManager, SendingToController}
+import kafka.server.{AwaitingMetadata, HostedPartition, InitDisklessLogManager, InitDisklessLogState, MockInitDisklessLogChannelManager, ReplicaManager, SendingToController}
 import kafka.server.share.SharePartitionManager
 import kafka.utils.TestUtils
 import org.apache.kafka.common.{Node, TopicPartition, Uuid}
@@ -28,6 +29,7 @@ import org.apache.kafka.common.config.{ConfigResource, TopicConfig}
 import org.apache.kafka.common.metadata.{ConfigRecord, PartitionChangeRecord, PartitionRecord, TopicRecord}
 import org.apache.kafka.image.{AclsImage, ClientQuotasImage, ClusterImageTest, ConfigurationsImage, DelegationTokenImage, FeaturesImage, MetadataDelta, MetadataImage, MetadataProvenance, ProducerIdsImage, ScramImage, TopicsDelta, TopicsImage}
 import org.apache.kafka.image.loader.LogDeltaManifest
+import org.apache.kafka.metadata.InitDisklessLogFields
 import org.apache.kafka.metadata.publisher.{AclPublisher, DelegationTokenPublisher, DynamicClientQuotaPublisher, ScramPublisher}
 import org.apache.kafka.raft.LeaderAndEpoch
 import org.apache.kafka.server.common.MetadataVersion
@@ -37,7 +39,7 @@ import org.apache.kafka.storage.internals.log.{LogConfig, LogDirFailureChannel}
 import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertTrue}
 import org.junit.jupiter.api.Test
 import org.mockito.ArgumentMatchers.{any, anyString}
-import org.mockito.Mockito.{mock, when}
+import org.mockito.Mockito.{mock, times, verify, when}
 
 import java.util
 import scala.jdk.CollectionConverters._
@@ -51,10 +53,81 @@ class InitDisklessLogFlowTest {
     replicaManager: ReplicaManager,
     initDisklessLogManager: InitDisklessLogManager,
     metadataPublisher: BrokerMetadataPublisher,
+    controlPlane: ControlPlane,
     channelManager: MockInitDisklessLogChannelManager,
     time: MockTime,
     scheduler: MockScheduler
   )
+
+  @Test
+  def testEndToEndFlowFromSealingToControlPlaneInit(): Unit = {
+    val ctx = newContext()
+    val topicName = "integration-e2e-seal-to-control-plane-init"
+    val topicId = Uuid.randomUuid()
+    val tp = new TopicPartition(topicName, 0)
+
+    when(ctx.replicaManager.inklessMetadataView().isDisklessTopic(anyString())).thenReturn(false)
+
+    try {
+      val createDelta = new TopicsDelta(TopicsImage.EMPTY)
+      createDelta.replay(new TopicRecord().setName(topicName).setTopicId(topicId))
+      createDelta.replay(new PartitionRecord()
+        .setTopicId(topicId).setPartitionId(0).setReplicas(util.Arrays.asList(0, 1))
+        .setIsr(util.Arrays.asList(0, 1)).setLeader(ctx.config.brokerId)
+        .setLeaderEpoch(0).setPartitionEpoch(0))
+      val createImage = imageFromTopics(createDelta.apply())
+      ctx.replicaManager.applyDelta(createDelta, createImage)
+
+      val partition = ctx.replicaManager.getPartitionOrException(tp)
+      assertFalse(partition.isSealed)
+
+      // Step 1: enable diskless and trigger sealing + controller init request path.
+      ctx.metadataPublisher._firstPublish = false
+      when(ctx.replicaManager.inklessMetadataView().isDisklessTopic(topicName)).thenReturn(true)
+      val enableDisklessDelta = new MetadataDelta(createImage)
+      enableDisklessDelta.replay(new ConfigRecord()
+        .setResourceType(ConfigResource.Type.TOPIC.id())
+        .setResourceName(topicName)
+        .setName(TopicConfig.DISKLESS_ENABLE_CONFIG)
+        .setValue("true"))
+      val disklessImage = withClusterBrokers(enableDisklessDelta.apply(MetadataProvenance.EMPTY))
+      ctx.metadataPublisher.onMetadataUpdate(enableDisklessDelta, disklessImage, metadataManifest())
+
+      ctx.time.sleep(ctx.initDisklessLogManager.lingerMs)
+      ctx.scheduler.tick()
+      assertTrue(partition.isSealed)
+      assertEquals(1, ctx.channelManager.requests.size())
+
+      // Simulate successful controller response.
+      ctx.channelManager.requests.poll().complete(new org.apache.kafka.common.message.InitDisklessLogResponseData().setTopics(util.List.of(
+        new org.apache.kafka.common.message.InitDisklessLogResponseData.TopicResponse()
+          .setTopicId(topicId)
+          .setPartitions(util.List.of(
+            new org.apache.kafka.common.message.InitDisklessLogResponseData.PartitionResponse()
+              .setPartitionId(0)
+              .setErrorCode(org.apache.kafka.common.protocol.Errors.NONE.code())
+          ))
+      )))
+
+      // Step 2: apply committed PartitionChangeRecord with diskless fields.
+      val pcrDelta = new MetadataDelta(disklessImage)
+      val pcr = new PartitionChangeRecord()
+        .setTopicId(topicId)
+        .setPartitionId(0)
+        .setIsr(util.Arrays.asList(0, 1))
+      pcr.unknownTaggedFields().add(InitDisklessLogFields.encodeDisklessStartOffset(100L))
+      pcr.unknownTaggedFields().add(InitDisklessLogFields.encodeProducerStates(util.List.of()))
+      pcrDelta.replay(pcr)
+      val pcrImage = withClusterBrokers(pcrDelta.apply(MetadataProvenance.EMPTY))
+      ctx.metadataPublisher.onMetadataUpdate(pcrDelta, pcrImage, metadataManifest())
+      ctx.scheduler.tick()
+
+      // Final check: metadata-triggered control-plane init executed.
+      verify(ctx.controlPlane, times(1)).initDisklessLog(any())
+    } finally {
+      shutdown(ctx)
+    }
+  }
 
   @Test
   def testOnMetadataUpdateSealsAndRegistersExistingClassicLeader(): Unit = {
@@ -477,6 +550,141 @@ class InitDisklessLogFlowTest {
     }
   }
 
+  @Test
+  def testOnMetadataUpdatePartitionChangeRecordWithDisklessFieldsTriggersControlPlaneInit(): Unit = {
+    val ctx = newContext()
+    val topicName = "integration-diskless-pcr-triggers-control-plane"
+    val topicId = Uuid.randomUuid()
+    val tp = new TopicPartition(topicName, 0)
+
+    when(ctx.replicaManager.inklessMetadataView().isDisklessTopic(anyString())).thenReturn(false)
+
+    try {
+      val createDelta = new TopicsDelta(TopicsImage.EMPTY)
+      createDelta.replay(new TopicRecord().setName(topicName).setTopicId(topicId))
+      createDelta.replay(new PartitionRecord()
+        .setTopicId(topicId).setPartitionId(0).setReplicas(util.Arrays.asList(0, 1))
+        .setIsr(util.Arrays.asList(0, 1)).setLeader(ctx.config.brokerId)
+        .setLeaderEpoch(0).setPartitionEpoch(0))
+      val createImage = imageFromTopics(createDelta.apply())
+      ctx.replicaManager.applyDelta(createDelta, createImage)
+
+      ctx.metadataPublisher._firstPublish = false
+      when(ctx.replicaManager.inklessMetadataView().isDisklessTopic(topicName)).thenReturn(true)
+      val disklessDelta = new MetadataDelta(createImage)
+      disklessDelta.replay(new ConfigRecord()
+        .setResourceType(ConfigResource.Type.TOPIC.id())
+        .setResourceName(topicName)
+        .setName(TopicConfig.DISKLESS_ENABLE_CONFIG)
+        .setValue("true"))
+      val disklessImage = withClusterBrokers(disklessDelta.apply(MetadataProvenance.EMPTY))
+      ctx.metadataPublisher.onMetadataUpdate(disklessDelta, disklessImage, metadataManifest())
+
+      ctx.time.sleep(ctx.initDisklessLogManager.lingerMs)
+      ctx.scheduler.tick()
+      assertEquals(1, ctx.channelManager.requests.size())
+      ctx.channelManager.requests.poll().complete(new org.apache.kafka.common.message.InitDisklessLogResponseData().setTopics(util.List.of(
+        new org.apache.kafka.common.message.InitDisklessLogResponseData.TopicResponse()
+          .setTopicId(topicId)
+          .setPartitions(util.List.of(
+            new org.apache.kafka.common.message.InitDisklessLogResponseData.PartitionResponse()
+              .setPartitionId(0)
+              .setErrorCode(org.apache.kafka.common.protocol.Errors.NONE.code())
+          ))
+      )))
+      assertTrackedStates(ctx, Map(tp -> classOf[AwaitingMetadata]))
+
+      val pcrDelta = new MetadataDelta(disklessImage)
+      val pcr = new PartitionChangeRecord()
+        .setTopicId(topicId)
+        .setPartitionId(0)
+        .setIsr(util.Arrays.asList(0, 1))
+      pcr.unknownTaggedFields().add(InitDisklessLogFields.encodeDisklessStartOffset(100L))
+      pcr.unknownTaggedFields().add(InitDisklessLogFields.encodeProducerStates(util.List.of()))
+      pcrDelta.replay(pcr)
+      val pcrImage = withClusterBrokers(pcrDelta.apply(MetadataProvenance.EMPTY))
+      ctx.metadataPublisher.onMetadataUpdate(pcrDelta, pcrImage, metadataManifest())
+
+      ctx.scheduler.tick()
+
+      verify(ctx.controlPlane, times(1)).initDisklessLog(any())
+      assertTrackedStates(ctx, Map.empty)
+      assertEquals(None, ctx.initDisklessLogManager.getInitState(tp))
+    } finally {
+      shutdown(ctx)
+    }
+  }
+
+  @Test
+  def testOnMetadataUpdateOnlyLeaderInvokesControlPlaneAfterCommittedMetadata(): Unit = {
+    val broker0Ctx = newContext(brokerId = 0)
+    val broker1Ctx = newContext(brokerId = 1)
+    val topicName = "integration-follower-can-init-control-plane"
+    val topicId = Uuid.randomUuid()
+
+    when(broker0Ctx.replicaManager.inklessMetadataView().isDisklessTopic(anyString())).thenReturn(false)
+    when(broker1Ctx.replicaManager.inklessMetadataView().isDisklessTopic(anyString())).thenReturn(false)
+
+    try {
+      val createDelta = new TopicsDelta(TopicsImage.EMPTY)
+      createDelta.replay(new TopicRecord().setName(topicName).setTopicId(topicId))
+      createDelta.replay(new PartitionRecord()
+        .setTopicId(topicId).setPartitionId(0).setReplicas(util.Arrays.asList(0, 1))
+        .setIsr(util.Arrays.asList(0, 1)).setLeader(0).setLeaderEpoch(0).setPartitionEpoch(0))
+      val createImage = imageFromTopics(createDelta.apply())
+      broker0Ctx.replicaManager.applyDelta(createDelta, createImage)
+      broker1Ctx.replicaManager.applyDelta(createDelta, createImage)
+
+      broker0Ctx.metadataPublisher._firstPublish = false
+      broker1Ctx.metadataPublisher._firstPublish = false
+      when(broker0Ctx.replicaManager.inklessMetadataView().isDisklessTopic(topicName)).thenReturn(true)
+      when(broker1Ctx.replicaManager.inklessMetadataView().isDisklessTopic(topicName)).thenReturn(true)
+      val disklessDelta = new MetadataDelta(createImage)
+      disklessDelta.replay(new ConfigRecord()
+        .setResourceType(ConfigResource.Type.TOPIC.id())
+        .setResourceName(topicName)
+        .setName(TopicConfig.DISKLESS_ENABLE_CONFIG)
+        .setValue("true"))
+      val disklessImage = withClusterBrokers(disklessDelta.apply(MetadataProvenance.EMPTY))
+      broker0Ctx.metadataPublisher.onMetadataUpdate(disklessDelta, disklessImage, metadataManifest())
+      broker1Ctx.metadataPublisher.onMetadataUpdate(disklessDelta, disklessImage, metadataManifest())
+
+      broker0Ctx.time.sleep(broker0Ctx.initDisklessLogManager.lingerMs)
+      broker0Ctx.scheduler.tick()
+      assertEquals(1, broker0Ctx.channelManager.requests.size())
+      broker0Ctx.channelManager.requests.poll().complete(new org.apache.kafka.common.message.InitDisklessLogResponseData().setTopics(util.List.of(
+        new org.apache.kafka.common.message.InitDisklessLogResponseData.TopicResponse()
+          .setTopicId(topicId)
+          .setPartitions(util.List.of(
+            new org.apache.kafka.common.message.InitDisklessLogResponseData.PartitionResponse()
+              .setPartitionId(0)
+              .setErrorCode(org.apache.kafka.common.protocol.Errors.NONE.code())
+          ))
+      )))
+
+      val pcrDelta = new MetadataDelta(disklessImage)
+      val pcr = new PartitionChangeRecord()
+        .setTopicId(topicId)
+        .setPartitionId(0)
+        .setIsr(util.Arrays.asList(0, 1))
+      pcr.unknownTaggedFields().add(InitDisklessLogFields.encodeDisklessStartOffset(100L))
+      pcr.unknownTaggedFields().add(InitDisklessLogFields.encodeProducerStates(util.List.of()))
+      pcrDelta.replay(pcr)
+      val pcrImage = withClusterBrokers(pcrDelta.apply(MetadataProvenance.EMPTY))
+      broker0Ctx.metadataPublisher.onMetadataUpdate(pcrDelta, pcrImage, metadataManifest())
+      broker1Ctx.metadataPublisher.onMetadataUpdate(pcrDelta, pcrImage, metadataManifest())
+
+      broker0Ctx.scheduler.tick()
+      broker1Ctx.scheduler.tick()
+
+      verify(broker0Ctx.controlPlane, times(1)).initDisklessLog(any())
+      verify(broker1Ctx.controlPlane, times(0)).initDisklessLog(any())
+    } finally {
+      shutdown(broker0Ctx)
+      shutdown(broker1Ctx)
+    }
+  }
+
   private def newContext(brokerId: Int = 0): TestContext = {
     val config = kafka.server.KafkaConfig.fromProps(TestUtils.createBrokerConfig(brokerId))
     val metadataCache = mock(classOf[KRaftMetadataCache])
@@ -488,8 +696,11 @@ class InitDisklessLogFlowTest {
     val time = new MockTime()
     val scheduler = new MockScheduler(time)
     val channelManager = new MockInitDisklessLogChannelManager()
+    val controlPlane = mock(classOf[ControlPlane])
+    when(controlPlane.initDisklessLog(any())).thenReturn(util.List.of(CpInitResponse.success()))
     val initDisklessLogManager = new InitDisklessLogManager(
       controllerChannelManager = channelManager,
+      controlPlane = controlPlane,
       scheduler = scheduler,
       brokerId = config.brokerId,
       brokerEpochSupplier = () => 1L
@@ -531,7 +742,7 @@ class InitDisklessLogFlowTest {
       faultHandler
     )
 
-    TestContext(config, metadataCache, logManager, replicaManager, initDisklessLogManager, metadataPublisher, channelManager, time, scheduler)
+    TestContext(config, metadataCache, logManager, replicaManager, initDisklessLogManager, metadataPublisher, controlPlane, channelManager, time, scheduler)
   }
 
   private def shutdown(ctx: TestContext): Unit = {


### PR DESCRIPTION
Complete the InitDisklessLogManager orchestration with the final transition from `AwaitingMetadata` to `Done`.