### PR TITLE
feat(inkless): POD-2392 Implement consolidating partition tracking

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -312,6 +312,7 @@ if (repo != null) {
         'inkless-benchmarks/**',
         'tests/kafkatest/tests/inkless/**',
         'inkless-sync/**',
+        'core/src/main/scala/io/aiven/inkless/**',
         // end of inkless ignored files
         'licenses/*',
         '**/generated/**',

--- a/core/src/main/scala/io/aiven/inkless/consolidation/ConsolidationFetcherManager.scala
+++ b/core/src/main/scala/io/aiven/inkless/consolidation/ConsolidationFetcherManager.scala
@@ -1,0 +1,46 @@
+/*
+ * Inkless
+ * Copyright (C) 2024 - 2026 Aiven OY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package io.aiven.inkless.consolidation
+
+import kafka.server.{AbstractFetcherManager, KafkaConfig, ReplicaManager, ReplicationQuotaManager}
+import org.apache.kafka.common.utils.LogContext
+import org.apache.kafka.server.network.BrokerEndPoint
+
+class ConsolidationFetcherManager(brokerConfig: KafkaConfig,
+                                  replicaManager: ReplicaManager,
+                                  quotaManager: ReplicationQuotaManager)
+  extends AbstractFetcherManager[ConsolidationFetcherThread](name = "ConsolidationFetcherManager on broker " + brokerConfig.brokerId,
+    clientId = "Consolidation",
+    numFetchers = brokerConfig.numReplicaFetchers) {
+
+  override def createFetcherThread(fetcherId: Int, sourceBroker: BrokerEndPoint): ConsolidationFetcherThread = {
+    val threadName = s"ConsolidationFetcherThread-$fetcherId-${sourceBroker.id}"
+    val logContext = new LogContext(s"[ConsolidationFetcher replicaId=${brokerConfig.brokerId}, leaderId=${sourceBroker.id}, " +
+      s"fetcherId=$fetcherId] ")
+    val disklessLeaderEndPoint = new DisklessLeaderEndPoint(sourceBroker)
+    new ConsolidationFetcherThread(threadName, disklessLeaderEndPoint, brokerConfig, failedPartitions, replicaManager,
+      quotaManager, logContext.logPrefix)
+  }
+
+  def shutdown(): Unit = {
+    info("shutting down")
+    closeAllFetchers()
+    info("shutdown completed")
+  }
+}

--- a/core/src/main/scala/io/aiven/inkless/consolidation/ConsolidationFetcherThread.scala
+++ b/core/src/main/scala/io/aiven/inkless/consolidation/ConsolidationFetcherThread.scala
@@ -1,0 +1,40 @@
+/*
+ * Inkless
+ * Copyright (C) 2024 - 2026 Aiven OY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package io.aiven.inkless.consolidation
+
+import io.aiven.inkless.consume.ConcatenatedRecords
+import kafka.server.{FailedPartitions, KafkaConfig, ReplicaFetcherThread, ReplicaManager, ReplicaQuota}
+import org.apache.kafka.common.record.{MemoryRecords, Records}
+import org.apache.kafka.server.LeaderEndPoint
+
+class ConsolidationFetcherThread(name: String,
+                                 leader: LeaderEndPoint,
+                                 brokerConfig: KafkaConfig,
+                                 failedPartitions: FailedPartitions,
+                                 replicaMgr: ReplicaManager,
+                                 quota: ReplicaQuota,
+                                 logPrefix: String) extends ReplicaFetcherThread(name, leader, brokerConfig, failedPartitions, replicaMgr, quota, logPrefix) {
+
+  override def toMemoryRecords(records: Records): MemoryRecords = {
+    (records: @unchecked) match {
+      case r: ConcatenatedRecords => r.toMemoryRecords
+      case _ => super.toMemoryRecords(records)
+    }
+  }
+}

--- a/core/src/main/scala/io/aiven/inkless/consolidation/DisklessLeaderEndPoint.scala
+++ b/core/src/main/scala/io/aiven/inkless/consolidation/DisklessLeaderEndPoint.scala
@@ -1,0 +1,120 @@
+/*
+ * Inkless
+ * Copyright (C) 2024 - 2026 Aiven OY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package io.aiven.inkless.consolidation
+
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.message.{FetchResponseData, OffsetForLeaderEpochRequestData, OffsetForLeaderEpochResponseData}
+import org.apache.kafka.common.requests.FetchRequest
+import org.apache.kafka.server.common.OffsetAndEpoch
+import org.apache.kafka.server.network.BrokerEndPoint
+import org.apache.kafka.server.{LeaderEndPoint, PartitionFetchState, ReplicaFetch, ResultWithPartitions}
+
+import java.util
+import java.util.Optional
+
+class DisklessLeaderEndPoint(brokerEndPoint: BrokerEndPoint) extends LeaderEndPoint {
+
+  /**
+   * A boolean specifying if truncation when fetching from the leader is supported
+   */
+  override def isTruncationOnFetchSupported: Boolean = false
+
+  /**
+   * Initiate closing access to fetches from leader.
+   */
+  override def initiateClose(): Unit = {
+  }
+
+  /**
+   * Closes access to fetches from leader.
+   * `initiateClose` must be called prior to invoking `close`.
+   */
+  override def close(): Unit = {
+  }
+
+  /**
+   * The specific broker (host:port) we want to connect to.
+   */
+  override def brokerEndPoint(): BrokerEndPoint = {
+    brokerEndPoint
+  }
+
+  /**
+   * Given a fetchRequest, carries out the expected request and returns
+   * the results from fetching from the leader.
+   *
+   * @param fetchRequest The fetch request we want to carry out
+   * @return A map of topic partition -> fetch data
+   */
+  override def fetch(fetchRequest: FetchRequest.Builder): util.Map[TopicPartition, FetchResponseData.PartitionData] =
+    util.Map.of[TopicPartition, FetchResponseData.PartitionData]
+
+  /**
+   * Fetches the epoch and log start offset of the given topic partition from the leader.
+   *
+   * @param topicPartition     The topic partition that we want to fetch from
+   * @param currentLeaderEpoch An int representing the current leader epoch of the requester
+   * @return An OffsetAndEpoch object representing the earliest offset and epoch in the leader's topic partition.
+   */
+  override def fetchEarliestOffset(topicPartition: TopicPartition, currentLeaderEpoch: Int): OffsetAndEpoch = {
+    return new OffsetAndEpoch(0, 0)
+  }
+
+  /**
+   * Fetches the epoch and log end offset of the given topic partition from the leader.
+   *
+   * @param topicPartition     The topic partition that we want to fetch from
+   * @param currentLeaderEpoch An int representing the current leader epoch of the requester
+   * @return An OffsetAndEpoch object representing the latest offset and epoch in the leader's topic partition.
+   */
+  override def fetchLatestOffset(topicPartition: TopicPartition, currentLeaderEpoch: Int): OffsetAndEpoch = {
+    return new OffsetAndEpoch(0, 0)
+  }
+
+  /**
+   * Fetches offset for leader epoch from the leader for each given topic partition
+   *
+   * @param partitions A map of topic partition -> leader epoch of the replica
+   * @return A map of topic partition -> end offset for a requested leader epoch
+   */
+  override def fetchEpochEndOffsets(partitions: util.Map[TopicPartition, OffsetForLeaderEpochRequestData.OffsetForLeaderPartition]): util.Map[TopicPartition, OffsetForLeaderEpochResponseData.EpochEndOffset] = {
+    util.Map.of[TopicPartition, OffsetForLeaderEpochResponseData.EpochEndOffset]()
+  }
+
+  /**
+   * Fetches the epoch and local log start offset from the leader for the given partition and the current leader-epoch
+   *
+   * @param topicPartition     The topic partition that we want to fetch from
+   * @param currentLeaderEpoch An int representing the current leader epoch of the requester
+   * @return An OffsetAndEpoch object representing the earliest local offset and epoch in the leader's topic partition.
+   */
+  override def fetchEarliestLocalOffset(topicPartition: TopicPartition, currentLeaderEpoch: Int): OffsetAndEpoch = {
+    new OffsetAndEpoch(0, 0)
+  }
+
+  /**
+   * Builds a fetch request, given a partition map.
+   *
+   * @param partitions A map of topic partitions to their respective partition fetch state
+   * @return A ResultWithPartitions, used to create the fetchRequest for fetch.
+   */
+  override def buildFetch(partitions: util.Map[TopicPartition, PartitionFetchState]): ResultWithPartitions[Optional[ReplicaFetch]] = {
+    new ResultWithPartitions[Optional[ReplicaFetch]](Optional.empty(), util.Set.of())
+  }
+}

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -2842,8 +2842,9 @@ class ReplicaManager(val config: KafkaConfig,
   ): Unit = {
     stateChangeLogger.info(s"Transitioning ${localLeaders.size} partition(s) to " +
       "local leaders.")
-    val classicLocalLeaders = localLeaders.keySet.filter(tp => !_inklessMetadataView.isDisklessTopic(tp.topic))
-    replicaFetcherManager.removeFetcherForPartitions(classicLocalLeaders)
+    replicaFetcherManager.removeFetcherForPartitions(localLeaders.keySet)
+    consolidationFetcherManager.foreach(_.removeFetcherForPartitions(localLeaders.keySet))
+
     val consolidatingDisklessPartitionsToStartFetching = new mutable.HashMap[TopicPartition, Partition]
     localLeaders.foreachEntry { (tp, info) =>
       val isDiskless = _inklessMetadataView.isDisklessTopic(tp.topic())
@@ -2892,9 +2893,6 @@ class ReplicaManager(val config: KafkaConfig,
     }
 
     if (consolidatingDisklessPartitionsToStartFetching.nonEmpty) {
-      consolidationFetcherManager.foreach(_.removeFetcherForPartitions(consolidatingDisklessPartitionsToStartFetching.keySet))
-      stateChangeLogger.info(s"Stopped consolidating diskless fetchers as part of become-leader for ${consolidatingDisklessPartitionsToStartFetching.size} partitions")
-
       val listenerName = config.interBrokerListenerName.value
       val consolidatingPartitionAndOffsets = new mutable.HashMap[TopicPartition, InitialFetchState]
 

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -23,6 +23,7 @@ import io.aiven.inkless.control_plane.{BatchInfo, FindBatchRequest, FindBatchRes
 import io.aiven.inkless.delete.{DeleteRecordsInterceptor, FileCleaner, RetentionEnforcer}
 import io.aiven.inkless.merge.FileMerger
 import io.aiven.inkless.produce.AppendHandler
+import io.aiven.inkless.consolidation.ConsolidationFetcherManager
 import kafka.cluster.Partition
 import kafka.log.LogManager
 import kafka.server.HostedPartition.Online
@@ -278,6 +279,10 @@ class ReplicaManager(val config: KafkaConfig,
   private val inklessFileCleaner: Option[FileCleaner] = inklessSharedState.map(new FileCleaner(_))
   // FIXME: FileMerger is having issues with hanging queries. Disabling until fixed.
   private val inklessFileMerger: Option[FileMerger] = None // inklessSharedState.map(new FileMerger(_))
+  private val consolidationFetcherManager: Option[ConsolidationFetcherManager] = if (config.disklessRemoteStorageConsolidationEnabled)
+    Some(new ConsolidationFetcherManager(config, this, quotaManagers.follower))
+  else
+    None
 
   /* epoch of the controller that last changed the leader */
   protected val localBrokerId = config.brokerId
@@ -470,6 +475,8 @@ class ReplicaManager(val config: KafkaConfig,
     val partitions = partitionsToStop.map(_.topicPartition)
     replicaFetcherManager.removeFetcherForPartitions(partitions)
     replicaAlterLogDirsManager.removeFetcherForPartitions(partitions)
+    consolidationFetcherManager.foreach(_.removeFetcherForPartitions(
+      partitions.filter(p => _inklessMetadataView.isConsolidatingDisklessTopic(p.topic))))
 
     // Second remove deleted partitions from the partition map. Fetchers rely on the
     // ReplicaManager to get Partition's information so they must be stopped first.
@@ -2513,6 +2520,7 @@ class ReplicaManager(val config: KafkaConfig,
 
       replicaFetcherManager.removeFetcherForPartitions(newOfflinePartitions)
       replicaAlterLogDirsManager.removeFetcherForPartitions(newOfflinePartitions ++ partitionsWithOfflineFutureReplica.map(_.topicPartition))
+      consolidationFetcherManager.foreach(_.removeFetcherForPartitions(newOfflinePartitions))
 
       partitionsWithOfflineFutureReplica.foreach(partition => partition.removeFutureLocalReplica(deleteFromLogDir = false))
       newOfflinePartitions.foreach { topicPartition =>
@@ -2567,6 +2575,7 @@ class ReplicaManager(val config: KafkaConfig,
     delayedShareFetchPurgatory.shutdown()
     if (checkpointHW)
       checkpointHighWatermarks()
+    consolidationFetcherManager.foreach(_.shutdown())
     replicaSelectorPlugin.foreach(_.close)
     removeAllTopicMetrics()
     addPartitionsToTxnManager.foreach(_.shutdown())
@@ -2800,7 +2809,7 @@ class ReplicaManager(val config: KafkaConfig,
         val leaderChangedPartitions = new mutable.HashSet[Partition]
         val followerChangedPartitions = new mutable.HashSet[Partition]
         if (!localChanges.leaders.isEmpty) {
-          applyLocalLeadersDelta(leaderChangedPartitions, delta, lazyOffsetCheckpoints, localChanges.leaders.asScala, localChanges.directoryIds.asScala)
+          applyLocalLeadersDelta(leaderChangedPartitions, newImage, delta, lazyOffsetCheckpoints, localChanges.leaders.asScala, localChanges.directoryIds.asScala)
         }
         if (!localChanges.followers.isEmpty) {
           applyLocalFollowersDelta(followerChangedPartitions, newImage, delta, lazyOffsetCheckpoints, localChanges.followers.asScala, localChanges.directoryIds.asScala)
@@ -2811,6 +2820,7 @@ class ReplicaManager(val config: KafkaConfig,
 
         replicaFetcherManager.shutdownIdleFetcherThreads()
         replicaAlterLogDirsManager.shutdownIdleFetcherThreads()
+        consolidationFetcherManager.foreach(_.shutdownIdleFetcherThreads())
 
         remoteLogManager.foreach(rlm => rlm.onLeadershipChange((leaderChangedPartitions.toSet: Set[TopicPartitionLog]).asJava, (followerChangedPartitions.toSet: Set[TopicPartitionLog]).asJava, localChanges.topicIds()))
       }
@@ -2824,6 +2834,7 @@ class ReplicaManager(val config: KafkaConfig,
 
   private def applyLocalLeadersDelta(
     changedPartitions: mutable.Set[Partition],
+    newImage: MetadataImage,
     delta: TopicsDelta,
     offsetCheckpoints: OffsetCheckpoints,
     localLeaders: mutable.Map[TopicPartition, LocalReplicaChanges.PartitionInfo],
@@ -2831,21 +2842,29 @@ class ReplicaManager(val config: KafkaConfig,
   ): Unit = {
     stateChangeLogger.info(s"Transitioning ${localLeaders.size} partition(s) to " +
       "local leaders.")
-    replicaFetcherManager.removeFetcherForPartitions(localLeaders.keySet)
+    val classicLocalLeaders = localLeaders.keySet.filter(tp => !_inklessMetadataView.isDisklessTopic(tp.topic))
+    replicaFetcherManager.removeFetcherForPartitions(classicLocalLeaders)
+    val consolidatingDisklessPartitionsToStartFetching = new mutable.HashMap[TopicPartition, Partition]
     localLeaders.foreachEntry { (tp, info) =>
       val isDiskless = _inklessMetadataView.isDisklessTopic(tp.topic())
+      val isConsolidatingDisklessTopic = _inklessMetadataView.isConsolidatingDisklessTopic(tp.topic)
       val existingPartition = onlinePartition(tp)
-      if (!isDiskless) {
+      if (!isDiskless || isConsolidatingDisklessTopic) {
         getOrCreatePartition(tp, delta, info.topicId).foreach { case (partition, isNew) =>
           try {
             val partitionAssignedDirectoryId = directoryIds.find(_._1.topicPartition() == tp).map(_._2)
             partition.makeLeader(info.partition, isNew, offsetCheckpoints, Some(info.topicId), partitionAssignedDirectoryId)
 
             changedPartitions.add(partition)
+            if (isConsolidatingDisklessTopic) {
+              partition.createLogIfNotExists(isNew = true, isFutureReplica = false, offsetCheckpoints = offsetCheckpoints, topicId = partition.topicId, targetLogDirectoryId = partitionAssignedDirectoryId)
+              consolidatingDisklessPartitionsToStartFetching.put(tp, partition)
+            }
           } catch {
             case e: KafkaStorageException =>
               stateChangeLogger.info(s"Skipped the become-leader state change for $tp " +
                 s"with topic id ${info.topicId} due to a storage error ${e.getMessage}")
+              consolidationFetcherManager.foreach(_.addFailedPartition(tp))
               // If there is an offline log directory, a Partition object may have been created by
               // `getOrCreatePartition()` before `createLogIfNotExists()` failed to create local replica due
               // to KafkaStorageException. In this case `ReplicaManager.allPartitions` will map this topic-partition
@@ -2853,7 +2872,7 @@ class ReplicaManager(val config: KafkaConfig,
               markPartitionOffline(tp)
           }
         }
-      } else if (existingPartition.isDefined) {
+      } else if (existingPartition.isDefined && !isConsolidatingDisklessTopic) {
         // Classic-to-diskless transition: seal the partition before making it leader
         // so that no produce request can ever be processed by the new leader.
         val partition = existingPartition.get
@@ -2872,6 +2891,37 @@ class ReplicaManager(val config: KafkaConfig,
         }
       }
     }
+
+    if (consolidatingDisklessPartitionsToStartFetching.nonEmpty) {
+      consolidationFetcherManager.foreach(_.removeFetcherForPartitions(consolidatingDisklessPartitionsToStartFetching.keySet))
+      stateChangeLogger.info(s"Stopped consolidating diskless fetchers as part of become-leader for ${consolidatingDisklessPartitionsToStartFetching.size} partitions")
+
+      val listenerName = config.interBrokerListenerName.value
+      val consolidatingPartitionAndOffsets = new mutable.HashMap[TopicPartition, InitialFetchState]
+
+      consolidatingDisklessPartitionsToStartFetching.foreachEntry { (topicPartition, partition) =>
+        val nodeOpt = partition.leaderReplicaIdOpt
+          .flatMap(leaderId => Option(newImage.cluster.broker(leaderId)))
+          .flatMap(_.node(listenerName).toScala)
+
+        nodeOpt match {
+          case Some(node) =>
+            val log = partition.localLogOrException
+            consolidatingPartitionAndOffsets.put(topicPartition, InitialFetchState(
+              log.topicId.toScala,
+              new BrokerEndPoint(node.id, node.host, node.port),
+              partition.getLeaderEpoch,
+              initialFetchOffset(log)
+            ))
+          case None =>
+            stateChangeLogger.trace(s"Unable to start fetching $topicPartition with topic ID ${partition.topicId} " +
+              s"from diskless subsystem ${partition.leaderReplicaIdOpt}.")
+        }
+      }
+
+      consolidationFetcherManager.foreach(_.addFetcherForPartitions(consolidatingPartitionAndOffsets))
+      stateChangeLogger.info(s"Started consolidating diskless fetchers as part of become-leader for ${consolidatingDisklessPartitionsToStartFetching.size} partitions")
+    }
   }
 
   private def applyLocalFollowersDelta(
@@ -2888,11 +2938,13 @@ class ReplicaManager(val config: KafkaConfig,
     val partitionsToStopFetching = new mutable.HashMap[TopicPartition, Boolean]
     val followerTopicSet = new mutable.HashSet[String]
     localFollowers.foreachEntry { (tp, info) =>
+      val isConsolidatingDisklessTopic = _inklessMetadataView.isConsolidatingDisklessTopic(tp.topic)
       if (_inklessMetadataView.isDisklessTopic(tp.topic())) {
-        // Already-diskless partitions have no local Partition object, so there is no
-        // makeFollower to call. Clean up migration tracking since only the leader drives migration.
+        // Clean up migration tracking since only the leader drives classic -> diskless migration.
         initDisklessLogManager.foreach(_.removePartition(tp))
-      } else getOrCreatePartition(tp, delta, info.topicId).foreach { case (partition, isNew) =>
+      }
+      if (!_inklessMetadataView.isDisklessTopic(tp.topic()) || isConsolidatingDisklessTopic) {
+        getOrCreatePartition(tp, delta, info.topicId).foreach { case (partition, isNew) =>
           try {
             followerTopicSet.add(tp.topic)
 
@@ -2921,7 +2973,10 @@ class ReplicaManager(val config: KafkaConfig,
             case e: KafkaStorageException =>
               stateChangeLogger.error(s"Unable to start fetching $tp " +
                 s"with topic ID ${info.topicId} due to a storage error ${e.getMessage}", e)
-              replicaFetcherManager.addFailedPartition(tp)
+              if (_inklessMetadataView.isConsolidatingDisklessTopic(tp.topic))
+                consolidationFetcherManager.foreach(_.addFailedPartition(tp))
+              else
+                replicaFetcherManager.addFailedPartition(tp)
               // If there is an offline log directory, a Partition object may have been created by
               // `getOrCreatePartition()` before `createLogIfNotExists()` failed to create local replica due
               // to KafkaStorageException. In this case `ReplicaManager.allPartitions` will map this topic-partition
@@ -2931,19 +2986,28 @@ class ReplicaManager(val config: KafkaConfig,
             case e: Throwable =>
               stateChangeLogger.error(s"Unable to start fetching $tp " +
                 s"with topic ID ${info.topicId} due to ${e.getClass.getSimpleName}", e)
-              replicaFetcherManager.addFailedPartition(tp)
+              if (_inklessMetadataView.isConsolidatingDisklessTopic(tp.topic))
+                consolidationFetcherManager.foreach(_.addFailedPartition(tp))
+              else
+                replicaFetcherManager.addFailedPartition(tp)
           }
         }
+      }
     }
 
     if (partitionsToStartFetching.nonEmpty) {
       // Stopping the fetchers must be done first in order to initialize the fetch
       // position correctly.
-      replicaFetcherManager.removeFetcherForPartitions(partitionsToStartFetching.keySet)
+      val (consolidatingDisklessPartitionsToAdd, classicPartitionsToAdd) = partitionsToStartFetching.partition { case (tp, p) =>
+        _inklessMetadataView.isConsolidatingDisklessTopic(tp.topic)
+      }
+      replicaFetcherManager.removeFetcherForPartitions(classicPartitionsToAdd.keySet)
+      consolidationFetcherManager.foreach(_.removeFetcherForPartitions(consolidatingDisklessPartitionsToAdd.keySet))
       stateChangeLogger.info(s"Stopped fetchers as part of become-follower for ${partitionsToStartFetching.size} partitions")
 
       val listenerName = config.interBrokerListenerName.value
       val partitionAndOffsets = new mutable.HashMap[TopicPartition, InitialFetchState]
+      val consolidatingPartitionAndOffsets = new mutable.HashMap[TopicPartition, InitialFetchState]
 
       partitionsToStartFetching.foreachEntry { (topicPartition, partition) =>
         val nodeOpt = partition.leaderReplicaIdOpt
@@ -2953,7 +3017,8 @@ class ReplicaManager(val config: KafkaConfig,
         nodeOpt match {
           case Some(node) =>
             val log = partition.localLogOrException
-            partitionAndOffsets.put(topicPartition, InitialFetchState(
+            val partitionAndOffsetMap = if (_inklessMetadataView.isConsolidatingDisklessTopic(partition.topic)) consolidatingPartitionAndOffsets else partitionAndOffsets
+            partitionAndOffsetMap.put(topicPartition, InitialFetchState(
               log.topicId.toScala,
               new BrokerEndPoint(node.id, node.host, node.port),
               partition.getLeaderEpoch,
@@ -2966,6 +3031,7 @@ class ReplicaManager(val config: KafkaConfig,
       }
 
       replicaFetcherManager.addFetcherForPartitions(partitionAndOffsets)
+      consolidationFetcherManager.foreach(_.addFetcherForPartitions(consolidatingPartitionAndOffsets))
       stateChangeLogger.info(s"Started fetchers as part of become-follower for ${partitionsToStartFetching.size} partitions")
 
       partitionsToStartFetching.foreach{ case (topicPartition, partition) =>

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -2937,7 +2937,9 @@ class ReplicaManager(val config: KafkaConfig,
     val partitionsToStopFetching = new mutable.HashMap[TopicPartition, Boolean]
     val followerTopicSet = new mutable.HashSet[String]
     localFollowers.foreachEntry { (tp, info) =>
-      val isConsolidatingDisklessTopic = _inklessMetadataView.isConsolidatingDisklessTopic(tp.topic)
+      val isConsolidatingDisklessTopic =
+        config.disklessRemoteStorageConsolidationEnabled &&
+          _inklessMetadataView.isConsolidatingDisklessTopic(tp.topic)
       if (_inklessMetadataView.isDisklessTopic(tp.topic())) {
         // Clean up migration tracking since only the leader drives classic -> diskless migration.
         initDisklessLogManager.foreach(_.removePartition(tp))

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -2848,7 +2848,9 @@ class ReplicaManager(val config: KafkaConfig,
     val consolidatingDisklessPartitionsToStartFetching = new mutable.HashMap[TopicPartition, Partition]
     localLeaders.foreachEntry { (tp, info) =>
       val isDiskless = _inklessMetadataView.isDisklessTopic(tp.topic())
-      val isConsolidatingDisklessTopic = _inklessMetadataView.isConsolidatingDisklessTopic(tp.topic)
+      val isConsolidatingDisklessTopic =
+        config.disklessRemoteStorageConsolidationEnabled &&
+          _inklessMetadataView.isConsolidatingDisklessTopic(tp.topic)
       val existingPartition = onlinePartition(tp)
       if (!isDiskless || isConsolidatingDisklessTopic) {
         getOrCreatePartition(tp, delta, info.topicId).foreach { case (partition, isNew) =>

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -2857,7 +2857,6 @@ class ReplicaManager(val config: KafkaConfig,
 
             changedPartitions.add(partition)
             if (isConsolidatingDisklessTopic) {
-              partition.createLogIfNotExists(isNew = true, isFutureReplica = false, offsetCheckpoints = offsetCheckpoints, topicId = partition.topicId, targetLogDirectoryId = partitionAssignedDirectoryId)
               consolidatingDisklessPartitionsToStartFetching.put(tp, partition)
             }
           } catch {

--- a/core/src/main/scala/kafka/server/metadata/InklessMetadataView.scala
+++ b/core/src/main/scala/kafka/server/metadata/InklessMetadataView.scala
@@ -75,6 +75,10 @@ class InklessMetadataView(val metadataCache: KRaftMetadataCache, val defaultConf
     metadataCache.topicConfig(topicName).getProperty(TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG, "false").toBoolean
   }
 
+  override def isConsolidatingDisklessTopic(topicName: String): Boolean = {
+    isDisklessTopic(topicName) && isRemoteStorageEnabled(topicName)
+  }
+
   override def getDisklessTopicPartitions: util.Set[TopicIdPartition] = {
     metadataCache.getAllTopics().stream()
       .filter(isDisklessTopic)

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -20,6 +20,7 @@ package kafka.server
 import com.yammer.metrics.core.{Gauge, Meter, Timer}
 import io.aiven.inkless.common.SharedState
 import io.aiven.inkless.config.InklessConfig
+import io.aiven.inkless.consolidation.ConsolidationFetcherManager
 import io.aiven.inkless.consume.{FetchHandler, FetchOffsetHandler}
 import io.aiven.inkless.control_plane.{BatchInfo, BatchMetadata, ControlPlane, ControlPlaneException, FindBatchResponse}
 import kafka.server.metadata.InklessMetadataView
@@ -7065,6 +7066,118 @@ class ReplicaManagerTest {
       assertEquals(OffsetsForLeaderEpochResponse.UNDEFINED_EPOCH_OFFSET, partitionResult.endOffset())
     }
 
+    @Test
+    def testConsolidationFetcherManagerConstructedWhenRemoteStorageConsolidationEnabled(): Unit = {
+      val consolidationCtor = mockConstruction(classOf[ConsolidationFetcherManager])
+      try {
+        val replicaManager = createReplicaManager(
+          List(disklessTopicPartition.topic()),
+          disklessRemoteStorageConsolidationEnabled = true,
+        )
+        try {
+          assertEquals(1, consolidationCtor.constructed().size())
+        } finally {
+          replicaManager.shutdown(checkpointHW = false)
+        }
+      } finally {
+        consolidationCtor.close()
+      }
+    }
+
+    @Test
+    def testConsolidationFetcherManagerWiredOnConsolidatingDisklessBecomeLeader(): Unit = {
+      val consolidatingTopic = disklessTopicPartition.topic()
+      val tp = disklessTopicPartition.topicPartition()
+      val leaderBrokerEndpoint = ClusterImageTest.IMAGE1.broker(1).listeners().get("PLAINTEXT")
+
+      val ctorInit: MockedConstruction.MockInitializer[ConsolidationFetcherManager] = {
+        case (mock, _) =>
+          when(mock.removeFetcherForPartitions(any())).thenReturn(Map.empty[TopicPartition, PartitionFetchState])
+      }
+      val consolidationCtor = mockConstruction(classOf[ConsolidationFetcherManager], ctorInit)
+      try {
+        val replicaManager = createReplicaManager(
+          List(consolidatingTopic),
+          disklessRemoteStorageConsolidationEnabled = true,
+          consolidatingDisklessTopics = Set(consolidatingTopic),
+        )
+        try {
+          val mockCfm = consolidationCtor.constructed().get(0)
+          val oneReplica = Seq[Integer](1).asJava
+          val delta = createLeaderDelta(
+            disklessTopicPartition.topicId,
+            tp,
+            1,
+            oneReplica,
+            oneReplica,
+          )
+          replicaManager.applyDelta(delta, imageFromTopics(delta.apply()))
+
+          verify(mockCfm, atLeastOnce()).shutdownIdleFetcherThreads()
+          verify(mockCfm).removeFetcherForPartitions(Set(tp))
+          verify(mockCfm).addFetcherForPartitions(
+            Map(tp -> InitialFetchState(
+              topicId = Some(disklessTopicPartition.topicId),
+              leader = new BrokerEndPoint(1, leaderBrokerEndpoint.host(), leaderBrokerEndpoint.port()),
+              currentLeaderEpoch = 0,
+              initOffset = 0
+            ))
+          )
+        } finally {
+          replicaManager.shutdown(checkpointHW = false)
+          verify(consolidationCtor.constructed().get(0)).shutdown()
+        }
+      } finally {
+        consolidationCtor.close()
+      }
+    }
+
+    @Test
+    def testConsolidationFetcherManagerWiredOnConsolidatingDisklessBecomeFollower(): Unit = {
+      val consolidatingTopic = disklessTopicPartition.topic()
+      val tp = disklessTopicPartition.topicPartition()
+      val remoteLeaderEndpoint = ClusterImageTest.IMAGE1.broker(2).listeners().get("PLAINTEXT")
+
+      val ctorInit: MockedConstruction.MockInitializer[ConsolidationFetcherManager] = {
+        case (mock, _) =>
+          when(mock.removeFetcherForPartitions(any())).thenReturn(Map.empty[TopicPartition, PartitionFetchState])
+      }
+      val consolidationCtor = mockConstruction(classOf[ConsolidationFetcherManager], ctorInit)
+      try {
+        val replicaManager = createReplicaManager(
+          List(consolidatingTopic),
+          disklessRemoteStorageConsolidationEnabled = true,
+          consolidatingDisklessTopics = Set(consolidatingTopic),
+        )
+        try {
+          val mockCfm = consolidationCtor.constructed().get(0)
+          val delta = createFollowerDelta(
+            disklessTopicPartition.topicId,
+            tp,
+            followerId = 1,
+            leaderId = 2,
+          )
+          replicaManager.applyDelta(delta, imageFromTopics(delta.apply()))
+
+          verify(mockCfm, atLeastOnce()).shutdownIdleFetcherThreads()
+          verify(mockCfm).removeFetcherForPartitions(Set(tp))
+          verify(mockCfm).addFetcherForPartitions(
+            Map(tp -> InitialFetchState(
+              topicId = Some(disklessTopicPartition.topicId),
+              leader = new BrokerEndPoint(2, remoteLeaderEndpoint.host(), remoteLeaderEndpoint.port()),
+              currentLeaderEpoch = 0,
+              initOffset = 0
+            ))
+          )
+        } finally {
+          replicaManager.shutdown(checkpointHW = false)
+          verify(consolidationCtor.constructed().get(0)).shutdown()
+        }
+      } finally {
+        consolidationCtor.close()
+      }
+    }
+
     private def mockFetchHandler(disklessResponse: Map[TopicIdPartition, FetchPartitionData]) = {
       // We use constructor mocking here to inject a FetchHandler mock into ReplicaManager,
       // because ReplicaManager internally constructs its own FetchHandler instance and does not
@@ -7084,13 +7197,22 @@ class ReplicaManagerTest {
       disklessTopics: Seq[String],
       controlPlane: Option[ControlPlane] = None,
       topicIdMapping: Map[String, Uuid] = Map.empty,
-      disklessManagedReplicasEnabled: Boolean = false
+      disklessManagedReplicasEnabled: Boolean = false,
+      disklessRemoteStorageConsolidationEnabled: Boolean = false,
+      consolidatingDisklessTopics: Set[String] = Set.empty
     ): ReplicaManager = {
       val props = TestUtils.createBrokerConfig(1, logDirCount = 2)
-      if (disklessManagedReplicasEnabled) {
+      if (disklessManagedReplicasEnabled || disklessRemoteStorageConsolidationEnabled) {
         props.put(ServerConfigs.DISKLESS_STORAGE_SYSTEM_ENABLE_CONFIG, "true")
       }
-      props.put(ServerConfigs.DISKLESS_MANAGED_REPLICAS_ENABLE_CONFIG, disklessManagedReplicasEnabled.toString)
+      if (disklessRemoteStorageConsolidationEnabled) {
+        props.put(ServerConfigs.DISKLESS_REMOTE_STORAGE_CONSOLIDATION_ENABLE_CONFIG, "true")
+        props.put(RemoteLogManagerConfig.REMOTE_LOG_STORAGE_SYSTEM_ENABLE_PROP, "true")
+      }
+      props.put(
+        ServerConfigs.DISKLESS_MANAGED_REPLICAS_ENABLE_CONFIG,
+        (disklessManagedReplicasEnabled || disklessRemoteStorageConsolidationEnabled).toString
+      )
       val config = KafkaConfig.fromProps(props)
       val mockLogMgr = TestUtils.createLogManager(config.logDirs.asScala.map(new File(_)), new LogConfig(new Properties()))
       val sharedState = mock(classOf[SharedState], Answers.RETURNS_DEEP_STUBS)
@@ -7104,6 +7226,7 @@ class ReplicaManagerTest {
         topicIdMapping.getOrElse(topicName, Uuid.ZERO_UUID)
       }
       disklessTopics.foreach(t => when(inklessMetadata.isDisklessTopic(t)).thenReturn(true))
+      consolidatingDisklessTopics.foreach(t => when(inklessMetadata.isConsolidatingDisklessTopic(t)).thenReturn(true))
       when(sharedState.metadata()).thenReturn(inklessMetadata)
 
       val logDirFailureChannel = new LogDirFailureChannel(config.logDirs.size)

--- a/storage/inkless/src/main/java/io/aiven/inkless/consume/ConcatenatedRecords.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/consume/ConcatenatedRecords.java
@@ -26,6 +26,7 @@ import org.apache.kafka.common.utils.AbstractIterator;
 import org.apache.kafka.common.utils.FlattenedIterator;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Objects;
 
@@ -86,5 +87,20 @@ public class ConcatenatedRecords extends AbstractRecords {
     @Override
     public int sizeInBytes() {
         return sizeInBytes;
+    }
+
+    public MemoryRecords toMemoryRecords() {
+        if (backingRecords.isEmpty()) {
+            return MemoryRecords.EMPTY;
+        } else if (backingRecords.size() == 1) {
+            return backingRecords.get(0);
+        } else {
+            var buffer = ByteBuffer.allocate(sizeInBytes());
+            for (MemoryRecords records : backingRecords) {
+                records.batches().forEach(b -> b.writeTo(buffer));
+            }
+            buffer.flip();
+            return MemoryRecords.readableRecords(buffer);
+        }
     }
 }

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/MetadataView.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/MetadataView.java
@@ -37,6 +37,8 @@ public interface MetadataView {
 
     boolean isRemoteStorageEnabled(String topicName);
 
+    boolean isConsolidatingDisklessTopic(String topicName);
+
     LogConfig getTopicConfig(String topicName);
 
     Set<TopicIdPartition> getDisklessTopicPartitions();

--- a/storage/inkless/src/test/java/io/aiven/inkless/consume/ConcatenatedRecordsTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/consume/ConcatenatedRecordsTest.java
@@ -20,6 +20,8 @@ package io.aiven.inkless.consume;
 import org.apache.kafka.common.compress.Compression;
 import org.apache.kafka.common.network.TransferableChannel;
 import org.apache.kafka.common.record.MemoryRecords;
+import org.apache.kafka.common.record.MutableRecordBatch;
+import org.apache.kafka.common.record.Record;
 import org.apache.kafka.common.record.SimpleRecord;
 
 import org.junit.jupiter.api.Test;
@@ -33,6 +35,7 @@ import org.mockito.quality.Strictness;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -202,5 +205,46 @@ class ConcatenatedRecordsTest {
         position = records.get(0).sizeInBytes() + 1;
         concatenatedRecords.writeTo(mockChannel, position, length);
         verify(mockChannel, times(3)).write(any(ByteBuffer.class));
+    }
+
+    @Test
+    public void testToMemoryRecordsEmpty() throws IOException {
+        ConcatenatedRecords records = new ConcatenatedRecords(List.of());
+        assertEquals(MemoryRecords.EMPTY, records.toMemoryRecords());
+    }
+
+    @Test
+    public void testToMemoryRecordsSingleRecord() throws IOException {
+        MemoryRecords records1 = mock(MemoryRecords.class);
+        ConcatenatedRecords records = new ConcatenatedRecords(List.of(records1));
+        assertEquals(records1, records.toMemoryRecords());
+    }
+
+    @Test
+    public void testToMemoryRecordsMultipleRecords() throws IOException {
+        List<MemoryRecords> parts = List.of(
+                MemoryRecords.withRecords(Compression.NONE, new SimpleRecord("record1".getBytes())),
+                MemoryRecords.withRecords(Compression.NONE, new SimpleRecord("record2".getBytes())));
+        ConcatenatedRecords concatenated = new ConcatenatedRecords(parts);
+        MemoryRecords result = concatenated.toMemoryRecords();
+
+        assertEquals(concatenated.sizeInBytes(), result.sizeInBytes());
+        List<byte[]> values = recordValues(result);
+        assertThat(values).hasSize(2);
+        assertThat(values.get(0)).isEqualTo("record1".getBytes());
+        assertThat(values.get(1)).isEqualTo("record2".getBytes());
+    }
+
+    private static List<byte[]> recordValues(MemoryRecords records) {
+        List<byte[]> values = new ArrayList<>();
+        for (MutableRecordBatch batch : records.batches()) {
+            for (Record record : batch) {
+                ByteBuffer value = record.value();
+                byte[] copy = new byte[value.remaining()];
+                value.duplicate().get(copy);
+                values.add(copy);
+            }
+        }
+        return values;
     }
 }


### PR DESCRIPTION
This commit implements ConsolidationFetcherManager and ConsolidationFetcherThread in ReplicaManager to track diskless partitions that are being consolidated into classic Kafka logs.
