### PR TITLE
feat(inkless:consume): Add request hedging for storage reads

### DIFF
--- a/docs/inkless/configs.rst
+++ b/docs/inkless/configs.rst
@@ -157,6 +157,22 @@ Under ``inkless.``
   * Valid Values: [0,...]
   * Importance: low
 
+``fetch.hedge.total.time.threshold.ms``
+  Total time threshold in milliseconds to trigger a hedge request. When a storage fetch has not completed within this threshold, a competing hedge request is submitted. The first request to complete wins; the other continues in the background and its result is ignored. Set to 0 to disable total-time-based hedging. When both hedging thresholds are enabled, this value must be strictly greater than fetch.hedge.ttfb.threshold.ms.
+
+  * Type: long
+  * Default: 0
+  * Valid Values: [0,...]
+  * Importance: low
+
+``fetch.hedge.ttfb.threshold.ms``
+  Time-to-first-byte threshold in milliseconds to trigger a hedge request. When a storage fetch has not received its first byte within this threshold, a competing hedge request is submitted. This catches stuck connections early, before the total-time threshold. Set to 0 to disable TTFB-based hedging. When both hedging thresholds are enabled, fetch.hedge.total.time.threshold.ms must be strictly greater than this value.
+
+  * Type: long
+  * Default: 0
+  * Valid Values: [0,...]
+  * Importance: low
+
 ``fetch.lagging.consumer.thread.pool.size``
   Thread pool size for lagging consumer fetch requests (consumers reading old data). Set to 0 to disable the lagging consumer feature (all requests will use the recent data path). The default value of 16 is designed as approximately half of the default fetch.data.thread.pool.size (32), providing sufficient capacity for typical cold storage access patterns while leaving headroom for the hot path. The queue capacity is automatically set to thread.pool.size * 100, providing burst buffering (e.g., 16 threads = 1600 queue capacity ≈ 8 seconds buffer at 200 req/s). Tune based on lagging consumer SLA and expected load patterns.
 

--- a/docs/inkless/configs.rst
+++ b/docs/inkless/configs.rst
@@ -40,7 +40,7 @@ Under ``inkless.``
   * Importance: high
 
 ``fetch.lagging.consumer.request.rate.limit``
-  Maximum requests per second for lagging consumer data fetches. Set to 0 to disable rate limiting. The upper bound of 10000 req/s is a safety limit to prevent misconfiguration. For high-throughput systems, consider the relationship between this rate limit, thread pool size, and storage backend capacity. At the default rate of 200 req/s with ~50ms per request latency, this allows ~10 concurrent requests.
+  Maximum requests per second for lagging consumer data fetches. Set to 0 to disable rate limiting. The upper bound of 10000 req/s is a safety limit to prevent misconfiguration. For high-throughput systems, consider the relationship between this rate limit, thread pool size, and storage backend capacity. At the default rate of 200 req/s with ~50ms per request latency, this allows ~10 concurrent requests. Note: hedge requests triggered by slow fetches are exempt from this limit. In the worst case, effective storage GET rate can reach up to 2x this value.
 
   * Type: int
   * Default: 200
@@ -158,7 +158,7 @@ Under ``inkless.``
   * Importance: low
 
 ``fetch.hedge.total.time.threshold.ms``
-  Total time threshold in milliseconds to trigger a hedge request. When a storage fetch has not completed within this threshold, a competing hedge request is submitted. The first request to complete wins; the other continues in the background and its result is ignored. Set to 0 to disable total-time-based hedging. When both hedging thresholds are enabled, this value must be strictly greater than fetch.hedge.ttfb.threshold.ms.
+  Total time threshold in milliseconds to trigger a hedge request. When a storage fetch has not completed within this threshold, a competing hedge request is submitted. The first request to complete wins; the other continues in the background and its result is ignored. Set to 0 to disable total-time-based hedging. When both hedging thresholds are enabled, this value must be strictly greater than fetch.hedge.ttfb.threshold.ms. Capacity impact: hedges submit to the same executor as primaries (fetch.data.thread.pool.size for hot path, fetch.lagging.consumer.thread.pool.size for cold path). Normal case: only tail-latency requests (exceeding threshold) trigger hedges — typically <5% of traffic. Worst case: if all in-flight requests exceed the threshold, effective storage GET rate doubles (one primary + one hedge per request), bounded by executor thread pool + queue capacity. Monitor HedgeRequestRate to detect excessive hedging. If hedge rate is too high, increase this threshold.
 
   * Type: long
   * Default: 0

--- a/docs/inkless/metrics.rst
+++ b/docs/inkless/metrics.rst
@@ -130,6 +130,10 @@ FetchTotalTime                       Total time spent processing a fetch request
 FileFetchErrorRate                   Rate of errors when fetching files from storage per second                          
 FindBatchesErrorRate                 Rate of errors when finding batches in the control plane per second                 
 FindBatchesTime                      Time spent finding batch coordinates in the control plane in milliseconds           
+HedgeRequestRate                     Rate of hedged fetch requests issued per second                                     
+HedgeTotalTimeTriggeredRate          Rate of hedge requests triggered by total time timeout per second                   
+HedgeTtfbTriggeredRate               Rate of hedge requests triggered by TTFB timeout per second                         
+HedgeWonRate                         Rate of hedge requests that completed before the original request per second        
 LaggingConsumerRateLimitWaitTime     Wait time for rate-limited lagging consumer requests in milliseconds                
 LaggingConsumerRequestRate           Rate of requests from lagging consumers (cold path, bypasses cache) per second      
 LaggingConsumerRequestRejectedRate   Rate of lagging consumer requests rejected due to executor unavailability per second

--- a/storage/inkless/src/main/java/io/aiven/inkless/config/InklessConfig.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/config/InklessConfig.java
@@ -179,7 +179,9 @@ public class InklessConfig extends AbstractConfig {
         + "Set to 0 to disable rate limiting. "
         + "The upper bound of 10000 req/s is a safety limit to prevent misconfiguration. For high-throughput systems, "
         + "consider the relationship between this rate limit, thread pool size, and storage backend capacity. "
-        + "At the default rate of 200 req/s with ~50ms per request latency, this allows ~10 concurrent requests.";
+        + "At the default rate of 200 req/s with ~50ms per request latency, this allows ~10 concurrent requests. "
+        + "Note: hedge requests triggered by slow fetches are exempt from this limit. In the worst case, "
+        + "effective storage GET rate can reach up to 2x this value.";
     // Default 200 req/s: Conservative limit based on typical object storage GET request costs and latency.
     // At ~50ms per request, 200 req/s = ~10 concurrent requests, balancing throughput with cost control.
     // Tune based on storage backend capacity and budget constraints.
@@ -199,7 +201,13 @@ public class InklessConfig extends AbstractConfig {
         + "The first request to complete wins; the other continues in the background and its result is ignored. "
         + "Set to 0 to disable total-time-based hedging. "
         + "When both hedging thresholds are enabled, this value must be strictly greater than "
-        + FETCH_HEDGE_TTFB_THRESHOLD_MS_CONFIG + ".";
+        + FETCH_HEDGE_TTFB_THRESHOLD_MS_CONFIG + ". "
+        + "Capacity impact: hedges submit to the same executor as primaries (fetch.data.thread.pool.size for hot path, "
+        + "fetch.lagging.consumer.thread.pool.size for cold path). "
+        + "Normal case: only tail-latency requests (exceeding threshold) trigger hedges — typically <5% of traffic. "
+        + "Worst case: if all in-flight requests exceed the threshold, effective storage GET rate doubles "
+        + "(one primary + one hedge per request), bounded by executor thread pool + queue capacity. "
+        + "Monitor HedgeRequestRate to detect excessive hedging. If hedge rate is too high, increase this threshold.";
     private static final long FETCH_HEDGE_TOTAL_TIME_THRESHOLD_MS_DEFAULT = 0;
 
     public static final String FETCH_FIND_BATCHES_MAX_BATCHES_PER_PARTITION_CONFIG = "fetch.find.batches.max.per.partition";

--- a/storage/inkless/src/main/java/io/aiven/inkless/config/InklessConfig.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/config/InklessConfig.java
@@ -185,6 +185,23 @@ public class InklessConfig extends AbstractConfig {
     // Tune based on storage backend capacity and budget constraints.
     private static final int FETCH_LAGGING_CONSUMER_REQUEST_RATE_LIMIT_DEFAULT = 200;
 
+    public static final String FETCH_HEDGE_TTFB_THRESHOLD_MS_CONFIG = "fetch.hedge.ttfb.threshold.ms";
+    public static final String FETCH_HEDGE_TTFB_THRESHOLD_MS_DOC = "Time-to-first-byte threshold in milliseconds to trigger a hedge request. "
+        + "When a storage fetch has not received its first byte within this threshold, a competing hedge request is submitted. "
+        + "This catches stuck connections early, before the total-time threshold. "
+        + "Set to 0 to disable TTFB-based hedging. "
+        + "When both hedging thresholds are enabled, fetch.hedge.total.time.threshold.ms must be strictly greater than this value.";
+    private static final long FETCH_HEDGE_TTFB_THRESHOLD_MS_DEFAULT = 0;
+
+    public static final String FETCH_HEDGE_TOTAL_TIME_THRESHOLD_MS_CONFIG = "fetch.hedge.total.time.threshold.ms";
+    public static final String FETCH_HEDGE_TOTAL_TIME_THRESHOLD_MS_DOC = "Total time threshold in milliseconds to trigger a hedge request. "
+        + "When a storage fetch has not completed within this threshold, a competing hedge request is submitted. "
+        + "The first request to complete wins; the other continues in the background and its result is ignored. "
+        + "Set to 0 to disable total-time-based hedging. "
+        + "When both hedging thresholds are enabled, this value must be strictly greater than "
+        + FETCH_HEDGE_TTFB_THRESHOLD_MS_CONFIG + ".";
+    private static final long FETCH_HEDGE_TOTAL_TIME_THRESHOLD_MS_DEFAULT = 0;
+
     public static final String FETCH_FIND_BATCHES_MAX_BATCHES_PER_PARTITION_CONFIG = "fetch.find.batches.max.per.partition";
     public static final String FETCH_FIND_BATCHES_MAX_BATCHES_PER_PARTITION_DOC = "The maximum number of batches to find per partition when processing a fetch request. "
         + "A value of 0 means all available batches are fetched. "
@@ -396,6 +413,22 @@ public class InklessConfig extends AbstractConfig {
             FETCH_LAGGING_CONSUMER_REQUEST_RATE_LIMIT_DOC
         );
         configDef.define(
+            FETCH_HEDGE_TOTAL_TIME_THRESHOLD_MS_CONFIG,
+            ConfigDef.Type.LONG,
+            FETCH_HEDGE_TOTAL_TIME_THRESHOLD_MS_DEFAULT,
+            ConfigDef.Range.atLeast(0),
+            ConfigDef.Importance.LOW,
+            FETCH_HEDGE_TOTAL_TIME_THRESHOLD_MS_DOC
+        );
+        configDef.define(
+            FETCH_HEDGE_TTFB_THRESHOLD_MS_CONFIG,
+            ConfigDef.Type.LONG,
+            FETCH_HEDGE_TTFB_THRESHOLD_MS_DEFAULT,
+            ConfigDef.Range.atLeast(0),
+            ConfigDef.Importance.LOW,
+            FETCH_HEDGE_TTFB_THRESHOLD_MS_DOC
+        );
+        configDef.define(
             FETCH_FIND_BATCHES_MAX_BATCHES_PER_PARTITION_CONFIG,
             ConfigDef.Type.INT,
             FETCH_FIND_BATCHES_MAX_BATCHES_PER_PARTITION_DEFAULT,
@@ -494,6 +527,24 @@ public class InklessConfig extends AbstractConfig {
                 thresholdMs,
                 "Lagging consumer threshold (" + thresholdMs + "ms) must be >= cache lifespan ("
                     + lifespanMs + "ms) to avoid routing requests for cached data to the lagging path."
+            );
+        }
+
+        final long hedgeTtfbMs =
+            ((Number) parsedProps.get(FETCH_HEDGE_TTFB_THRESHOLD_MS_CONFIG)).longValue();
+        final long hedgeTotalTimeMs =
+            ((Number) parsedProps.get(FETCH_HEDGE_TOTAL_TIME_THRESHOLD_MS_CONFIG)).longValue();
+
+        // When both hedging triggers are enabled, total-time threshold must be > TTFB threshold.
+        // TTFB fires early to catch stuck connections; total-time is a broader safety net.
+        // If total-time <= TTFB, the total-time timer would fire first (or simultaneously),
+        // making TTFB redundant and defeating the two-tier design.
+        if (hedgeTtfbMs > 0 && hedgeTotalTimeMs > 0 && hedgeTotalTimeMs <= hedgeTtfbMs) {
+            throw new ConfigException(
+                FETCH_HEDGE_TOTAL_TIME_THRESHOLD_MS_CONFIG,
+                hedgeTotalTimeMs,
+                FETCH_HEDGE_TOTAL_TIME_THRESHOLD_MS_CONFIG + " (" + hedgeTotalTimeMs + "ms) must be greater than "
+                    + FETCH_HEDGE_TTFB_THRESHOLD_MS_CONFIG + " (" + hedgeTtfbMs + "ms) when both are enabled."
             );
         }
 
@@ -616,6 +667,14 @@ public class InklessConfig extends AbstractConfig {
 
     public int fetchLaggingConsumerRequestRateLimit() {
         return getInt(FETCH_LAGGING_CONSUMER_REQUEST_RATE_LIMIT_CONFIG);
+    }
+
+    public long fetchHedgeTtfbThresholdMs() {
+        return getLong(FETCH_HEDGE_TTFB_THRESHOLD_MS_CONFIG);
+    }
+
+    public long fetchHedgeTotalTimeThresholdMs() {
+        return getLong(FETCH_HEDGE_TOTAL_TIME_THRESHOLD_MS_CONFIG);
     }
 
     public int maxBatchesPerPartitionToFind() {

--- a/storage/inkless/src/main/java/io/aiven/inkless/consume/FetchHandler.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/consume/FetchHandler.java
@@ -59,6 +59,8 @@ public class FetchHandler implements Closeable {
                 state.config().fetchLaggingConsumerThresholdMs(),
                 state.config().fetchLaggingConsumerRequestRateLimit(),
                 state.config().fetchLaggingConsumerThreadPoolSize(),
+                state.config().fetchHedgeTtfbThresholdMs(),
+                state.config().fetchHedgeTotalTimeThresholdMs(),
                 state.config().maxBatchesPerPartitionToFind()
             )
         );

--- a/storage/inkless/src/main/java/io/aiven/inkless/consume/FetchPlanner.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/consume/FetchPlanner.java
@@ -21,12 +21,18 @@ import org.apache.kafka.common.TopicIdPartition;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.utils.Time;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -76,6 +82,9 @@ public class FetchPlanner implements Supplier<List<FetchPlanner.FetchRequestWith
     private final ObjectFetcher laggingObjectFetcher;
     private final long laggingConsumerThresholdMs;
     private final Bucket laggingRateLimiter;
+    private final ScheduledExecutorService hedgeScheduler;
+    private final long hedgeTtfbThresholdMs;
+    private final long hedgeTotalTimeThresholdMs;
     private final Map<TopicIdPartition, FindBatchResponse> batchCoordinates;
     private final InklessFetchMetrics metrics;
 
@@ -90,6 +99,9 @@ public class FetchPlanner implements Supplier<List<FetchPlanner.FetchRequestWith
         long laggingConsumerThresholdMs,
         Bucket laggingRateLimiter,
         ExecutorService laggingFetchDataExecutor,
+        ScheduledExecutorService hedgeScheduler,
+        long hedgeTtfbThresholdMs,
+        long hedgeTotalTimeThresholdMs,
         Map<TopicIdPartition, FindBatchResponse> batchCoordinates,
         InklessFetchMetrics metrics
     ) {
@@ -103,6 +115,9 @@ public class FetchPlanner implements Supplier<List<FetchPlanner.FetchRequestWith
         this.laggingFetchDataExecutor = laggingFetchDataExecutor;
         this.laggingConsumerThresholdMs = laggingConsumerThresholdMs;
         this.laggingRateLimiter = laggingRateLimiter;
+        this.hedgeScheduler = hedgeScheduler;
+        this.hedgeTtfbThresholdMs = hedgeTtfbThresholdMs;
+        this.hedgeTotalTimeThresholdMs = hedgeTotalTimeThresholdMs;
         this.batchCoordinates = batchCoordinates;
         this.metrics = metrics;
     }
@@ -229,11 +244,18 @@ public class FetchPlanner implements Supplier<List<FetchPlanner.FetchRequestWith
         if (!request.lagging()) {
             // Hot path: up-to-date consumers use cache + recentDataExecutor
             metrics.recordRecentDataRequest();
-            return cache.computeIfAbsent(
+            // Per-request TTFB signal: set by the load function's TTFB callback when first byte arrives.
+            // On a cache dedup (computeIfAbsent returns an existing in-flight future), the load function
+            // doesn't run, so this flag stays false. A TTFB hedge may fire for the deduped request —
+            // this is benign: the CAS guard limits it to one hedge, and the shared future is already
+            // in progress so it will likely complete before the timer fires.
+            final AtomicBoolean firstByteReceived = new AtomicBoolean(false);
+            final CompletableFuture<FileExtent> primary = cache.computeIfAbsent(
                 request.toCacheKey(),
-                k -> fetchFileExtent(objectFetcher, request),
+                k -> fetchFileExtent(objectFetcher, request, firstByteReceived),
                 fetchDataExecutor
             );
+            return withHedge(primary, objectFetcher, request, fetchDataExecutor, firstByteReceived);
         } else {
             // Cold path: lagging consumers bypass cache, use dedicated executor with rate limiting.
             // Cache bypass rationale: Objects are multi-partition blobs, caching them would evict hot data
@@ -241,12 +263,13 @@ public class FetchPlanner implements Supplier<List<FetchPlanner.FetchRequestWith
             // → RejectedExecutionException → Kafka error handler → consumer backs off (fetch purgatory).
             metrics.recordLaggingConsumerRequest();
             try {
-                return CompletableFuture.supplyAsync(() -> {
+                final AtomicBoolean firstByteReceived = new AtomicBoolean(false);
+                final CompletableFuture<FileExtent> primary = CompletableFuture.supplyAsync(() -> {
                         // Apply rate limiting if configured (rate limit > 0)
                         if (laggingRateLimiter != null) {
                             applyRateLimit(); // InterruptedException here is wrapped in FetchException
                         }
-                        return fetchFileExtent(laggingObjectFetcher, request);
+                        return fetchFileExtent(laggingObjectFetcher, request, firstByteReceived);
                     },
                     laggingFetchDataExecutor
                 ).whenComplete((result, throwable) -> {
@@ -265,6 +288,7 @@ public class FetchPlanner implements Supplier<List<FetchPlanner.FetchRequestWith
                         }
                     }
                 });
+                return withHedge(primary, laggingObjectFetcher, request, laggingFetchDataExecutor, firstByteReceived);
             } catch (final RejectedExecutionException e) {
                 // Sync rejection (executor shut down or queue full at submission) - return failed future
                 // instead of propagating exception. This allows allOfFileExtents to handle the failure
@@ -273,6 +297,136 @@ public class FetchPlanner implements Supplier<List<FetchPlanner.FetchRequestWith
                 // Metrics recorded here since the task never executes (vs async rejection tracked in whenComplete).
                 metrics.recordLaggingConsumerRejection();
                 return CompletableFuture.failedFuture(e);
+            }
+        }
+    }
+
+    /**
+     * Wraps a primary fetch future with hedging. Two independent triggers can fire a hedge request:
+     * <ul>
+     *   <li><b>TTFB trigger:</b> If the first byte has not been received within {@code hedgeTtfbThresholdMs},
+     *       a hedge is fired. This catches stuck connections (DNS, TLS, backend routing) early.</li>
+     *   <li><b>Total-time trigger:</b> If the primary has not completed within {@code hedgeTotalTimeThresholdMs},
+     *       a hedge is fired. This catches slow transfers even after the first byte arrived.</li>
+     * </ul>
+     *
+     * <p>At most one hedge request is submitted (guarded by {@code hedgeFired} CAS).
+     * The hedge resolves the race by calling {@code primary.complete(hedgeValue)} directly —
+     * since {@link CompletableFuture#complete} is a CAS, the first caller (primary's natural completion
+     * or hedge) wins. This makes hedging transparent to the cache: on the hot path, the cache holds
+     * a reference to {@code primary}, so whichever value resolves it is what the cache sees.
+     *
+     * <p>When hedging is disabled ({@code hedgeScheduler == null}), returns the primary future as-is.
+     * If the primary is already complete (e.g. cache hit), returns it immediately without scheduling.
+     *
+     * <p><strong>Fast-failure semantics:</strong> If the primary fails before any hedge threshold,
+     * the error propagates immediately and no hedge is attempted. Hedging mitigates slow responses,
+     * not fast failures — retries are the appropriate mechanism for those.
+     *
+     * @param primary           the original fetch future
+     * @param fetcher           the object fetcher to use for the hedge request
+     * @param request           the fetch request (object key + byte range)
+     * @param executor          the executor to submit the hedge request to
+     * @param firstByteReceived signal set by the primary's TTFB callback when first byte arrives
+     * @return the primary future (hedge resolves it directly if it wins the race)
+     */
+    private CompletableFuture<FileExtent> withHedge(
+        final CompletableFuture<FileExtent> primary,
+        final ObjectFetcher fetcher,
+        final ObjectFetchRequest request,
+        final ExecutorService executor,
+        final AtomicBoolean firstByteReceived
+    ) {
+        if (hedgeScheduler == null || primary.isDone()) {
+            return primary;
+        }
+
+        final AtomicBoolean hedgeFired = new AtomicBoolean(false);
+        final List<ScheduledFuture<?>> timers = new ArrayList<>(2);
+
+        try {
+            // TTFB trigger: fire hedge if first byte hasn't arrived within threshold
+            if (hedgeTtfbThresholdMs > 0) {
+                timers.add(hedgeScheduler.schedule(() -> {
+                    if (!primary.isDone() && !firstByteReceived.get()) {
+                        tryFireHedge(hedgeFired, primary, fetcher, request, executor,
+                            metrics::recordHedgeTtfbTriggered);
+                    }
+                }, hedgeTtfbThresholdMs, TimeUnit.MILLISECONDS));
+            }
+
+            // Total-time trigger: fire hedge if primary hasn't completed within threshold
+            if (hedgeTotalTimeThresholdMs > 0) {
+                timers.add(hedgeScheduler.schedule(() -> {
+                    if (!primary.isDone()) {
+                        tryFireHedge(hedgeFired, primary, fetcher, request, executor,
+                            metrics::recordHedgeTotalTimeTriggered);
+                    }
+                }, hedgeTotalTimeThresholdMs, TimeUnit.MILLISECONDS));
+            }
+        } catch (final RejectedExecutionException e) {
+            // Scheduler shut down — cancel any timer that was already scheduled before the failure,
+            // then fall back to primary without hedging.
+            timers.forEach(timer -> timer.cancel(false));
+            return primary;
+        }
+
+        if (timers.isEmpty()) {
+            // Both thresholds are 0 — no hedging
+            return primary;
+        }
+
+        // Cancel timers when primary completes (naturally or via hedge)
+        primary.whenComplete((value, error) ->
+            timers.forEach(timer -> timer.cancel(false))
+        );
+
+        return primary;
+    }
+
+    /**
+     * Attempts to fire a single hedge request. Uses compare-and-set on {@code hedgeFired} to ensure at most
+     * one hedge is submitted, even if both TTFB and total-time triggers fire concurrently.
+     *
+     * <p>The hedge uses the 2-arg {@link #fetchFileExtent(ObjectFetcher, ObjectFetchRequest)} overload
+     * (no {@code firstByteReceived} flag) intentionally: the TTFB signal is only needed for the primary's
+     * hedge trigger decision, and the CAS guard ensures at most one hedge fires regardless.
+     *
+     * <p>The hedge resolves the race by completing the {@code primary} future directly. This is
+     * transparent to the cache: on the hot path, the cache holds a reference to this same future.
+     *
+     * <p>The losing in-flight fetch (primary or hedge) is not cancelled — {@code CompletableFuture.cancel()}
+     * does not interrupt S3/GCS I/O, so the HTTP request would run to completion regardless. The loser's
+     * result is simply ignored (its {@code complete()} call is a no-op on the already-resolved future).
+     */
+    private void tryFireHedge(
+        final AtomicBoolean hedgeFired,
+        final CompletableFuture<FileExtent> primary,
+        final ObjectFetcher fetcher,
+        final ObjectFetchRequest request,
+        final ExecutorService executor,
+        final Runnable triggerMetric
+    ) {
+        // There is a small race between the timer's !primary.isDone() check and this CAS —
+        // the primary can complete in between, causing an unnecessary hedge. This is intentionally
+        // non-blocking: eliminating the race would require synchronizing with primary completion,
+        // adding contention on the hot path. The trade-off is an occasional redundant fetch whose
+        // primary.complete() is a no-op. HedgeWonRate remains accurate; HedgeRequestRate may be
+        // slightly inflated, which is acceptable for monitoring purposes.
+        if (hedgeFired.compareAndSet(false, true)) {
+            metrics.recordHedgeRequest();
+            triggerMetric.run();
+            try {
+                final CompletableFuture<FileExtent> hedge = CompletableFuture.supplyAsync(
+                    () -> fetchFileExtent(fetcher, request), executor
+                );
+                hedge.whenComplete((value, error) -> {
+                    if (error == null && primary.complete(value)) {
+                        metrics.recordHedgeWon();
+                    }
+                });
+            } catch (final RejectedExecutionException ignored) {
+                // Executor full — fall back to primary only
             }
         }
     }
@@ -298,6 +452,37 @@ public class FetchPlanner implements Supplier<List<FetchPlanner.FetchRequestWith
                     throw new FetchException("Rate limit wait interrupted for lagging consumer", e);
                 }
             }, metrics::recordRateLimitWaitTime);
+    }
+
+    /**
+     * Fetches a file extent from remote storage, signaling when the first byte is received.
+     * The {@code firstByteReceived} flag is set by the TTFB callback before the metrics callback,
+     * enabling the TTFB hedge trigger to detect stuck connections.
+     */
+    private FileExtent fetchFileExtent(
+        final ObjectFetcher fetcher,
+        final ObjectFetchRequest request,
+        final AtomicBoolean firstByteReceived
+    ) {
+        final Consumer<Long> ttfbCallback = ttfbMs -> {
+            firstByteReceived.set(true);
+            metrics.fetchFirstByteFinished(ttfbMs);
+        };
+        try {
+            final FileFetchJob job = new FileFetchJob(
+                time,
+                fetcher,
+                request.objectKey(),
+                request.byteRange(),
+                metrics::fetchFileFinished,
+                ttfbCallback
+            );
+            final FileExtent fileExtent = job.call();
+            metrics.cacheEntrySize(fileExtent.data().length);
+            return fileExtent;
+        } catch (final Exception e) {
+            throw new FileFetchException(e);
+        }
     }
 
     /**

--- a/storage/inkless/src/main/java/io/aiven/inkless/consume/FetchPlanner.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/consume/FetchPlanner.java
@@ -21,12 +21,12 @@ import org.apache.kafka.common.TopicIdPartition;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.utils.Time;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
@@ -258,7 +258,9 @@ public class FetchPlanner implements Supplier<List<FetchPlanner.FetchRequestWith
                 k -> fetchFileExtent(objectFetcher, request, firstByteReceived),
                 fetchDataExecutor
             );
-            return withHedge(primary, objectFetcher, request, fetchDataExecutor, firstByteReceived);
+            // Hot path: no rate limiting, timers start immediately (completedFuture runs thenRun inline).
+            return withHedge(primary, objectFetcher, request, fetchDataExecutor, firstByteReceived,
+                CompletableFuture.completedFuture(null));
         } else {
             // Cold path: lagging consumers bypass cache, use dedicated executor with rate limiting.
             // Cache bypass rationale: Objects are multi-partition blobs, caching them would evict hot data
@@ -267,15 +269,25 @@ public class FetchPlanner implements Supplier<List<FetchPlanner.FetchRequestWith
             metrics.recordLaggingConsumerRequest();
             try {
                 final AtomicBoolean firstByteReceived = new AtomicBoolean(false);
+                // Signal that defers hedge timer scheduling until the actual fetch starts (after rate limiting).
+                // This prevents hedges from firing while the primary is waiting for a rate limit token.
+                final CompletableFuture<Void> fetchStarted = new CompletableFuture<>();
                 final CompletableFuture<FileExtent> primary = CompletableFuture.supplyAsync(() -> {
                         // Apply rate limiting if configured (rate limit > 0)
                         if (laggingRateLimiter != null) {
                             applyRateLimit(); // InterruptedException here is wrapped in FetchException
                         }
+                        // Signal that rate limiting is done and the fetch is starting.
+                        // Hedge timers begin counting from this point.
+                        fetchStarted.complete(null);
                         return fetchFileExtent(laggingObjectFetcher, request, firstByteReceived);
                     },
                     laggingFetchDataExecutor
                 ).whenComplete((result, throwable) -> {
+                    // Safety net: ensure fetchStarted completes even on failure (e.g., applyRateLimit() throws).
+                    // Prevents thenRun callbacks from becoming permanent GC roots.
+                    // No-op if already completed by the happy path above.
+                    fetchStarted.complete(null);
                     // Track async rejections that occur during task execution:
                     // - RejectedExecutionException: rejection when executor is shut down or queue is full.
                     //   This may surface either as the throwable itself or as its cause (e.g., via CompletionException).
@@ -291,7 +303,9 @@ public class FetchPlanner implements Supplier<List<FetchPlanner.FetchRequestWith
                         }
                     }
                 });
-                return withHedge(primary, laggingObjectFetcher, request, laggingFetchDataExecutor, firstByteReceived);
+                // Cold path: timers deferred until fetchStarted completes (after rate limiting).
+                return withHedge(primary, laggingObjectFetcher, request, laggingFetchDataExecutor, firstByteReceived,
+                    fetchStarted);
             } catch (final RejectedExecutionException e) {
                 // Sync rejection (executor shut down or queue full at submission) - return failed future
                 // instead of propagating exception. This allows allOfFileExtents to handle the failure
@@ -308,6 +322,12 @@ public class FetchPlanner implements Supplier<List<FetchPlanner.FetchRequestWith
     // primary is too slow. Two triggers: TTFB (stuck connection) and total-time (slow transfer).
     // Timers run on the hedge scheduler; actual fetches run on the data executor.
     //
+    // Timer deferral: timers are scheduled inside fetchStarted.thenRun(), so they only start
+    // counting once the actual fetch begins. For the hot path (no rate limiting), fetchStarted
+    // is already complete and thenRun executes inline — no behavioral change. For the cold path,
+    // timers are deferred until after rate limiting completes, preventing premature hedges during
+    // intentional backpressure.
+    //
     // Race resolution: hedge calls primary.complete(value) — CF.complete() is a CAS, first caller wins.
     // This makes hedging transparent to the cache (cache holds a reference to primary).
     //
@@ -323,9 +343,15 @@ public class FetchPlanner implements Supplier<List<FetchPlanner.FetchRequestWith
         final ObjectFetcher fetcher,
         final ObjectFetchRequest request,
         final ExecutorService executor,
-        final AtomicBoolean firstByteReceived
+        final AtomicBoolean firstByteReceived,
+        final CompletableFuture<Void> fetchStarted
     ) {
         if (hedgeScheduler == null || primary.isDone()) {
+            return primary;
+        }
+
+        if (hedgeTtfbThresholdMs <= 0 && hedgeTotalTimeThresholdMs <= 0) {
+            // Both thresholds are 0 — no hedging
             return primary;
         }
 
@@ -335,41 +361,46 @@ public class FetchPlanner implements Supplier<List<FetchPlanner.FetchRequestWith
             k.whenComplete((v, e) -> hedgeGuards.remove(k));
             return new AtomicBoolean(false);
         });
-        final List<ScheduledFuture<?>> timers = new ArrayList<>(2);
+        final List<ScheduledFuture<?>> timers = new CopyOnWriteArrayList<>();
 
-        try {
-            // TTFB trigger: fire hedge if first byte hasn't arrived within threshold
-            if (hedgeTtfbThresholdMs > 0) {
-                timers.add(hedgeScheduler.schedule(() -> {
-                    if (!primary.isDone() && !firstByteReceived.get()) {
-                        tryFireHedge(hedgeFired, primary, fetcher, request, executor,
-                            metrics::recordHedgeTtfbTriggered);
-                    }
-                }, hedgeTtfbThresholdMs, TimeUnit.MILLISECONDS));
+        // Schedule timers only after the fetch actually starts (fetchStarted completes).
+        // For hot path: fetchStarted is already complete, thenRun executes inline on this thread.
+        // For cold path: thenRun executes on the executor thread that completed fetchStarted
+        // (after rate limiting). If fetchStarted never completes (sync rejection), no timers fire.
+        fetchStarted.thenRun(() -> {
+            // If primary already completed (e.g., fast fetch right after rate limit), skip scheduling.
+            if (primary.isDone()) {
+                return;
             }
+            try {
+                // TTFB trigger: fire hedge if first byte hasn't arrived within threshold
+                if (hedgeTtfbThresholdMs > 0) {
+                    timers.add(hedgeScheduler.schedule(() -> {
+                        if (!primary.isDone() && !firstByteReceived.get()) {
+                            tryFireHedge(hedgeFired, primary, fetcher, request, executor,
+                                metrics::recordHedgeTtfbTriggered);
+                        }
+                    }, hedgeTtfbThresholdMs, TimeUnit.MILLISECONDS));
+                }
 
-            // Total-time trigger: fire hedge if primary hasn't completed within threshold
-            if (hedgeTotalTimeThresholdMs > 0) {
-                timers.add(hedgeScheduler.schedule(() -> {
-                    if (!primary.isDone()) {
-                        tryFireHedge(hedgeFired, primary, fetcher, request, executor,
-                            metrics::recordHedgeTotalTimeTriggered);
-                    }
-                }, hedgeTotalTimeThresholdMs, TimeUnit.MILLISECONDS));
+                // Total-time trigger: fire hedge if primary hasn't completed within threshold
+                if (hedgeTotalTimeThresholdMs > 0) {
+                    timers.add(hedgeScheduler.schedule(() -> {
+                        if (!primary.isDone()) {
+                            tryFireHedge(hedgeFired, primary, fetcher, request, executor,
+                                metrics::recordHedgeTotalTimeTriggered);
+                        }
+                    }, hedgeTotalTimeThresholdMs, TimeUnit.MILLISECONDS));
+                }
+            } catch (final RejectedExecutionException e) {
+                // Scheduler shut down — cancel any timer that was already scheduled before the failure.
+                timers.forEach(timer -> timer.cancel(false));
             }
-        } catch (final RejectedExecutionException e) {
-            // Scheduler shut down — cancel any timer that was already scheduled before the failure,
-            // then fall back to primary without hedging.
-            timers.forEach(timer -> timer.cancel(false));
-            return primary;
-        }
+        });
 
-        if (timers.isEmpty()) {
-            // Both thresholds are 0 — no hedging
-            return primary;
-        }
-
-        // Cancel timers when primary completes (naturally or via hedge)
+        // Cancel timers when primary completes (naturally or via hedge).
+        // If thenRun hasn't fired yet, timers list is empty and this is a no-op.
+        // Timer lambdas additionally check primary.isDone() as a safety guard.
         primary.whenComplete((value, error) ->
             timers.forEach(timer -> timer.cancel(false))
         );
@@ -381,6 +412,13 @@ public class FetchPlanner implements Supplier<List<FetchPlanner.FetchRequestWith
     // All operations are non-blocking: CAS, meter marks, and supplyAsync (only enqueues a task;
     // actual I/O runs on the data executor). Executor-full → RejectedExecutionException thrown
     // immediately and caught.
+    //
+    // Rate limiting: hedges intentionally bypass the lagging consumer rate limiter. A rate-limited
+    // hedge would be equally slow as the primary — useless. Hedges are bounded by:
+    // (1) per-key dedup (hedgeGuards CAS) — at most one hedge per primary, and
+    // (2) executor capacity — submission to a full executor is rejected immediately.
+    // Timer deferral (fetchStarted signal) ensures hedges only fire when the actual fetch is slow,
+    // not when the primary is waiting on the rate limiter.
     //
     // The losing fetch (primary or hedge) is not cancelled — CF.cancel() doesn't interrupt S3/GCS
     // I/O, so the request runs to completion regardless. The loser's complete() is a no-op.

--- a/storage/inkless/src/main/java/io/aiven/inkless/consume/FetchPlanner.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/consume/FetchPlanner.java
@@ -244,11 +244,11 @@ public class FetchPlanner implements Supplier<List<FetchPlanner.FetchRequestWith
         if (!request.lagging()) {
             // Hot path: up-to-date consumers use cache + recentDataExecutor
             metrics.recordRecentDataRequest();
-            // Per-request TTFB signal: set by the load function's TTFB callback when first byte arrives.
+            // Per-caller TTFB signal: set by the load function's TTFB callback when first byte arrives.
             // On a cache dedup (computeIfAbsent returns an existing in-flight future), the load function
-            // doesn't run, so this flag stays false. A TTFB hedge may fire for the deduped request —
-            // this is benign: the CAS guard limits it to one hedge, and the shared future is already
-            // in progress so it will likely complete before the timer fires.
+            // doesn't run, so this flag stays false — a TTFB hedge may fire for the deduped caller.
+            // This is bounded: each caller can fire at most one hedge (hedgeFired CAS), and the first
+            // hedge to complete resolves the shared primary for all waiters.
             final AtomicBoolean firstByteReceived = new AtomicBoolean(false);
             final CompletableFuture<FileExtent> primary = cache.computeIfAbsent(
                 request.toCacheKey(),
@@ -301,35 +301,19 @@ public class FetchPlanner implements Supplier<List<FetchPlanner.FetchRequestWith
         }
     }
 
-    /**
-     * Wraps a primary fetch future with hedging. Two independent triggers can fire a hedge request:
-     * <ul>
-     *   <li><b>TTFB trigger:</b> If the first byte has not been received within {@code hedgeTtfbThresholdMs},
-     *       a hedge is fired. This catches stuck connections (DNS, TLS, backend routing) early.</li>
-     *   <li><b>Total-time trigger:</b> If the primary has not completed within {@code hedgeTotalTimeThresholdMs},
-     *       a hedge is fired. This catches slow transfers even after the first byte arrived.</li>
-     * </ul>
-     *
-     * <p>At most one hedge request is submitted (guarded by {@code hedgeFired} CAS).
-     * The hedge resolves the race by calling {@code primary.complete(hedgeValue)} directly —
-     * since {@link CompletableFuture#complete} is a CAS, the first caller (primary's natural completion
-     * or hedge) wins. This makes hedging transparent to the cache: on the hot path, the cache holds
-     * a reference to {@code primary}, so whichever value resolves it is what the cache sees.
-     *
-     * <p>When hedging is disabled ({@code hedgeScheduler == null}), returns the primary future as-is.
-     * If the primary is already complete (e.g. cache hit), returns it immediately without scheduling.
-     *
-     * <p><strong>Fast-failure semantics:</strong> If the primary fails before any hedge threshold,
-     * the error propagates immediately and no hedge is attempted. Hedging mitigates slow responses,
-     * not fast failures — retries are the appropriate mechanism for those.
-     *
-     * @param primary           the original fetch future
-     * @param fetcher           the object fetcher to use for the hedge request
-     * @param request           the fetch request (object key + byte range)
-     * @param executor          the executor to submit the hedge request to
-     * @param firstByteReceived signal set by the primary's TTFB callback when first byte arrives
-     * @return the primary future (hedge resolves it directly if it wins the race)
-     */
+    // Wraps a primary future with hedging: schedules timer(s) that fire a competing fetch if the
+    // primary is too slow. Two triggers: TTFB (stuck connection) and total-time (slow transfer).
+    // Timers run on the hedge scheduler; actual fetches run on the data executor.
+    //
+    // Race resolution: hedge calls primary.complete(value) — CF.complete() is a CAS, first caller wins.
+    // This makes hedging transparent to the cache (cache holds a reference to primary).
+    //
+    // Scope: hedgeFired is per-call. On cache dedup, N concurrent callers sharing the same primary
+    // each call withHedge() independently and can each spawn one hedge — bounded by executor
+    // backpressure, and the first hedge to complete resolves the shared future for all waiters.
+    //
+    // Early exits: returns primary as-is when disabled (null scheduler) or already complete (cache hit).
+    // Fast failures propagate immediately — hedging mitigates slow responses, not errors.
     private CompletableFuture<FileExtent> withHedge(
         final CompletableFuture<FileExtent> primary,
         final ObjectFetcher fetcher,
@@ -384,21 +368,13 @@ public class FetchPlanner implements Supplier<List<FetchPlanner.FetchRequestWith
         return primary;
     }
 
-    /**
-     * Attempts to fire a single hedge request. Uses compare-and-set on {@code hedgeFired} to ensure at most
-     * one hedge is submitted, even if both TTFB and total-time triggers fire concurrently.
-     *
-     * <p>The hedge uses the 2-arg {@link #fetchFileExtent(ObjectFetcher, ObjectFetchRequest)} overload
-     * (no {@code firstByteReceived} flag) intentionally: the TTFB signal is only needed for the primary's
-     * hedge trigger decision, and the CAS guard ensures at most one hedge fires regardless.
-     *
-     * <p>The hedge resolves the race by completing the {@code primary} future directly. This is
-     * transparent to the cache: on the hot path, the cache holds a reference to this same future.
-     *
-     * <p>The losing in-flight fetch (primary or hedge) is not cancelled — {@code CompletableFuture.cancel()}
-     * does not interrupt S3/GCS I/O, so the HTTP request would run to completion regardless. The loser's
-     * result is simply ignored (its {@code complete()} call is a no-op on the already-resolved future).
-     */
+    // Fires a single hedge request. Runs on the hedge scheduler thread — must never block.
+    // All operations are non-blocking: CAS, meter marks, and supplyAsync (only enqueues a task;
+    // actual I/O runs on the data executor). Executor-full → RejectedExecutionException thrown
+    // immediately and caught.
+    //
+    // The losing fetch (primary or hedge) is not cancelled — CF.cancel() doesn't interrupt S3/GCS
+    // I/O, so the request runs to completion regardless. The loser's complete() is a no-op.
     private void tryFireHedge(
         final AtomicBoolean hedgeFired,
         final CompletableFuture<FileExtent> primary,

--- a/storage/inkless/src/main/java/io/aiven/inkless/consume/FetchPlanner.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/consume/FetchPlanner.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
@@ -85,6 +86,7 @@ public class FetchPlanner implements Supplier<List<FetchPlanner.FetchRequestWith
     private final ScheduledExecutorService hedgeScheduler;
     private final long hedgeTtfbThresholdMs;
     private final long hedgeTotalTimeThresholdMs;
+    private final ConcurrentHashMap<CompletableFuture<?>, AtomicBoolean> hedgeGuards;
     private final Map<TopicIdPartition, FindBatchResponse> batchCoordinates;
     private final InklessFetchMetrics metrics;
 
@@ -102,6 +104,7 @@ public class FetchPlanner implements Supplier<List<FetchPlanner.FetchRequestWith
         ScheduledExecutorService hedgeScheduler,
         long hedgeTtfbThresholdMs,
         long hedgeTotalTimeThresholdMs,
+        ConcurrentHashMap<CompletableFuture<?>, AtomicBoolean> hedgeGuards,
         Map<TopicIdPartition, FindBatchResponse> batchCoordinates,
         InklessFetchMetrics metrics
     ) {
@@ -118,6 +121,7 @@ public class FetchPlanner implements Supplier<List<FetchPlanner.FetchRequestWith
         this.hedgeScheduler = hedgeScheduler;
         this.hedgeTtfbThresholdMs = hedgeTtfbThresholdMs;
         this.hedgeTotalTimeThresholdMs = hedgeTotalTimeThresholdMs;
+        this.hedgeGuards = hedgeGuards;
         this.batchCoordinates = batchCoordinates;
         this.metrics = metrics;
     }
@@ -246,9 +250,8 @@ public class FetchPlanner implements Supplier<List<FetchPlanner.FetchRequestWith
             metrics.recordRecentDataRequest();
             // Per-caller TTFB signal: set by the load function's TTFB callback when first byte arrives.
             // On a cache dedup (computeIfAbsent returns an existing in-flight future), the load function
-            // doesn't run, so this flag stays false — a TTFB hedge may fire for the deduped caller.
-            // This is bounded: each caller can fire at most one hedge (hedgeFired CAS), and the first
-            // hedge to complete resolves the shared primary for all waiters.
+            // doesn't run, so this flag stays false — but with per-key hedge dedup (hedgeGuards),
+            // at most one hedge fires per primary regardless of how many callers have stale TTFB flags.
             final AtomicBoolean firstByteReceived = new AtomicBoolean(false);
             final CompletableFuture<FileExtent> primary = cache.computeIfAbsent(
                 request.toCacheKey(),
@@ -308,9 +311,10 @@ public class FetchPlanner implements Supplier<List<FetchPlanner.FetchRequestWith
     // Race resolution: hedge calls primary.complete(value) — CF.complete() is a CAS, first caller wins.
     // This makes hedging transparent to the cache (cache holds a reference to primary).
     //
-    // Scope: hedgeFired is per-call. On cache dedup, N concurrent callers sharing the same primary
-    // each call withHedge() independently and can each spawn one hedge — bounded by executor
-    // backpressure, and the first hedge to complete resolves the shared future for all waiters.
+    // Per-key dedup: hedgeFired is shared across all callers of the same primary (via hedgeGuards map).
+    // On cache dedup, N concurrent callers share the same primary and the same guard — at most one
+    // hedge fires per primary, preventing hedge storms under high fan-out. The guard is removed
+    // when the primary completes.
     //
     // Early exits: returns primary as-is when disabled (null scheduler) or already complete (cache hit).
     // Fast failures propagate immediately — hedging mitigates slow responses, not errors.
@@ -325,7 +329,12 @@ public class FetchPlanner implements Supplier<List<FetchPlanner.FetchRequestWith
             return primary;
         }
 
-        final AtomicBoolean hedgeFired = new AtomicBoolean(false);
+        // Per-key dedup: all callers sharing the same primary (via cache dedup) share one guard.
+        // At most one hedge fires per primary, regardless of concurrent caller count.
+        final AtomicBoolean hedgeFired = hedgeGuards.computeIfAbsent(primary, k -> {
+            k.whenComplete((v, e) -> hedgeGuards.remove(k));
+            return new AtomicBoolean(false);
+        });
         final List<ScheduledFuture<?>> timers = new ArrayList<>(2);
 
         try {

--- a/storage/inkless/src/main/java/io/aiven/inkless/consume/FetchPlanner.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/consume/FetchPlanner.java
@@ -357,9 +357,9 @@ public class FetchPlanner implements Supplier<List<FetchPlanner.FetchRequestWith
 
         // Per-key dedup: all callers sharing the same primary (via cache dedup) share one guard.
         // At most one hedge fires per primary, regardless of concurrent caller count.
+        // whenCompleteAsync ensures remove never runs inline during computeIfAbsent.
         final AtomicBoolean hedgeFired = hedgeGuards.computeIfAbsent(primary, k -> {
-            // deferred remove, otherwise violates ConcurrentHashMap's contract
-            k.whenComplete((v, e) -> hedgeGuards.remove(k));
+            k.whenCompleteAsync((v, e) -> hedgeGuards.remove(k), hedgeScheduler);
             return new AtomicBoolean(false);
         });
         final List<ScheduledFuture<?>> timers = new CopyOnWriteArrayList<>();

--- a/storage/inkless/src/main/java/io/aiven/inkless/consume/FetchPlanner.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/consume/FetchPlanner.java
@@ -358,6 +358,7 @@ public class FetchPlanner implements Supplier<List<FetchPlanner.FetchRequestWith
         // Per-key dedup: all callers sharing the same primary (via cache dedup) share one guard.
         // At most one hedge fires per primary, regardless of concurrent caller count.
         final AtomicBoolean hedgeFired = hedgeGuards.computeIfAbsent(primary, k -> {
+            // deferred remove, otherwise violates ConcurrentHashMap's contract
             k.whenComplete((v, e) -> hedgeGuards.remove(k));
             return new AtomicBoolean(false);
         });

--- a/storage/inkless/src/main/java/io/aiven/inkless/consume/InklessFetchMetrics.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/consume/InklessFetchMetrics.java
@@ -89,9 +89,13 @@ public class InklessFetchMetrics {
     private static final String LAGGING_CONSUMER_RATE_LIMIT_WAIT_TIME = "LaggingConsumerRateLimitWaitTime";
     private static final String LAGGING_CONSUMER_RATE_LIMIT_WAIT_TIME_DOC = "Wait time for rate-limited lagging consumer requests in milliseconds";
     private static final String HEDGE_REQUEST_RATE = "HedgeRequestRate";
+    private static final String HEDGE_REQUEST_RATE_DOC = "Rate of hedged fetch requests issued per second";
     private static final String HEDGE_TTFB_TRIGGERED_RATE = "HedgeTtfbTriggeredRate";
+    private static final String HEDGE_TTFB_TRIGGERED_RATE_DOC = "Rate of hedge requests triggered by TTFB timeout per second";
     private static final String HEDGE_TOTAL_TIME_TRIGGERED_RATE = "HedgeTotalTimeTriggeredRate";
+    private static final String HEDGE_TOTAL_TIME_TRIGGERED_RATE_DOC = "Rate of hedge requests triggered by total time timeout per second";
     private static final String HEDGE_WON_RATE = "HedgeWonRate";
+    private static final String HEDGE_WON_RATE_DOC = "Rate of hedge requests that completed before the original request per second";
     // Tracks wait time (including zero-wait) for ALL lagging consumer requests when rate limiting is enabled.
     // When rate limiter is disabled (config = 0), LaggingConsumerRequestRate > 0 but this metric rate = 0.
     // Always records wait time to avoid histogram bias - zero-wait cases show when rate limiting is NOT a bottleneck.
@@ -126,7 +130,11 @@ public class InklessFetchMetrics {
             new MetricNameTemplate(RECENT_DATA_REQUEST_RATE, GROUP, RECENT_DATA_REQUEST_RATE_DOC),
             new MetricNameTemplate(LAGGING_CONSUMER_REQUEST_RATE, GROUP, LAGGING_CONSUMER_REQUEST_RATE_DOC),
             new MetricNameTemplate(LAGGING_CONSUMER_REQUEST_REJECTED_RATE, GROUP, LAGGING_CONSUMER_REQUEST_REJECTED_RATE_DOC),
-            new MetricNameTemplate(LAGGING_CONSUMER_RATE_LIMIT_WAIT_TIME, GROUP, LAGGING_CONSUMER_RATE_LIMIT_WAIT_TIME_DOC)
+            new MetricNameTemplate(LAGGING_CONSUMER_RATE_LIMIT_WAIT_TIME, GROUP, LAGGING_CONSUMER_RATE_LIMIT_WAIT_TIME_DOC),
+            new MetricNameTemplate(HEDGE_REQUEST_RATE, GROUP, HEDGE_REQUEST_RATE_DOC),
+            new MetricNameTemplate(HEDGE_TTFB_TRIGGERED_RATE, GROUP, HEDGE_TTFB_TRIGGERED_RATE_DOC),
+            new MetricNameTemplate(HEDGE_TOTAL_TIME_TRIGGERED_RATE, GROUP, HEDGE_TOTAL_TIME_TRIGGERED_RATE_DOC),
+            new MetricNameTemplate(HEDGE_WON_RATE, GROUP, HEDGE_WON_RATE_DOC)
         );
     }
 

--- a/storage/inkless/src/main/java/io/aiven/inkless/consume/InklessFetchMetrics.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/consume/InklessFetchMetrics.java
@@ -88,6 +88,14 @@ public class InklessFetchMetrics {
     private static final String LAGGING_CONSUMER_REQUEST_REJECTED_RATE_DOC = "Rate of lagging consumer requests rejected due to executor unavailability per second";
     private static final String LAGGING_CONSUMER_RATE_LIMIT_WAIT_TIME = "LaggingConsumerRateLimitWaitTime";
     private static final String LAGGING_CONSUMER_RATE_LIMIT_WAIT_TIME_DOC = "Wait time for rate-limited lagging consumer requests in milliseconds";
+    private static final String HEDGE_REQUEST_RATE = "HedgeRequestRate";
+    private static final String HEDGE_TTFB_TRIGGERED_RATE = "HedgeTtfbTriggeredRate";
+    private static final String HEDGE_TOTAL_TIME_TRIGGERED_RATE = "HedgeTotalTimeTriggeredRate";
+    private static final String HEDGE_WON_RATE = "HedgeWonRate";
+    // Tracks wait time (including zero-wait) for ALL lagging consumer requests when rate limiting is enabled.
+    // When rate limiter is disabled (config = 0), LaggingConsumerRequestRate > 0 but this metric rate = 0.
+    // Always records wait time to avoid histogram bias - zero-wait cases show when rate limiting is NOT a bottleneck.
+    // Use to monitor: rate limiting latency distribution, actual throttling pressure, and limiter effectiveness.
 
     /**
      * This method returns a list of all the metric name templates for the InklessFetchMetrics class.
@@ -150,6 +158,10 @@ public class InklessFetchMetrics {
     private final Meter laggingConsumerRequestRate;
     private final Meter laggingConsumerRejectedRate;
     private final Histogram laggingRateLimitWaitTime;
+    private final Meter hedgeRequestRate;
+    private final Meter hedgeTtfbTriggeredRate;
+    private final Meter hedgeTotalTimeTriggeredRate;
+    private final Meter hedgeWonRate;
 
     public InklessFetchMetrics(final Time time, final ObjectCache cache) {
         this.time = Objects.requireNonNull(time, "time cannot be null");
@@ -177,6 +189,10 @@ public class InklessFetchMetrics {
         laggingConsumerRequestRate = metricsGroup.newMeter(LAGGING_CONSUMER_REQUEST_RATE, "requests", TimeUnit.SECONDS, Map.of());
         laggingConsumerRejectedRate = metricsGroup.newMeter(LAGGING_CONSUMER_REQUEST_REJECTED_RATE, "rejections", TimeUnit.SECONDS, Map.of());
         laggingRateLimitWaitTime = metricsGroup.newHistogram(LAGGING_CONSUMER_RATE_LIMIT_WAIT_TIME, true, Map.of());
+        hedgeRequestRate = metricsGroup.newMeter(HEDGE_REQUEST_RATE, "hedges", TimeUnit.SECONDS, Map.of());
+        hedgeTtfbTriggeredRate = metricsGroup.newMeter(HEDGE_TTFB_TRIGGERED_RATE, "hedges", TimeUnit.SECONDS, Map.of());
+        hedgeTotalTimeTriggeredRate = metricsGroup.newMeter(HEDGE_TOTAL_TIME_TRIGGERED_RATE, "hedges", TimeUnit.SECONDS, Map.of());
+        hedgeWonRate = metricsGroup.newMeter(HEDGE_WON_RATE, "wins", TimeUnit.SECONDS, Map.of());
     }
 
     public void fetchCompleted(Instant startAt) {
@@ -265,6 +281,10 @@ public class InklessFetchMetrics {
         metricsGroup.removeMetric(LAGGING_CONSUMER_REQUEST_RATE);
         metricsGroup.removeMetric(LAGGING_CONSUMER_REQUEST_REJECTED_RATE);
         metricsGroup.removeMetric(LAGGING_CONSUMER_RATE_LIMIT_WAIT_TIME);
+        metricsGroup.removeMetric(HEDGE_REQUEST_RATE);
+        metricsGroup.removeMetric(HEDGE_TTFB_TRIGGERED_RATE);
+        metricsGroup.removeMetric(HEDGE_TOTAL_TIME_TRIGGERED_RATE);
+        metricsGroup.removeMetric(HEDGE_WON_RATE);
     }
 
     public void fetchStarted(int partitionSize) {
@@ -343,5 +363,21 @@ public class InklessFetchMetrics {
      */
     public void recordRateLimitWaitTime(long waitMs) {
         laggingRateLimitWaitTime.update(waitMs);
+    }
+
+    public void recordHedgeRequest() {
+        hedgeRequestRate.mark();
+    }
+
+    public void recordHedgeTtfbTriggered() {
+        hedgeTtfbTriggeredRate.mark();
+    }
+
+    public void recordHedgeTotalTimeTriggered() {
+        hedgeTotalTimeTriggeredRate.mark();
+    }
+
+    public void recordHedgeWon() {
+        hedgeWonRate.mark();
     }
 }

--- a/storage/inkless/src/main/java/io/aiven/inkless/consume/InklessFetchMetrics.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/consume/InklessFetchMetrics.java
@@ -86,8 +86,13 @@ public class InklessFetchMetrics {
     private static final String LAGGING_CONSUMER_REQUEST_RATE_DOC = "Rate of requests from lagging consumers (cold path, bypasses cache) per second";
     private static final String LAGGING_CONSUMER_REQUEST_REJECTED_RATE = "LaggingConsumerRequestRejectedRate";
     private static final String LAGGING_CONSUMER_REQUEST_REJECTED_RATE_DOC = "Rate of lagging consumer requests rejected due to executor unavailability per second";
+    // Tracks wait time (including zero-wait) for ALL lagging consumer requests when rate limiting is enabled.
+    // When rate limiter is disabled (config = 0), LaggingConsumerRequestRate > 0 but this metric rate = 0.
+    // Always records wait time to avoid histogram bias - zero-wait cases show when rate limiting is NOT a bottleneck.
+    // Use to monitor: rate limiting latency distribution, actual throttling pressure, and limiter effectiveness.
     private static final String LAGGING_CONSUMER_RATE_LIMIT_WAIT_TIME = "LaggingConsumerRateLimitWaitTime";
     private static final String LAGGING_CONSUMER_RATE_LIMIT_WAIT_TIME_DOC = "Wait time for rate-limited lagging consumer requests in milliseconds";
+
     private static final String HEDGE_REQUEST_RATE = "HedgeRequestRate";
     private static final String HEDGE_REQUEST_RATE_DOC = "Rate of hedged fetch requests issued per second";
     private static final String HEDGE_TTFB_TRIGGERED_RATE = "HedgeTtfbTriggeredRate";
@@ -96,10 +101,6 @@ public class InklessFetchMetrics {
     private static final String HEDGE_TOTAL_TIME_TRIGGERED_RATE_DOC = "Rate of hedge requests triggered by total time timeout per second";
     private static final String HEDGE_WON_RATE = "HedgeWonRate";
     private static final String HEDGE_WON_RATE_DOC = "Rate of hedge requests that completed before the original request per second";
-    // Tracks wait time (including zero-wait) for ALL lagging consumer requests when rate limiting is enabled.
-    // When rate limiter is disabled (config = 0), LaggingConsumerRequestRate > 0 but this metric rate = 0.
-    // Always records wait time to avoid histogram bias - zero-wait cases show when rate limiting is NOT a bottleneck.
-    // Use to monitor: rate limiting latency distribution, actual throttling pressure, and limiter effectiveness.
 
     /**
      * This method returns a list of all the metric name templates for the InklessFetchMetrics class.

--- a/storage/inkless/src/main/java/io/aiven/inkless/consume/Reader.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/consume/Reader.java
@@ -39,6 +39,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
@@ -103,6 +105,9 @@ public class Reader implements AutoCloseable {
      * <p>Trade-off: Doubles connection pools (~500KB) but prevents hot path degradation.
      */
     private final ObjectFetcher laggingConsumerObjectFetcher;
+    private final ScheduledExecutorService hedgeScheduler;
+    private final long hedgeTtfbThresholdMs;
+    private final long hedgeTotalTimeThresholdMs;
     private final InklessFetchMetrics fetchMetrics;
     private final BrokerTopicStats brokerTopicStats;
     private final Bucket rateLimiter;
@@ -124,6 +129,8 @@ public class Reader implements AutoCloseable {
         long laggingConsumerThresholdMs,
         int laggingConsumerRequestRateLimit,
         int laggingConsumerThreadPoolSize,
+        long hedgeTtfbThresholdMs,
+        long hedgeTotalTimeThresholdMs,
         int maxBatchesPerPartitionToFind
     ) {
         this(
@@ -149,9 +156,31 @@ public class Reader implements AutoCloseable {
             laggingConsumerThreadPoolSize > 0
                 ? createBoundedThreadPool(laggingConsumerThreadPoolSize)
                 : null,
+            // Only create hedge scheduler when any hedging trigger is enabled (threshold > 0).
+            // Single-threaded: only schedules timer tasks, actual fetches run on data executors.
+            (hedgeTtfbThresholdMs > 0 || hedgeTotalTimeThresholdMs > 0)
+                ? createHedgeScheduler()
+                : null,
+            hedgeTtfbThresholdMs,
+            hedgeTotalTimeThresholdMs,
             new InklessFetchMetrics(time, cache),
             brokerTopicStats
         );
+    }
+
+    private static ScheduledExecutorService createHedgeScheduler() {
+        final var scheduler = new ScheduledThreadPoolExecutor(
+            1, new InklessThreadFactory("inkless-hedge-scheduler-", true));
+        // Remove cancelled tasks from the queue immediately to prevent accumulation
+        // under high QPS with large hedge thresholds (most timer tasks are cancelled
+        // when the primary completes before the threshold).
+        scheduler.setRemoveOnCancelPolicy(true);
+        // Note on shutdown: executeExistingDelayedTasksAfterShutdownPolicy defaults to true,
+        // so already-scheduled timers may still fire after shutdown() is called. This is harmless:
+        // tryFireHedge guards with hedgeFired CAS and catches RejectedExecutionException from
+        // data executors that are shutting down concurrently. At worst, a timer fires, the CAS
+        // succeeds, the data executor rejects the hedge submission, and it's silently discarded.
+        return scheduler;
     }
 
     private static ExecutorService createBoundedThreadPool(int poolSize) {
@@ -185,6 +214,9 @@ public class Reader implements AutoCloseable {
         long laggingConsumerThresholdMs,
         int laggingConsumerRequestRateLimit,
         ExecutorService laggingFetchDataExecutor,
+        ScheduledExecutorService hedgeScheduler,
+        long hedgeTtfbThresholdMs,
+        long hedgeTotalTimeThresholdMs,
         InklessFetchMetrics fetchMetrics,
         BrokerTopicStats brokerTopicStats
     ) {
@@ -200,6 +232,9 @@ public class Reader implements AutoCloseable {
         this.laggingFetchDataExecutor = laggingFetchDataExecutor;
         this.laggingConsumerThresholdMs = laggingConsumerThresholdMs;
         this.laggingConsumerObjectFetcher = laggingConsumerObjectFetcher;
+        this.hedgeScheduler = hedgeScheduler;
+        this.hedgeTtfbThresholdMs = hedgeTtfbThresholdMs;
+        this.hedgeTotalTimeThresholdMs = hedgeTotalTimeThresholdMs;
 
         // Validate that lagging consumer resources are consistently configured:
         // both executor and fetcher must be null (feature disabled) or both must be non-null (feature enabled).
@@ -316,6 +351,9 @@ public class Reader implements AutoCloseable {
                     laggingConsumerThresholdMs,
                     rateLimiter,
                     laggingFetchDataExecutor,
+                    hedgeScheduler,
+                    hedgeTtfbThresholdMs,
+                    hedgeTotalTimeThresholdMs,
                     coordinates,
                     fetchMetrics
                 ).get();
@@ -432,6 +470,8 @@ public class Reader implements AutoCloseable {
 
     @Override
     public void close() throws IOException {
+        // Shut down hedge scheduler first to prevent it from submitting new tasks to executors being shut down
+        ThreadUtils.shutdownExecutorServiceQuietly(hedgeScheduler, EXECUTOR_SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         ThreadUtils.shutdownExecutorServiceQuietly(metadataExecutor, EXECUTOR_SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         ThreadUtils.shutdownExecutorServiceQuietly(fetchDataExecutor, EXECUTOR_SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         ThreadUtils.shutdownExecutorServiceQuietly(laggingFetchDataExecutor, EXECUTOR_SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS);

--- a/storage/inkless/src/main/java/io/aiven/inkless/consume/Reader.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/consume/Reader.java
@@ -37,12 +37,14 @@ import java.util.Optional;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import io.aiven.inkless.TimeUtils;
 import io.aiven.inkless.cache.KeyAlignmentStrategy;
@@ -108,6 +110,9 @@ public class Reader implements AutoCloseable {
     private final ScheduledExecutorService hedgeScheduler;
     private final long hedgeTtfbThresholdMs;
     private final long hedgeTotalTimeThresholdMs;
+    // Per-key hedge dedup: ensures at most one hedge per primary future across all concurrent callers.
+    // Keyed by CF identity (same instance = same cache-deduped primary). Entries are removed on completion.
+    private final ConcurrentHashMap<CompletableFuture<?>, AtomicBoolean> hedgeGuards = new ConcurrentHashMap<>();
     private final InklessFetchMetrics fetchMetrics;
     private final BrokerTopicStats brokerTopicStats;
     private final Bucket rateLimiter;
@@ -354,6 +359,7 @@ public class Reader implements AutoCloseable {
                     hedgeScheduler,
                     hedgeTtfbThresholdMs,
                     hedgeTotalTimeThresholdMs,
+                    hedgeGuards,
                     coordinates,
                     fetchMetrics
                 ).get();

--- a/storage/inkless/src/test/java/io/aiven/inkless/config/InklessConfigTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/config/InklessConfigTest.java
@@ -545,6 +545,77 @@ class InklessConfigTest {
     }
 
     @Test
+    void hedgeTotalTimeMustBeGreaterThanTtfbWhenBothEnabled() {
+        final Map<String, String> config = Map.of(
+            "control.plane.class", InMemoryControlPlane.class.getCanonicalName(),
+            "storage.backend.class", ConfigTestStorageBackend.class.getCanonicalName(),
+            "fetch.hedge.ttfb.threshold.ms", "500",
+            "fetch.hedge.total.time.threshold.ms", "300"  // less than TTFB
+        );
+
+        assertThatThrownBy(() -> new InklessConfig(config))
+            .isInstanceOf(ConfigException.class)
+            .hasMessageContaining("fetch.hedge.total.time.threshold.ms")
+            .hasMessageContaining("must be greater than")
+            .hasMessageContaining("fetch.hedge.ttfb.threshold.ms");
+    }
+
+    @Test
+    void hedgeTotalTimeEqualToTtfbInvalid() {
+        final Map<String, String> config = Map.of(
+            "control.plane.class", InMemoryControlPlane.class.getCanonicalName(),
+            "storage.backend.class", ConfigTestStorageBackend.class.getCanonicalName(),
+            "fetch.hedge.ttfb.threshold.ms", "500",
+            "fetch.hedge.total.time.threshold.ms", "500"  // equal to TTFB
+        );
+
+        assertThatThrownBy(() -> new InklessConfig(config))
+            .isInstanceOf(ConfigException.class)
+            .hasMessageContaining("must be greater than");
+    }
+
+    @Test
+    void hedgeTotalTimeGreaterThanTtfbValid() {
+        final Map<String, String> configs = new HashMap<>();
+        configs.put("control.plane.class", InMemoryControlPlane.class.getCanonicalName());
+        configs.put("storage.backend.class", ConfigTestStorageBackend.class.getCanonicalName());
+        configs.put("fetch.hedge.ttfb.threshold.ms", "200");
+        configs.put("fetch.hedge.total.time.threshold.ms", "1000");
+
+        final var config = new InklessConfig(configs);
+        assertThat(config.fetchHedgeTtfbThresholdMs()).isEqualTo(200);
+        assertThat(config.fetchHedgeTotalTimeThresholdMs()).isEqualTo(1000);
+    }
+
+    @Test
+    void hedgeOnlyTtfbEnabledValid() {
+        final Map<String, String> config = Map.of(
+            "control.plane.class", InMemoryControlPlane.class.getCanonicalName(),
+            "storage.backend.class", ConfigTestStorageBackend.class.getCanonicalName(),
+            "fetch.hedge.ttfb.threshold.ms", "500",
+            "fetch.hedge.total.time.threshold.ms", "0"  // disabled
+        );
+
+        final var inklessConfig = new InklessConfig(config);
+        assertThat(inklessConfig.fetchHedgeTtfbThresholdMs()).isEqualTo(500);
+        assertThat(inklessConfig.fetchHedgeTotalTimeThresholdMs()).isEqualTo(0);
+    }
+
+    @Test
+    void hedgeOnlyTotalTimeEnabledValid() {
+        final Map<String, String> config = Map.of(
+            "control.plane.class", InMemoryControlPlane.class.getCanonicalName(),
+            "storage.backend.class", ConfigTestStorageBackend.class.getCanonicalName(),
+            "fetch.hedge.ttfb.threshold.ms", "0",  // disabled
+            "fetch.hedge.total.time.threshold.ms", "1000"
+        );
+
+        final var inklessConfig = new InklessConfig(config);
+        assertThat(inklessConfig.fetchHedgeTtfbThresholdMs()).isEqualTo(0);
+        assertThat(inklessConfig.fetchHedgeTotalTimeThresholdMs()).isEqualTo(1000);
+    }
+
+    @Test
     void fullConfigWithLaggingConsumer() {
         // Test complete configuration including all lagging consumer settings
         final String controlPlaneClass = InMemoryControlPlane.class.getCanonicalName();

--- a/storage/inkless/src/test/java/io/aiven/inkless/consume/FetchPlannerTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/consume/FetchPlannerTest.java
@@ -41,6 +41,7 @@ import java.util.Set;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -49,6 +50,7 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 import io.aiven.inkless.cache.CaffeineCache;
@@ -1052,6 +1054,7 @@ public class FetchPlannerTest {
                             null, // no hedge scheduler
                             0, // TTFB hedging disabled
                             0, // total-time hedging disabled
+                            new ConcurrentHashMap<>(),
                             coordinates,
                             metrics
                         );
@@ -1130,6 +1133,7 @@ public class FetchPlannerTest {
                         null, // no hedge scheduler
                         0, // TTFB hedging disabled
                         0, // total-time hedging disabled
+                        new ConcurrentHashMap<>(),
                         coordinates,
                         metrics
                     );
@@ -1252,6 +1256,7 @@ public class FetchPlannerTest {
                             null, // no hedge scheduler
                             0, // TTFB hedging disabled
                             0, // total-time hedging disabled
+                            new ConcurrentHashMap<>(),
                             coordinates,
                             metrics
                         );
@@ -1603,6 +1608,7 @@ public class FetchPlannerTest {
             null, // no hedge scheduler
             0, // TTFB hedging disabled
             0, // total-time hedging disabled
+            new ConcurrentHashMap<>(),
             batchCoordinatesFuture,
             metrics
         );
@@ -1651,6 +1657,7 @@ public class FetchPlannerTest {
         private final long hedgeThresholdMs = 50;
         private final java.util.concurrent.ScheduledExecutorService hedgeScheduler =
             Executors.newSingleThreadScheduledExecutor(new InklessThreadFactory("test-hedge-", true));
+        private final ConcurrentHashMap<CompletableFuture<?>, AtomicBoolean> hedgeGuards = new ConcurrentHashMap<>();
 
         @AfterEach
         void shutdownHedgeScheduler() {
@@ -1675,6 +1682,7 @@ public class FetchPlannerTest {
                 hedgeScheduler,
                 0, // TTFB hedging disabled by default
                 hedgeThresholdMs,
+                hedgeGuards,
                 coordinates,
                 metrics
             );
@@ -1723,21 +1731,23 @@ public class FetchPlannerTest {
             );
 
             final CountDownLatch primaryBlocked = new CountDownLatch(1);
-            final CountDownLatch hedgeCanProceed = new CountDownLatch(1);
+            final CountDownLatch hedgeStarted = new CountDownLatch(1);
+            final CountDownLatch releasePrimary = new CountDownLatch(1);
             final byte[] data = {1, 2, 3};
 
-            // First call (primary) blocks; second call (hedge) returns immediately
+            // Primary blocks until released; hedge signals start then returns immediately
             when(fetcher.fetch(any(), any())).thenReturn(mock(ReadableByteChannel.class));
             when(fetcher.readToByteBuffer(any()))
                 .thenAnswer(invocation -> {
                     primaryBlocked.countDown();
-                    // Block primary until test releases it
-                    hedgeCanProceed.await(10, TimeUnit.SECONDS);
+                    releasePrimary.await(10, TimeUnit.SECONDS);
                     return ByteBuffer.wrap(data);
                 })
-                .thenAnswer(invocation -> ByteBuffer.wrap(data));
+                .thenAnswer(invocation -> {
+                    hedgeStarted.countDown();
+                    return ByteBuffer.wrap(data);
+                });
 
-            // Use a multi-threaded executor so primary and hedge can run concurrently
             final ExecutorService multiExecutor = Executors.newFixedThreadPool(2);
             try {
                 final FetchPlanner planner = new FetchPlanner(
@@ -1754,6 +1764,7 @@ public class FetchPlannerTest {
                     hedgeScheduler,
                     0, // TTFB hedging disabled
                     hedgeThresholdMs,
+                    hedgeGuards,
                     coordinates,
                     metrics
                 );
@@ -1764,7 +1775,10 @@ public class FetchPlannerTest {
                 // Wait for primary to start blocking
                 assertThat(primaryBlocked.await(5, TimeUnit.SECONDS)).isTrue();
 
-                // The result should complete via hedge (after threshold)
+                // Wait for hedge to actually start (deterministic sync, no timing dependency)
+                assertThat(hedgeStarted.await(5, TimeUnit.SECONDS)).isTrue();
+
+                // The result should complete via hedge (it returned immediately)
                 final FileExtent result = results.get(0).future().get(5, TimeUnit.SECONDS);
                 assertThat(result.object()).isEqualTo(OBJECT_KEY_A.value());
 
@@ -1774,7 +1788,7 @@ public class FetchPlannerTest {
                 verify(metrics, never()).recordHedgeTtfbTriggered();
                 verify(metrics).recordHedgeWon();
             } finally {
-                hedgeCanProceed.countDown();
+                releasePrimary.countDown();
                 multiExecutor.shutdownNow();
             }
         }
@@ -1853,6 +1867,7 @@ public class FetchPlannerTest {
                     hedgeScheduler,
                     0, // TTFB hedging disabled
                     hedgeThresholdMs,
+                    hedgeGuards,
                     coordinates,
                     metrics
                 );
@@ -1863,7 +1878,7 @@ public class FetchPlannerTest {
                 // Wait for primary to start
                 assertThat(primaryBlocked.await(5, TimeUnit.SECONDS)).isTrue();
 
-                // Wait for hedge attempt (rejected) — use Mockito timeout instead of Thread.sleep
+                // Hedge fires (recordHedgeRequest) but submission to executor is rejected
                 verify(metrics, timeout(5000)).recordHedgeRequest();
 
                 // Release primary so it can complete
@@ -1916,6 +1931,7 @@ public class FetchPlannerTest {
                     hedgeScheduler,
                     0, // TTFB hedging disabled
                     hedgeThresholdMs,
+                    hedgeGuards,
                     coordinates,
                     metrics
                 );
@@ -1946,6 +1962,7 @@ public class FetchPlannerTest {
             );
 
             final CountDownLatch primaryBlocked = new CountDownLatch(1);
+            final CountDownLatch hedgeStarted = new CountDownLatch(1);
             final CountDownLatch primaryRelease = new CountDownLatch(1);
 
             when(fetcher.fetch(any(), any())).thenReturn(mock(ReadableByteChannel.class));
@@ -1956,7 +1973,10 @@ public class FetchPlannerTest {
                     primaryRelease.await(10, TimeUnit.SECONDS);
                     throw new RuntimeException("primary storage error");
                 })
-                .thenThrow(new RuntimeException("hedge storage error"));
+                .thenAnswer(invocation -> {
+                    hedgeStarted.countDown();
+                    throw new RuntimeException("hedge storage error");
+                });
 
             final ExecutorService multiExecutor = Executors.newFixedThreadPool(2);
             try {
@@ -1974,6 +1994,7 @@ public class FetchPlannerTest {
                     hedgeScheduler,
                     0, // TTFB hedging disabled
                     hedgeThresholdMs,
+                    hedgeGuards,
                     coordinates,
                     metrics
                 );
@@ -1983,8 +2004,8 @@ public class FetchPlannerTest {
 
                 assertThat(primaryBlocked.await(5, TimeUnit.SECONDS)).isTrue();
 
-                // Wait for hedge to fire, then release primary
-                verify(metrics, timeout(5000)).recordHedgeRequest();
+                // Wait for hedge to actually start, then release primary
+                assertThat(hedgeStarted.await(5, TimeUnit.SECONDS)).isTrue();
                 primaryRelease.countDown();
 
                 // Both fail — primary error should propagate
@@ -2013,20 +2034,19 @@ public class FetchPlannerTest {
             );
 
             final CountDownLatch primaryBlocked = new CountDownLatch(1);
-            final CountDownLatch hedgeCanProceed = new CountDownLatch(1);
+            final CountDownLatch releasePrimary = new CountDownLatch(1);
             final byte[] data = {1, 2, 3};
 
-            // First call (primary) blocks; second call (hedge) returns immediately
+            // Primary blocks until released; hedge returns immediately
             when(fetcher.fetch(any(), any())).thenReturn(mock(ReadableByteChannel.class));
             when(fetcher.readToByteBuffer(any()))
                 .thenAnswer(invocation -> {
                     primaryBlocked.countDown();
-                    hedgeCanProceed.await(10, TimeUnit.SECONDS);
+                    releasePrimary.await(10, TimeUnit.SECONDS);
                     return ByteBuffer.wrap(data);
                 })
                 .thenAnswer(invocation -> ByteBuffer.wrap(data));
 
-            // Use a multi-threaded executor for the lagging path so primary and hedge can run concurrently
             final ExecutorService multiExecutor = Executors.newFixedThreadPool(2);
             try {
                 final FetchPlanner planner = new FetchPlanner(
@@ -2043,6 +2063,7 @@ public class FetchPlannerTest {
                     hedgeScheduler,
                     0, // TTFB hedging disabled
                     hedgeThresholdMs,
+                    hedgeGuards,
                     coordinates,
                     metrics
                 );
@@ -2063,7 +2084,7 @@ public class FetchPlannerTest {
                 verify(metrics, never()).recordHedgeTtfbTriggered();
                 verify(metrics).recordHedgeWon();
             } finally {
-                hedgeCanProceed.countDown();
+                releasePrimary.countDown();
                 multiExecutor.shutdownNow();
             }
         }
@@ -2084,18 +2105,22 @@ public class FetchPlannerTest {
             );
 
             final CountDownLatch primaryBlocked = new CountDownLatch(1);
-            final CountDownLatch hedgeCanProceed = new CountDownLatch(1);
+            final CountDownLatch hedgeStarted = new CountDownLatch(1);
+            final CountDownLatch releasePrimary = new CountDownLatch(1);
             final byte[] data = {1, 2, 3};
 
-            // First call (primary) blocks before first byte; second call (hedge) returns immediately
+            // Primary blocks until released; hedge signals start then returns immediately
             when(fetcher.fetch(any(), any())).thenReturn(mock(ReadableByteChannel.class));
             when(fetcher.readToByteBuffer(any()))
                 .thenAnswer(invocation -> {
                     primaryBlocked.countDown();
-                    hedgeCanProceed.await(10, TimeUnit.SECONDS);
+                    releasePrimary.await(10, TimeUnit.SECONDS);
                     return ByteBuffer.wrap(data);
                 })
-                .thenAnswer(invocation -> ByteBuffer.wrap(data));
+                .thenAnswer(invocation -> {
+                    hedgeStarted.countDown();
+                    return ByteBuffer.wrap(data);
+                });
 
             final ExecutorService multiExecutor = Executors.newFixedThreadPool(2);
             try {
@@ -2113,6 +2138,7 @@ public class FetchPlannerTest {
                     hedgeScheduler,
                     ttfbThreshold,
                     totalTimeThreshold,
+                    hedgeGuards,
                     coordinates,
                     metrics
                 );
@@ -2122,6 +2148,9 @@ public class FetchPlannerTest {
 
                 // Wait for primary to start blocking
                 assertThat(primaryBlocked.await(5, TimeUnit.SECONDS)).isTrue();
+
+                // Wait for hedge to actually start (deterministic sync)
+                assertThat(hedgeStarted.await(5, TimeUnit.SECONDS)).isTrue();
 
                 // TTFB threshold fires hedge (primary hasn't received first byte)
                 final FileExtent result = results.get(0).future().get(5, TimeUnit.SECONDS);
@@ -2133,7 +2162,7 @@ public class FetchPlannerTest {
                 verify(metrics, never()).recordHedgeTotalTimeTriggered();
                 verify(metrics).recordHedgeWon();
             } finally {
-                hedgeCanProceed.countDown();
+                releasePrimary.countDown();
                 multiExecutor.shutdownNow();
             }
         }
@@ -2173,6 +2202,7 @@ public class FetchPlannerTest {
                 hedgeScheduler,
                 ttfbThreshold,
                 totalTimeThreshold,
+                hedgeGuards,
                 coordinates,
                 metrics
             );
@@ -2204,15 +2234,15 @@ public class FetchPlannerTest {
             );
 
             final CountDownLatch primaryBlocked = new CountDownLatch(1);
-            final CountDownLatch hedgeCanProceed = new CountDownLatch(1);
+            final CountDownLatch releasePrimary = new CountDownLatch(1);
             final byte[] data = {1, 2, 3};
 
-            // Primary blocks; hedge returns immediately
+            // Primary blocks until released; hedge returns immediately
             when(fetcher.fetch(any(), any())).thenReturn(mock(ReadableByteChannel.class));
             when(fetcher.readToByteBuffer(any()))
                 .thenAnswer(invocation -> {
                     primaryBlocked.countDown();
-                    hedgeCanProceed.await(10, TimeUnit.SECONDS);
+                    releasePrimary.await(10, TimeUnit.SECONDS);
                     return ByteBuffer.wrap(data);
                 })
                 .thenAnswer(invocation -> ByteBuffer.wrap(data));
@@ -2233,6 +2263,7 @@ public class FetchPlannerTest {
                     hedgeScheduler,
                     ttfbThreshold,
                     totalTimeThreshold,
+                    hedgeGuards,
                     coordinates,
                     metrics
                 );
@@ -2253,19 +2284,19 @@ public class FetchPlannerTest {
                 verify(metrics, never()).recordHedgeTtfbTriggered();
                 verify(metrics).recordHedgeWon();
             } finally {
-                hedgeCanProceed.countDown();
+                releasePrimary.countDown();
                 multiExecutor.shutdownNow();
             }
         }
 
         @Test
-        void concurrentCallersOnSameKeyEachFireHedge() throws Exception {
+        void concurrentCallersOnSameKeyDedupToOneHedge() throws Exception {
             // Scenario: multiple consumers reading the same partition/offset range concurrently
             // (e.g., consumer group rebalance, or multiple groups on the same topic). Each consumer's
             // Reader.fetch() creates a FetchPlanner that hits the same cache key. CaffeineCache deduplicates
-            // the load — all callers share the same primary future. Each caller's withHedge() fires
-            // independently (hedgeFired is per-call, not per-future), so multiple hedges can spawn.
-            // Verifies they resolve correctly: first primary.complete() wins, rest are no-ops.
+            // the load — all callers share the same primary future. With per-key hedge dedup (hedgeGuards),
+            // all callers sharing the same primary share one hedgeFired guard — at most one hedge fires,
+            // preventing hedge storms under high fan-out.
             final long recentTimestamp = time.milliseconds();
             final Map<TopicIdPartition, FindBatchResponse> coordinates = Map.of(
                 partition0, FindBatchResponse.success(List.of(
@@ -2275,12 +2306,12 @@ public class FetchPlannerTest {
             );
 
             final CountDownLatch primaryBlocked = new CountDownLatch(1);
+            final CountDownLatch hedgeStarted = new CountDownLatch(1);
             final CountDownLatch releaseHedges = new CountDownLatch(1);
             final CountDownLatch releasePrimary = new CountDownLatch(1);
             final byte[] data = {1, 2, 3};
 
-            // Primary blocks; hedges also block until released (ensures both timers fire before
-            // either hedge completes and resolves the primary).
+            // Primary blocks; hedge signals start then blocks until released.
             when(fetcher.fetch(any(), any())).thenReturn(mock(ReadableByteChannel.class));
             when(fetcher.readToByteBuffer(any()))
                 .thenAnswer(invocation -> {
@@ -2290,12 +2321,8 @@ public class FetchPlannerTest {
                     return ByteBuffer.wrap(data);
                 })
                 .thenAnswer(invocation -> {
-                    // First hedge: block until released so second hedge timer also fires
-                    releaseHedges.await(10, TimeUnit.SECONDS);
-                    return ByteBuffer.wrap(data);
-                })
-                .thenAnswer(invocation -> {
-                    // Second hedge: also block briefly
+                    // Hedge: signal start, then block until released
+                    hedgeStarted.countDown();
                     releaseHedges.await(10, TimeUnit.SECONDS);
                     return ByteBuffer.wrap(data);
                 });
@@ -2308,12 +2335,12 @@ public class FetchPlannerTest {
                 final FetchPlanner planner1 = new FetchPlanner(
                     time, OBJECT_KEY_CREATOR, keyAlignmentStrategy, cache, fetcher,
                     multiExecutor, fetcher, 60 * 1000L, null, laggingFetchDataExecutor,
-                    hedgeScheduler, 0, hedgeThresholdMs, coordinates, metrics
+                    hedgeScheduler, 0, hedgeThresholdMs, hedgeGuards, coordinates, metrics
                 );
                 final FetchPlanner planner2 = new FetchPlanner(
                     time, OBJECT_KEY_CREATOR, keyAlignmentStrategy, cache, fetcher,
                     multiExecutor, fetcher, 60 * 1000L, null, laggingFetchDataExecutor,
-                    hedgeScheduler, 0, hedgeThresholdMs, coordinates, metrics
+                    hedgeScheduler, 0, hedgeThresholdMs, hedgeGuards, coordinates, metrics
                 );
 
                 final List<FetchPlanner.FetchRequestWithFuture> results1 = planner1.get();
@@ -2329,18 +2356,23 @@ public class FetchPlannerTest {
                 // Wait for primary to block
                 assertThat(primaryBlocked.await(5, TimeUnit.SECONDS)).isTrue();
 
-                // Both callers should fire a hedge (2 hedge requests total)
-                verify(metrics, timeout(5000).times(2)).recordHedgeRequest();
+                // Wait for hedge to actually start (deterministic sync)
+                assertThat(hedgeStarted.await(5, TimeUnit.SECONDS)).isTrue();
 
-                // Release hedges — first to complete wins the primary.complete() CAS
+                // Per-key dedup: only one hedge fires despite two callers (shared hedgeFired guard)
+                verify(metrics, times(1)).recordHedgeRequest();
+
+                // Release both: Caffeine's AsyncCache manages its own future, so external complete()
+                // doesn't resolve it — the primary load function must finish for the future to complete.
                 releaseHedges.countDown();
+                releasePrimary.countDown();
 
-                // The shared future resolves correctly (via one of the hedges)
+                // The shared future resolves correctly
                 final FileExtent result = results1.get(0).future().get(5, TimeUnit.SECONDS);
                 assertThat(result.object()).isEqualTo(OBJECT_KEY_A.value());
 
-                // Only one hedge can win (first complete() succeeds, second is a no-op)
-                verify(metrics, times(1)).recordHedgeWon();
+                // Key assertion: only ONE hedge fired (dedup), not two
+                verify(metrics, times(1)).recordHedgeTotalTimeTriggered();
             } finally {
                 releaseHedges.countDown();
                 releasePrimary.countDown();

--- a/storage/inkless/src/test/java/io/aiven/inkless/consume/FetchPlannerTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/consume/FetchPlannerTest.java
@@ -2257,5 +2257,96 @@ public class FetchPlannerTest {
                 multiExecutor.shutdownNow();
             }
         }
+
+        @Test
+        void concurrentCallersOnSameKeyEachFireHedge() throws Exception {
+            // Scenario: multiple consumers reading the same partition/offset range concurrently
+            // (e.g., consumer group rebalance, or multiple groups on the same topic). Each consumer's
+            // Reader.fetch() creates a FetchPlanner that hits the same cache key. CaffeineCache deduplicates
+            // the load — all callers share the same primary future. Each caller's withHedge() fires
+            // independently (hedgeFired is per-call, not per-future), so multiple hedges can spawn.
+            // Verifies they resolve correctly: first primary.complete() wins, rest are no-ops.
+            final long recentTimestamp = time.milliseconds();
+            final Map<TopicIdPartition, FindBatchResponse> coordinates = Map.of(
+                partition0, FindBatchResponse.success(List.of(
+                    new BatchInfo(1L, OBJECT_KEY_A.value(),
+                        BatchMetadata.of(partition0, 0, 10, 0, 0, 10, recentTimestamp, TimestampType.CREATE_TIME))
+                ), 0, 1)
+            );
+
+            final CountDownLatch primaryBlocked = new CountDownLatch(1);
+            final CountDownLatch releaseHedges = new CountDownLatch(1);
+            final CountDownLatch releasePrimary = new CountDownLatch(1);
+            final byte[] data = {1, 2, 3};
+
+            // Primary blocks; hedges also block until released (ensures both timers fire before
+            // either hedge completes and resolves the primary).
+            when(fetcher.fetch(any(), any())).thenReturn(mock(ReadableByteChannel.class));
+            when(fetcher.readToByteBuffer(any()))
+                .thenAnswer(invocation -> {
+                    // Primary: block until test releases
+                    primaryBlocked.countDown();
+                    releasePrimary.await(10, TimeUnit.SECONDS);
+                    return ByteBuffer.wrap(data);
+                })
+                .thenAnswer(invocation -> {
+                    // First hedge: block until released so second hedge timer also fires
+                    releaseHedges.await(10, TimeUnit.SECONDS);
+                    return ByteBuffer.wrap(data);
+                })
+                .thenAnswer(invocation -> {
+                    // Second hedge: also block briefly
+                    releaseHedges.await(10, TimeUnit.SECONDS);
+                    return ByteBuffer.wrap(data);
+                });
+
+            // CaffeineCache deduplicates: both planners get the same future for the same key
+            final CaffeineCache cache = new CaffeineCache(100, 0, 60, -1);
+            final ExecutorService multiExecutor = Executors.newFixedThreadPool(4);
+            try {
+                // Two planners sharing the same cache and metrics — simulates two concurrent Reader.fetch() calls
+                final FetchPlanner planner1 = new FetchPlanner(
+                    time, OBJECT_KEY_CREATOR, keyAlignmentStrategy, cache, fetcher,
+                    multiExecutor, fetcher, 60 * 1000L, null, laggingFetchDataExecutor,
+                    hedgeScheduler, 0, hedgeThresholdMs, coordinates, metrics
+                );
+                final FetchPlanner planner2 = new FetchPlanner(
+                    time, OBJECT_KEY_CREATOR, keyAlignmentStrategy, cache, fetcher,
+                    multiExecutor, fetcher, 60 * 1000L, null, laggingFetchDataExecutor,
+                    hedgeScheduler, 0, hedgeThresholdMs, coordinates, metrics
+                );
+
+                final List<FetchPlanner.FetchRequestWithFuture> results1 = planner1.get();
+                final List<FetchPlanner.FetchRequestWithFuture> results2 = planner2.get();
+
+                // Both should get futures for the same request
+                assertThat(results1).hasSize(1);
+                assertThat(results2).hasSize(1);
+
+                // Both share the same underlying future (cache dedup)
+                assertThat(results1.get(0).future()).isSameAs(results2.get(0).future());
+
+                // Wait for primary to block
+                assertThat(primaryBlocked.await(5, TimeUnit.SECONDS)).isTrue();
+
+                // Both callers should fire a hedge (2 hedge requests total)
+                verify(metrics, timeout(5000).times(2)).recordHedgeRequest();
+
+                // Release hedges — first to complete wins the primary.complete() CAS
+                releaseHedges.countDown();
+
+                // The shared future resolves correctly (via one of the hedges)
+                final FileExtent result = results1.get(0).future().get(5, TimeUnit.SECONDS);
+                assertThat(result.object()).isEqualTo(OBJECT_KEY_A.value());
+
+                // Only one hedge can win (first complete() succeeds, second is a no-op)
+                verify(metrics, times(1)).recordHedgeWon();
+            } finally {
+                releaseHedges.countDown();
+                releasePrimary.countDown();
+                multiExecutor.shutdownNow();
+                cache.close();
+            }
+        }
     }
 }

--- a/storage/inkless/src/test/java/io/aiven/inkless/consume/FetchPlannerTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/consume/FetchPlannerTest.java
@@ -46,6 +46,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -75,6 +76,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -1047,6 +1049,9 @@ public class FetchPlannerTest {
                             threshold,
                             null, // No rate limiter
                             saturatedExecutor, // Saturated executor
+                            null, // no hedge scheduler
+                            0, // TTFB hedging disabled
+                            0, // total-time hedging disabled
                             coordinates,
                             metrics
                         );
@@ -1122,6 +1127,9 @@ public class FetchPlannerTest {
                         threshold,
                         null, // No rate limiter
                         shutdownExecutor, // Shutdown executor
+                        null, // no hedge scheduler
+                        0, // TTFB hedging disabled
+                        0, // total-time hedging disabled
                         coordinates,
                         metrics
                     );
@@ -1241,6 +1249,9 @@ public class FetchPlannerTest {
                             threshold,
                             null, // No rate limiter
                             coldExecutor, // Cold path executor
+                            null, // no hedge scheduler
+                            0, // TTFB hedging disabled
+                            0, // total-time hedging disabled
                             coordinates,
                             metrics
                         );
@@ -1589,6 +1600,9 @@ public class FetchPlannerTest {
             thresholdMs,
             rateLimiter,
             laggingConsumerExecutor,
+            null, // no hedge scheduler
+            0, // TTFB hedging disabled
+            0, // total-time hedging disabled
             batchCoordinatesFuture,
             metrics
         );
@@ -1630,5 +1644,618 @@ public class FetchPlannerTest {
         FetchPlanner planner = createFetchPlannerHotPathOnly(keyAlignmentStrategy, cache, coordinates);
         List<ObjectFetchRequest> actualJobs = planner.planJobs(coordinates);
         assertThat(new HashSet<>(actualJobs)).isEqualTo(expectedJobs);
+    }
+
+    @Nested
+    class HedgingTests {
+        private final long hedgeThresholdMs = 50;
+        private final java.util.concurrent.ScheduledExecutorService hedgeScheduler =
+            Executors.newSingleThreadScheduledExecutor(new InklessThreadFactory("test-hedge-", true));
+
+        @AfterEach
+        void shutdownHedgeScheduler() {
+            hedgeScheduler.shutdownNow();
+        }
+
+        private FetchPlanner createHedgingPlanner(
+            ObjectCache cache,
+            Map<TopicIdPartition, FindBatchResponse> coordinates
+        ) {
+            return new FetchPlanner(
+                time,
+                OBJECT_KEY_CREATOR,
+                keyAlignmentStrategy,
+                cache,
+                fetcher,
+                fetchDataExecutor,
+                fetcher,
+                60 * 1000L,
+                null, // no rate limiter
+                laggingFetchDataExecutor,
+                hedgeScheduler,
+                0, // TTFB hedging disabled by default
+                hedgeThresholdMs,
+                coordinates,
+                metrics
+            );
+        }
+
+        @Test
+        void hedgeNotTriggeredWhenDisabled() throws Exception {
+            // Setup: hedging disabled (null scheduler, threshold=0)
+            final long recentTimestamp = time.milliseconds();
+            final Map<TopicIdPartition, FindBatchResponse> coordinates = Map.of(
+                partition0, FindBatchResponse.success(List.of(
+                    new BatchInfo(1L, OBJECT_KEY_A.value(),
+                        BatchMetadata.of(partition0, 0, 10, 0, 0, 10, recentTimestamp, TimestampType.CREATE_TIME))
+                ), 0, 1)
+            );
+
+            when(fetcher.fetch(any(), any())).thenReturn(mock(ReadableByteChannel.class));
+            when(fetcher.readToByteBuffer(any())).thenReturn(ByteBuffer.wrap(new byte[]{1, 2, 3}));
+
+            // Use planner WITHOUT hedging
+            final FetchPlanner planner = createFetchPlannerHotPathOnly(
+                keyAlignmentStrategy, new NullCache(), coordinates);
+
+            final List<FetchPlanner.FetchRequestWithFuture> results = planner.get();
+            assertThat(results).hasSize(1);
+
+            final FileExtent result = results.get(0).future().get(5, TimeUnit.SECONDS);
+            assertThat(result.object()).isEqualTo(OBJECT_KEY_A.value());
+
+            // No hedge metrics should be recorded
+            verify(metrics, never()).recordHedgeRequest();
+            verify(metrics, never()).recordHedgeTtfbTriggered();
+            verify(metrics, never()).recordHedgeTotalTimeTriggered();
+            verify(metrics, never()).recordHedgeWon();
+        }
+
+        @Test
+        void hedgeTriggeredWhenPrimaryIsSlow() throws Exception {
+            // Setup: primary fetch blocks, hedge should fire and win
+            final long recentTimestamp = time.milliseconds();
+            final Map<TopicIdPartition, FindBatchResponse> coordinates = Map.of(
+                partition0, FindBatchResponse.success(List.of(
+                    new BatchInfo(1L, OBJECT_KEY_A.value(),
+                        BatchMetadata.of(partition0, 0, 10, 0, 0, 10, recentTimestamp, TimestampType.CREATE_TIME))
+                ), 0, 1)
+            );
+
+            final CountDownLatch primaryBlocked = new CountDownLatch(1);
+            final CountDownLatch hedgeCanProceed = new CountDownLatch(1);
+            final byte[] data = {1, 2, 3};
+
+            // First call (primary) blocks; second call (hedge) returns immediately
+            when(fetcher.fetch(any(), any())).thenReturn(mock(ReadableByteChannel.class));
+            when(fetcher.readToByteBuffer(any()))
+                .thenAnswer(invocation -> {
+                    primaryBlocked.countDown();
+                    // Block primary until test releases it
+                    hedgeCanProceed.await(10, TimeUnit.SECONDS);
+                    return ByteBuffer.wrap(data);
+                })
+                .thenAnswer(invocation -> ByteBuffer.wrap(data));
+
+            // Use a multi-threaded executor so primary and hedge can run concurrently
+            final ExecutorService multiExecutor = Executors.newFixedThreadPool(2);
+            try {
+                final FetchPlanner planner = new FetchPlanner(
+                    time,
+                    OBJECT_KEY_CREATOR,
+                    keyAlignmentStrategy,
+                    new NullCache(),
+                    fetcher,
+                    multiExecutor,
+                    fetcher,
+                    60 * 1000L,
+                    null,
+                    laggingFetchDataExecutor,
+                    hedgeScheduler,
+                    0, // TTFB hedging disabled
+                    hedgeThresholdMs,
+                    coordinates,
+                    metrics
+                );
+
+                final List<FetchPlanner.FetchRequestWithFuture> results = planner.get();
+                assertThat(results).hasSize(1);
+
+                // Wait for primary to start blocking
+                assertThat(primaryBlocked.await(5, TimeUnit.SECONDS)).isTrue();
+
+                // The result should complete via hedge (after threshold)
+                final FileExtent result = results.get(0).future().get(5, TimeUnit.SECONDS);
+                assertThat(result.object()).isEqualTo(OBJECT_KEY_A.value());
+
+                // Hedge metrics should be recorded (total-time triggered since TTFB is disabled)
+                verify(metrics).recordHedgeRequest();
+                verify(metrics).recordHedgeTotalTimeTriggered();
+                verify(metrics, never()).recordHedgeTtfbTriggered();
+                verify(metrics).recordHedgeWon();
+            } finally {
+                hedgeCanProceed.countDown();
+                multiExecutor.shutdownNow();
+            }
+        }
+
+        @Test
+        void primaryWinsBeforeHedge() throws Exception {
+            // Setup: primary returns fast, before hedge threshold
+            final long recentTimestamp = time.milliseconds();
+            final Map<TopicIdPartition, FindBatchResponse> coordinates = Map.of(
+                partition0, FindBatchResponse.success(List.of(
+                    new BatchInfo(1L, OBJECT_KEY_A.value(),
+                        BatchMetadata.of(partition0, 0, 10, 0, 0, 10, recentTimestamp, TimestampType.CREATE_TIME))
+                ), 0, 1)
+            );
+
+            when(fetcher.fetch(any(), any())).thenReturn(mock(ReadableByteChannel.class));
+            when(fetcher.readToByteBuffer(any())).thenReturn(ByteBuffer.wrap(new byte[]{1, 2, 3}));
+
+            final FetchPlanner planner = createHedgingPlanner(new NullCache(), coordinates);
+            final List<FetchPlanner.FetchRequestWithFuture> results = planner.get();
+            assertThat(results).hasSize(1);
+
+            final FileExtent result = results.get(0).future().get(5, TimeUnit.SECONDS);
+            assertThat(result.object()).isEqualTo(OBJECT_KEY_A.value());
+
+            // Primary completed before hedge fired, so no hedge metrics
+            verify(metrics, never()).recordHedgeRequest();
+            verify(metrics, never()).recordHedgeTtfbTriggered();
+            verify(metrics, never()).recordHedgeTotalTimeTriggered();
+            verify(metrics, never()).recordHedgeWon();
+        }
+
+        @Test
+        void hedgeRejectedWhenExecutorFull() throws Exception {
+            // Setup: saturated executor, hedge submission should fail gracefully
+            final long recentTimestamp = time.milliseconds();
+            final Map<TopicIdPartition, FindBatchResponse> coordinates = Map.of(
+                partition0, FindBatchResponse.success(List.of(
+                    new BatchInfo(1L, OBJECT_KEY_A.value(),
+                        BatchMetadata.of(partition0, 0, 10, 0, 0, 10, recentTimestamp, TimestampType.CREATE_TIME))
+                ), 0, 1)
+            );
+
+            final CountDownLatch primaryBlocked = new CountDownLatch(1);
+            final CountDownLatch primaryRelease = new CountDownLatch(1);
+            final byte[] data = {1, 2, 3};
+
+            when(fetcher.fetch(any(), any())).thenReturn(mock(ReadableByteChannel.class));
+            when(fetcher.readToByteBuffer(any())).thenAnswer(invocation -> {
+                primaryBlocked.countDown();
+                primaryRelease.await(10, TimeUnit.SECONDS);
+                return ByteBuffer.wrap(data);
+            });
+
+            // 1 thread + SynchronousQueue (zero capacity): primary occupies the sole thread,
+            // so the hedge submission is guaranteed to be rejected (SynchronousQueue.offer fails
+            // when no thread is waiting to take, and max pool size is already reached).
+            final ExecutorService tinyExecutor = new ThreadPoolExecutor(
+                1, 1, 0L, TimeUnit.MILLISECONDS,
+                new SynchronousQueue<>(),
+                new ThreadPoolExecutor.AbortPolicy()
+            );
+
+            try {
+                final FetchPlanner planner = new FetchPlanner(
+                    time,
+                    OBJECT_KEY_CREATOR,
+                    keyAlignmentStrategy,
+                    new NullCache(),
+                    fetcher,
+                    tinyExecutor,
+                    fetcher,
+                    60 * 1000L,
+                    null,
+                    laggingFetchDataExecutor,
+                    hedgeScheduler,
+                    0, // TTFB hedging disabled
+                    hedgeThresholdMs,
+                    coordinates,
+                    metrics
+                );
+
+                final List<FetchPlanner.FetchRequestWithFuture> results = planner.get();
+                assertThat(results).hasSize(1);
+
+                // Wait for primary to start
+                assertThat(primaryBlocked.await(5, TimeUnit.SECONDS)).isTrue();
+
+                // Wait for hedge attempt (rejected) — use Mockito timeout instead of Thread.sleep
+                verify(metrics, timeout(5000)).recordHedgeRequest();
+
+                // Release primary so it can complete
+                primaryRelease.countDown();
+
+                // Should still get a result from the primary
+                final FileExtent result = results.get(0).future().get(5, TimeUnit.SECONDS);
+                assertThat(result.object()).isEqualTo(OBJECT_KEY_A.value());
+
+                // Hedge was never submitted successfully, so no hedgeWon
+                verify(metrics, never()).recordHedgeWon();
+            } finally {
+                primaryRelease.countDown();
+                tinyExecutor.shutdownNow();
+            }
+        }
+
+        @Test
+        void primaryFailsFastErrorPropagatesBeforeHedge() throws Exception {
+            // Setup: primary throws immediately — error propagates before hedge threshold
+            final long recentTimestamp = time.milliseconds();
+            final Map<TopicIdPartition, FindBatchResponse> coordinates = Map.of(
+                partition0, FindBatchResponse.success(List.of(
+                    new BatchInfo(1L, OBJECT_KEY_A.value(),
+                        BatchMetadata.of(partition0, 0, 10, 0, 0, 10, recentTimestamp, TimestampType.CREATE_TIME))
+                ), 0, 1)
+            );
+
+            final byte[] data = {1, 2, 3};
+
+            // Primary fails immediately — error propagates before hedge threshold elapses
+            when(fetcher.fetch(any(), any())).thenReturn(mock(ReadableByteChannel.class));
+            when(fetcher.readToByteBuffer(any()))
+                .thenThrow(new RuntimeException("primary storage error"))
+                .thenReturn(ByteBuffer.wrap(data));
+
+            final ExecutorService multiExecutor = Executors.newFixedThreadPool(2);
+            try {
+                final FetchPlanner planner = new FetchPlanner(
+                    time,
+                    OBJECT_KEY_CREATOR,
+                    keyAlignmentStrategy,
+                    new NullCache(),
+                    fetcher,
+                    multiExecutor,
+                    fetcher,
+                    60 * 1000L,
+                    null,
+                    laggingFetchDataExecutor,
+                    hedgeScheduler,
+                    0, // TTFB hedging disabled
+                    hedgeThresholdMs,
+                    coordinates,
+                    metrics
+                );
+
+                final List<FetchPlanner.FetchRequestWithFuture> results = planner.get();
+                assertThat(results).hasSize(1);
+
+                // Primary fails fast, result future should complete exceptionally
+                // (primary error propagates before hedge can fire)
+                assertThatThrownBy(() -> results.get(0).future().get(5, TimeUnit.SECONDS))
+                    .isInstanceOf(ExecutionException.class)
+                    .hasCauseInstanceOf(FileFetchException.class);
+            } finally {
+                multiExecutor.shutdownNow();
+            }
+        }
+
+        @Test
+        void bothFailPrimaryErrorPropagates() throws Exception {
+            // Setup: both primary and hedge fail — primary is slow enough for hedge to fire,
+            // but both throw. Primary error should propagate.
+            final long recentTimestamp = time.milliseconds();
+            final Map<TopicIdPartition, FindBatchResponse> coordinates = Map.of(
+                partition0, FindBatchResponse.success(List.of(
+                    new BatchInfo(1L, OBJECT_KEY_A.value(),
+                        BatchMetadata.of(partition0, 0, 10, 0, 0, 10, recentTimestamp, TimestampType.CREATE_TIME))
+                ), 0, 1)
+            );
+
+            final CountDownLatch primaryBlocked = new CountDownLatch(1);
+            final CountDownLatch primaryRelease = new CountDownLatch(1);
+
+            when(fetcher.fetch(any(), any())).thenReturn(mock(ReadableByteChannel.class));
+            when(fetcher.readToByteBuffer(any()))
+                .thenAnswer(invocation -> {
+                    // Primary: block until released by test (after hedge fires), then fail
+                    primaryBlocked.countDown();
+                    primaryRelease.await(10, TimeUnit.SECONDS);
+                    throw new RuntimeException("primary storage error");
+                })
+                .thenThrow(new RuntimeException("hedge storage error"));
+
+            final ExecutorService multiExecutor = Executors.newFixedThreadPool(2);
+            try {
+                final FetchPlanner planner = new FetchPlanner(
+                    time,
+                    OBJECT_KEY_CREATOR,
+                    keyAlignmentStrategy,
+                    new NullCache(),
+                    fetcher,
+                    multiExecutor,
+                    fetcher,
+                    60 * 1000L,
+                    null,
+                    laggingFetchDataExecutor,
+                    hedgeScheduler,
+                    0, // TTFB hedging disabled
+                    hedgeThresholdMs,
+                    coordinates,
+                    metrics
+                );
+
+                final List<FetchPlanner.FetchRequestWithFuture> results = planner.get();
+                assertThat(results).hasSize(1);
+
+                assertThat(primaryBlocked.await(5, TimeUnit.SECONDS)).isTrue();
+
+                // Wait for hedge to fire, then release primary
+                verify(metrics, timeout(5000)).recordHedgeRequest();
+                primaryRelease.countDown();
+
+                // Both fail — primary error should propagate
+                assertThatThrownBy(() -> results.get(0).future().get(10, TimeUnit.SECONDS))
+                    .isInstanceOf(ExecutionException.class)
+                    .hasCauseInstanceOf(FileFetchException.class);
+
+                // Hedge did not win (it also failed)
+                verify(metrics, never()).recordHedgeWon();
+            } finally {
+                primaryRelease.countDown();
+                multiExecutor.shutdownNow();
+            }
+        }
+
+        @Test
+        void hedgeTriggeredOnColdPath() throws Exception {
+            // Verify hedging works on the cold (lagging consumer) path, not just hot path.
+            // Cold path is triggered when batch timestamp is older than the threshold.
+            final long oldTimestamp = time.milliseconds() - 120_000L; // 2 minutes ago, well past 60s threshold
+            final Map<TopicIdPartition, FindBatchResponse> coordinates = Map.of(
+                partition0, FindBatchResponse.success(List.of(
+                    new BatchInfo(1L, OBJECT_KEY_A.value(),
+                        BatchMetadata.of(partition0, 0, 10, 0, 0, 10, oldTimestamp, TimestampType.CREATE_TIME))
+                ), 0, 1)
+            );
+
+            final CountDownLatch primaryBlocked = new CountDownLatch(1);
+            final CountDownLatch hedgeCanProceed = new CountDownLatch(1);
+            final byte[] data = {1, 2, 3};
+
+            // First call (primary) blocks; second call (hedge) returns immediately
+            when(fetcher.fetch(any(), any())).thenReturn(mock(ReadableByteChannel.class));
+            when(fetcher.readToByteBuffer(any()))
+                .thenAnswer(invocation -> {
+                    primaryBlocked.countDown();
+                    hedgeCanProceed.await(10, TimeUnit.SECONDS);
+                    return ByteBuffer.wrap(data);
+                })
+                .thenAnswer(invocation -> ByteBuffer.wrap(data));
+
+            // Use a multi-threaded executor for the lagging path so primary and hedge can run concurrently
+            final ExecutorService multiExecutor = Executors.newFixedThreadPool(2);
+            try {
+                final FetchPlanner planner = new FetchPlanner(
+                    time,
+                    OBJECT_KEY_CREATOR,
+                    keyAlignmentStrategy,
+                    new NullCache(),
+                    fetcher,
+                    fetchDataExecutor, // hot path executor (not used for this request)
+                    fetcher,
+                    60 * 1000L, // lagging threshold
+                    null, // no rate limiter
+                    multiExecutor, // cold path executor
+                    hedgeScheduler,
+                    0, // TTFB hedging disabled
+                    hedgeThresholdMs,
+                    coordinates,
+                    metrics
+                );
+
+                final List<FetchPlanner.FetchRequestWithFuture> results = planner.get();
+                assertThat(results).hasSize(1);
+
+                // Wait for primary to start blocking
+                assertThat(primaryBlocked.await(5, TimeUnit.SECONDS)).isTrue();
+
+                // The result should complete via hedge (after threshold)
+                final FileExtent result = results.get(0).future().get(5, TimeUnit.SECONDS);
+                assertThat(result.object()).isEqualTo(OBJECT_KEY_A.value());
+
+                // Hedge metrics should be recorded (total-time triggered)
+                verify(metrics).recordHedgeRequest();
+                verify(metrics).recordHedgeTotalTimeTriggered();
+                verify(metrics, never()).recordHedgeTtfbTriggered();
+                verify(metrics).recordHedgeWon();
+            } finally {
+                hedgeCanProceed.countDown();
+                multiExecutor.shutdownNow();
+            }
+        }
+
+        @Test
+        void hedgeTriggeredByTtfbThreshold() throws Exception {
+            // Setup: primary fetch blocks before receiving first byte,
+            // TTFB threshold fires hedge while total-time threshold is set much higher.
+            final long recentTimestamp = time.milliseconds();
+            final long ttfbThreshold = 30; // short TTFB threshold
+            final long totalTimeThreshold = 10_000; // long total-time threshold (won't fire)
+
+            final Map<TopicIdPartition, FindBatchResponse> coordinates = Map.of(
+                partition0, FindBatchResponse.success(List.of(
+                    new BatchInfo(1L, OBJECT_KEY_A.value(),
+                        BatchMetadata.of(partition0, 0, 10, 0, 0, 10, recentTimestamp, TimestampType.CREATE_TIME))
+                ), 0, 1)
+            );
+
+            final CountDownLatch primaryBlocked = new CountDownLatch(1);
+            final CountDownLatch hedgeCanProceed = new CountDownLatch(1);
+            final byte[] data = {1, 2, 3};
+
+            // First call (primary) blocks before first byte; second call (hedge) returns immediately
+            when(fetcher.fetch(any(), any())).thenReturn(mock(ReadableByteChannel.class));
+            when(fetcher.readToByteBuffer(any()))
+                .thenAnswer(invocation -> {
+                    primaryBlocked.countDown();
+                    hedgeCanProceed.await(10, TimeUnit.SECONDS);
+                    return ByteBuffer.wrap(data);
+                })
+                .thenAnswer(invocation -> ByteBuffer.wrap(data));
+
+            final ExecutorService multiExecutor = Executors.newFixedThreadPool(2);
+            try {
+                final FetchPlanner planner = new FetchPlanner(
+                    time,
+                    OBJECT_KEY_CREATOR,
+                    keyAlignmentStrategy,
+                    new NullCache(),
+                    fetcher,
+                    multiExecutor,
+                    fetcher,
+                    60 * 1000L,
+                    null,
+                    laggingFetchDataExecutor,
+                    hedgeScheduler,
+                    ttfbThreshold,
+                    totalTimeThreshold,
+                    coordinates,
+                    metrics
+                );
+
+                final List<FetchPlanner.FetchRequestWithFuture> results = planner.get();
+                assertThat(results).hasSize(1);
+
+                // Wait for primary to start blocking
+                assertThat(primaryBlocked.await(5, TimeUnit.SECONDS)).isTrue();
+
+                // TTFB threshold fires hedge (primary hasn't received first byte)
+                final FileExtent result = results.get(0).future().get(5, TimeUnit.SECONDS);
+                assertThat(result.object()).isEqualTo(OBJECT_KEY_A.value());
+
+                // Hedge was triggered by TTFB threshold and won
+                verify(metrics).recordHedgeRequest();
+                verify(metrics).recordHedgeTtfbTriggered();
+                verify(metrics, never()).recordHedgeTotalTimeTriggered();
+                verify(metrics).recordHedgeWon();
+            } finally {
+                hedgeCanProceed.countDown();
+                multiExecutor.shutdownNow();
+            }
+        }
+
+        @Test
+        void ttfbHedgeNotTriggeredWhenFirstByteArrived() throws Exception {
+            // Setup: primary receives first byte quickly (before TTFB threshold),
+            // but transfer is slow. TTFB hedge should NOT fire.
+            final long recentTimestamp = time.milliseconds();
+            final long ttfbThreshold = 30;
+            final long totalTimeThreshold = 10_000; // won't fire either
+
+            final Map<TopicIdPartition, FindBatchResponse> coordinates = Map.of(
+                partition0, FindBatchResponse.success(List.of(
+                    new BatchInfo(1L, OBJECT_KEY_A.value(),
+                        BatchMetadata.of(partition0, 0, 10, 0, 0, 10, recentTimestamp, TimestampType.CREATE_TIME))
+                ), 0, 1)
+            );
+
+            final byte[] data = {1, 2, 3};
+
+            // Primary returns quickly (first byte arrives before TTFB threshold)
+            when(fetcher.fetch(any(), any())).thenReturn(mock(ReadableByteChannel.class));
+            when(fetcher.readToByteBuffer(any())).thenReturn(ByteBuffer.wrap(data));
+
+            final FetchPlanner planner = new FetchPlanner(
+                time,
+                OBJECT_KEY_CREATOR,
+                keyAlignmentStrategy,
+                new NullCache(),
+                fetcher,
+                fetchDataExecutor,
+                fetcher,
+                60 * 1000L,
+                null,
+                laggingFetchDataExecutor,
+                hedgeScheduler,
+                ttfbThreshold,
+                totalTimeThreshold,
+                coordinates,
+                metrics
+            );
+
+            final List<FetchPlanner.FetchRequestWithFuture> results = planner.get();
+            assertThat(results).hasSize(1);
+
+            final FileExtent result = results.get(0).future().get(5, TimeUnit.SECONDS);
+            assertThat(result.object()).isEqualTo(OBJECT_KEY_A.value());
+
+            // No hedge should have fired — primary completed before any threshold
+            verify(metrics, never()).recordHedgeRequest();
+            verify(metrics, never()).recordHedgeWon();
+        }
+
+        @Test
+        void totalTimeHedgeFiresWhenTtfbDisabled() throws Exception {
+            // Setup: TTFB hedging disabled, only total-time threshold configured.
+            // Verifies total-time trigger metric is recorded correctly.
+            final long recentTimestamp = time.milliseconds();
+            final long ttfbThreshold = 0;          // TTFB disabled
+            final long totalTimeThreshold = 60;    // total-time threshold — will fire
+
+            final Map<TopicIdPartition, FindBatchResponse> coordinates = Map.of(
+                partition0, FindBatchResponse.success(List.of(
+                    new BatchInfo(1L, OBJECT_KEY_A.value(),
+                        BatchMetadata.of(partition0, 0, 10, 0, 0, 10, recentTimestamp, TimestampType.CREATE_TIME))
+                ), 0, 1)
+            );
+
+            final CountDownLatch primaryBlocked = new CountDownLatch(1);
+            final CountDownLatch hedgeCanProceed = new CountDownLatch(1);
+            final byte[] data = {1, 2, 3};
+
+            // Primary blocks; hedge returns immediately
+            when(fetcher.fetch(any(), any())).thenReturn(mock(ReadableByteChannel.class));
+            when(fetcher.readToByteBuffer(any()))
+                .thenAnswer(invocation -> {
+                    primaryBlocked.countDown();
+                    hedgeCanProceed.await(10, TimeUnit.SECONDS);
+                    return ByteBuffer.wrap(data);
+                })
+                .thenAnswer(invocation -> ByteBuffer.wrap(data));
+
+            final ExecutorService multiExecutor = Executors.newFixedThreadPool(2);
+            try {
+                final FetchPlanner planner = new FetchPlanner(
+                    time,
+                    OBJECT_KEY_CREATOR,
+                    keyAlignmentStrategy,
+                    new NullCache(),
+                    fetcher,
+                    multiExecutor,
+                    fetcher,
+                    60 * 1000L,
+                    null,
+                    laggingFetchDataExecutor,
+                    hedgeScheduler,
+                    ttfbThreshold,
+                    totalTimeThreshold,
+                    coordinates,
+                    metrics
+                );
+
+                final List<FetchPlanner.FetchRequestWithFuture> results = planner.get();
+                assertThat(results).hasSize(1);
+
+                // Wait for primary to start blocking
+                assertThat(primaryBlocked.await(5, TimeUnit.SECONDS)).isTrue();
+
+                // Total-time threshold fires hedge
+                final FileExtent result = results.get(0).future().get(5, TimeUnit.SECONDS);
+                assertThat(result.object()).isEqualTo(OBJECT_KEY_A.value());
+
+                // Hedge was triggered by total-time and won
+                verify(metrics).recordHedgeRequest();
+                verify(metrics).recordHedgeTotalTimeTriggered();
+                verify(metrics, never()).recordHedgeTtfbTriggered();
+                verify(metrics).recordHedgeWon();
+            } finally {
+                hedgeCanProceed.countDown();
+                multiExecutor.shutdownNow();
+            }
+        }
     }
 }

--- a/storage/inkless/src/test/java/io/aiven/inkless/consume/FetchPlannerTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/consume/FetchPlannerTest.java
@@ -2380,5 +2380,144 @@ public class FetchPlannerTest {
                 cache.close();
             }
         }
+
+        @Test
+        void hedgeNotTriggeredDuringRateLimitWait() throws Exception {
+            // Scenario: Cold path with rate limiting. The rate limiter blocks the primary for longer
+            // than the hedge threshold. With deferred timer scheduling, hedge timers only start after
+            // rate limiting completes — so no hedge fires when the fetch itself is fast.
+            final long oldTimestamp = time.milliseconds() - 120_000L; // 2 minutes ago, well past 60s threshold
+            final Map<TopicIdPartition, FindBatchResponse> coordinates = Map.of(
+                partition0, FindBatchResponse.success(List.of(
+                    new BatchInfo(1L, OBJECT_KEY_A.value(),
+                        BatchMetadata.of(partition0, 0, 10, 0, 0, 10, oldTimestamp, TimestampType.CREATE_TIME))
+                ), 0, 1)
+            );
+
+            final byte[] data = {1, 2, 3};
+            when(fetcher.fetch(any(), any())).thenReturn(mock(ReadableByteChannel.class));
+            when(fetcher.readToByteBuffer(any())).thenReturn(ByteBuffer.wrap(data));
+
+            // Rate limiter with 0 initial tokens and slow refill (~200ms for first token).
+            // hedgeThresholdMs = 50ms. Without deferred scheduling, the hedge would fire at ~50ms
+            // while the primary waits for the rate limit token. With deferral, timers start at ~200ms
+            // (after rate limit releases), and the fetch completes instantly — no hedge fires.
+            final Bucket rateLimiter = Bucket.builder()
+                .addLimit(limit -> limit.capacity(1).refillGreedy(1, java.time.Duration.ofMillis(200))
+                    .initialTokens(0))
+                .build();
+
+            final ExecutorService multiExecutor = Executors.newFixedThreadPool(2);
+            try {
+                final FetchPlanner planner = new FetchPlanner(
+                    time,
+                    OBJECT_KEY_CREATOR,
+                    keyAlignmentStrategy,
+                    new NullCache(),
+                    fetcher,
+                    fetchDataExecutor,  // hot path executor (not used)
+                    fetcher,
+                    60 * 1000L,         // lagging threshold
+                    rateLimiter,        // rate limiter that blocks ~200ms
+                    multiExecutor,      // cold path executor
+                    hedgeScheduler,
+                    0,                  // TTFB hedging disabled
+                    hedgeThresholdMs,   // 50ms total-time threshold
+                    hedgeGuards,
+                    coordinates,
+                    metrics
+                );
+
+                final List<FetchPlanner.FetchRequestWithFuture> results = planner.get();
+                assertThat(results).hasSize(1);
+
+                // Primary should complete successfully (after ~200ms rate limit wait + instant fetch)
+                final FileExtent result = results.get(0).future().get(5, TimeUnit.SECONDS);
+                assertThat(result.object()).isEqualTo(OBJECT_KEY_A.value());
+
+                // Hedge should NOT have fired: timers deferred until after rate limiting,
+                // fetch completed instantly after that, so threshold was never exceeded.
+                verify(metrics, never()).recordHedgeRequest();
+                verify(metrics, never()).recordHedgeTotalTimeTriggered();
+                verify(metrics, never()).recordHedgeWon();
+
+                // Confirm it went through the cold path with rate limiting
+                verify(metrics).recordLaggingConsumerRequest();
+                verify(metrics).recordRateLimitWaitTime(any(Long.class));
+            } finally {
+                multiExecutor.shutdownNow();
+            }
+        }
+
+        @Test
+        void hedgeStillFiresWhenFetchIsSlowAfterRateLimit() throws Exception {
+            // Verify: after rate limiting completes, if the actual fetch is slow,
+            // the hedge still fires correctly.
+            final long oldTimestamp = time.milliseconds() - 120_000L;
+            final Map<TopicIdPartition, FindBatchResponse> coordinates = Map.of(
+                partition0, FindBatchResponse.success(List.of(
+                    new BatchInfo(1L, OBJECT_KEY_A.value(),
+                        BatchMetadata.of(partition0, 0, 10, 0, 0, 10, oldTimestamp, TimestampType.CREATE_TIME))
+                ), 0, 1)
+            );
+
+            final CountDownLatch primaryBlocked = new CountDownLatch(1);
+            final CountDownLatch releasePrimary = new CountDownLatch(1);
+            final byte[] data = {1, 2, 3};
+
+            // Primary blocks after rate limit; hedge returns immediately
+            when(fetcher.fetch(any(), any())).thenReturn(mock(ReadableByteChannel.class));
+            when(fetcher.readToByteBuffer(any()))
+                .thenAnswer(invocation -> {
+                    primaryBlocked.countDown();
+                    releasePrimary.await(10, TimeUnit.SECONDS);
+                    return ByteBuffer.wrap(data);
+                })
+                .thenAnswer(invocation -> ByteBuffer.wrap(data));
+
+            // Generous rate limiter (won't block significantly)
+            final Bucket rateLimiter = Bucket.builder()
+                .addLimit(limit -> limit.capacity(10).refillGreedy(10, java.time.Duration.ofSeconds(1)))
+                .build();
+
+            final ExecutorService multiExecutor = Executors.newFixedThreadPool(2);
+            try {
+                final FetchPlanner planner = new FetchPlanner(
+                    time,
+                    OBJECT_KEY_CREATOR,
+                    keyAlignmentStrategy,
+                    new NullCache(),
+                    fetcher,
+                    fetchDataExecutor,
+                    fetcher,
+                    60 * 1000L,
+                    rateLimiter,        // non-blocking rate limiter
+                    multiExecutor,
+                    hedgeScheduler,
+                    0,                  // TTFB disabled
+                    hedgeThresholdMs,   // 50ms total-time threshold
+                    hedgeGuards,
+                    coordinates,
+                    metrics
+                );
+
+                final List<FetchPlanner.FetchRequestWithFuture> results = planner.get();
+                assertThat(results).hasSize(1);
+
+                // Wait for primary to start the actual fetch (past rate limiting)
+                assertThat(primaryBlocked.await(5, TimeUnit.SECONDS)).isTrue();
+
+                // Hedge fires after threshold and wins
+                final FileExtent result = results.get(0).future().get(5, TimeUnit.SECONDS);
+                assertThat(result.object()).isEqualTo(OBJECT_KEY_A.value());
+
+                verify(metrics).recordHedgeRequest();
+                verify(metrics).recordHedgeTotalTimeTriggered();
+                verify(metrics).recordHedgeWon();
+            } finally {
+                releasePrimary.countDown();
+                multiExecutor.shutdownNow();
+            }
+        }
     }
 }

--- a/storage/inkless/src/test/java/io/aiven/inkless/consume/FetchPlannerTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/consume/FetchPlannerTest.java
@@ -1786,7 +1786,7 @@ public class FetchPlannerTest {
                 verify(metrics).recordHedgeRequest();
                 verify(metrics).recordHedgeTotalTimeTriggered();
                 verify(metrics, never()).recordHedgeTtfbTriggered();
-                verify(metrics).recordHedgeWon();
+                verify(metrics, timeout(1000)).recordHedgeWon();
             } finally {
                 releasePrimary.countDown();
                 multiExecutor.shutdownNow();
@@ -2082,7 +2082,7 @@ public class FetchPlannerTest {
                 verify(metrics).recordHedgeRequest();
                 verify(metrics).recordHedgeTotalTimeTriggered();
                 verify(metrics, never()).recordHedgeTtfbTriggered();
-                verify(metrics).recordHedgeWon();
+                verify(metrics, timeout(1000)).recordHedgeWon();
             } finally {
                 releasePrimary.countDown();
                 multiExecutor.shutdownNow();
@@ -2160,7 +2160,7 @@ public class FetchPlannerTest {
                 verify(metrics).recordHedgeRequest();
                 verify(metrics).recordHedgeTtfbTriggered();
                 verify(metrics, never()).recordHedgeTotalTimeTriggered();
-                verify(metrics).recordHedgeWon();
+                verify(metrics, timeout(1000)).recordHedgeWon();
             } finally {
                 releasePrimary.countDown();
                 multiExecutor.shutdownNow();
@@ -2282,7 +2282,7 @@ public class FetchPlannerTest {
                 verify(metrics).recordHedgeRequest();
                 verify(metrics).recordHedgeTotalTimeTriggered();
                 verify(metrics, never()).recordHedgeTtfbTriggered();
-                verify(metrics).recordHedgeWon();
+                verify(metrics, timeout(1000)).recordHedgeWon();
             } finally {
                 releasePrimary.countDown();
                 multiExecutor.shutdownNow();
@@ -2513,7 +2513,7 @@ public class FetchPlannerTest {
 
                 verify(metrics).recordHedgeRequest();
                 verify(metrics).recordHedgeTotalTimeTriggered();
-                verify(metrics).recordHedgeWon();
+                verify(metrics, timeout(1000)).recordHedgeWon();
             } finally {
                 releasePrimary.countDown();
                 multiExecutor.shutdownNow();

--- a/storage/inkless/src/test/java/io/aiven/inkless/consume/ReaderTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/consume/ReaderTest.java
@@ -695,6 +695,9 @@ public class ReaderTest {
             Long.MAX_VALUE,
             0,
             laggingFetchDataExecutor,
+            null, // no hedge scheduler
+            0, // TTFB hedging disabled
+            0, // total-time hedging disabled
             fetchMetrics,
             new BrokerTopicStats());
     }
@@ -784,6 +787,9 @@ public class ReaderTest {
                 LAGGING_THRESHOLD_MS,
                 RATE_LIMIT_REQ_PER_SEC,
                 laggingFetchDataExecutor,
+                null, // no hedge scheduler
+                0, // TTFB hedging disabled
+                0, // total-time hedging disabled
                 fetchMetrics,
                 new BrokerTopicStats())) {
 
@@ -863,6 +869,9 @@ public class ReaderTest {
                 LAGGING_THRESHOLD_MS,
                 0, // Rate limiting disabled
                 laggingFetchDataExecutor,
+                null, // no hedge scheduler
+                0, // TTFB hedging disabled
+                0, // total-time hedging disabled
                 fetchMetrics,
                 new BrokerTopicStats())) {
 
@@ -998,6 +1007,9 @@ public class ReaderTest {
                 LAGGING_THRESHOLD_MS,
                 RATE_LIMIT_REQ_PER_SEC,
                 saturatedLaggingExecutor, // Saturated executor for lagging path
+                null, // no hedge scheduler
+                0, // TTFB hedging disabled
+                0, // total-time hedging disabled
                 fetchMetrics,
                 new BrokerTopicStats())) {
 
@@ -1093,6 +1105,9 @@ public class ReaderTest {
                 LAGGING_THRESHOLD_MS,
                 RATE_LIMIT_REQ_PER_SEC,
                 laggingFetchDataExecutor,
+                null, // no hedge scheduler
+                0, // TTFB hedging disabled
+                0, // total-time hedging disabled
                 fetchMetrics,
                 new BrokerTopicStats())) {
 

--- a/storage/inkless/src/test/java/io/aiven/inkless/consume/ReaderTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/consume/ReaderTest.java
@@ -1153,6 +1153,8 @@ public class ReaderTest {
                 60_000L, // laggingConsumerThresholdMs
                 0, // laggingConsumerRequestRateLimit
                 0, // laggingConsumerThreadPoolSize — feature disabled
+                0, // hedgeTtfbThresholdMs — disabled
+                0, // hedgeTotalTimeThresholdMs — disabled
                 10 // maxBatchesPerPartitionToFind
             );
             reader.close();
@@ -1174,6 +1176,8 @@ public class ReaderTest {
                 60_000L, // laggingConsumerThresholdMs
                 0, // laggingConsumerRequestRateLimit
                 4, // laggingConsumerThreadPoolSize — feature enabled
+                0, // hedgeTtfbThresholdMs — disabled
+                0, // hedgeTotalTimeThresholdMs — disabled
                 10 // maxBatchesPerPartitionToFind
             );
             reader.close();
@@ -1195,6 +1199,8 @@ public class ReaderTest {
                 60_000L, // laggingConsumerThresholdMs
                 0, // laggingConsumerRequestRateLimit
                 4, // laggingConsumerThreadPoolSize — feature enabled but no storage
+                0, // hedgeTtfbThresholdMs — disabled
+                0, // hedgeTotalTimeThresholdMs — disabled
                 10 // maxBatchesPerPartitionToFind
             )).isInstanceOf(IllegalStateException.class)
               .hasMessageContaining("no lagging fetch storage was provided");


### PR DESCRIPTION
to mitigate tail latency

When a storage fetch (S3/GCS/Azure) hasn't completed within a configurable threshold, a competing hedge request is fired. First to complete wins; the loser is best-effort cancelled. Applies to both hot (cached) and cold (lagging consumer) paths.

Two independent hedge triggers (at most one hedge per primary):
- TTFB: fetch.hedge.ttfb.threshold.ms — fires when first byte hasn't arrived, catching stuck connections early (default 0 = disabled)
- Total time: fetch.hedge.total.time.threshold.ms — fires when the entire fetch is slow (default 0 = disabled)

When both are enabled, total-time must be > TTFB (validated at startup).

Metrics: HedgeRequestRate, HedgeWonRate