### PR TITLE
feat(inkless): POD-2393 Add DisklessLeaderEndPoint to handle fetch requests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -313,6 +313,7 @@ if (repo != null) {
         'tests/kafkatest/tests/inkless/**',
         'inkless-sync/**',
         'core/src/main/scala/io/aiven/inkless/**',
+        'core/src/test/scala/io/aiven/inkless/**',
         // end of inkless ignored files
         'licenses/*',
         '**/generated/**',

--- a/core/src/main/scala/io/aiven/inkless/consolidation/ConsolidationFetcherManager.scala
+++ b/core/src/main/scala/io/aiven/inkless/consolidation/ConsolidationFetcherManager.scala
@@ -18,13 +18,16 @@
 
 package io.aiven.inkless.consolidation
 
+import io.aiven.inkless.consume.{FetchHandler, FetchOffsetHandler}
 import kafka.server.{AbstractFetcherManager, KafkaConfig, ReplicaManager, ReplicationQuotaManager}
 import org.apache.kafka.common.utils.LogContext
 import org.apache.kafka.server.network.BrokerEndPoint
 
 class ConsolidationFetcherManager(brokerConfig: KafkaConfig,
                                   replicaManager: ReplicaManager,
-                                  quotaManager: ReplicationQuotaManager)
+                                  quotaManager: ReplicationQuotaManager,
+                                  fetchHandler: FetchHandler,
+                                  fetchOffsetHandler: FetchOffsetHandler)
   extends AbstractFetcherManager[ConsolidationFetcherThread](name = "ConsolidationFetcherManager on broker " + brokerConfig.brokerId,
     clientId = "Consolidation",
     numFetchers = brokerConfig.numReplicaFetchers) {
@@ -33,7 +36,16 @@ class ConsolidationFetcherManager(brokerConfig: KafkaConfig,
     val threadName = s"ConsolidationFetcherThread-$fetcherId-${sourceBroker.id}"
     val logContext = new LogContext(s"[ConsolidationFetcher replicaId=${brokerConfig.brokerId}, leaderId=${sourceBroker.id}, " +
       s"fetcherId=$fetcherId] ")
-    val disklessLeaderEndPoint = new DisklessLeaderEndPoint(sourceBroker)
+    val disklessLeaderEndPoint = new DisklessLeaderEndPoint(
+      sourceBroker,
+      fetchHandler,
+      fetchOffsetHandler,
+      replicaManager,
+      brokerConfig,
+      quotaManager,
+      () => replicaManager.metadataCache.metadataVersion(),
+      replicaManager.brokerEpochSupplier
+    )
     new ConsolidationFetcherThread(threadName, disklessLeaderEndPoint, brokerConfig, failedPartitions, replicaManager,
       quotaManager, logContext.logPrefix)
   }

--- a/core/src/main/scala/io/aiven/inkless/consolidation/DisklessLeaderEndPoint.scala
+++ b/core/src/main/scala/io/aiven/inkless/consolidation/DisklessLeaderEndPoint.scala
@@ -18,103 +18,231 @@
 
 package io.aiven.inkless.consolidation
 
+import io.aiven.inkless.consume.{FetchHandler, FetchOffsetHandler}
+import kafka.server.{KafkaConfig, ReplicaManager, ReplicaQuota}
+import org.apache.kafka.common.Uuid
+import org.apache.kafka.common.errors.KafkaStorageException
+import org.apache.kafka.common.message.{FetchResponseData, OffsetForLeaderEpochRequestData}
+import org.apache.kafka.common.message.ListOffsetsRequestData.ListOffsetsPartition
+import org.apache.kafka.common.message.OffsetForLeaderEpochResponseData.EpochEndOffset
+import org.apache.kafka.common.protocol.Errors
+import org.apache.kafka.common.record.FileRecords.TimestampAndOffset
+import org.apache.kafka.common.requests.{FetchRequest, FetchResponse, ListOffsetsRequest, OffsetsForLeaderEpochResponse}
 import org.apache.kafka.common.TopicPartition
-import org.apache.kafka.common.message.{FetchResponseData, OffsetForLeaderEpochRequestData, OffsetForLeaderEpochResponseData}
-import org.apache.kafka.common.requests.FetchRequest
-import org.apache.kafka.server.common.OffsetAndEpoch
+import org.apache.kafka.metadata.LeaderAndIsr
+import org.apache.kafka.server.common.{MetadataVersion, OffsetAndEpoch}
 import org.apache.kafka.server.network.BrokerEndPoint
+import org.apache.kafka.server.storage.log.{FetchIsolation, FetchParams}
 import org.apache.kafka.server.{LeaderEndPoint, PartitionFetchState, ReplicaFetch, ResultWithPartitions}
+import org.apache.kafka.storage.internals.log.OffsetResultHolder.FileRecordsOrError
 
 import java.util
 import java.util.Optional
+import java.util.concurrent.CompletableFuture
+import scala.collection.mutable
+import scala.jdk.CollectionConverters._
 
-class DisklessLeaderEndPoint(brokerEndPoint: BrokerEndPoint) extends LeaderEndPoint {
+/**
+ * Leader endpoint for consolidation fetching from Inkless (object storage) on this broker.
+ * [[FetchHandler]] performs the same diskless fetch path as the broker’s main fetch pipeline;
+ * [[FetchOffsetHandler]] backs list-offsets style APIs used by [[kafka.server.AbstractFetcherThread]].
+ *
+ * Fetch and offset handler instances are owned by [[kafka.server.ReplicaManager]]; this class does not close them.
+ */
+class DisklessLeaderEndPoint(
+  brokerEndPoint: BrokerEndPoint,
+  fetchHandler: FetchHandler,
+  fetchOffsetHandler: FetchOffsetHandler,
+  replicaManager: ReplicaManager,
+  brokerConfig: KafkaConfig,
+  quota: ReplicaQuota,
+  metadataVersionSupplier: () => MetadataVersion,
+  brokerEpochSupplier: () => Long
+) extends LeaderEndPoint {
 
-  /**
-   * A boolean specifying if truncation when fetching from the leader is supported
-   */
+  private val replicaId = brokerConfig.brokerId
+  private val maxWait = brokerConfig.replicaFetchWaitMaxMs
+  private val minBytes = brokerConfig.replicaFetchMinBytes
+  private val maxBytes = brokerConfig.replicaFetchResponseMaxBytes
+  private val fetchSize = brokerConfig.replicaFetchMaxBytes
+
   override def isTruncationOnFetchSupported: Boolean = false
 
-  /**
-   * Initiate closing access to fetches from leader.
-   */
-  override def initiateClose(): Unit = {
+  override def initiateClose(): Unit = ()
+
+  override def close(): Unit = ()
+
+  override def brokerEndPoint(): BrokerEndPoint = brokerEndPoint
+
+  override def fetch(fetchRequest: FetchRequest.Builder): util.Map[TopicPartition, FetchResponseData.PartitionData] = {
+    val request = fetchRequest.build()
+    val topicNames = new mutable.HashMap[Uuid, String]()
+    request.data.topics.forEach { topic =>
+      topicNames.put(topic.topicId, topic.topic)
+    }
+    val fetchInfos = request.fetchData(topicNames.asJava)
+
+    val fetchParams = new FetchParams(
+      FetchRequest.FUTURE_LOCAL_REPLICA_ID,
+      -1,
+      0L,
+      request.minBytes,
+      request.maxBytes,
+      FetchIsolation.LOG_END,
+      Optional.empty()
+    )
+
+    val response = fetchHandler.handle(fetchParams, fetchInfos).get()
+    response.asScala.map { case (tp, data) =>
+      val abortedTransactions = data.abortedTransactions.orElse(null)
+      val lastStableOffset: Long = data.lastStableOffset.orElse(FetchResponse.INVALID_LAST_STABLE_OFFSET)
+      tp.topicPartition -> new FetchResponseData.PartitionData()
+        .setPartitionIndex(tp.topicPartition.partition)
+        .setErrorCode(data.error.code)
+        .setHighWatermark(data.highWatermark)
+        .setLastStableOffset(lastStableOffset)
+        .setLogStartOffset(data.logStartOffset)
+        .setAbortedTransactions(abortedTransactions)
+        .setRecords(data.records)
+    }.toMap.asJava
   }
 
-  /**
-   * Closes access to fetches from leader.
-   * `initiateClose` must be called prior to invoking `close`.
-   */
-  override def close(): Unit = {
+  override def fetchEarliestOffset(topicPartition: TopicPartition, currentLeaderEpoch: Int): OffsetAndEpoch =
+    listDisklessOffset(topicPartition, currentLeaderEpoch, ListOffsetsRequest.EARLIEST_TIMESTAMP)
+
+  override def fetchLatestOffset(topicPartition: TopicPartition, currentLeaderEpoch: Int): OffsetAndEpoch =
+    listDisklessOffset(topicPartition, currentLeaderEpoch, ListOffsetsRequest.LATEST_TIMESTAMP)
+
+  override def fetchEarliestLocalOffset(topicPartition: TopicPartition, currentLeaderEpoch: Int): OffsetAndEpoch =
+    listDisklessOffset(topicPartition, currentLeaderEpoch, ListOffsetsRequest.EARLIEST_LOCAL_TIMESTAMP)
+
+  private def listDisklessOffset(topicPartition: TopicPartition, currentLeaderEpoch: Int, timestamp: Long): OffsetAndEpoch = {
+    val job = fetchOffsetHandler.createJob()
+    if (!job.mustHandle(topicPartition.topic)) {
+      throw Errors.UNKNOWN_TOPIC_OR_PARTITION.exception()
+    }
+    val partitionRequest = new ListOffsetsPartition()
+      .setPartitionIndex(topicPartition.partition)
+      .setCurrentLeaderEpoch(currentLeaderEpoch)
+      .setTimestamp(timestamp)
+    val future = job.add(topicPartition, partitionRequest)
+    job.start()
+    val holder = future.get()
+    if (holder.hasException) {
+      throw Errors.forException(holder.exception().get()).exception()
+    }
+    val tao: TimestampAndOffset = holder.timestampAndOffset().get()
+    new OffsetAndEpoch(tao.offset, tao.leaderEpoch.orElse(0))
   }
 
-  /**
-   * The specific broker (host:port) we want to connect to.
-   */
-  override def brokerEndPoint(): BrokerEndPoint = {
-    brokerEndPoint
+  override def fetchEpochEndOffsets(
+    partitions: util.Map[TopicPartition, OffsetForLeaderEpochRequestData.OffsetForLeaderPartition]
+  ): util.Map[TopicPartition, EpochEndOffset] = {
+    if (partitions.isEmpty) {
+      return util.Map.of()
+    }
+
+    val job = fetchOffsetHandler.createJob()
+    val futures = mutable.Map.empty[TopicPartition, CompletableFuture[FileRecordsOrError]]
+
+    // TODO: POD-2419, offsets for leader epoch needs to be implemented for proper truncation
+    partitions.forEach { (tp, epochData) =>
+      if (epochData.leaderEpoch != OffsetsForLeaderEpochResponse.UNDEFINED_EPOCH && job.mustHandle(tp.topic)) {
+        val partitionRequest = new ListOffsetsPartition()
+          .setPartitionIndex(tp.partition)
+          .setCurrentLeaderEpoch(LeaderAndIsr.INITIAL_LEADER_EPOCH)
+          .setTimestamp(ListOffsetsRequest.LATEST_TIMESTAMP)
+        futures.put(tp, job.add(tp, partitionRequest))
+      }
+    }
+
+    job.start()
+
+    partitions.asScala.map { case (tp, epochData) =>
+      if (epochData.leaderEpoch == OffsetsForLeaderEpochResponse.UNDEFINED_EPOCH) {
+        tp -> new EpochEndOffset()
+          .setPartition(tp.partition)
+          .setErrorCode(Errors.NONE.code)
+      } else if (!futures.contains(tp)) {
+        tp -> new EpochEndOffset()
+          .setPartition(tp.partition)
+          .setErrorCode(Errors.UNKNOWN_TOPIC_OR_PARTITION.code)
+      } else {
+        try {
+          val holder = futures(tp).get()
+          val leaderEpoch = epochData.leaderEpoch
+          if (holder.hasException) {
+            val err = Errors.forException(holder.exception().get())
+            tp -> new EpochEndOffset()
+              .setPartition(tp.partition)
+              .setErrorCode(err.code)
+          } else {
+            val endOffset = holder.timestampAndOffset().get().offset
+            tp -> new EpochEndOffset()
+              .setPartition(tp.partition)
+              .setErrorCode(Errors.NONE.code)
+              .setLeaderEpoch(leaderEpoch)
+              .setEndOffset(endOffset)
+          }
+        } catch {
+          case t: Throwable =>
+            tp -> new EpochEndOffset()
+              .setPartition(tp.partition)
+              .setErrorCode(Errors.forException(t).code)
+        }
+      }
+    }.toMap.asJava
   }
 
-  /**
-   * Given a fetchRequest, carries out the expected request and returns
-   * the results from fetching from the leader.
-   *
-   * @param fetchRequest The fetch request we want to carry out
-   * @return A map of topic partition -> fetch data
-   */
-  override def fetch(fetchRequest: FetchRequest.Builder): util.Map[TopicPartition, FetchResponseData.PartitionData] =
-    util.Map.of[TopicPartition, FetchResponseData.PartitionData]
-
-  /**
-   * Fetches the epoch and log start offset of the given topic partition from the leader.
-   *
-   * @param topicPartition     The topic partition that we want to fetch from
-   * @param currentLeaderEpoch An int representing the current leader epoch of the requester
-   * @return An OffsetAndEpoch object representing the earliest offset and epoch in the leader's topic partition.
-   */
-  override def fetchEarliestOffset(topicPartition: TopicPartition, currentLeaderEpoch: Int): OffsetAndEpoch = {
-    return new OffsetAndEpoch(0, 0)
-  }
-
-  /**
-   * Fetches the epoch and log end offset of the given topic partition from the leader.
-   *
-   * @param topicPartition     The topic partition that we want to fetch from
-   * @param currentLeaderEpoch An int representing the current leader epoch of the requester
-   * @return An OffsetAndEpoch object representing the latest offset and epoch in the leader's topic partition.
-   */
-  override def fetchLatestOffset(topicPartition: TopicPartition, currentLeaderEpoch: Int): OffsetAndEpoch = {
-    return new OffsetAndEpoch(0, 0)
-  }
-
-  /**
-   * Fetches offset for leader epoch from the leader for each given topic partition
-   *
-   * @param partitions A map of topic partition -> leader epoch of the replica
-   * @return A map of topic partition -> end offset for a requested leader epoch
-   */
-  override def fetchEpochEndOffsets(partitions: util.Map[TopicPartition, OffsetForLeaderEpochRequestData.OffsetForLeaderPartition]): util.Map[TopicPartition, OffsetForLeaderEpochResponseData.EpochEndOffset] = {
-    util.Map.of[TopicPartition, OffsetForLeaderEpochResponseData.EpochEndOffset]()
-  }
-
-  /**
-   * Fetches the epoch and local log start offset from the leader for the given partition and the current leader-epoch
-   *
-   * @param topicPartition     The topic partition that we want to fetch from
-   * @param currentLeaderEpoch An int representing the current leader epoch of the requester
-   * @return An OffsetAndEpoch object representing the earliest local offset and epoch in the leader's topic partition.
-   */
-  override def fetchEarliestLocalOffset(topicPartition: TopicPartition, currentLeaderEpoch: Int): OffsetAndEpoch = {
-    new OffsetAndEpoch(0, 0)
-  }
-
-  /**
-   * Builds a fetch request, given a partition map.
-   *
-   * @param partitions A map of topic partitions to their respective partition fetch state
-   * @return A ResultWithPartitions, used to create the fetchRequest for fetch.
-   */
   override def buildFetch(partitions: util.Map[TopicPartition, PartitionFetchState]): ResultWithPartitions[Optional[ReplicaFetch]] = {
-    new ResultWithPartitions[Optional[ReplicaFetch]](Optional.empty(), util.Set.of())
+    if (quota.isQuotaExceeded) {
+      new ResultWithPartitions(Optional.empty(), util.Set.of())
+    } else {
+      val partitionsWithError = mutable.Set[TopicPartition]()
+      val requestMap = new util.LinkedHashMap[TopicPartition, FetchRequest.PartitionData]()
+
+      partitions.forEach { (topicPartition, fetchState) =>
+        if (fetchState.isReadyForFetch && !shouldFollowerThrottle(quota, fetchState, topicPartition)) {
+          try {
+            val logStartOffset = replicaManager.localLogOrException(topicPartition).logStartOffset
+            val lastFetchedEpoch = Optional.empty[Integer]()
+            requestMap.put(
+              topicPartition,
+              new FetchRequest.PartitionData(
+                fetchState.topicId().orElse(Uuid.ZERO_UUID),
+                fetchState.fetchOffset(),
+                logStartOffset,
+                fetchSize,
+                Optional.of(fetchState.currentLeaderEpoch()),
+                lastFetchedEpoch
+              )
+            )
+          } catch {
+            case _: KafkaStorageException =>
+              partitionsWithError += topicPartition
+          }
+        }
+      }
+
+      val fetchRequestOpt = if (requestMap.isEmpty) {
+        Optional.empty[ReplicaFetch]()
+      } else {
+        val metadataVersion = metadataVersionSupplier()
+        val canUseTopicIds = requestMap.asScala.values.forall(_.topicId != Uuid.ZERO_UUID)
+        val version: Short =
+          if (!canUseTopicIds) 12
+          else metadataVersion.fetchRequestVersion
+        val requestBuilder = FetchRequest.Builder
+          .forReplica(version, replicaId, brokerEpochSupplier(), maxWait, minBytes, requestMap)
+          .setMaxBytes(maxBytes)
+        Optional.of(new ReplicaFetch(requestMap, requestBuilder))
+      }
+
+      new ResultWithPartitions(fetchRequestOpt, partitionsWithError.asJava)
+    }
+  }
+
+  private def shouldFollowerThrottle(quota: ReplicaQuota, fetchState: PartitionFetchState, topicPartition: TopicPartition): Boolean = {
+    !fetchState.isReplicaInSync() && quota.isThrottled(topicPartition) && quota.isQuotaExceeded
   }
 }

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -280,12 +280,16 @@ class ReplicaManager(val config: KafkaConfig,
   // FIXME: FileMerger is having issues with hanging queries. Disabling until fixed.
   private val inklessFileMerger: Option[FileMerger] = None // inklessSharedState.map(new FileMerger(_))
   private val consolidationFetcherManager: Option[ConsolidationFetcherManager] =
-    if (config.disklessRemoteStorageConsolidationEnabled)
+    if (config.disklessRemoteStorageConsolidationEnabled) {
+      if (inklessFetchHandler.isEmpty || inklessFetchOffsetHandler.isEmpty) {
+        logger.warn("Remote storage consolidation is enabled, however Inkless doesn't seem to be configured properly.")
+      }
       inklessFetchHandler.zip(inklessFetchOffsetHandler).map { case (fetchHandler, fetchOffsetHandler) =>
         new ConsolidationFetcherManager(config, this, quotaManagers.follower, fetchHandler, fetchOffsetHandler)
       }
-    else
+    } else {
       None
+    }
 
   /* epoch of the controller that last changed the leader */
   protected val localBrokerId = config.brokerId

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -279,10 +279,13 @@ class ReplicaManager(val config: KafkaConfig,
   private val inklessFileCleaner: Option[FileCleaner] = inklessSharedState.map(new FileCleaner(_))
   // FIXME: FileMerger is having issues with hanging queries. Disabling until fixed.
   private val inklessFileMerger: Option[FileMerger] = None // inklessSharedState.map(new FileMerger(_))
-  private val consolidationFetcherManager: Option[ConsolidationFetcherManager] = if (config.disklessRemoteStorageConsolidationEnabled)
-    Some(new ConsolidationFetcherManager(config, this, quotaManagers.follower))
-  else
-    None
+  private val consolidationFetcherManager: Option[ConsolidationFetcherManager] =
+    if (config.disklessRemoteStorageConsolidationEnabled)
+      inklessFetchHandler.zip(inklessFetchOffsetHandler).map { case (fetchHandler, fetchOffsetHandler) =>
+        new ConsolidationFetcherManager(config, this, quotaManagers.follower, fetchHandler, fetchOffsetHandler)
+      }
+    else
+      None
 
   /* epoch of the controller that last changed the leader */
   protected val localBrokerId = config.brokerId

--- a/core/src/test/scala/io/aiven/inkless/consolidation/DisklessLeaderEndPointTest.scala
+++ b/core/src/test/scala/io/aiven/inkless/consolidation/DisklessLeaderEndPointTest.scala
@@ -200,9 +200,7 @@ class DisklessLeaderEndPointTest {
     when(fetchOffsetHandler.createJob()).thenReturn(job)
     when(job.mustHandle(topicPartition.topic())).thenReturn(true)
     when(job.add(eqTo(topicPartition), any())).thenReturn(CompletableFuture.completedFuture(holder))
-    when(job.start()).thenAnswer { _ =>
-      ()
-    }
+    doNothing().when(job).start()
 
     val endPoint = newEndPoint(fetchHandler, fetchOffsetHandler, replicaManager)
     val result = invoke(endPoint)

--- a/core/src/test/scala/io/aiven/inkless/consolidation/DisklessLeaderEndPointTest.scala
+++ b/core/src/test/scala/io/aiven/inkless/consolidation/DisklessLeaderEndPointTest.scala
@@ -1,0 +1,483 @@
+/*
+ * Inkless
+ * Copyright (C) 2024 - 2026 Aiven OY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package io.aiven.inkless.consolidation
+
+import io.aiven.inkless.consume.{FetchHandler, FetchOffsetHandler}
+import kafka.server.{KafkaConfig, QuotaFactory, ReplicaManager, ReplicaQuota}
+import kafka.utils.TestUtils
+import org.apache.kafka.common.errors.{KafkaStorageException, UnknownTopicOrPartitionException}
+import org.apache.kafka.common.message.FetchResponseData
+import org.apache.kafka.common.message.OffsetForLeaderEpochRequestData.OffsetForLeaderPartition
+import org.apache.kafka.common.message.OffsetForLeaderEpochResponseData.EpochEndOffset
+import org.apache.kafka.common.protocol.Errors
+import org.apache.kafka.common.record.FileRecords.TimestampAndOffset
+import org.apache.kafka.common.record.MemoryRecords
+import org.apache.kafka.common.requests.{FetchRequest, FetchResponse, ListOffsetsRequest, OffsetsForLeaderEpochResponse}
+import org.apache.kafka.common.{TopicIdPartition, TopicPartition, Uuid}
+import org.apache.kafka.server.common.{MetadataVersion, OffsetAndEpoch}
+import org.apache.kafka.server.network.BrokerEndPoint
+import org.apache.kafka.server.storage.log.FetchPartitionData
+import org.apache.kafka.server.{PartitionFetchState, ReplicaState}
+import org.apache.kafka.storage.internals.log.OffsetResultHolder.FileRecordsOrError
+import org.apache.kafka.storage.internals.log.UnifiedLog
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentCaptor
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
+import org.mockito.Mockito.{doNothing, mock, verify, when}
+
+import java.util
+import java.util.Optional
+import java.util.OptionalInt
+import java.util.OptionalLong
+import java.util.concurrent.CompletableFuture
+import scala.jdk.CollectionConverters._
+
+class DisklessLeaderEndPointTest {
+
+  private val brokerEndPoint = new BrokerEndPoint(1, "localhost", 9092)
+  private val topicPartition = new TopicPartition("diskless-topic", 0)
+  private val topicId = Uuid.randomUuid()
+  private val topicIdPartition = new TopicIdPartition(topicId, topicPartition)
+
+  private def kafkaConfig: KafkaConfig = {
+    val props = TestUtils.createBrokerConfig(brokerEndPoint.id, port = brokerEndPoint.port)
+    KafkaConfig.fromProps(props)
+  }
+
+  private def newEndPoint(
+    fetchHandler: FetchHandler,
+    fetchOffsetHandler: FetchOffsetHandler,
+    replicaManager: ReplicaManager,
+    quota: ReplicaQuota = QuotaFactory.UNBOUNDED_QUOTA,
+    metadataVersion: MetadataVersion = MetadataVersion.LATEST_PRODUCTION,
+    brokerEpoch: Long = 7L
+  ): DisklessLeaderEndPoint =
+    new DisklessLeaderEndPoint(
+      brokerEndPoint,
+      fetchHandler,
+      fetchOffsetHandler,
+      replicaManager,
+      kafkaConfig,
+      quota,
+      () => metadataVersion,
+      () => brokerEpoch
+    )
+
+  @Test
+  def testBuildFetchProducesReplicaFetch(): Unit = {
+    val fetchHandler = mock(classOf[FetchHandler])
+    val fetchOffsetHandler = mock(classOf[FetchOffsetHandler])
+    val replicaManager = mock(classOf[ReplicaManager])
+    val log = mock(classOf[UnifiedLog])
+    when(log.logStartOffset).thenReturn(11L)
+    when(replicaManager.localLogOrException(topicPartition)).thenReturn(log)
+
+    val endPoint = newEndPoint(fetchHandler, fetchOffsetHandler, replicaManager)
+    val fetchState = new PartitionFetchState(
+      Optional.of(topicId),
+      99L,
+      Optional.empty(),
+      4,
+      ReplicaState.FETCHING,
+      Optional.empty()
+    )
+    val result = endPoint.buildFetch(util.Map.of(topicPartition, fetchState))
+
+    assertTrue(result.partitionsWithError.isEmpty)
+    assertTrue(result.result.isPresent)
+    val replicaFetch = result.result.get
+    assertTrue(replicaFetch.partitionData.containsKey(topicPartition))
+    assertEquals(topicId, replicaFetch.partitionData.get(topicPartition).topicId)
+    assertEquals(99L, replicaFetch.partitionData.get(topicPartition).fetchOffset)
+  }
+
+  @Test
+  def testFetchMapsFetchHandlerResponseToPartitionData(): Unit = {
+    val fetchHandler = mock(classOf[FetchHandler])
+    val fetchOffsetHandler = mock(classOf[FetchOffsetHandler])
+    val replicaManager = mock(classOf[ReplicaManager])
+
+    val aborted = util.List.of(new FetchResponseData.AbortedTransaction())
+    val fetchData = new FetchPartitionData(
+      Errors.NONE,
+      99L,
+      1L,
+      MemoryRecords.EMPTY,
+      Optional.empty(),
+      OptionalLong.of(88L),
+      Optional.of(aborted),
+      OptionalInt.empty(),
+      false
+    )
+    val responseMap = Map(topicIdPartition -> fetchData).asJava
+    when(fetchHandler.handle(any(), any())).thenReturn(CompletableFuture.completedFuture(responseMap))
+
+    val endPoint = newEndPoint(fetchHandler, fetchOffsetHandler, replicaManager)
+    val partitionData = new util.HashMap[TopicPartition, FetchRequest.PartitionData]()
+    val fetchBuilder = FetchRequest.Builder.forReplica(12, 1, 1L, 100, 1, partitionData).setMaxBytes(100_000)
+
+    val result = endPoint.fetch(fetchBuilder).asScala
+
+    assertEquals(1, result.size)
+    val pd = result(topicPartition)
+    assertEquals(Errors.NONE.code, pd.errorCode)
+    assertEquals(99L, pd.highWatermark)
+    assertEquals(88L, pd.lastStableOffset)
+    assertEquals(1L, pd.logStartOffset)
+    assertEquals(aborted, pd.abortedTransactions)
+    assertEquals(MemoryRecords.EMPTY, pd.records)
+  }
+
+  @Test
+  def testFetchUsesInvalidLastStableOffsetWhenOptionalEmpty(): Unit = {
+    val fetchHandler = mock(classOf[FetchHandler])
+    val fetchOffsetHandler = mock(classOf[FetchOffsetHandler])
+    val replicaManager = mock(classOf[ReplicaManager])
+
+    val fetchData = new FetchPartitionData(
+      Errors.NONE,
+      10L,
+      0L,
+      MemoryRecords.EMPTY,
+      Optional.empty(),
+      OptionalLong.empty(),
+      Optional.empty(),
+      OptionalInt.empty(),
+      false
+    )
+    when(fetchHandler.handle(any(), any())).thenReturn(CompletableFuture.completedFuture(Map(topicIdPartition -> fetchData).asJava))
+
+    val endPoint = newEndPoint(fetchHandler, fetchOffsetHandler, replicaManager)
+    val partitionData = new util.HashMap[TopicPartition, FetchRequest.PartitionData]()
+    val fetchBuilder = FetchRequest.Builder.forReplica(12, 1, 1L, 100, 1, partitionData).setMaxBytes(100_000)
+
+    val pd = endPoint.fetch(fetchBuilder).get(topicPartition)
+    assertEquals(FetchResponse.INVALID_LAST_STABLE_OFFSET, pd.lastStableOffset)
+  }
+
+  @Test
+  def testFetchEarliestOffsetUsesEarliestTimestamp(): Unit = {
+    verifyListOffsetTimestamp(ListOffsetsRequest.EARLIEST_TIMESTAMP, _.fetchEarliestOffset(topicPartition, 3))
+  }
+
+  @Test
+  def testFetchLatestOffsetUsesLatestTimestamp(): Unit = {
+    verifyListOffsetTimestamp(ListOffsetsRequest.LATEST_TIMESTAMP, _.fetchLatestOffset(topicPartition, 3))
+  }
+
+  @Test
+  def testFetchEarliestLocalOffsetUsesEarliestLocalTimestamp(): Unit = {
+    verifyListOffsetTimestamp(ListOffsetsRequest.EARLIEST_LOCAL_TIMESTAMP, _.fetchEarliestLocalOffset(topicPartition, 3))
+  }
+
+  private def verifyListOffsetTimestamp(expectedTimestamp: Long, invoke: DisklessLeaderEndPoint => OffsetAndEpoch): Unit = {
+    val fetchHandler = mock(classOf[FetchHandler])
+    val fetchOffsetHandler = mock(classOf[FetchOffsetHandler])
+    val replicaManager = mock(classOf[ReplicaManager])
+    val job = mock(classOf[FetchOffsetHandler.Job])
+
+    val holder = new FileRecordsOrError(
+      Optional.empty(),
+      Optional.of(new TimestampAndOffset(0L, 10L, Optional.of(5)))
+    )
+    when(fetchOffsetHandler.createJob()).thenReturn(job)
+    when(job.mustHandle(topicPartition.topic())).thenReturn(true)
+    when(job.add(eqTo(topicPartition), any())).thenReturn(CompletableFuture.completedFuture(holder))
+    when(job.start()).thenAnswer { _ =>
+      ()
+    }
+
+    val endPoint = newEndPoint(fetchHandler, fetchOffsetHandler, replicaManager)
+    val result = invoke(endPoint)
+
+    assertEquals(new OffsetAndEpoch(10L, 5), result)
+
+    val captor = ArgumentCaptor.forClass(classOf[org.apache.kafka.common.message.ListOffsetsRequestData.ListOffsetsPartition])
+    verify(job).add(eqTo(topicPartition), captor.capture())
+    assertEquals(expectedTimestamp, captor.getValue.timestamp)
+    assertEquals(topicPartition.partition, captor.getValue.partitionIndex)
+    assertEquals(3, captor.getValue.currentLeaderEpoch)
+  }
+
+  @Test
+  def testListDisklessOffsetThrowsWhenTopicNotDiskless(): Unit = {
+    val fetchHandler = mock(classOf[FetchHandler])
+    val fetchOffsetHandler = mock(classOf[FetchOffsetHandler])
+    val replicaManager = mock(classOf[ReplicaManager])
+    val job = mock(classOf[FetchOffsetHandler.Job])
+
+    when(fetchOffsetHandler.createJob()).thenReturn(job)
+    when(job.mustHandle(topicPartition.topic())).thenReturn(false)
+
+    val endPoint = newEndPoint(fetchHandler, fetchOffsetHandler, replicaManager)
+    assertThrows(
+      classOf[UnknownTopicOrPartitionException],
+      () => endPoint.fetchLatestOffset(topicPartition, 0)
+    )
+  }
+
+  @Test
+  def testListDisklessOffsetPropagatesHolderException(): Unit = {
+    val fetchHandler = mock(classOf[FetchHandler])
+    val fetchOffsetHandler = mock(classOf[FetchOffsetHandler])
+    val replicaManager = mock(classOf[ReplicaManager])
+    val job = mock(classOf[FetchOffsetHandler.Job])
+
+    val holder = new FileRecordsOrError(
+      Optional.of(new UnknownTopicOrPartitionException("missing")),
+      Optional.empty()
+    )
+    when(fetchOffsetHandler.createJob()).thenReturn(job)
+    when(job.mustHandle(topicPartition.topic())).thenReturn(true)
+    when(job.add(eqTo(topicPartition), any())).thenReturn(CompletableFuture.completedFuture(holder))
+
+    val endPoint = newEndPoint(fetchHandler, fetchOffsetHandler, replicaManager)
+    assertThrows(
+      classOf[UnknownTopicOrPartitionException],
+      () => endPoint.fetchEarliestOffset(topicPartition, 0)
+    )
+  }
+
+  @Test
+  def testFetchEpochEndOffsetsReturnsEmptyForEmptyInput(): Unit = {
+    val fetchHandler = mock(classOf[FetchHandler])
+    val fetchOffsetHandler = mock(classOf[FetchOffsetHandler])
+    val replicaManager = mock(classOf[ReplicaManager])
+    val endPoint = newEndPoint(fetchHandler, fetchOffsetHandler, replicaManager)
+
+    assertTrue(endPoint.fetchEpochEndOffsets(util.Map.of()).isEmpty)
+  }
+
+  @Test
+  def testFetchEpochEndOffsetsUndefinedEpoch(): Unit = {
+    val fetchHandler = mock(classOf[FetchHandler])
+    val fetchOffsetHandler = mock(classOf[FetchOffsetHandler])
+    val replicaManager = mock(classOf[ReplicaManager])
+    val job = mock(classOf[FetchOffsetHandler.Job])
+    when(fetchOffsetHandler.createJob()).thenReturn(job)
+    doNothing().when(job).start()
+
+    val endPoint = newEndPoint(fetchHandler, fetchOffsetHandler, replicaManager)
+
+    val result = endPoint.fetchEpochEndOffsets(
+      util.Map.of(
+        topicPartition,
+        new OffsetForLeaderPartition()
+          .setPartition(topicPartition.partition)
+          .setLeaderEpoch(OffsetsForLeaderEpochResponse.UNDEFINED_EPOCH)
+      )
+    ).asScala
+
+    val expected = new EpochEndOffset()
+      .setPartition(topicPartition.partition)
+      .setErrorCode(Errors.NONE.code)
+    assertEquals(Map(topicPartition -> expected), result)
+  }
+
+  @Test
+  def testFetchEpochEndOffsetsUnknownTopicPartition(): Unit = {
+    val fetchHandler = mock(classOf[FetchHandler])
+    val fetchOffsetHandler = mock(classOf[FetchOffsetHandler])
+    val replicaManager = mock(classOf[ReplicaManager])
+    val job = mock(classOf[FetchOffsetHandler.Job])
+
+    when(fetchOffsetHandler.createJob()).thenReturn(job)
+    when(job.mustHandle(topicPartition.topic())).thenReturn(false)
+
+    val endPoint = newEndPoint(fetchHandler, fetchOffsetHandler, replicaManager)
+    val result = endPoint.fetchEpochEndOffsets(
+      util.Map.of(
+        topicPartition,
+        new OffsetForLeaderPartition()
+          .setPartition(topicPartition.partition)
+          .setLeaderEpoch(1)
+      )
+    ).asScala
+
+    val expected = new EpochEndOffset()
+      .setPartition(topicPartition.partition)
+      .setErrorCode(Errors.UNKNOWN_TOPIC_OR_PARTITION.code)
+    assertEquals(Map(topicPartition -> expected), result)
+  }
+
+  @Test
+  def testFetchEpochEndOffsetsSuccess(): Unit = {
+    val fetchHandler = mock(classOf[FetchHandler])
+    val fetchOffsetHandler = mock(classOf[FetchOffsetHandler])
+    val replicaManager = mock(classOf[ReplicaManager])
+    val job = mock(classOf[FetchOffsetHandler.Job])
+
+    val holder = new FileRecordsOrError(
+      Optional.empty(),
+      Optional.of(new TimestampAndOffset(0L, 100L, Optional.of(2)))
+    )
+    when(fetchOffsetHandler.createJob()).thenReturn(job)
+    when(job.mustHandle(topicPartition.topic())).thenReturn(true)
+    when(job.add(eqTo(topicPartition), any())).thenReturn(CompletableFuture.completedFuture(holder))
+
+    val endPoint = newEndPoint(fetchHandler, fetchOffsetHandler, replicaManager)
+    val leaderEpoch = 9
+    val result = endPoint.fetchEpochEndOffsets(
+      util.Map.of(
+        topicPartition,
+        new OffsetForLeaderPartition()
+          .setPartition(topicPartition.partition)
+          .setLeaderEpoch(leaderEpoch)
+      )
+    ).asScala
+
+    val expected = new EpochEndOffset()
+      .setPartition(topicPartition.partition)
+      .setErrorCode(Errors.NONE.code)
+      .setLeaderEpoch(leaderEpoch)
+      .setEndOffset(100L)
+    assertEquals(Map(topicPartition -> expected), result)
+  }
+
+  @Test
+  def testFetchEpochEndOffsetsHolderException(): Unit = {
+    val fetchHandler = mock(classOf[FetchHandler])
+    val fetchOffsetHandler = mock(classOf[FetchOffsetHandler])
+    val replicaManager = mock(classOf[ReplicaManager])
+    val job = mock(classOf[FetchOffsetHandler.Job])
+
+    val holder = new FileRecordsOrError(
+      Optional.of(new KafkaStorageException("offline")),
+      Optional.empty()
+    )
+    when(fetchOffsetHandler.createJob()).thenReturn(job)
+    when(job.mustHandle(topicPartition.topic())).thenReturn(true)
+    when(job.add(eqTo(topicPartition), any())).thenReturn(CompletableFuture.completedFuture(holder))
+
+    val endPoint = newEndPoint(fetchHandler, fetchOffsetHandler, replicaManager)
+    val result = endPoint.fetchEpochEndOffsets(
+      util.Map.of(
+        topicPartition,
+        new OffsetForLeaderPartition()
+          .setPartition(topicPartition.partition)
+          .setLeaderEpoch(3)
+      )
+    ).asScala
+
+    assertEquals(Errors.KAFKA_STORAGE_ERROR.code, result(topicPartition).errorCode)
+  }
+
+  @Test
+  def testFetchEpochEndOffsetsFutureGetThrows(): Unit = {
+    val fetchHandler = mock(classOf[FetchHandler])
+    val fetchOffsetHandler = mock(classOf[FetchOffsetHandler])
+    val replicaManager = mock(classOf[ReplicaManager])
+    val job = mock(classOf[FetchOffsetHandler.Job])
+
+    val failed = new CompletableFuture[FileRecordsOrError]()
+    failed.completeExceptionally(new RuntimeException("boom"))
+    when(fetchOffsetHandler.createJob()).thenReturn(job)
+    when(job.mustHandle(topicPartition.topic())).thenReturn(true)
+    when(job.add(eqTo(topicPartition), any())).thenReturn(failed)
+
+    val endPoint = newEndPoint(fetchHandler, fetchOffsetHandler, replicaManager)
+    val result = endPoint.fetchEpochEndOffsets(
+      util.Map.of(
+        topicPartition,
+        new OffsetForLeaderPartition()
+          .setPartition(topicPartition.partition)
+          .setLeaderEpoch(2)
+      )
+    ).asScala
+
+    assertEquals(Errors.UNKNOWN_SERVER_ERROR.code, result(topicPartition).errorCode)
+  }
+
+  @Test
+  def testBuildFetchReturnsEmptyWhenQuotaExceeded(): Unit = {
+    val fetchHandler = mock(classOf[FetchHandler])
+    val fetchOffsetHandler = mock(classOf[FetchOffsetHandler])
+    val replicaManager = mock(classOf[ReplicaManager])
+    val quota = mock(classOf[ReplicaQuota])
+    when(quota.isQuotaExceeded).thenReturn(true)
+
+    val endPoint = newEndPoint(fetchHandler, fetchOffsetHandler, replicaManager, quota = quota)
+    val fetchState = new PartitionFetchState(
+      Optional.of(topicId),
+      0L,
+      Optional.empty(),
+      1,
+      Optional.empty(),
+      ReplicaState.FETCHING,
+      Optional.empty()
+    )
+    val result = endPoint.buildFetch(util.Map.of(topicPartition, fetchState))
+
+    assertTrue(result.result.isEmpty)
+    assertTrue(result.partitionsWithError.isEmpty)
+  }
+
+  @Test
+  def testBuildFetchMarksPartitionWithKafkaStorageException(): Unit = {
+    val fetchHandler = mock(classOf[FetchHandler])
+    val fetchOffsetHandler = mock(classOf[FetchOffsetHandler])
+    val replicaManager = mock(classOf[ReplicaManager])
+    when(replicaManager.localLogOrException(topicPartition)).thenThrow(new KafkaStorageException("bad log"))
+
+    val endPoint = newEndPoint(fetchHandler, fetchOffsetHandler, replicaManager)
+    val fetchState = new PartitionFetchState(
+      Optional.of(topicId),
+      0L,
+      Optional.empty(),
+      1,
+      Optional.empty(),
+      ReplicaState.FETCHING,
+      Optional.empty()
+    )
+    val result = endPoint.buildFetch(util.Map.of(topicPartition, fetchState))
+
+    assertTrue(result.result.isEmpty)
+    assertEquals(Set(topicPartition), result.partitionsWithError.asScala.toSet)
+  }
+
+  @Test
+  def testBuildFetchSkipsPartitionWhenFollowerShouldThrottle(): Unit = {
+    val fetchHandler = mock(classOf[FetchHandler])
+    val fetchOffsetHandler = mock(classOf[FetchOffsetHandler])
+    val replicaManager = mock(classOf[ReplicaManager])
+    val log = mock(classOf[UnifiedLog])
+    when(log.logStartOffset).thenReturn(0L)
+    when(replicaManager.localLogOrException(topicPartition)).thenReturn(log)
+
+    val quota = mock(classOf[ReplicaQuota])
+    when(quota.isQuotaExceeded).thenReturn(false, true)
+    when(quota.isThrottled(topicPartition)).thenReturn(true)
+
+    val endPoint = newEndPoint(fetchHandler, fetchOffsetHandler, replicaManager, quota = quota)
+    val fetchState = new PartitionFetchState(
+      Optional.of(topicId),
+      0L,
+      Optional.of(100L),
+      1,
+      Optional.empty(),
+      ReplicaState.FETCHING,
+      Optional.empty()
+    )
+    val result = endPoint.buildFetch(util.Map.of(topicPartition, fetchState))
+
+    assertTrue(result.result.isEmpty)
+    assertTrue(result.partitionsWithError.isEmpty)
+  }
+}


### PR DESCRIPTION
This commit adds the implementation for DisklessLeaderEndPoint. It uses FetchHandler and FetchOffsetHandler to fetch from the diskless coordinator and append to the local log (which is handled by the fetcher thread).