### PR TITLE
fix(inkless): Fixes for migration deadlock and hybrid topics read path

### DIFF
--- a/core/src/main/scala/kafka/server/InitDisklessLogBatchQueue.scala
+++ b/core/src/main/scala/kafka/server/InitDisklessLogBatchQueue.scala
@@ -237,10 +237,18 @@ abstract class RetriableInitDisklessLogBatchQueue[S <: InitDisklessLogState](
     }
   }
 
-  private def completeAndRemovePromise(tp: TopicPartition, accepted: Boolean): Unit = withQueueLock {
-    if (!queuedByTp.containsKey(tp)) {
-      Option(resultPromiseByTp.remove(tp)).foreach(_.trySuccess(accepted))
+  private def completeAndRemovePromise(tp: TopicPartition, accepted: Boolean): Unit = {
+    val promiseOpt = withQueueLock {
+      if (!queuedByTp.containsKey(tp)) {
+        Option(resultPromiseByTp.remove(tp))
+      } else {
+        None
+      }
     }
+    // Complete the promise outside queueLock to avoid deadlock:
+    // the parasitic callback on the promise may call ConcurrentHashMap.computeIfPresent,
+    // while another thread may hold the ConcurrentHashMap bin lock and try to acquire queueLock.
+    promiseOpt.foreach(_.trySuccess(accepted))
   }
 
   private def computeRetryDelayMs(): Long = {

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1895,7 +1895,7 @@ class ReplicaManager(val config: KafkaConfig,
       } else {
         val classicToDisklessStartOffset = _inklessMetadataView.getClassicToDisklessStartOffset(tp.topicPartition())
         val shouldReadFromUnifiedLog =
-          classicToDisklessStartOffset != PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET &&
+          classicToDisklessStartOffset == PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET ||
             partitionData.fetchOffset < classicToDisklessStartOffset
 
         (shouldReadFromUnifiedLog, config.disklessManagedReplicasEnabled) match {


### PR DESCRIPTION
Commit 1:
**Always read from UnifiedLog when there is no classicToDisklessStartOffset**

Fix a condition bug where fetch requests were routed to diskless when classicToDisklessStartOffset was not set.

Commit 2:
**Avoid deadlock in InitDisklessLogBatchQueue**

`completeAndRemovePromise` previously called `promise.trySuccess` inside `queueLock`. Because callers in `InitDisklessLogManager` register parasitic callbacks on the returned Future (e.g. `enqueueSendingToController`,
`enqueueAwaitingMetadata`), `trySuccess` executes the callback on the same thread, still holding `queueLock`.
Those callbacks call `tracked.computeIfPresent`, which acquires a ConcurrentHashMap bin lock.
Meanwhile, a partition-update thread can enter `tracked.computeIfPresent` (acquiring the bin lock) and, inside the
lambda, call `handleWaitingOutcome` -> `enqueueSendingToController` -> `enqueue`, which tries to acquire `queueLock`.
This creates a lock-ordering inversion:
 - Thread A: queueLock -> tracked bin lock  (via parasitic callback)
 - Thread B: tracked bin lock -> queueLock  (via partition update)

Fix by extracting the promise from the `queueLock` block and calling `trySuccess` after releasing the lock, so the parasitic callback never runs while `queueLock` is held.