### PR TITLE
feat(inkless): Abort transactions on partition sealing

### DIFF
--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -261,6 +261,10 @@ class Partition(val topicPartition: TopicPartition,
 
   def isSealed: Boolean = _sealed
 
+  /**
+   * Seal this Partition so that no more records can be appended locally.
+   * @throws KafkaStorageException If transaction abortion fails due to an I/O error.
+   */
   def seal(): Unit = inWriteLock(leaderIsrUpdateLock) {
     if (!_sealed) {
       val leaderLog = localLogOrException
@@ -276,6 +280,7 @@ class Partition(val topicPartition: TopicPartition,
    * Abort all ongoing transactions by appending ABORT markers directly to the log.
    * Diskless topics do not support transactions, so any in-flight transaction must
    * be resolved before migration proceeds.
+   * @throws KafkaStorageException If transaction abortion fails due to an I/O error.
    */
   private def abortOngoingTransactions(leaderLog: UnifiedLog): Unit = {
     val producerStateManager = leaderLog.producerStateManager()

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -32,7 +32,7 @@ import org.apache.kafka.common.message.{DescribeProducersResponseData, FetchResp
 import org.apache.kafka.common.message.OffsetForLeaderEpochResponseData.EpochEndOffset
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.record.FileRecords.TimestampAndOffset
-import org.apache.kafka.common.record.{FileRecords, MemoryRecords, RecordBatch}
+import org.apache.kafka.common.record.{ControlRecordType, EndTransactionMarker, FileRecords, MemoryRecords, RecordBatch}
 import org.apache.kafka.common.requests._
 import org.apache.kafka.common.requests.OffsetsForLeaderEpochResponse.{UNDEFINED_EPOCH, UNDEFINED_EPOCH_OFFSET}
 import org.apache.kafka.common.utils.Time
@@ -263,8 +263,43 @@ class Partition(val topicPartition: TopicPartition,
 
   def seal(): Unit = inWriteLock(leaderIsrUpdateLock) {
     if (!_sealed) {
+      val leaderLog = localLogOrException
+      if (leaderLog.producerStateManager().firstUndecidedOffset().isPresent) {
+        abortOngoingTransactions(leaderLog)
+      }
       _sealed = true
-      stateChangeLogger.info(s"Sealed partition $topicPartition for diskless migration with LEO ${localLogOrException.logEndOffset}")
+      stateChangeLogger.info(s"Sealed partition $topicPartition for diskless migration with LEO ${leaderLog.logEndOffset}")
+    }
+  }
+
+  /**
+   * Abort all ongoing transactions by appending ABORT markers directly to the log.
+   * Diskless topics do not support transactions, so any in-flight transaction must
+   * be resolved before migration proceeds.
+   */
+  private def abortOngoingTransactions(leaderLog: UnifiedLog): Unit = {
+    val producerStateManager = leaderLog.producerStateManager()
+    val toAbort = new java.util.ArrayList[(Long, Short, Int, Long)]()
+    producerStateManager.activeProducers().forEach { (producerId, entry) =>
+      if (entry.currentTxnFirstOffset().isPresent) {
+        toAbort.add((producerId, entry.producerEpoch(), entry.coordinatorEpoch(), entry.currentTxnFirstOffset().getAsLong))
+      }
+    }
+    toAbort.forEach { case (producerId, producerEpoch, coordinatorEpoch, txnFirstOffset) =>
+      val abortMarker = MemoryRecords.withEndTransactionMarker(
+        producerId,
+        producerEpoch,
+        new EndTransactionMarker(ControlRecordType.ABORT, coordinatorEpoch)
+      )
+      // Use TV_0 because its epoch validation (markerEpoch >= currentEpoch) allows
+      // writing the abort marker with the producer's current epoch. Higher transaction
+      // versions require a bumped epoch, which only the transaction coordinator can
+      // perform.
+      leaderLog.appendAsLeader(abortMarker, leaderEpoch, AppendOrigin.COORDINATOR,
+        RequestLocal.noCaching(), VerificationGuard.SENTINEL, TransactionVersion.TV_0.featureLevel())
+      stateChangeLogger.info(s"Aborted ongoing transaction for producer $producerId " +
+        s"(epoch=$producerEpoch, txnFirstOffset=$txnFirstOffset) " +
+        s"on partition $topicPartition before sealing for diskless migration")
     }
   }
 

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -560,7 +560,7 @@ class ReplicaManager(val config: KafkaConfig,
     }
   }
 
-  def sealTopicPartitions(topic: String): Unit = {
+  private def sealTopicPartitions(topic: String): Unit = {
     if (initDisklessLogManager.isEmpty) {
       error(s"Cannot seal partitions for topic $topic: InitDisklessLogManager is not enabled.")
       return
@@ -571,8 +571,15 @@ class ReplicaManager(val config: KafkaConfig,
           case HostedPartition.Online(partition) if partition.isLeader =>
             partition.topicId match {
               case Some(id) =>
-                partition.seal()
-                initDisklessLogManager.foreach(_.registerPartition(partition, id))
+                try {
+                  partition.seal()
+                  initDisklessLogManager.foreach(_.registerPartition(partition, id))
+                } catch {
+                  case e: KafkaStorageException =>
+                    stateChangeLogger.error(s"Failed to seal partition ${partition.topicPartition} " +
+                      s"for diskless migration due to a storage error ${e.getMessage}")
+                    markPartitionOffline(tp)
+                }
               case None =>
                 error(s"Partition ${partition.topicPartition} has no topic ID, skipping seal and migration registration")
             }

--- a/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
@@ -53,7 +53,7 @@ import org.apache.kafka.common.replica.ClientMetadata
 import org.apache.kafka.common.replica.ClientMetadata.DefaultClientMetadata
 import org.apache.kafka.common.security.auth.{KafkaPrincipal, SecurityProtocol}
 import org.apache.kafka.coordinator.transaction.TransactionLogConfig
-import org.apache.kafka.server.common.{ControllerRequestCompletionHandler, NodeToControllerChannelManager, RequestLocal}
+import org.apache.kafka.server.common.{ControllerRequestCompletionHandler, NodeToControllerChannelManager, RequestLocal, TransactionVersion}
 import org.apache.kafka.server.metrics.KafkaYammerMetrics
 import org.apache.kafka.server.partition.{AlterPartitionListener, OngoingReassignmentState, PartitionListener, PendingShrinkIsr, SimpleAssignmentState}
 import org.apache.kafka.server.purgatory.{DelayedDeleteRecords, DelayedOperationPurgatory, TopicPartitionOperationKey}
@@ -4194,5 +4194,116 @@ class PartitionTest extends AbstractPartitionTest {
     val records = TestUtils.records(List(new SimpleRecord("k".getBytes, "v".getBytes)))
     assertThrows(classOf[ReplicaNotAvailableException], () =>
       partition.appendRecordsToLeader(records, origin = AppendOrigin.CLIENT, requiredAcks = 0, requestLocal))
+  }
+
+  private def appendTransactionalRecords(
+    log: UnifiedLog,
+    leaderEpoch: Int,
+    producerId: Long,
+    producerEpoch: Short,
+    sequence: Int,
+    records: SimpleRecord*
+  ): Unit = {
+    val guard = log.maybeStartTransactionVerification(producerId, sequence, producerEpoch, false)
+    val txnRecords = MemoryRecords.withTransactionalRecords(
+      Compression.NONE, producerId, producerEpoch, sequence, records: _*
+    )
+    log.appendAsLeader(txnRecords, leaderEpoch, AppendOrigin.CLIENT,
+      RequestLocal.noCaching(), guard, TransactionVersion.TV_0.featureLevel())
+  }
+
+  @Test
+  def testSealAbortsOngoingTransactions(): Unit = {
+    val leaderEpoch = 1
+    partition = setupPartitionWithMocks(leaderEpoch, isLeader = true)
+    val log = partition.localLogOrException
+
+    val producerId = 137L
+    val producerEpoch: Short = 5
+
+    appendTransactionalRecords(log, leaderEpoch, producerId, producerEpoch, 0,
+      new SimpleRecord("k1".getBytes, "v1".getBytes),
+      new SimpleRecord("k2".getBytes, "v2".getBytes)
+    )
+
+    assertTrue(log.hasOngoingTransaction(producerId, producerEpoch))
+    assertTrue(log.firstUnstableOffset().isPresent)
+
+    partition.seal()
+
+    assertTrue(partition.isSealed)
+    assertFalse(log.hasOngoingTransaction(producerId, producerEpoch),
+      "Ongoing transaction should have been aborted by seal")
+    assertTrue(log.producerStateManager().firstUndecidedOffset().isEmpty,
+      "There should be no undecided transactions after aborting")
+  }
+
+  @Test
+  def testSealAbortsMultipleOngoingTransactions(): Unit = {
+    val leaderEpoch = 1
+    partition = setupPartitionWithMocks(leaderEpoch, isLeader = true)
+    val log = partition.localLogOrException
+
+    val pid1 = 137L
+    val pid2 = 983L
+    val epoch: Short = 5
+
+    appendTransactionalRecords(log, leaderEpoch, pid1, epoch, 0,
+      new SimpleRecord("a".getBytes, "b".getBytes)
+    )
+
+    appendTransactionalRecords(log, leaderEpoch, pid2, epoch, 0,
+      new SimpleRecord("c".getBytes, "d".getBytes)
+    )
+
+    assertTrue(log.hasOngoingTransaction(pid1, epoch))
+    assertTrue(log.hasOngoingTransaction(pid2, epoch))
+
+    partition.seal()
+
+    assertTrue(partition.isSealed)
+    assertFalse(log.hasOngoingTransaction(pid1, epoch))
+    assertFalse(log.hasOngoingTransaction(pid2, epoch))
+    assertTrue(log.producerStateManager().firstUndecidedOffset().isEmpty,
+      "There should be no undecided transactions after aborting")
+  }
+
+  @Test
+  def testSealWithNoOngoingTransactions(): Unit = {
+    val leaderEpoch = 1
+    partition = setupPartitionWithMocks(leaderEpoch, isLeader = true)
+    val log = partition.localLogOrException
+
+    val records = TestUtils.records(List(new SimpleRecord("k".getBytes, "v".getBytes)))
+    partition.appendRecordsToLeader(records, origin = AppendOrigin.CLIENT, requiredAcks = 0,
+      RequestLocal.withThreadConfinedCaching)
+
+    val leoBefore = log.logEndOffset
+
+    partition.seal()
+
+    assertTrue(partition.isSealed)
+    assertEquals(leoBefore, log.logEndOffset, "LEO should not change when there are no transactions to abort")
+  }
+
+  @Test
+  def testSealAbortsTransactionAndIncreasesLeo(): Unit = {
+    val leaderEpoch = 1
+    partition = setupPartitionWithMocks(leaderEpoch, isLeader = true)
+    val log = partition.localLogOrException
+
+    val producerId = 42L
+    val producerEpoch: Short = 1
+
+    appendTransactionalRecords(log, leaderEpoch, producerId, producerEpoch, 0,
+      new SimpleRecord("k".getBytes, "v".getBytes)
+    )
+
+    val leoBeforeSeal = log.logEndOffset
+
+    partition.seal()
+
+    assertTrue(log.logEndOffset > leoBeforeSeal,
+      "LEO should have increased due to the ABORT marker appended during seal")
   }
 }


### PR DESCRIPTION
If there are ongoing transactions in partitions being migrated from classic to diskless, add an ABORT transaction record.