### PR TITLE
fix(inkless:migration): Fix InitDisklessLogManager gaps during partition registration

### DIFF
--- a/core/src/main/scala/kafka/server/InitDisklessLogManager.scala
+++ b/core/src/main/scala/kafka/server/InitDisklessLogManager.scala
@@ -65,7 +65,10 @@ class InitDisklessLogManager(
    */
   def registerPartition(partition: Partition, topicId: Uuid): Unit = {
     val waitingState = WaitingForReplication(partition, topicId, onPartitionUpdate = (tp, outcome) => {
-      tracked.computeIfPresent(tp, (_, _) => handleWaitingOutcome(tp, outcome))
+      tracked.computeIfPresent(tp, (_, currentState) => currentState match {
+        case _: WaitingForReplication => handleWaitingOutcome(tp, outcome)
+        case other => other
+      })
     })
 
     val tp = partition.topicPartition

--- a/core/src/main/scala/kafka/server/InitDisklessLogManager.scala
+++ b/core/src/main/scala/kafka/server/InitDisklessLogManager.scala
@@ -90,8 +90,13 @@ class InitDisklessLogManager(
     if (inserted) {
       Option(tracked.get(tp)).foreach {
         case waitingForReplication: WaitingForReplication =>
-          // Listener is only needed while still waiting for HW advancement.
           partition.maybeAddListener(waitingForReplication)
+          // Re-evaluate after adding the listener to catch HW updates that
+          // occurred between the initial maybeAdvanceState() and addListener().
+          tracked.computeIfPresent(tp, (_, currentState) => currentState match {
+            case w: WaitingForReplication => handleWaitingOutcome(tp, w.maybeAdvanceState())
+            case other => other
+          })
         case _ =>
       }
     }

--- a/core/src/test/scala/unit/kafka/server/InitDisklessLogManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/InitDisklessLogManagerTest.scala
@@ -859,6 +859,46 @@ class InitDisklessLogManagerTest {
   }
 
   @Test
+  def testHWCatchesUpBetweenCheckAndListenerRegistration(): Unit = {
+    // Simulate HW advancing to LEO between the initial maybeAdvanceState()
+    // check and the maybeAddListener() call, with no further HW updates.
+    val partition = mock(classOf[Partition])
+    val log = mock(classOf[UnifiedLog])
+    val producerStateManager = mock(classOf[ProducerStateManager])
+
+    when(partition.topicPartition).thenReturn(tp0)
+    when(partition.isSealed).thenReturn(true)
+    when(partition.isLeader).thenReturn(true)
+    when(partition.getLeaderEpoch).thenReturn(1)
+    when(partition.log).thenReturn(Some(log))
+    when(log.logEndOffset).thenReturn(100L)
+    when(log.producerStateManager()).thenReturn(producerStateManager)
+    when(producerStateManager.activeProducers()).thenReturn(new util.HashMap())
+
+    // HW starts below LEO for the initial evaluation
+    when(log.highWatermark).thenReturn(50L)
+
+    // When maybeAddListener is called, HW has caught up — simulating
+    // the race where replicas finish between check and listener registration
+    doAnswer { invocation =>
+      when(log.highWatermark).thenReturn(100L)
+      listenersByTp.put(tp0, invocation.getArgument[PartitionListener](0))
+      true
+    }.when(partition).maybeAddListener(any(classOf[PartitionListener]))
+
+    manager.registerPartition(partition, topicId)
+
+    // Then the partition advances to SendingToController despite no explicit
+    // HW listener callback, because the post-listener re-evaluation catches it
+    assertState[SendingToController](tp0)
+
+    // And the flow completes normally
+    fireLinger()
+    pollAndComplete(makeSuccessResponse(topicId, 0))
+    assertState[AwaitingMetadata](tp0)
+  }
+
+  @Test
   def testStaleListenerCallbackDoesNotRegressState(): Unit = {
     // Given a partition registered with HW < LEO (WaitingForReplication)
     val partition = mockPartition(hw = 50, leo = 100)

--- a/core/src/test/scala/unit/kafka/server/InitDisklessLogManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/InitDisklessLogManagerTest.scala
@@ -858,6 +858,56 @@ class InitDisklessLogManagerTest {
     assertState[AwaitingMetadata](tp1)
   }
 
+  @Test
+  def testStaleListenerCallbackDoesNotRegressState(): Unit = {
+    // Given a partition registered with HW < LEO (WaitingForReplication)
+    val partition = mockPartition(hw = 50, leo = 100)
+    manager.registerPartition(partition, topicId)
+    assertState[WaitingForReplication](tp0)
+
+    // When HW catches up to LEO, advancing state to SendingToController
+    val log = partition.log.get
+    when(log.highWatermark).thenReturn(100L)
+    triggerHighWatermarkUpdate(tp0, 100)
+    assertState[SendingToController](tp0)
+
+    // And a stale HW listener callback fires after the state has already advanced
+    triggerHighWatermarkUpdate(tp0, 100)
+
+    // Then the state is NOT regressed back to SendingToController (a new instance) —
+    // the existing SendingToController state is preserved
+    assertState[SendingToController](tp0)
+
+    // And the flow completes normally
+    fireLinger()
+    pollAndComplete(makeSuccessResponse(topicId, 0))
+    assertState[AwaitingMetadata](tp0)
+  }
+
+  @Test
+  def testStaleListenerCallbackDoesNotRegressFromAwaitingMetadata(): Unit = {
+    // Given a partition registered with HW < LEO so a listener is captured
+    val partition = mockPartition(hw = 50, leo = 100)
+    manager.registerPartition(partition, topicId)
+    assertState[WaitingForReplication](tp0)
+
+    // When HW catches up, advancing to SendingToController, then to AwaitingMetadata
+    val log = partition.log.get
+    when(log.highWatermark).thenReturn(100L)
+    triggerHighWatermarkUpdate(tp0, 100)
+    assertState[SendingToController](tp0)
+    fireLinger()
+    pollAndComplete(makeSuccessResponse(topicId, 0))
+    assertState[AwaitingMetadata](tp0)
+
+    // And a stale HW listener callback fires after the state has already advanced
+    triggerHighWatermarkUpdate(tp0, 100)
+
+    // Then the state remains AwaitingMetadata and no spurious controller call is made
+    assertState[AwaitingMetadata](tp0)
+    assertTrue(channelManager.requests.isEmpty)
+  }
+
   private def makeSuccessResponse(topicId: Uuid, partitionId: Int): InitDisklessLogResponseData = {
     new InitDisklessLogResponseData().setTopics(util.List.of(
       new InitDisklessLogResponseData.TopicResponse()


### PR DESCRIPTION
Summary

- **Stale listener callback regression**: The `onPartitionUpdate` callback in `WaitingForReplication` unconditionally replaced the tracked state, ignoring whether it had already advanced past `WaitingForReplication`. A late HW listener callback could regress `SendingToController` or `AwaitingMetadata` back to an earlier state. Fixed by guarding the callback to only apply when the tracked state is still `WaitingForReplication`.

- **Missed HW update between check and listener registration**: There is a window between the initial `maybeAdvanceState()` evaluation and the `maybeAddListener()` call where HW can advance to LEO. If no further HW updates occur after the listener is registered, the partition is stuck in `WaitingForReplication` forever. Fixed by re-evaluating the state immediately after adding the listener.
