### PR TITLE
feat(inkless): Set migrating partitions in KRaft metadata

### DIFF
--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1894,9 +1894,10 @@ class ReplicaManager(val config: KafkaConfig,
         classicFetchInfos += fetchInfo
       } else {
         val classicToDisklessStartOffset = _inklessMetadataView.getClassicToDisklessStartOffset(tp.topicPartition())
-        val shouldReadFromUnifiedLog =
-          classicToDisklessStartOffset != PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET &&
-            partitionData.fetchOffset < classicToDisklessStartOffset
+        val migrationPending =
+          classicToDisklessStartOffset == PartitionRegistration.CLASSIC_TO_DISKLESS_MIGRATION_PENDING
+        val shouldReadFromUnifiedLog = migrationPending || (
+          classicToDisklessStartOffset >= 0 && partitionData.fetchOffset < classicToDisklessStartOffset)
 
         (shouldReadFromUnifiedLog, config.disklessManagedReplicasEnabled) match {
           case (false, _) =>
@@ -2850,7 +2851,7 @@ class ReplicaManager(val config: KafkaConfig,
             Option(topicImage.partitions().get(partitionId))
           }
           val shouldInitOnControlPlane = previousPartition.exists { previous =>
-            previous.classicToDisklessStartOffset == PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET &&
+            previous.classicToDisklessStartOffset < 0 &&
               partitionRegistration.classicToDisklessStartOffset >= 0
           }
 

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -6428,6 +6428,148 @@ class ReplicaManagerTest {
     }
 
     @Test
+    def testFetchDisklessMigrationPendingReadsFromClassicLogWhenManagedReplicasEnabled(): Unit = {
+      val fetchHandlerCtor = mockFetchHandler(Map.empty)
+      try {
+        val cp = mock(classOf[ControlPlane])
+        val replicaManager = spy(createReplicaManager(List(disklessTopicPartition.topic()), controlPlane = Some(cp), disklessManagedReplicasEnabled = true))
+
+        // Given a diskless topic with classicToDisklessStartOffset = -2 (migration pending)
+        when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
+          .thenReturn(PartitionRegistration.CLASSIC_TO_DISKLESS_MIGRATION_PENDING)
+
+        doReturn(Seq(disklessTopicPartition ->
+          new LogReadResult(
+            new FetchDataInfo(new LogOffsetMetadata(1L, 0L, 0), RECORDS),
+            Optional.empty(), 10L, 0L, 10L, 0L, 0L, OptionalLong.empty(), Errors.NONE
+          ))
+        ).when(replicaManager).readFromLog(any(), any(), any(), any())
+
+        val fetchParams = new FetchParams(
+          -1, -1L,
+          0L, 1, 1024, FetchIsolation.HIGH_WATERMARK, Optional.empty()
+        )
+        val fetchInfos = Seq(
+          disklessTopicPartition -> new PartitionData(disklessTopicPartition.topicId(), 50L, 0L, 1024, Optional.empty())
+        )
+
+        @volatile var responseData: Map[TopicIdPartition, FetchPartitionData] = null
+        val responseCallback = (response: Seq[(TopicIdPartition, FetchPartitionData)]) => {
+          responseData = response.toMap
+        }
+        replicaManager.fetchMessages(fetchParams, fetchInfos, QuotaFactory.UNBOUNDED_QUOTA, responseCallback)
+
+        // Then the request is served from the unified log (classic path) because migration is still pending
+        assertNotNull(responseData)
+        assertEquals(1, responseData.size)
+        assertEquals(RECORDS, responseData(disklessTopicPartition).records)
+        verify(replicaManager, times(1)).readFromLog(any(), any(), any(), any())
+        verify(fetchHandlerCtor.constructed().get(0), never()).handle(any(), any())
+        verify(cp, never()).findBatches(any(), any(), any())
+      } finally {
+        fetchHandlerCtor.close()
+      }
+    }
+
+    @Test
+    def testFetchDisklessMigrationPendingFailsWhenManagedReplicasDisabled(): Unit = {
+      val fetchHandlerCtor = mockFetchHandler(Map.empty)
+      try {
+        val cp = mock(classOf[ControlPlane])
+        val replicaManager = spy(createReplicaManager(
+          List(disklessTopicPartition.topic()),
+          controlPlane = Some(cp),
+          disklessManagedReplicasEnabled = false,
+        ))
+
+        // Given a diskless topic with classicToDisklessStartOffset = -2 (migration pending)
+        when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
+          .thenReturn(PartitionRegistration.CLASSIC_TO_DISKLESS_MIGRATION_PENDING)
+
+        val fetchParams = new FetchParams(
+          -1, -1L,
+          0L, 1, 1024, FetchIsolation.HIGH_WATERMARK, Optional.empty()
+        )
+        val fetchInfos = Seq(
+          disklessTopicPartition -> new PartitionData(disklessTopicPartition.topicId(), 50L, 0L, 1024, Optional.empty())
+        )
+
+        @volatile var responseData: Map[TopicIdPartition, FetchPartitionData] = null
+        val responseCallback = (response: Seq[(TopicIdPartition, FetchPartitionData)]) => {
+          responseData = response.toMap
+        }
+        replicaManager.fetchMessages(fetchParams, fetchInfos, QuotaFactory.UNBOUNDED_QUOTA, responseCallback)
+
+        // Then the request fails because managed replicas are disabled and data is still in UnifiedLog
+        assertNotNull(responseData)
+        assertEquals(1, responseData.size)
+        assertEquals(Errors.INVALID_REQUEST, responseData(disklessTopicPartition).error)
+        verify(replicaManager, never()).readFromLog(any(), any(), any(), any())
+        verify(fetchHandlerCtor.constructed().get(0), never()).handle(any(), any())
+        verify(cp, never()).findBatches(any(), any(), any())
+      } finally {
+        fetchHandlerCtor.close()
+      }
+    }
+
+    @Test
+    def testFetchFullDisklessTopicRoutesDiskless(): Unit = {
+      val disklessResponse = Map(disklessTopicPartition ->
+        new FetchPartitionData(
+          Errors.NONE,
+          110L, 100L,
+          RECORDS,
+          Optional.empty(), OptionalLong.empty(), Optional.empty(), OptionalInt.empty(), false)
+      )
+      val fetchHandlerCtor = mockFetchHandler(disklessResponse)
+      try {
+        val batchMetadata = mock(classOf[BatchMetadata])
+        when(batchMetadata.topicIdPartition()).thenReturn(disklessTopicPartition)
+        val batch = mock(classOf[BatchInfo])
+        when(batch.metadata()).thenReturn(batchMetadata)
+        val findBatchResponse = mock(classOf[FindBatchResponse])
+        when(findBatchResponse.batches()).thenReturn(util.List.of(batch))
+        when(findBatchResponse.highWatermark()).thenReturn(110L)
+        when(findBatchResponse.estimatedByteSize(50L)).thenReturn(RECORDS.sizeInBytes())
+        when(findBatchResponse.errors()).thenReturn(Errors.NONE)
+        val cp = mock(classOf[ControlPlane])
+        when(cp.findBatches(any(), any(), any())).thenReturn(util.List.of(findBatchResponse))
+        val replicaManager = spy(createReplicaManager(
+          List(disklessTopicPartition.topic()),
+          controlPlane = Some(cp),
+          disklessManagedReplicasEnabled = true,
+        ))
+
+        // Given a full diskless topic with classicToDisklessStartOffset = -1 (never migrated)
+        when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
+          .thenReturn(PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET)
+
+        val fetchParams = new FetchParams(
+          -1, -1L,
+          0L, 1, 1024, FetchIsolation.HIGH_WATERMARK, Optional.empty()
+        )
+        val fetchInfos = Seq(
+          disklessTopicPartition -> new PartitionData(disklessTopicPartition.topicId(), 50L, 0L, 1024, Optional.empty())
+        )
+
+        @volatile var responseData: Map[TopicIdPartition, FetchPartitionData] = null
+        val responseCallback = (response: Seq[(TopicIdPartition, FetchPartitionData)]) => {
+          responseData = response.toMap
+        }
+        replicaManager.fetchMessages(fetchParams, fetchInfos, QuotaFactory.UNBOUNDED_QUOTA, responseCallback)
+
+        // Then the request is served from diskless path (not from UnifiedLog)
+        assertNotNull(responseData)
+        assertEquals(1, responseData.size)
+        assertEquals(Errors.NONE, responseData(disklessTopicPartition).error)
+        verify(replicaManager, never()).readFromLog(any(), any(), any(), any())
+        verify(fetchHandlerCtor.constructed().get(0), times(1)).handle(any(), any())
+      } finally {
+        fetchHandlerCtor.close()
+      }
+    }
+
+    @Test
     def testFetchFailDisklessWhenFromReplicaAndUnmanagedReplicas(): Unit = {
       val fetchHandlerCtor = mockFetchHandler(Map.empty)
       try {

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -1936,7 +1936,7 @@ public final class QuorumController implements Controller {
                     List<ApiMessageAndVersion> allRecords = BoundedList.newArrayBacked(MAX_RECORDS_PER_USER_OP);
                     allRecords.addAll(result.records());
                     allRecords.addAll(migrationRecords);
-                    return ControllerResult.of(allRecords, result.response());
+                    return ControllerResult.atomicOf(allRecords, result.response());
                 }
                 return result;
             }

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -121,6 +121,7 @@ import org.apache.kafka.server.common.KRaftVersion;
 import org.apache.kafka.server.common.OffsetAndEpoch;
 import org.apache.kafka.server.fault.FaultHandler;
 import org.apache.kafka.server.fault.FaultHandlerException;
+import org.apache.kafka.server.mutable.BoundedList;
 import org.apache.kafka.server.policy.AlterConfigPolicy;
 import org.apache.kafka.server.policy.CreateTopicPolicy;
 import org.apache.kafka.snapshot.SnapshotReader;
@@ -129,7 +130,6 @@ import org.apache.kafka.timeline.SnapshotRegistry;
 
 import org.slf4j.Logger;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -1931,9 +1931,10 @@ public final class QuorumController implements Controller {
                 return result.withoutRecords();
             } else {
                 List<ApiMessageAndVersion> migrationRecords =
-                    replicationControl.markClassicToDisklessMigrationStarted(configChanges);
+                    replicationControl.markClassicToDisklessMigrationStarted(configChanges, result.response());
                 if (!migrationRecords.isEmpty()) {
-                    List<ApiMessageAndVersion> allRecords = new ArrayList<>(result.records());
+                    List<ApiMessageAndVersion> allRecords = BoundedList.newArrayBacked(MAX_RECORDS_PER_USER_OP);
+                    allRecords.addAll(result.records());
                     allRecords.addAll(migrationRecords);
                     return ControllerResult.of(allRecords, result.response());
                 }

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -129,6 +129,7 @@ import org.apache.kafka.timeline.SnapshotRegistry;
 
 import org.slf4j.Logger;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -1929,6 +1930,13 @@ public final class QuorumController implements Controller {
             if (validateOnly) {
                 return result.withoutRecords();
             } else {
+                List<ApiMessageAndVersion> migrationRecords =
+                    replicationControl.markClassicToDisklessMigrationStarted(configChanges);
+                if (!migrationRecords.isEmpty()) {
+                    List<ApiMessageAndVersion> allRecords = new ArrayList<>(result.records());
+                    allRecords.addAll(migrationRecords);
+                    return ControllerResult.of(allRecords, result.response());
+                }
                 return result;
             }
         });

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -2876,12 +2876,15 @@ public class ReplicationControlManager {
     }
 
     List<ApiMessageAndVersion> markClassicToDisklessMigrationStarted(
-        Map<ConfigResource, Map<String, Entry<OpType, String>>> configChanges
+        Map<ConfigResource, Map<String, Entry<OpType, String>>> configChanges,
+        Map<ConfigResource, ApiError> configResults
     ) {
-        List<ApiMessageAndVersion> records = new ArrayList<>();
+        List<ApiMessageAndVersion> records = BoundedList.newArrayBacked(MAX_RECORDS_PER_USER_OP);
         for (Entry<ConfigResource, Map<String, Entry<OpType, String>>> entry : configChanges.entrySet()) {
             ConfigResource resource = entry.getKey();
             if (resource.type() != TOPIC) continue;
+            ApiError error = configResults.get(resource);
+            if (error != null && error != ApiError.NONE) continue;
             Map<String, Entry<OpType, String>> changes = entry.getValue();
             Entry<OpType, String> disklessChange = changes.get(DISKLESS_ENABLE_CONFIG);
             if (disklessChange == null) continue;
@@ -2894,6 +2897,7 @@ public class ReplicationControlManager {
             TopicControlInfo topicInfo = topics.get(topicId);
             if (topicInfo == null) continue;
 
+            int sizeBefore = records.size();
             for (Entry<Integer, PartitionRegistration> partEntry : topicInfo.parts.entrySet()) {
                 PartitionRegistration partition = partEntry.getValue();
                 if (partition.classicToDisklessStartOffset == PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET) {
@@ -2907,7 +2911,7 @@ public class ReplicationControlManager {
                 }
             }
             log.info("Marked {} partition(s) for topic {} as classic-to-diskless migration pending",
-                records.size(), topicName);
+                records.size() - sizeBefore, topicName);
         }
         return records;
     }

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -1515,7 +1515,7 @@ public class ReplicationControlManager {
                     continue;
                 }
 
-                if (partition.classicToDisklessStartOffset != PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET) {
+                if (partition.classicToDisklessStartOffset >= 0) {
                     log.info("Rejecting InitDisklessLog request from node {} for {}-{} because " +
                             "the partition is already initialized with classicToDisklessStartOffset={}.",
                         request.brokerId(), topic.name, partitionId, partition.classicToDisklessStartOffset);
@@ -2873,6 +2873,43 @@ public class ReplicationControlManager {
             throw new InvalidReplicationFactorException("The replication factor is changed from " +
                     currentReassignmentSetSize + " to " + target.replicas().size());
         }
+    }
+
+    List<ApiMessageAndVersion> markClassicToDisklessMigrationStarted(
+        Map<ConfigResource, Map<String, Entry<OpType, String>>> configChanges
+    ) {
+        List<ApiMessageAndVersion> records = new ArrayList<>();
+        for (Entry<ConfigResource, Map<String, Entry<OpType, String>>> entry : configChanges.entrySet()) {
+            ConfigResource resource = entry.getKey();
+            if (resource.type() != TOPIC) continue;
+            Map<String, Entry<OpType, String>> changes = entry.getValue();
+            Entry<OpType, String> disklessChange = changes.get(DISKLESS_ENABLE_CONFIG);
+            if (disklessChange == null) continue;
+            if (disklessChange.getKey() != SET || !Boolean.parseBoolean(disklessChange.getValue())) continue;
+            if (isDisklessTopic(resource.name())) continue;
+
+            String topicName = resource.name();
+            Uuid topicId = topicsByName.get(topicName);
+            if (topicId == null) continue;
+            TopicControlInfo topicInfo = topics.get(topicId);
+            if (topicInfo == null) continue;
+
+            for (Entry<Integer, PartitionRegistration> partEntry : topicInfo.parts.entrySet()) {
+                PartitionRegistration partition = partEntry.getValue();
+                if (partition.classicToDisklessStartOffset == PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET) {
+                    PartitionChangeRecord record = new PartitionChangeRecord()
+                        .setTopicId(topicId)
+                        .setPartitionId(partEntry.getKey());
+                    record.unknownTaggedFields().add(
+                        InitDisklessLogFields.encodeClassicToDisklessStartOffset(
+                            PartitionRegistration.CLASSIC_TO_DISKLESS_MIGRATION_PENDING));
+                    records.add(new ApiMessageAndVersion(record, (short) 0));
+                }
+            }
+            log.info("Marked {} partition(s) for topic {} as classic-to-diskless migration pending",
+                records.size(), topicName);
+        }
+        return records;
     }
 
     private boolean isDisklessTopic(String topicName) {

--- a/metadata/src/main/java/org/apache/kafka/metadata/PartitionRegistration.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/PartitionRegistration.java
@@ -165,6 +165,7 @@ public class PartitionRegistration {
     }
 
     public static final long NO_CLASSIC_TO_DISKLESS_START_OFFSET = -1L;
+    public static final long CLASSIC_TO_DISKLESS_MIGRATION_PENDING = -2L;
 
     public final int[] replicas;
     public final Uuid[] directories;

--- a/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
@@ -6161,38 +6161,137 @@ public class ReplicationControlManagerTest {
         }
 
         @Test
-        public void testInitDisklessLogRejectsAlreadyInitializedPartition() {
+        public void testMarkClassicToDisklessMigrationStartedSuccess() {
             ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder().build();
             ReplicationControlManager replicationControl = ctx.replicationControl;
             ctx.registerBrokers(0, 1, 2);
             ctx.unfenceBrokers(0, 1, 2);
             CreatableTopicResult createTopicResult = ctx.createTestTopic("foo",
-                new int[][] {new int[] {0, 1, 2}});
+                new int[][] {new int[] {0, 1, 2}, new int[] {1, 2, 0}});
 
             Uuid topicId = createTopicResult.topicId();
-            PartitionRegistration partition = replicationControl.getPartition(topicId, 0);
+
+            ConfigResource resource = new ConfigResource(ConfigResource.Type.TOPIC, "foo");
+            Map<ConfigResource, Map<String, Map.Entry<AlterConfigOp.OpType, String>>> configChanges = Map.of(
+                resource, Map.of(DISKLESS_ENABLE_CONFIG,
+                    new AbstractMap.SimpleImmutableEntry<>(AlterConfigOp.OpType.SET, "true")));
+            Map<ConfigResource, ApiError> configResults = Map.of(resource, ApiError.NONE);
+
+            List<ApiMessageAndVersion> records =
+                replicationControl.markClassicToDisklessMigrationStarted(configChanges, configResults);
+
+            assertEquals(2, records.size());
+            for (int i = 0; i < 2; i++) {
+                assertInstanceOf(PartitionChangeRecord.class, records.get(i).message());
+                PartitionChangeRecord record = (PartitionChangeRecord) records.get(i).message();
+                assertEquals(topicId, record.topicId());
+                assertEquals(PartitionRegistration.CLASSIC_TO_DISKLESS_MIGRATION_PENDING,
+                    InitDisklessLogFields.decodeClassicToDisklessStartOffset(record.unknownTaggedFields()));
+            }
+
+            ctx.replay(records);
+            for (int i = 0; i < 2; i++) {
+                PartitionRegistration partition = replicationControl.getPartition(topicId, i);
+                assertEquals(PartitionRegistration.CLASSIC_TO_DISKLESS_MIGRATION_PENDING,
+                    partition.classicToDisklessStartOffset);
+            }
+        }
+
+        @Test
+        public void testMarkClassicToDisklessMigrationStartedSkipsIneligibleChanges() {
+            ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder()
+                .setDisklessStorageSystemEnabled(true)
+                .build();
+            ReplicationControlManager replicationControl = ctx.replicationControl;
+            ctx.registerBrokers(0, 1, 2);
+            ctx.unfenceBrokers(0, 1, 2);
+            ctx.createTestTopic("classic-topic", new int[][] {new int[] {0, 1, 2}});
+            ctx.createTestTopic("already-diskless", 1, (short) 1,
+                Map.of(DISKLESS_ENABLE_CONFIG, "true"), NONE.code());
+
+            ConfigResource classicTopic = new ConfigResource(ConfigResource.Type.TOPIC, "classic-topic");
+            ConfigResource alreadyDiskless = new ConfigResource(ConfigResource.Type.TOPIC, "already-diskless");
+            ConfigResource brokerResource = new ConfigResource(ConfigResource.Type.BROKER, "0");
+            ConfigResource unknownTopic = new ConfigResource(ConfigResource.Type.TOPIC, "no-such-topic");
+
+            Map<ConfigResource, Map<String, Map.Entry<AlterConfigOp.OpType, String>>> configChanges = new java.util.HashMap<>();
+            // Config error on the topic
+            configChanges.put(classicTopic, Map.of(DISKLESS_ENABLE_CONFIG,
+                new AbstractMap.SimpleImmutableEntry<>(AlterConfigOp.OpType.SET, "true")));
+            // Already-diskless topic
+            configChanges.put(alreadyDiskless, Map.of(DISKLESS_ENABLE_CONFIG,
+                new AbstractMap.SimpleImmutableEntry<>(AlterConfigOp.OpType.SET, "true")));
+            // Non-TOPIC resource
+            configChanges.put(brokerResource, Map.of(DISKLESS_ENABLE_CONFIG,
+                new AbstractMap.SimpleImmutableEntry<>(AlterConfigOp.OpType.SET, "true")));
+            // Unknown topic
+            configChanges.put(unknownTopic, Map.of(DISKLESS_ENABLE_CONFIG,
+                new AbstractMap.SimpleImmutableEntry<>(AlterConfigOp.OpType.SET, "true")));
+
+            Map<ConfigResource, ApiError> configResults = new java.util.HashMap<>();
+            configResults.put(classicTopic, new ApiError(Errors.INVALID_REQUEST, "bad config"));
+            configResults.put(alreadyDiskless, ApiError.NONE);
+            configResults.put(brokerResource, ApiError.NONE);
+            configResults.put(unknownTopic, ApiError.NONE);
+
+            List<ApiMessageAndVersion> records =
+                replicationControl.markClassicToDisklessMigrationStarted(configChanges, configResults);
+            assertEquals(0, records.size());
+
+            // Also verify DELETE op and SET to "false" are skipped
+            configChanges.clear();
+            configResults.clear();
+            configChanges.put(classicTopic, Map.of(DISKLESS_ENABLE_CONFIG,
+                new AbstractMap.SimpleImmutableEntry<>(AlterConfigOp.OpType.DELETE, "true")));
+            configResults.put(classicTopic, ApiError.NONE);
+
+            records = replicationControl.markClassicToDisklessMigrationStarted(configChanges, configResults);
+            assertEquals(0, records.size());
+
+            configChanges.put(classicTopic, Map.of(DISKLESS_ENABLE_CONFIG,
+                new AbstractMap.SimpleImmutableEntry<>(AlterConfigOp.OpType.SET, "false")));
+
+            records = replicationControl.markClassicToDisklessMigrationStarted(configChanges, configResults);
+            assertEquals(0, records.size());
+        }
+
+        @Test
+        public void testMarkClassicToDisklessMigrationStartedSkipsAlreadyInitializedPartitions() {
+            ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder().build();
+            ReplicationControlManager replicationControl = ctx.replicationControl;
+            ctx.registerBrokers(0, 1, 2);
+            ctx.unfenceBrokers(0, 1, 2);
+            CreatableTopicResult createTopicResult = ctx.createTestTopic("foo",
+                new int[][] {new int[] {0, 1, 2}, new int[] {1, 2, 0}});
+
+            Uuid topicId = createTopicResult.topicId();
+            PartitionRegistration partition0 = replicationControl.getPartition(topicId, 0);
 
             ControllerRequestContext requestContext = anonymousContextFor(ApiKeys.ALTER_PARTITION);
+            InitDisklessLogRequestData initRequest = singlePartitionRequest(
+                0, defaultBrokerEpoch(0), topicId, 0, 100L, partition0.leaderEpoch, List.of());
+            ControllerResult<InitDisklessLogResponseData> initResult =
+                replicationControl.initDisklessLog(requestContext, initRequest);
+            ctx.replay(initResult.records());
 
-            // First init succeeds
-            InitDisklessLogRequestData firstRequest = singlePartitionRequest(
-                0, defaultBrokerEpoch(0), topicId, 0, 100L, partition.leaderEpoch, List.of());
-            ControllerResult<InitDisklessLogResponseData> firstResult =
-                replicationControl.initDisklessLog(requestContext, firstRequest);
-            ctx.replay(firstResult.records());
-            assertEquals(NONE.code(),
-                firstResult.response().topics().get(0).partitions().get(0).errorCode());
+            ConfigResource resource = new ConfigResource(ConfigResource.Type.TOPIC, "foo");
+            Map<ConfigResource, Map<String, Map.Entry<AlterConfigOp.OpType, String>>> configChanges = Map.of(
+                resource, Map.of(DISKLESS_ENABLE_CONFIG,
+                    new AbstractMap.SimpleImmutableEntry<>(AlterConfigOp.OpType.SET, "true")));
+            Map<ConfigResource, ApiError> configResults = Map.of(resource, ApiError.NONE);
 
-            // Second init with different offset is rejected (offset >= 0 means already committed)
-            PartitionRegistration updatedPartition = replicationControl.getPartition(topicId, 0);
-            InitDisklessLogRequestData secondRequest = singlePartitionRequest(
-                0, defaultBrokerEpoch(0), topicId, 0, 200L, updatedPartition.leaderEpoch, List.of());
-            ControllerResult<InitDisklessLogResponseData> secondResult =
-                replicationControl.initDisklessLog(requestContext, secondRequest);
-            assertEquals(0, secondResult.records().size());
-            assertEquals(INVALID_REQUEST.code(),
-                secondResult.response().topics().get(0).partitions().get(0).errorCode());
+            List<ApiMessageAndVersion> records =
+                replicationControl.markClassicToDisklessMigrationStarted(configChanges, configResults);
+
+            // Only partition 1 should be marked — partition 0 was already initialized
+            assertEquals(1, records.size());
+            PartitionChangeRecord record = (PartitionChangeRecord) records.get(0).message();
+            assertEquals(topicId, record.topicId());
+            assertEquals(1, record.partitionId());
+            assertEquals(PartitionRegistration.CLASSIC_TO_DISKLESS_MIGRATION_PENDING,
+                InitDisklessLogFields.decodeClassicToDisklessStartOffset(record.unknownTaggedFields()));
         }
+
     }
 
 }

--- a/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
@@ -6119,6 +6119,80 @@ public class ReplicationControlManagerTest {
             assertEquals(2L, updatedPartition.disklessProducerStates.get(1).producerId());
             assertEquals(3L, updatedPartition.disklessProducerStates.get(2).producerId());
         }
+
+        @Test
+        public void testInitDisklessLogAcceptsMigrationPendingPartition() {
+            ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder().build();
+            ReplicationControlManager replicationControl = ctx.replicationControl;
+            ctx.registerBrokers(0, 1, 2);
+            ctx.unfenceBrokers(0, 1, 2);
+            CreatableTopicResult createTopicResult = ctx.createTestTopic("foo",
+                new int[][] {new int[] {0, 1, 2}});
+
+            Uuid topicId = createTopicResult.topicId();
+
+            // Simulate migration pending by replaying a PartitionChangeRecord with -2
+            PartitionChangeRecord migrationPendingRecord = new PartitionChangeRecord()
+                .setTopicId(topicId)
+                .setPartitionId(0);
+            migrationPendingRecord.unknownTaggedFields().add(
+                InitDisklessLogFields.encodeClassicToDisklessStartOffset(
+                    PartitionRegistration.CLASSIC_TO_DISKLESS_MIGRATION_PENDING));
+            ctx.replay(List.of(new ApiMessageAndVersion(migrationPendingRecord, (short) 0)));
+
+            PartitionRegistration pendingPartition = replicationControl.getPartition(topicId, 0);
+            assertEquals(PartitionRegistration.CLASSIC_TO_DISKLESS_MIGRATION_PENDING, pendingPartition.classicToDisklessStartOffset);
+
+            // InitDisklessLog should succeed even though classicToDisklessStartOffset is -2
+            ControllerRequestContext requestContext = anonymousContextFor(ApiKeys.ALTER_PARTITION);
+            InitDisklessLogRequestData request = singlePartitionRequest(
+                0, defaultBrokerEpoch(0), topicId, 0, 100L, pendingPartition.leaderEpoch, List.of());
+
+            ControllerResult<InitDisklessLogResponseData> result =
+                replicationControl.initDisklessLog(requestContext, request);
+
+            assertEquals(1, result.records().size());
+            assertEquals(NONE.code(),
+                result.response().topics().get(0).partitions().get(0).errorCode());
+
+            ctx.replay(result.records());
+            PartitionRegistration updatedPartition = replicationControl.getPartition(topicId, 0);
+            assertEquals(100L, updatedPartition.classicToDisklessStartOffset);
+        }
+
+        @Test
+        public void testInitDisklessLogRejectsAlreadyInitializedPartition() {
+            ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder().build();
+            ReplicationControlManager replicationControl = ctx.replicationControl;
+            ctx.registerBrokers(0, 1, 2);
+            ctx.unfenceBrokers(0, 1, 2);
+            CreatableTopicResult createTopicResult = ctx.createTestTopic("foo",
+                new int[][] {new int[] {0, 1, 2}});
+
+            Uuid topicId = createTopicResult.topicId();
+            PartitionRegistration partition = replicationControl.getPartition(topicId, 0);
+
+            ControllerRequestContext requestContext = anonymousContextFor(ApiKeys.ALTER_PARTITION);
+
+            // First init succeeds
+            InitDisklessLogRequestData firstRequest = singlePartitionRequest(
+                0, defaultBrokerEpoch(0), topicId, 0, 100L, partition.leaderEpoch, List.of());
+            ControllerResult<InitDisklessLogResponseData> firstResult =
+                replicationControl.initDisklessLog(requestContext, firstRequest);
+            ctx.replay(firstResult.records());
+            assertEquals(NONE.code(),
+                firstResult.response().topics().get(0).partitions().get(0).errorCode());
+
+            // Second init with different offset is rejected (offset >= 0 means already committed)
+            PartitionRegistration updatedPartition = replicationControl.getPartition(topicId, 0);
+            InitDisklessLogRequestData secondRequest = singlePartitionRequest(
+                0, defaultBrokerEpoch(0), topicId, 0, 200L, updatedPartition.leaderEpoch, List.of());
+            ControllerResult<InitDisklessLogResponseData> secondResult =
+                replicationControl.initDisklessLog(requestContext, secondRequest);
+            assertEquals(0, secondResult.records().size());
+            assertEquals(INVALID_REQUEST.code(),
+                secondResult.response().topics().get(0).partitions().get(0).errorCode());
+        }
     }
 
 }

--- a/metadata/src/test/java/org/apache/kafka/metadata/PartitionRegistrationTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/PartitionRegistrationTest.java
@@ -497,4 +497,52 @@ public class PartitionRegistrationTest {
         assertNotEquals(a, c);
         assertNotEquals(a, d);
     }
+
+    @Test
+    public void testMigrationPendingRoundTrip() {
+        PartitionRegistration original = new PartitionRegistration.Builder().
+            setReplicas(new int[]{1, 2, 3}).setDirectories(DirectoryId.unassignedArray(3)).
+            setIsr(new int[]{1, 2, 3}).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
+            setLeaderEpoch(0).setPartitionEpoch(0).
+            setClassicToDisklessStartOffset(PartitionRegistration.CLASSIC_TO_DISKLESS_MIGRATION_PENDING).build();
+
+        assertEquals(PartitionRegistration.CLASSIC_TO_DISKLESS_MIGRATION_PENDING, original.classicToDisklessStartOffset);
+
+        Uuid topicId = Uuid.randomUuid();
+        ApiMessageAndVersion record = original.toRecord(topicId, 0,
+            new ImageWriterOptions.Builder(MetadataVersion.latestTesting()).build());
+        PartitionRecord partitionRecord = (PartitionRecord) record.message();
+        PartitionRegistration restored = new PartitionRegistration(partitionRecord);
+        assertEquals(PartitionRegistration.CLASSIC_TO_DISKLESS_MIGRATION_PENDING, restored.classicToDisklessStartOffset);
+    }
+
+    @Test
+    public void testMergeFromMigrationPendingToActualOffset() {
+        PartitionRegistration original = new PartitionRegistration.Builder().
+            setReplicas(new int[]{1, 2, 3}).setDirectories(DirectoryId.unassignedArray(3)).
+            setIsr(new int[]{1, 2, 3}).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
+            setLeaderEpoch(0).setPartitionEpoch(0).
+            setClassicToDisklessStartOffset(PartitionRegistration.CLASSIC_TO_DISKLESS_MIGRATION_PENDING).build();
+
+        PartitionChangeRecord changeRecord = new PartitionChangeRecord();
+        changeRecord.unknownTaggedFields().add(
+            InitDisklessLogFields.encodeClassicToDisklessStartOffset(100L));
+
+        PartitionRegistration merged = original.merge(changeRecord);
+        assertEquals(100L, merged.classicToDisklessStartOffset);
+    }
+
+    @Test
+    public void testMergePreservesMigrationPending() {
+        PartitionRegistration original = new PartitionRegistration.Builder().
+            setReplicas(new int[]{1, 2, 3}).setDirectories(DirectoryId.unassignedArray(3)).
+            setIsr(new int[]{1, 2, 3}).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
+            setLeaderEpoch(0).setPartitionEpoch(0).
+            setClassicToDisklessStartOffset(PartitionRegistration.CLASSIC_TO_DISKLESS_MIGRATION_PENDING).build();
+
+        PartitionRegistration merged = original.merge(new PartitionChangeRecord().
+            setLeader(2).setIsr(List.of(2, 3)));
+
+        assertEquals(PartitionRegistration.CLASSIC_TO_DISKLESS_MIGRATION_PENDING, merged.classicToDisklessStartOffset);
+    }
 }


### PR DESCRIPTION
When service fetch requests, it's necessary to discern between a topic being migrated from classic to diskless but that has not yet committed the disklessStartOffset to KRaft (in this case fetch still need to go through UnifiedLog) and a full diskless topic (fetch goes through diskless read path).
Introduce a new sentinel value (-2) for `PartitionRegistration.classicToDisklessStartOffset` that indicates that the partition is being migrated from classic to diskless.

Before these changes:
1. Classic topic: `diskless.enable=false`, `PartitionRegistration.classicToDisklessStartOffset = -1`
1. Full diskless topic: `diskless.enable=true`, `PartitionRegistration.classicToDisklessStartOffset = -1`
1. Classic topic being migrated to diskless, that has not committed the diskless start offset yet to KRaft: `diskless.enable=true`, `PartitionRegistration.classicToDisklessStartOffset = -1`
1. Classic topic being migrated to diskless, that has committed the diskless start offset to KRaft: `diskless.enable=true`, `PartitionRegistration.classicToDisklessStartOffset = $disklessStartOffset`

*Case 2 and 3 are equal, even though 2 requires reading from UnifiedLog and 3 needs to read from diskless path.*

After the change:
1. Classic topic: `diskless.enable=false`, `PartitionRegistration.classicToDisklessStartOffset = -1`
1. Full diskless topic: `diskless.enable=true`, `PartitionRegistration.classicToDisklessStartOffset = -1`
1. Classic topic being migrated to diskless, that has not committed the diskless start offset yet to KRaft: `diskless.enable=true`, `PartitionRegistration.classicToDisklessStartOffset = -2`
1. Classic topic being migrated to diskless, that has committed the diskless start offset to KRaft: `diskless.enable=true`, `PartitionRegistration.classicToDisklessStartOffset = $disklessStartOffset`

*All cases can be individually distinguished.*