### PR TITLE
feat(inkless): Support basic ListOffset for hybrid topics

### DIFF
--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1629,86 +1629,21 @@ class ReplicaManager(val config: KafkaConfig,
           statusByPartition += topicPartition ->
             ListOffsetsPartitionStatus.builder().responseOpt(Optional.of(buildErrorResponse(Errors.UNSUPPORTED_VERSION, partition))).build()
         } else if (maybeFetchOffsetJob.exists(_.mustHandle(topic.name()))) {
-          statusByPartition += topicPartition ->
-            disklessFetchOffset(maybeFetchOffsetJob.get, topicPartition, partition)
-        } else {
-          try {
-            val fetchOnlyFromLeader = replicaId != ListOffsetsRequest.DEBUGGING_REPLICA_ID
-            val isClientRequest = replicaId == ListOffsetsRequest.CONSUMER_REPLICA_ID
-            val isolationLevelOpt = if (isClientRequest)
-              Some(isolationLevel)
-            else
-              None
+          val migrationPending =
+            _inklessMetadataView.getClassicToDisklessStartOffset(topicPartition) == PartitionRegistration.CLASSIC_TO_DISKLESS_MIGRATION_PENDING
 
-            val resultHolder = fetchOffsetForTimestamp(topicPartition,
-              partition.timestamp,
-              isolationLevelOpt,
-              if (partition.currentLeaderEpoch == ListOffsetsResponse.UNKNOWN_EPOCH) Optional.empty() else Optional.of(partition.currentLeaderEpoch),
-              fetchOnlyFromLeader)
-
-            val status = {
-              if (resultHolder.timestampAndOffsetOpt().isPresent) {
-                // This case is for normal topic that does not have remote storage.
-                val timestampAndOffsetOpt = resultHolder.timestampAndOffsetOpt.get
-                var partitionResponse = buildErrorResponse(Errors.NONE, partition)
-                if (resultHolder.lastFetchableOffset.isPresent &&
-                  timestampAndOffsetOpt.offset >= resultHolder.lastFetchableOffset.get) {
-                  resultHolder.maybeOffsetsError.map(e => throw e)
-                } else {
-                  partitionResponse = new ListOffsetsPartitionResponse()
-                    .setPartitionIndex(partition.partitionIndex)
-                    .setErrorCode(Errors.NONE.code)
-                    .setTimestamp(timestampAndOffsetOpt.timestamp)
-                    .setOffset(timestampAndOffsetOpt.offset)
-                  if (timestampAndOffsetOpt.leaderEpoch.isPresent && version >= 4)
-                    partitionResponse.setLeaderEpoch(timestampAndOffsetOpt.leaderEpoch.get)
-                }
-                ListOffsetsPartitionStatus.builder().responseOpt(Optional.of(partitionResponse)).build()
-              } else if (resultHolder.timestampAndOffsetOpt.isEmpty && resultHolder.futureHolderOpt.isEmpty) {
-                // This is an empty offset response scenario
-                resultHolder.maybeOffsetsError.map(e => throw e)
-                ListOffsetsPartitionStatus.builder().responseOpt(Optional.of(buildErrorResponse(Errors.NONE, partition))).build()
-              } else if (resultHolder.timestampAndOffsetOpt.isEmpty && resultHolder.futureHolderOpt.isPresent) {
-                // This case is for topic enabled with remote storage and we want to search the timestamp in
-                // remote storage using async fashion.
-                ListOffsetsPartitionStatus.builder()
-                  .futureHolderOpt(resultHolder.futureHolderOpt())
-                  .lastFetchableOffset(resultHolder.lastFetchableOffset)
-                  .maybeOffsetsError(resultHolder.maybeOffsetsError)
-                  .build()
-              } else {
-                throw new IllegalStateException(s"Unexpected result holder state $resultHolder")
-              }
-            }
-            statusByPartition += topicPartition -> status
-          } catch {
-            // NOTE: These exceptions are special cases since these error messages are typically transient or the client
-            // would have received a clear exception and there is no value in logging the entire stack trace for the same
-            case e @ (_ : UnknownTopicOrPartitionException |
-                      _ : NotLeaderOrFollowerException |
-                      _ : UnknownLeaderEpochException |
-                      _ : FencedLeaderEpochException |
-                      _ : KafkaStorageException |
-                      _ : UnsupportedForMessageFormatException) =>
-              debug(s"Offset request with correlation id $correlationId from client $clientId on " +
-                s"partition $topicPartition failed due to ${e.getMessage}")
-              statusByPartition += topicPartition ->
-                ListOffsetsPartitionStatus.builder().responseOpt(Optional.of(buildErrorResponse(Errors.forException(e), partition))).build()
-            // Only V5 and newer ListOffset calls should get OFFSET_NOT_AVAILABLE
-            case e: OffsetNotAvailableException =>
-              if (version >= 5) {
-                statusByPartition += topicPartition ->
-                  ListOffsetsPartitionStatus.builder().responseOpt(Optional.of(buildErrorResponse(Errors.forException(e), partition))).build()
-              } else {
-                statusByPartition += topicPartition ->
-                  ListOffsetsPartitionStatus.builder().responseOpt(Optional.of(buildErrorResponse(Errors.LEADER_NOT_AVAILABLE, partition))).build()
-              }
-
-            case e: Throwable =>
-              error("Error while responding to offset request", e)
-              statusByPartition += topicPartition ->
-                ListOffsetsPartitionStatus.builder().responseOpt(Optional.of(buildErrorResponse(Errors.forException(e), partition))).build()
+          if (migrationPending) {
+            statusByPartition += topicPartition ->
+              classicFetchOffset(topicPartition, partition, replicaId, isolationLevel, version,
+                correlationId, clientId, buildErrorResponse)
+          } else {
+            statusByPartition += topicPartition ->
+              disklessFetchOffset(maybeFetchOffsetJob.get, topicPartition, partition)
           }
+        } else {
+          statusByPartition += topicPartition ->
+            classicFetchOffset(topicPartition, partition, replicaId, isolationLevel, version,
+              correlationId, clientId, buildErrorResponse)
         }
       }
     }
@@ -1748,6 +1683,86 @@ class ReplicaManager(val config: KafkaConfig,
     ListOffsetsPartitionStatus.builder()
       .futureHolderOpt(Optional.of(futureHolder))
       .build()
+  }
+
+  private def classicFetchOffset(topicPartition: TopicPartition,
+                                 partition: ListOffsetsPartition,
+                                 replicaId: Int,
+                                 isolationLevel: IsolationLevel,
+                                 version: Short,
+                                 correlationId: Int,
+                                 clientId: String,
+                                 buildErrorResponse: (Errors, ListOffsetsPartition) => ListOffsetsPartitionResponse
+                                ): ListOffsetsPartitionStatus = {
+    try {
+      val fetchOnlyFromLeader = replicaId != ListOffsetsRequest.DEBUGGING_REPLICA_ID
+      val isClientRequest = replicaId == ListOffsetsRequest.CONSUMER_REPLICA_ID
+      val isolationLevelOpt = if (isClientRequest)
+        Some(isolationLevel)
+      else
+        None
+
+      val resultHolder = fetchOffsetForTimestamp(topicPartition,
+        partition.timestamp,
+        isolationLevelOpt,
+        if (partition.currentLeaderEpoch == ListOffsetsResponse.UNKNOWN_EPOCH) Optional.empty() else Optional.of(partition.currentLeaderEpoch),
+        fetchOnlyFromLeader)
+
+      if (resultHolder.timestampAndOffsetOpt().isPresent) {
+        // This case is for normal topic that does not have remote storage.
+        val timestampAndOffsetOpt = resultHolder.timestampAndOffsetOpt.get
+        var partitionResponse = buildErrorResponse(Errors.NONE, partition)
+        if (resultHolder.lastFetchableOffset.isPresent &&
+          timestampAndOffsetOpt.offset >= resultHolder.lastFetchableOffset.get) {
+          resultHolder.maybeOffsetsError.map(e => throw e)
+        } else {
+          partitionResponse = new ListOffsetsPartitionResponse()
+            .setPartitionIndex(partition.partitionIndex)
+            .setErrorCode(Errors.NONE.code)
+            .setTimestamp(timestampAndOffsetOpt.timestamp)
+            .setOffset(timestampAndOffsetOpt.offset)
+          if (timestampAndOffsetOpt.leaderEpoch.isPresent && version >= 4)
+            partitionResponse.setLeaderEpoch(timestampAndOffsetOpt.leaderEpoch.get)
+        }
+        ListOffsetsPartitionStatus.builder().responseOpt(Optional.of(partitionResponse)).build()
+      } else if (resultHolder.timestampAndOffsetOpt.isEmpty && resultHolder.futureHolderOpt.isEmpty) {
+        // This is an empty offset response scenario
+        resultHolder.maybeOffsetsError.map(e => throw e)
+        ListOffsetsPartitionStatus.builder().responseOpt(Optional.of(buildErrorResponse(Errors.NONE, partition))).build()
+      } else if (resultHolder.timestampAndOffsetOpt.isEmpty && resultHolder.futureHolderOpt.isPresent) {
+        // This case is for topic enabled with remote storage and we want to search the timestamp in
+        // remote storage using async fashion.
+        ListOffsetsPartitionStatus.builder()
+          .futureHolderOpt(resultHolder.futureHolderOpt())
+          .lastFetchableOffset(resultHolder.lastFetchableOffset)
+          .maybeOffsetsError(resultHolder.maybeOffsetsError)
+          .build()
+      } else {
+        throw new IllegalStateException(s"Unexpected result holder state $resultHolder")
+      }
+    } catch {
+      // NOTE: These exceptions are special cases since these error messages are typically transient or the client
+      // would have received a clear exception and there is no value in logging the entire stack trace for the same
+      case e @ (_ : UnknownTopicOrPartitionException |
+                _ : NotLeaderOrFollowerException |
+                _ : UnknownLeaderEpochException |
+                _ : FencedLeaderEpochException |
+                _ : KafkaStorageException |
+                _ : UnsupportedForMessageFormatException) =>
+        debug(s"Offset request with correlation id $correlationId from client $clientId on " +
+          s"partition $topicPartition failed due to ${e.getMessage}")
+        ListOffsetsPartitionStatus.builder().responseOpt(Optional.of(buildErrorResponse(Errors.forException(e), partition))).build()
+      // Only V5 and newer ListOffset calls should get OFFSET_NOT_AVAILABLE
+      case e: OffsetNotAvailableException =>
+        if (version >= 5) {
+          ListOffsetsPartitionStatus.builder().responseOpt(Optional.of(buildErrorResponse(Errors.forException(e), partition))).build()
+        } else {
+          ListOffsetsPartitionStatus.builder().responseOpt(Optional.of(buildErrorResponse(Errors.LEADER_NOT_AVAILABLE, partition))).build()
+        }
+      case e: Throwable =>
+        error("Error while responding to offset request", e)
+        ListOffsetsPartitionStatus.builder().responseOpt(Optional.of(buildErrorResponse(Errors.forException(e), partition))).build()
+    }
   }
 
   private def delayedRemoteListOffsetsRequired(responseByPartition: Map[TopicPartition, ListOffsetsPartitionStatus]): Boolean = {

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -43,6 +43,8 @@ import org.apache.kafka.common.compress.Compression
 import org.apache.kafka.common.config.TopicConfig
 import org.apache.kafka.common.errors.{InvalidPidMappingException, UnknownTopicOrPartitionException}
 import org.apache.kafka.common.internals.Topic
+import org.apache.kafka.common.message.ListOffsetsRequestData.{ListOffsetsPartition, ListOffsetsTopic}
+import org.apache.kafka.common.message.ListOffsetsResponseData.{ListOffsetsPartitionResponse, ListOffsetsTopicResponse}
 import org.apache.kafka.common.message.{DeleteRecordsResponseData, FetchResponseData, ShareFetchResponseData}
 import org.apache.kafka.common.message.OffsetForLeaderEpochRequestData.{OffsetForLeaderPartition, OffsetForLeaderTopic}
 import org.apache.kafka.common.message.OffsetForLeaderEpochResponseData.EpochEndOffset
@@ -7206,6 +7208,261 @@ class ReplicaManagerTest {
       val partitionResult = topicResult.partitions().get(0)
       assertEquals(Errors.UNKNOWN_TOPIC_OR_PARTITION.code, partitionResult.errorCode())
       assertEquals(OffsetsForLeaderEpochResponse.UNDEFINED_EPOCH_OFFSET, partitionResult.endOffset())
+    }
+
+    @Test
+    def testFetchOffsetLatestUsesClassicPathWhenMigrationPending(): Unit = {
+      val jobMock = Mockito.mock(classOf[FetchOffsetHandler.Job])
+      when(jobMock.mustHandle(any())).thenReturn(true)
+      doNothing().when(jobMock).start()
+
+      val fetchOffsetHandlerCtorInit: MockedConstruction.MockInitializer[FetchOffsetHandler] = {
+        case (handlerMock, _) =>
+          when(handlerMock.createJob()).thenReturn(jobMock)
+      }
+      val fetchOffsetHandlerCtor = mockConstruction(classOf[FetchOffsetHandler], fetchOffsetHandlerCtorInit)
+
+      val replicaManager = try {
+        spy(createReplicaManager(List(disklessTopicPartition.topic()), disklessManagedReplicasEnabled = true))
+      } finally {
+        fetchOffsetHandlerCtor.close()
+      }
+
+      when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
+        .thenReturn(PartitionRegistration.CLASSIC_TO_DISKLESS_MIGRATION_PENDING)
+
+      val resultHolder = new OffsetResultHolder(
+        Optional.of(new FileRecords.TimestampAndOffset(RecordBatch.NO_TIMESTAMP, 50L, Optional.of[Integer](0))))
+      doReturn(resultHolder).when(replicaManager).fetchOffsetForTimestamp(
+        ArgumentMatchers.eq(disklessTopicPartition.topicPartition()), anyLong(), any(), any(), anyBoolean())
+
+      val topics = Seq(new ListOffsetsTopic()
+        .setName(disklessTopicPartition.topic())
+        .setPartitions(util.List.of(new ListOffsetsPartition()
+          .setPartitionIndex(disklessTopicPartition.partition())
+          .setTimestamp(ListOffsetsRequest.LATEST_TIMESTAMP)
+          .setCurrentLeaderEpoch(0))))
+
+      @volatile var responseTopics: util.Collection[ListOffsetsTopicResponse] = null
+      val callback: Consumer[util.Collection[ListOffsetsTopicResponse]] = (r: util.Collection[ListOffsetsTopicResponse]) => responseTopics = r
+
+      replicaManager.fetchOffset(topics, Set.empty, IsolationLevel.READ_UNCOMMITTED,
+        ListOffsetsRequest.CONSUMER_REPLICA_ID, "client", 0, 1.toShort,
+        (e, p) => new ListOffsetsPartitionResponse().setPartitionIndex(p.partitionIndex).setErrorCode(e.code),
+        callback)
+
+      assertNotNull(responseTopics)
+      val partitionResponse = responseTopics.asScala.head.partitions().get(0)
+      assertEquals(Errors.NONE.code, partitionResponse.errorCode())
+      assertEquals(50L, partitionResponse.offset())
+
+      verify(replicaManager).fetchOffsetForTimestamp(
+        ArgumentMatchers.eq(disklessTopicPartition.topicPartition()), anyLong(), any(), any(), anyBoolean())
+      verify(jobMock, never()).add(any(), any())
+    }
+
+    @Test
+    def testFetchOffsetLatestUsesDisklessPathWhenMigrationComplete(): Unit = {
+      val successResult = new OffsetResultHolder.FileRecordsOrError(
+        Optional.empty(),
+        Optional.of(new FileRecords.TimestampAndOffset(RecordBatch.NO_TIMESTAMP, 200L, Optional.of[Integer](0))))
+
+      val jobMock = Mockito.mock(classOf[FetchOffsetHandler.Job])
+      when(jobMock.mustHandle(any())).thenReturn(true)
+      when(jobMock.add(any(), any())).thenReturn(CompletableFuture.completedFuture(successResult))
+      when(jobMock.cancelHandler()).thenReturn(new CompletableFuture[Void]())
+      doNothing().when(jobMock).start()
+
+      val fetchOffsetHandlerCtorInit: MockedConstruction.MockInitializer[FetchOffsetHandler] = {
+        case (handlerMock, _) =>
+          when(handlerMock.createJob()).thenReturn(jobMock)
+      }
+      val fetchOffsetHandlerCtor = mockConstruction(classOf[FetchOffsetHandler], fetchOffsetHandlerCtorInit)
+
+      val replicaManager = try {
+        spy(createReplicaManager(List(disklessTopicPartition.topic()), disklessManagedReplicasEnabled = true))
+      } finally {
+        fetchOffsetHandlerCtor.close()
+      }
+
+      when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
+        .thenReturn(100L)
+
+      val topics = Seq(new ListOffsetsTopic()
+        .setName(disklessTopicPartition.topic())
+        .setPartitions(util.List.of(new ListOffsetsPartition()
+          .setPartitionIndex(disklessTopicPartition.partition())
+          .setTimestamp(ListOffsetsRequest.LATEST_TIMESTAMP)
+          .setCurrentLeaderEpoch(0))))
+
+      @volatile var responseTopics: util.Collection[ListOffsetsTopicResponse] = null
+      val callback: Consumer[util.Collection[ListOffsetsTopicResponse]] = (r: util.Collection[ListOffsetsTopicResponse]) => responseTopics = r
+
+      replicaManager.fetchOffset(topics, Set.empty, IsolationLevel.READ_UNCOMMITTED,
+        ListOffsetsRequest.CONSUMER_REPLICA_ID, "client", 0, 1.toShort,
+        (e, p) => new ListOffsetsPartitionResponse().setPartitionIndex(p.partitionIndex).setErrorCode(e.code),
+        callback)
+
+      assertNotNull(responseTopics)
+      val partitionResponse = responseTopics.asScala.head.partitions().get(0)
+      assertEquals(Errors.NONE.code, partitionResponse.errorCode())
+      assertEquals(200L, partitionResponse.offset())
+
+      verify(jobMock).add(ArgumentMatchers.eq(disklessTopicPartition.topicPartition()), any())
+      verify(replicaManager, never()).fetchOffsetForTimestamp(any(), anyLong(), any(), any(), anyBoolean())
+    }
+
+    @Test
+    def testFetchOffsetEarliestUsesClassicPathWhenMigrationPending(): Unit = {
+      val jobMock = Mockito.mock(classOf[FetchOffsetHandler.Job])
+      when(jobMock.mustHandle(any())).thenReturn(true)
+      doNothing().when(jobMock).start()
+
+      val fetchOffsetHandlerCtorInit: MockedConstruction.MockInitializer[FetchOffsetHandler] = {
+        case (handlerMock, _) =>
+          when(handlerMock.createJob()).thenReturn(jobMock)
+      }
+      val fetchOffsetHandlerCtor = mockConstruction(classOf[FetchOffsetHandler], fetchOffsetHandlerCtorInit)
+
+      val replicaManager = try {
+        spy(createReplicaManager(List(disklessTopicPartition.topic()), disklessManagedReplicasEnabled = true))
+      } finally {
+        fetchOffsetHandlerCtor.close()
+      }
+
+      when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
+        .thenReturn(PartitionRegistration.CLASSIC_TO_DISKLESS_MIGRATION_PENDING)
+
+      val resultHolder = new OffsetResultHolder(
+        Optional.of(new FileRecords.TimestampAndOffset(RecordBatch.NO_TIMESTAMP, 0L, Optional.of[Integer](0))))
+      doReturn(resultHolder).when(replicaManager).fetchOffsetForTimestamp(
+        ArgumentMatchers.eq(disklessTopicPartition.topicPartition()), anyLong(), any(), any(), anyBoolean())
+
+      val topics = Seq(new ListOffsetsTopic()
+        .setName(disklessTopicPartition.topic())
+        .setPartitions(util.List.of(new ListOffsetsPartition()
+          .setPartitionIndex(disklessTopicPartition.partition())
+          .setTimestamp(ListOffsetsRequest.EARLIEST_TIMESTAMP)
+          .setCurrentLeaderEpoch(0))))
+
+      @volatile var responseTopics: util.Collection[ListOffsetsTopicResponse] = null
+      val callback: Consumer[util.Collection[ListOffsetsTopicResponse]] = (r: util.Collection[ListOffsetsTopicResponse]) => responseTopics = r
+
+      replicaManager.fetchOffset(topics, Set.empty, IsolationLevel.READ_UNCOMMITTED,
+        ListOffsetsRequest.CONSUMER_REPLICA_ID, "client", 0, 1.toShort,
+        (e, p) => new ListOffsetsPartitionResponse().setPartitionIndex(p.partitionIndex).setErrorCode(e.code),
+        callback)
+
+      assertNotNull(responseTopics)
+      val partitionResponse = responseTopics.asScala.head.partitions().get(0)
+      assertEquals(Errors.NONE.code, partitionResponse.errorCode())
+      assertEquals(0L, partitionResponse.offset())
+
+      verify(replicaManager).fetchOffsetForTimestamp(
+        ArgumentMatchers.eq(disklessTopicPartition.topicPartition()), anyLong(), any(), any(), anyBoolean())
+      verify(jobMock, never()).add(any(), any())
+    }
+
+    @Test
+    def testFetchOffsetEarliestUsesDisklessPathWhenMigrationCompleteAndManagedReplicasEnabled(): Unit = {
+      val successResult = new OffsetResultHolder.FileRecordsOrError(
+        Optional.empty(),
+        Optional.of(new FileRecords.TimestampAndOffset(RecordBatch.NO_TIMESTAMP, 0L, Optional.of[Integer](0))))
+
+      val jobMock = Mockito.mock(classOf[FetchOffsetHandler.Job])
+      when(jobMock.mustHandle(any())).thenReturn(true)
+      when(jobMock.add(any(), any())).thenReturn(CompletableFuture.completedFuture(successResult))
+      when(jobMock.cancelHandler()).thenReturn(new CompletableFuture[Void]())
+      doNothing().when(jobMock).start()
+
+      val fetchOffsetHandlerCtorInit: MockedConstruction.MockInitializer[FetchOffsetHandler] = {
+        case (handlerMock, _) =>
+          when(handlerMock.createJob()).thenReturn(jobMock)
+      }
+      val fetchOffsetHandlerCtor = mockConstruction(classOf[FetchOffsetHandler], fetchOffsetHandlerCtorInit)
+
+      val replicaManager = try {
+        spy(createReplicaManager(List(disklessTopicPartition.topic()), disklessManagedReplicasEnabled = true))
+      } finally {
+        fetchOffsetHandlerCtor.close()
+      }
+
+      when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
+        .thenReturn(100L)
+
+      val topics = Seq(new ListOffsetsTopic()
+        .setName(disklessTopicPartition.topic())
+        .setPartitions(util.List.of(new ListOffsetsPartition()
+          .setPartitionIndex(disklessTopicPartition.partition())
+          .setTimestamp(ListOffsetsRequest.EARLIEST_TIMESTAMP)
+          .setCurrentLeaderEpoch(0))))
+
+      @volatile var responseTopics: util.Collection[ListOffsetsTopicResponse] = null
+      val callback: Consumer[util.Collection[ListOffsetsTopicResponse]] = (r: util.Collection[ListOffsetsTopicResponse]) => responseTopics = r
+
+      replicaManager.fetchOffset(topics, Set.empty, IsolationLevel.READ_UNCOMMITTED,
+        ListOffsetsRequest.CONSUMER_REPLICA_ID, "client", 0, 1.toShort,
+        (e, p) => new ListOffsetsPartitionResponse().setPartitionIndex(p.partitionIndex).setErrorCode(e.code),
+        callback)
+
+      assertNotNull(responseTopics)
+      val partitionResponse = responseTopics.asScala.head.partitions().get(0)
+      assertEquals(Errors.NONE.code, partitionResponse.errorCode())
+      assertEquals(0L, partitionResponse.offset())
+
+      verify(jobMock).add(ArgumentMatchers.eq(disklessTopicPartition.topicPartition()), any())
+      verify(replicaManager, never()).fetchOffsetForTimestamp(any(), anyLong(), any(), any(), anyBoolean())
+    }
+
+    @Test
+    def testFetchOffsetEarliestUsesDisklessPathWhenMigrationCompleteAndManagedReplicasDisabled(): Unit = {
+      val successResult = new OffsetResultHolder.FileRecordsOrError(
+        Optional.empty(),
+        Optional.of(new FileRecords.TimestampAndOffset(RecordBatch.NO_TIMESTAMP, 0L, Optional.of[Integer](0))))
+
+      val jobMock = Mockito.mock(classOf[FetchOffsetHandler.Job])
+      when(jobMock.mustHandle(any())).thenReturn(true)
+      when(jobMock.add(any(), any())).thenReturn(CompletableFuture.completedFuture(successResult))
+      when(jobMock.cancelHandler()).thenReturn(new CompletableFuture[Void]())
+      doNothing().when(jobMock).start()
+
+      val fetchOffsetHandlerCtorInit: MockedConstruction.MockInitializer[FetchOffsetHandler] = {
+        case (handlerMock, _) =>
+          when(handlerMock.createJob()).thenReturn(jobMock)
+      }
+      val fetchOffsetHandlerCtor = mockConstruction(classOf[FetchOffsetHandler], fetchOffsetHandlerCtorInit)
+
+      val replicaManager = try {
+        spy(createReplicaManager(List(disklessTopicPartition.topic()), disklessManagedReplicasEnabled = false))
+      } finally {
+        fetchOffsetHandlerCtor.close()
+      }
+
+      when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
+        .thenReturn(100L)
+
+      val topics = Seq(new ListOffsetsTopic()
+        .setName(disklessTopicPartition.topic())
+        .setPartitions(util.List.of(new ListOffsetsPartition()
+          .setPartitionIndex(disklessTopicPartition.partition())
+          .setTimestamp(ListOffsetsRequest.EARLIEST_TIMESTAMP)
+          .setCurrentLeaderEpoch(0))))
+
+      @volatile var responseTopics: util.Collection[ListOffsetsTopicResponse] = null
+      val callback: Consumer[util.Collection[ListOffsetsTopicResponse]] = (r: util.Collection[ListOffsetsTopicResponse]) => responseTopics = r
+
+      replicaManager.fetchOffset(topics, Set.empty, IsolationLevel.READ_UNCOMMITTED,
+        ListOffsetsRequest.CONSUMER_REPLICA_ID, "client", 0, 1.toShort,
+        (e, p) => new ListOffsetsPartitionResponse().setPartitionIndex(p.partitionIndex).setErrorCode(e.code),
+        callback)
+
+      assertNotNull(responseTopics)
+      val partitionResponse = responseTopics.asScala.head.partitions().get(0)
+      assertEquals(Errors.NONE.code, partitionResponse.errorCode())
+      assertEquals(0L, partitionResponse.offset())
+
+      verify(jobMock).add(ArgumentMatchers.eq(disklessTopicPartition.topicPartition()), any())
+      verify(replicaManager, never()).fetchOffsetForTimestamp(any(), anyLong(), any(), any(), anyBoolean())
     }
 
     @Test


### PR DESCRIPTION
Fetch offset for timestamp inside UnifiedLog for classic topics and classic topics still not migrated yet fully to diskless.
Migrated topics still fetch offsets through diskless, which is not correct but the correct routing will be implemented in a follow up PR.
Extract ListOffset logic for classic topics into its own method. This makes the logic reusable for the next changes necessary to support hybrid topics.