### PR TITLE
feat(inkless:consume): Add time-to-first-byte (TTFB) metric for storage reads

### DIFF
--- a/storage/inkless/src/main/java/io/aiven/inkless/consume/FetchPlanner.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/consume/FetchPlanner.java
@@ -314,7 +314,8 @@ public class FetchPlanner implements Supplier<List<FetchPlanner.FetchRequestWith
                 fetcher,
                 request.objectKey(),
                 request.byteRange(),
-                metrics::fetchFileFinished
+                metrics::fetchFileFinished,
+                metrics::fetchFirstByteFinished
             );
             final FileExtent fileExtent = job.call();
 

--- a/storage/inkless/src/main/java/io/aiven/inkless/consume/FileFetchJob.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/consume/FileFetchJob.java
@@ -31,6 +31,7 @@ import io.aiven.inkless.common.ObjectKey;
 import io.aiven.inkless.generated.FileExtent;
 import io.aiven.inkless.storage_backend.common.ObjectFetcher;
 import io.aiven.inkless.storage_backend.common.StorageBackendException;
+import io.aiven.inkless.storage_backend.common.TimingReadableByteChannel;
 
 public class FileFetchJob implements Callable<FileExtent> {
 
@@ -40,17 +41,20 @@ public class FileFetchJob implements Callable<FileExtent> {
     private final ByteRange range;
     private final int size;
     private final Consumer<Long> durationCallback;
+    private final Consumer<Long> ttfbCallback;
 
     public FileFetchJob(Time time,
                         ObjectFetcher objectFetcher,
                         ObjectKey key,
                         ByteRange range,
-                        Consumer<Long> durationCallback) {
+                        Consumer<Long> durationCallback,
+                        Consumer<Long> ttfbCallback) {
         this.time = time;
         this.objectFetcher = objectFetcher;
         this.key = key;
         this.range = range;
         this.durationCallback = durationCallback;
+        this.ttfbCallback = ttfbCallback;
         this.size = range.bufferSize();
     }
 
@@ -70,8 +74,11 @@ public class FileFetchJob implements Callable<FileExtent> {
     }
 
     private FileExtent doWork() throws IOException, StorageBackendException {
-        final ByteBuffer byteBuffer = objectFetcher.readToByteBuffer(objectFetcher.fetch(key, range));
-        return createFileExtent(key, range, byteBuffer);
+        final var startTime = TimeUtils.durationMeasurementNow(time);
+        try (final var channel = new TimingReadableByteChannel(objectFetcher.fetch(key, range), time, startTime, ttfbCallback)) {
+            final ByteBuffer byteBuffer = objectFetcher.readToByteBuffer(channel);
+            return createFileExtent(key, range, byteBuffer);
+        }
     }
 
 

--- a/storage/inkless/src/main/java/io/aiven/inkless/consume/InklessFetchMetrics.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/consume/InklessFetchMetrics.java
@@ -45,6 +45,7 @@ public class InklessFetchMetrics {
     private static final String CACHE_MISS_COUNT = "CacheMissCount";
     private static final String CACHE_ENTRY_SIZE = "CacheEntrySize";
     private static final String CACHE_SIZE = "CacheSize";
+    private static final String FETCH_FIRST_BYTE_TIME = "FetchFirstByteTime";
     private static final String FETCH_FILE_TIME = "FetchFileTime";
     private static final String FETCH_COMPLETION_TIME = "FetchCompletionTime";
     private static final String FETCH_RATE = "FetchRate";
@@ -77,6 +78,7 @@ public class InklessFetchMetrics {
     private final Gauge<Long> cacheSize;
     private final Meter cacheHits;
     private final Meter cacheMisses;
+    private final Histogram fetchFirstByteTimeHistogram;
     private final Histogram fetchFileTimeHistogram;
     private final Histogram fetchCompletionTimeHistogram;
     private final Meter fetchRate;
@@ -101,6 +103,7 @@ public class InklessFetchMetrics {
         cacheStoreTimeHistogram = metricsGroup.newHistogram(CACHE_STORE_TIME, true, Map.of());
         cacheHits = metricsGroup.newMeter(CACHE_HIT_COUNT, "hits", TimeUnit.SECONDS, Map.of());
         cacheMisses = metricsGroup.newMeter(CACHE_MISS_COUNT, "misses", TimeUnit.SECONDS, Map.of());
+        fetchFirstByteTimeHistogram = metricsGroup.newHistogram(FETCH_FIRST_BYTE_TIME, true, Map.of());
         fetchFileTimeHistogram = metricsGroup.newHistogram(FETCH_FILE_TIME, true, Map.of());
         fetchCompletionTimeHistogram = metricsGroup.newHistogram(FETCH_COMPLETION_TIME, true, Map.of());
         fetchRate = metricsGroup.newMeter(FETCH_RATE, "fetches", TimeUnit.SECONDS, Map.of());
@@ -152,6 +155,10 @@ public class InklessFetchMetrics {
         cacheEntrySize.update(size);
     }
 
+    public void fetchFirstByteFinished(final long durationMs) {
+        fetchFirstByteTimeHistogram.update(durationMs);
+    }
+
     public void fetchFileFinished(final long durationMs) {
         fetchFileTimeHistogram.update(durationMs);
     }
@@ -178,6 +185,7 @@ public class InklessFetchMetrics {
 
     public void close() {
         metricsGroup.removeMetric(FETCH_TOTAL_TIME);
+        metricsGroup.removeMetric(FETCH_FIRST_BYTE_TIME);
         metricsGroup.removeMetric(FETCH_FILE_TIME);
         metricsGroup.removeMetric(FETCH_PLAN_TIME);
         metricsGroup.removeMetric(CACHE_QUERY_TIME);

--- a/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/common/TimingReadableByteChannel.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/common/TimingReadableByteChannel.java
@@ -1,0 +1,86 @@
+/*
+ * Inkless
+ * Copyright (C) 2024 - 2026 Aiven OY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.aiven.inkless.storage_backend.common;
+
+import org.apache.kafka.common.utils.Time;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.ReadableByteChannel;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.function.Consumer;
+
+import io.aiven.inkless.TimeUtils;
+
+/**
+ * A {@link ReadableByteChannel} decorator that measures time-to-first-byte (TTFB):
+ * the duration from a caller-supplied start time to when the first {@code read()} call returns data.
+ *
+ * <p>The start time is provided externally so that it can be captured <em>before</em> the storage
+ * fetch is initiated (e.g., before {@code ObjectFetcher.fetch()}). This ensures TTFB includes
+ * all setup overhead (DNS, TLS, HTTP request, metadata lookup) regardless of whether the backend
+ * downloads eagerly (S3) or streams lazily (GCS, Azure).
+ *
+ * <p><strong>Measurement granularity:</strong> The timestamp is captured <em>after</em>
+ * {@code delegate.read(dst)} returns, so the reported TTFB includes the transfer time for the
+ * first chunk (typically up to the buffer size), not the precise instant the first byte arrives
+ * on the wire. For most storage backends and buffer sizes this difference is negligible.
+ *
+ * <p>The callback is invoked at most once, on the first successful read that returns &gt; 0 bytes.
+ * If the channel is closed or exhausted without ever returning data, the callback is never invoked.
+ */
+public class TimingReadableByteChannel implements ReadableByteChannel {
+
+    private final ReadableByteChannel delegate;
+    private final Instant startTime;
+    private final Time time;
+    private final Consumer<Long> ttfbCallback;
+    // Not volatile: channel is confined to a single thread within FileFetchJob.doWork().
+    private boolean firstByteRecorded;
+
+    public TimingReadableByteChannel(ReadableByteChannel delegate, Time time, Instant startTime, Consumer<Long> ttfbCallback) {
+        this.delegate = Objects.requireNonNull(delegate, "delegate");
+        this.time = Objects.requireNonNull(time, "time");
+        this.startTime = Objects.requireNonNull(startTime, "startTime");
+        this.ttfbCallback = Objects.requireNonNull(ttfbCallback, "ttfbCallback");
+        this.firstByteRecorded = false;
+    }
+
+    @Override
+    public int read(ByteBuffer dst) throws IOException {
+        final int bytesRead = delegate.read(dst);
+        if (bytesRead > 0 && !firstByteRecorded) {
+            firstByteRecorded = true;
+            final Instant now = TimeUtils.durationMeasurementNow(time);
+            ttfbCallback.accept(Duration.between(startTime, now).toMillis());
+        }
+        return bytesRead;
+    }
+
+    @Override
+    public boolean isOpen() {
+        return delegate.isOpen();
+    }
+
+    @Override
+    public void close() throws IOException {
+        delegate.close();
+    }
+}

--- a/storage/inkless/src/test/java/io/aiven/inkless/consume/FetchPlannerTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/consume/FetchPlannerTest.java
@@ -33,6 +33,7 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
 import java.nio.ByteBuffer;
+import java.nio.channels.ReadableByteChannel;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -72,6 +73,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -353,9 +355,9 @@ public class FetchPlannerTest {
                 // Mock the fetcher's two-step process: fetch() is called first, then readToByteBuffer()
                 // For this test, we only care about the final data returned by readToByteBuffer()
                 when(fetcher.fetch(eq(OBJECT_KEY_A), any(ByteRange.class)))
-                    .thenReturn(null); // Return value doesn't matter, readToByteBuffer() is also mocked
+                    .thenReturn(mock(ReadableByteChannel.class));
                 when(fetcher.fetch(eq(OBJECT_KEY_B), any(ByteRange.class)))
-                    .thenReturn(null); // Return value doesn't matter, readToByteBuffer() is also mocked
+                    .thenReturn(mock(ReadableByteChannel.class));
 
                 // Mock readToByteBuffer to return the test data we want to verify
                 // Order matters: first call returns dataA, second call returns dataB
@@ -421,7 +423,7 @@ public class FetchPlannerTest {
 
                 // Mock the fetcher to return data via ByteBuffer
                 when(fetcher.fetch(any(ObjectKey.class), any(ByteRange.class)))
-                    .thenReturn(null); // channel not used directly
+                    .thenReturn(mock(ReadableByteChannel.class));
                 when(fetcher.readToByteBuffer(any()))
                     .thenReturn(byteBuffer);
 
@@ -552,7 +554,7 @@ public class FetchPlannerTest {
                 // First call fails, second call succeeds
                 when(fetcher.fetch(any(ObjectKey.class), any(ByteRange.class)))
                     .thenThrow(new RuntimeException("Transient S3 error"))
-                    .thenReturn(null);
+                    .thenReturn(mock(ReadableByteChannel.class));
                 when(fetcher.readToByteBuffer(any()))
                     .thenReturn(ByteBuffer.wrap(expectedData));
 
@@ -605,7 +607,7 @@ public class FetchPlannerTest {
 
                 // Mock fetcher to return data
                 when(fetcher.fetch(eq(OBJECT_KEY_A), any(ByteRange.class)))
-                    .thenReturn(null);
+                    .thenReturn(mock(ReadableByteChannel.class));
                 when(fetcher.readToByteBuffer(any()))
                     .thenReturn(ByteBuffer.wrap(expectedData));
 
@@ -653,8 +655,8 @@ public class FetchPlannerTest {
                 final byte[] dataA = "data-a".getBytes();
                 final byte[] dataB = "data-bb".getBytes();
 
-                when(fetcher.fetch(eq(OBJECT_KEY_A), any(ByteRange.class))).thenReturn(null);
-                when(fetcher.fetch(eq(OBJECT_KEY_B), any(ByteRange.class))).thenReturn(null);
+                when(fetcher.fetch(eq(OBJECT_KEY_A), any(ByteRange.class))).thenReturn(mock(ReadableByteChannel.class));
+                when(fetcher.fetch(eq(OBJECT_KEY_B), any(ByteRange.class))).thenReturn(mock(ReadableByteChannel.class));
                 when(fetcher.readToByteBuffer(any()))
                     .thenReturn(ByteBuffer.wrap(dataA))
                     .thenReturn(ByteBuffer.wrap(dataB));
@@ -700,7 +702,7 @@ public class FetchPlannerTest {
             try (CaffeineCache caffeineCache = new CaffeineCache(100, 0, 3600, 180)) {
                 final byte[] expectedData = "old-data-but-hot-path".getBytes();
 
-                when(fetcher.fetch(eq(OBJECT_KEY_A), any(ByteRange.class))).thenReturn(null);
+                when(fetcher.fetch(eq(OBJECT_KEY_A), any(ByteRange.class))).thenReturn(mock(ReadableByteChannel.class));
                 when(fetcher.readToByteBuffer(any())).thenReturn(ByteBuffer.wrap(expectedData));
 
                 // Very old timestamp - would be "lagging" if feature was enabled
@@ -782,7 +784,7 @@ public class FetchPlannerTest {
                         .addLimit(limit -> limit.capacity(1).refillGreedy(1, java.time.Duration.ofSeconds(1)))
                         .build();
 
-                    when(fetcher.fetch(eq(OBJECT_KEY_A), any(ByteRange.class))).thenReturn(null);
+                    when(fetcher.fetch(eq(OBJECT_KEY_A), any(ByteRange.class))).thenReturn(mock(ReadableByteChannel.class));
                     when(fetcher.readToByteBuffer(any())).thenReturn(ByteBuffer.wrap(expectedData));
 
                     final long recentTimestamp = time.milliseconds() - 30000L; // 30 seconds ago (recent)
@@ -822,7 +824,7 @@ public class FetchPlannerTest {
                     final byte[] expectedData = "boundary-data".getBytes();
                     final long threshold = 60 * 1000L;
 
-                    when(fetcher.fetch(eq(OBJECT_KEY_A), any(ByteRange.class))).thenReturn(null);
+                    when(fetcher.fetch(eq(OBJECT_KEY_A), any(ByteRange.class))).thenReturn(mock(ReadableByteChannel.class));
                     when(fetcher.readToByteBuffer(any())).thenReturn(ByteBuffer.wrap(expectedData));
 
                     final long exactThresholdTimestamp = time.milliseconds() - threshold;
@@ -864,7 +866,7 @@ public class FetchPlannerTest {
                         .addLimit(limit -> limit.capacity(10).refillGreedy(10, java.time.Duration.ofSeconds(1)))
                         .build();
 
-                    when(fetcher.fetch(eq(OBJECT_KEY_A), any(ByteRange.class))).thenReturn(null);
+                    when(fetcher.fetch(eq(OBJECT_KEY_A), any(ByteRange.class))).thenReturn(mock(ReadableByteChannel.class));
                     when(fetcher.readToByteBuffer(any())).thenReturn(ByteBuffer.wrap(expectedData));
 
                     final long oldTimestamp = time.milliseconds() - 120000L; // 2 minutes ago (old)
@@ -904,7 +906,7 @@ public class FetchPlannerTest {
                 try (CaffeineCache caffeineCache = new CaffeineCache(100, 0, 3600, 180)) {
                     final byte[] expectedData = "old-data-no-limit".getBytes();
 
-                    when(fetcher.fetch(eq(OBJECT_KEY_A), any(ByteRange.class))).thenReturn(null);
+                    when(fetcher.fetch(eq(OBJECT_KEY_A), any(ByteRange.class))).thenReturn(mock(ReadableByteChannel.class));
                     when(fetcher.readToByteBuffer(any())).thenReturn(ByteBuffer.wrap(expectedData));
 
                     final long oldTimestamp = time.milliseconds() - 120000L;
@@ -1159,8 +1161,8 @@ public class FetchPlannerTest {
                     final byte[] oldData = "old".getBytes();
                     final long threshold = 60 * 1000L;
 
-                    when(fetcher.fetch(eq(OBJECT_KEY_A), any(ByteRange.class))).thenReturn(null);
-                    when(fetcher.fetch(eq(OBJECT_KEY_B), any(ByteRange.class))).thenReturn(null);
+                    when(fetcher.fetch(eq(OBJECT_KEY_A), any(ByteRange.class))).thenReturn(mock(ReadableByteChannel.class));
+                    when(fetcher.fetch(eq(OBJECT_KEY_B), any(ByteRange.class))).thenReturn(mock(ReadableByteChannel.class));
                     when(fetcher.readToByteBuffer(any()))
                         .thenReturn(ByteBuffer.wrap(recentData))
                         .thenReturn(ByteBuffer.wrap(oldData));
@@ -1210,8 +1212,8 @@ public class FetchPlannerTest {
                     final ExecutorService coldExecutor = Executors.newFixedThreadPool(2);
 
                     try {
-                        when(fetcher.fetch(eq(OBJECT_KEY_A), any(ByteRange.class))).thenReturn(null);
-                        when(fetcher.fetch(eq(OBJECT_KEY_B), any(ByteRange.class))).thenReturn(null);
+                        when(fetcher.fetch(eq(OBJECT_KEY_A), any(ByteRange.class))).thenReturn(mock(ReadableByteChannel.class));
+                        when(fetcher.fetch(eq(OBJECT_KEY_B), any(ByteRange.class))).thenReturn(mock(ReadableByteChannel.class));
                         when(fetcher.readToByteBuffer(any()))
                             .thenReturn(ByteBuffer.wrap(recentData))
                             .thenReturn(ByteBuffer.wrap(oldData));
@@ -1287,7 +1289,7 @@ public class FetchPlannerTest {
                 // Validates: laggingConsumerExecutor = null → feature disabled, all use hot path
                 try (CaffeineCache caffeineCache = new CaffeineCache(100, 0, 3600, 180)) {
                     final byte[] expectedData = "all-recent".getBytes();
-                    when(fetcher.fetch(eq(OBJECT_KEY_A), any(ByteRange.class))).thenReturn(null);
+                    when(fetcher.fetch(eq(OBJECT_KEY_A), any(ByteRange.class))).thenReturn(mock(ReadableByteChannel.class));
                     when(fetcher.readToByteBuffer(any())).thenReturn(ByteBuffer.wrap(expectedData));
 
                     final long oldTimestamp = time.milliseconds() - 120000L; // Would be lagging if feature enabled
@@ -1320,7 +1322,7 @@ public class FetchPlannerTest {
                 // Validates: rateLimiter = null → cold path without rate limiting
                 try (CaffeineCache caffeineCache = new CaffeineCache(100, 0, 3600, 180)) {
                     final byte[] expectedData = "cold-no-limit".getBytes();
-                    when(fetcher.fetch(eq(OBJECT_KEY_A), any(ByteRange.class))).thenReturn(null);
+                    when(fetcher.fetch(eq(OBJECT_KEY_A), any(ByteRange.class))).thenReturn(mock(ReadableByteChannel.class));
                     when(fetcher.readToByteBuffer(any())).thenReturn(ByteBuffer.wrap(expectedData));
 
                     final long oldTimestamp = time.milliseconds() - 120000L;
@@ -1357,7 +1359,7 @@ public class FetchPlannerTest {
                     final Bucket rateLimiter = Bucket.builder()
                         .addLimit(limit -> limit.capacity(10).refillGreedy(10, java.time.Duration.ofSeconds(1)))
                         .build();
-                    when(fetcher.fetch(eq(OBJECT_KEY_A), any(ByteRange.class))).thenReturn(null);
+                    when(fetcher.fetch(eq(OBJECT_KEY_A), any(ByteRange.class))).thenReturn(mock(ReadableByteChannel.class));
                     when(fetcher.readToByteBuffer(any())).thenReturn(ByteBuffer.wrap(expectedData));
 
                     final long oldTimestamp = time.milliseconds() - 120000L;

--- a/storage/inkless/src/test/java/io/aiven/inkless/consume/FileFetchJobTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/consume/FileFetchJobTest.java
@@ -42,6 +42,7 @@ import io.aiven.inkless.storage_backend.common.ObjectFetcher;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -57,7 +58,7 @@ public class FileFetchJobTest {
 
     @Test
     public void testOversizeFileFetch() {
-        assertThrows(IllegalArgumentException.class, () -> new FileFetchJob(time, fetcher, objectA, ByteRange.maxRange(), durationMs -> {}));
+        assertThrows(IllegalArgumentException.class, () -> new FileFetchJob(time, fetcher, objectA, ByteRange.maxRange(), durationMs -> {}, ttfbMs -> {}));
     }
 
     @Test
@@ -68,15 +69,45 @@ public class FileFetchJobTest {
             array[i] = (byte) i;
         }
         ByteRange range = new ByteRange(0, size);
-        FileFetchJob job = new FileFetchJob(time, fetcher, objectA, range, durationMs -> { });
+        FileFetchJob job = new FileFetchJob(time, fetcher, objectA, range, durationMs -> { }, ttfbMs -> { });
         FileExtent expectedFile = FileFetchJob.createFileExtent(objectA, range, ByteBuffer.wrap(array));
 
         final ReadableByteChannel channel = mock(ReadableByteChannel.class);
         when(fetcher.fetch(objectA, range)).thenReturn(channel);
-        when(fetcher.readToByteBuffer(channel)).thenReturn(ByteBuffer.wrap(array));
+        // readToByteBuffer receives a TimingReadableByteChannel wrapper, so match with any()
+        when(fetcher.readToByteBuffer(any())).thenReturn(ByteBuffer.wrap(array));
         FileExtent actualFile = job.call();
 
         assertThat(actualFile).isEqualTo(expectedFile);
+    }
+
+    @Test
+    public void testTtfbCallbackInvoked() throws Exception {
+        int size = 10;
+        byte[] array = new byte[size];
+        ByteRange range = new ByteRange(0, size);
+        final List<Long> ttfbValues = new ArrayList<>();
+        FileFetchJob job = new FileFetchJob(time, fetcher, objectA, range, durationMs -> { }, ttfbValues::add);
+
+        final ReadableByteChannel channel = mock(ReadableByteChannel.class);
+        when(fetcher.fetch(objectA, range)).thenReturn(channel);
+        // Stub readToByteBuffer to actually read from the TimingReadableByteChannel wrapper,
+        // which triggers the TTFB callback on first read() returning data.
+        when(fetcher.readToByteBuffer(any())).thenAnswer(invocation -> {
+            final ReadableByteChannel timingChannel = invocation.getArgument(0);
+            time.sleep(123);
+            final ByteBuffer buf = ByteBuffer.allocate(size);
+            when(channel.read(any(ByteBuffer.class))).thenAnswer(readInvocation -> {
+                ByteBuffer dst = readInvocation.getArgument(0);
+                dst.put(array);
+                return size;
+            }).thenReturn(-1);
+            timingChannel.read(buf);
+            return ByteBuffer.wrap(array);
+        });
+        job.call();
+
+        assertThat(ttfbValues).containsExactly(123L);
     }
 
     private List<FileExtent> createCacheAlignedFileExtents(int fileSize, int blockSize) {

--- a/storage/inkless/src/test/java/io/aiven/inkless/consume/ReaderTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/consume/ReaderTest.java
@@ -620,7 +620,7 @@ public class ReaderTest {
             when(objectFetcher.fetch(any(), any())).thenReturn(file1Channel);
             // Corrupted data with size that doesn't match expected batch size
             final ByteBuffer corruptedRecords = ByteBuffer.wrap("invalid-batch-data".getBytes(StandardCharsets.UTF_8));
-            when(objectFetcher.readToByteBuffer(file1Channel)).thenReturn(corruptedRecords);
+            when(objectFetcher.readToByteBuffer(any())).thenReturn(corruptedRecords);
 
             try (final var reader = getReader()) {
                 final CompletableFuture<Map<TopicIdPartition, FetchPartitionData>> fetch = reader.fetch(fetchParams, fetchInfos);
@@ -655,7 +655,7 @@ public class ReaderTest {
             // Simulate fetcher returning valid data
             final ReadableByteChannel file1Channel = mock(ReadableByteChannel.class);
             when(objectFetcher.fetch(any(), any())).thenReturn(file1Channel);
-            when(objectFetcher.readToByteBuffer(file1Channel)).thenReturn(records.buffer());
+            when(objectFetcher.readToByteBuffer(any())).thenReturn(records.buffer());
 
             try (final var reader = getReader()) {
                 final CompletableFuture<Map<TopicIdPartition, FetchPartitionData>> fetch = reader.fetch(fetchParams, fetchInfos);
@@ -767,7 +767,7 @@ public class ReaderTest {
 
             final ReadableByteChannel channel = mock(ReadableByteChannel.class);
             when(objectFetcher.fetch(any(), any())).thenReturn(channel);
-            when(objectFetcher.readToByteBuffer(channel)).thenReturn(records.buffer());
+            when(objectFetcher.readToByteBuffer(any())).thenReturn(records.buffer());
 
             try (final var reader = new Reader(
                 time,
@@ -846,7 +846,7 @@ public class ReaderTest {
 
             final ReadableByteChannel channel = mock(ReadableByteChannel.class);
             when(objectFetcher.fetch(any(), any())).thenReturn(channel);
-            when(objectFetcher.readToByteBuffer(channel)).thenReturn(records.buffer());
+            when(objectFetcher.readToByteBuffer(any())).thenReturn(records.buffer());
 
             try (final var reader = new Reader(
                 time,
@@ -973,7 +973,7 @@ public class ReaderTest {
             final ReadableByteChannel channel = mock(ReadableByteChannel.class);
             when(objectFetcher.fetch(any(ObjectKey.class), any(ByteRange.class))).thenReturn(channel);
             // Return a fresh buffer each time to avoid buffer exhaustion issues
-            when(objectFetcher.readToByteBuffer(channel)).thenAnswer(invocation -> records.buffer().duplicate());
+            when(objectFetcher.readToByteBuffer(any())).thenAnswer(invocation -> records.buffer().duplicate());
 
             // Create a lagging executor and immediately shut it down - will reject all tasks
             final ExecutorService saturatedLaggingExecutor = Executors.newSingleThreadExecutor();
@@ -1076,7 +1076,7 @@ public class ReaderTest {
 
             final ReadableByteChannel channel = mock(ReadableByteChannel.class);
             when(objectFetcher.fetch(any(), any())).thenReturn(channel);
-            when(objectFetcher.readToByteBuffer(channel)).thenReturn(records.buffer());
+            when(objectFetcher.readToByteBuffer(any())).thenReturn(records.buffer());
 
             try (final var reader = new Reader(
                 time,

--- a/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/common/TimingReadableByteChannelTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/common/TimingReadableByteChannelTest.java
@@ -1,0 +1,103 @@
+/*
+ * Inkless
+ * Copyright (C) 2024 - 2026 Aiven OY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.aiven.inkless.storage_backend.common;
+
+import org.apache.kafka.common.utils.MockTime;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.nio.channels.ReadableByteChannel;
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicLong;
+
+import io.aiven.inkless.TimeUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TimingReadableByteChannelTest {
+
+    @Test
+    void callbackInvokedOnFirstRead() throws IOException {
+        final MockTime time = new MockTime();
+        final AtomicLong recordedTtfb = new AtomicLong(-1);
+        final Instant startTime = TimeUtils.durationMeasurementNow(time);
+        final ReadableByteChannel delegate = Channels.newChannel(new ByteArrayInputStream(new byte[]{1, 2, 3}));
+
+        final TimingReadableByteChannel channel = new TimingReadableByteChannel(delegate, time, startTime, recordedTtfb::set);
+
+        // Advance time before first read
+        time.sleep(42);
+
+        final ByteBuffer buf = ByteBuffer.allocate(2);
+        final int bytesRead = channel.read(buf);
+
+        assertThat(bytesRead).isEqualTo(2);
+        assertThat(recordedTtfb.get()).isEqualTo(42);
+    }
+
+    @Test
+    void callbackInvokedOnlyOnce() throws IOException {
+        final MockTime time = new MockTime();
+        final AtomicLong callCount = new AtomicLong(0);
+        final Instant startTime = TimeUtils.durationMeasurementNow(time);
+        final ReadableByteChannel delegate = Channels.newChannel(new ByteArrayInputStream(new byte[]{1, 2, 3, 4}));
+
+        final TimingReadableByteChannel channel = new TimingReadableByteChannel(delegate, time, startTime, ttfb -> callCount.incrementAndGet());
+
+        time.sleep(10);
+        channel.read(ByteBuffer.allocate(2));
+        time.sleep(20);
+        channel.read(ByteBuffer.allocate(2));
+
+        assertThat(callCount.get()).isEqualTo(1);
+    }
+
+    @Test
+    void callbackNotInvokedOnEmptyRead() throws IOException {
+        final MockTime time = new MockTime();
+        final AtomicLong recordedTtfb = new AtomicLong(-1);
+        final Instant startTime = TimeUtils.durationMeasurementNow(time);
+        // Empty stream returns -1 on read
+        final ReadableByteChannel delegate = Channels.newChannel(new ByteArrayInputStream(new byte[0]));
+
+        final TimingReadableByteChannel channel = new TimingReadableByteChannel(delegate, time, startTime, recordedTtfb::set);
+
+        time.sleep(10);
+        final int bytesRead = channel.read(ByteBuffer.allocate(10));
+
+        assertThat(bytesRead).isEqualTo(-1);
+        assertThat(recordedTtfb.get()).isEqualTo(-1); // callback never invoked
+    }
+
+    @Test
+    void delegatesIsOpenAndClose() throws IOException {
+        final MockTime time = new MockTime();
+        final Instant startTime = TimeUtils.durationMeasurementNow(time);
+        final ReadableByteChannel delegate = Channels.newChannel(new ByteArrayInputStream(new byte[]{1}));
+
+        final TimingReadableByteChannel channel = new TimingReadableByteChannel(delegate, time, startTime, ttfb -> {});
+
+        assertThat(channel.isOpen()).isTrue();
+        channel.close();
+        assertThat(channel.isOpen()).isFalse();
+    }
+}


### PR DESCRIPTION
Introduces a FetchFirstByteTime histogram measuring latency from initiating a storage fetch to receiving the first byte of data. Covers all backends (S3, GCS, Azure) by capturing start time before objectFetcher.fetch().

- TimingReadableByteChannel: ReadableByteChannel decorator that fires a callback on first read() returning data
- FileFetchJob: wraps fetched channel with try-with-resources to prevent connection leaks on streaming backends (GCS, Azure)
- InklessFetchMetrics: FetchFirstByteTime histogram
- FetchPlanner: wires TTFB callback into FileFetchJob