### PR TITLE
feat(inkless): POD-2394 Implement read path for consolidated logs

### DIFF
--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1999,7 +1999,7 @@ class ReplicaManager(val config: KafkaConfig,
     }
 
     if (classicFetchInfos.isEmpty && disklessFetchInfosWithoutTopicId.isEmpty &&
-      invalidDisklessFetchResponses.isEmpty && invalidConsolidatingPartitionFetchResponses.nonEmpty) {
+      immediateFetchResponses.isEmpty && invalidConsolidatingPartitionFetchResponses.nonEmpty) {
       respond(Seq.empty)
       return
     }

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1912,14 +1912,22 @@ class ReplicaManager(val config: KafkaConfig,
 
     fetchInfos.foreach { case (tp, partitionData) =>
       val fetchInfo = tp -> partitionData
-      if (!_inklessMetadataView.isDisklessTopic(tp.topic())) {
+      val isDiskless = _inklessMetadataView.isDisklessTopic(tp.topic)
+      if (!isDiskless) {
         classicFetchInfos += fetchInfo
       } else {
         val classicToDisklessStartOffset = _inklessMetadataView.getClassicToDisklessStartOffset(tp.topicPartition())
-        val migrationPending =
-          classicToDisklessStartOffset == PartitionRegistration.CLASSIC_TO_DISKLESS_MIGRATION_PENDING
-        val shouldReadFromUnifiedLog = migrationPending || (
-          classicToDisklessStartOffset >= 0 && partitionData.fetchOffset < classicToDisklessStartOffset)
+        var shouldReadFromUnifiedLog = classicToDisklessStartOffset == PartitionRegistration.CLASSIC_TO_DISKLESS_MIGRATION_PENDING
+        val isConsolidatingPartition =
+          _inklessMetadataView.isConsolidatingDisklessTopic(tp.topic) &&
+            config.disklessRemoteStorageConsolidationEnabled
+        if (isConsolidatingPartition) {
+          shouldReadFromUnifiedLog = shouldReadFromUnifiedLog ||
+            getPartitionOrException(tp).log.exists(partitionData.fetchOffset < _.logEndOffset)
+        } else {
+          shouldReadFromUnifiedLog = shouldReadFromUnifiedLog ||
+            (classicToDisklessStartOffset >= 0 && partitionData.fetchOffset < classicToDisklessStartOffset)
+        }
 
         if (params.isFromFollower && !shouldReadFromUnifiedLog && classicToDisklessStartOffset >= 0) {
           // The partition has fully migrated to diskless and the follower is asking for an offset at or beyond it.

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1909,10 +1909,12 @@ class ReplicaManager(val config: KafkaConfig,
     val disklessFetchInfosWithoutTopicId = new mutable.ArrayBuffer[(TopicIdPartition, PartitionData)]()
     val classicFetchInfos = new mutable.ArrayBuffer[(TopicIdPartition, PartitionData)]()
     val immediateFetchResponses = new mutable.ArrayBuffer[(TopicIdPartition, FetchPartitionData)]()
+    val invalidConsolidatingPartitionFetchResponses = new mutable.ArrayBuffer[(TopicIdPartition, FetchPartitionData)]()
 
     fetchInfos.foreach { case (tp, partitionData) =>
       val fetchInfo = tp -> partitionData
       val isDiskless = _inklessMetadataView.isDisklessTopic(tp.topic)
+      var partitionAlreadyHandled = false
       if (!isDiskless) {
         classicFetchInfos += fetchInfo
       } else {
@@ -1922,40 +1924,11 @@ class ReplicaManager(val config: KafkaConfig,
           _inklessMetadataView.isConsolidatingDisklessTopic(tp.topic) &&
             config.disklessRemoteStorageConsolidationEnabled
         if (isConsolidatingPartition) {
-          shouldReadFromUnifiedLog = shouldReadFromUnifiedLog ||
-            getPartitionOrException(tp).log.exists(partitionData.fetchOffset < _.logEndOffset)
-        } else {
-          shouldReadFromUnifiedLog = shouldReadFromUnifiedLog ||
-            (classicToDisklessStartOffset >= 0 && partitionData.fetchOffset < classicToDisklessStartOffset)
-        }
-
-        if (params.isFromFollower && !shouldReadFromUnifiedLog && classicToDisklessStartOffset >= 0) {
-          // The partition has fully migrated to diskless and the follower is asking for an offset at or beyond it.
-          // Followers must never replicate diskless records into their local log. Return
-          // an empty response with HW clamped to the seal offset so the fetcher loop sees the
-          // partition as caught up and goes idle, rather than treating it as out of range.
-          // Deliberately pass logStartOffset=0 (a no-op for the follower since
-          // maybeIncrementLogStartOffset only ever advances) so the follower keeps its classic
-          // local data intact and remains able to serve consumer reads from the local log.
-          immediateFetchResponses += tp -> new FetchPartitionData(
-            Errors.NONE,
-            classicToDisklessStartOffset,
-            0L,
-            MemoryRecords.EMPTY,
-            Optional.empty(),
-            OptionalLong.empty(),
-            Optional.empty(),
-            OptionalInt.empty(),
-            false
-          )
-        } else {
-          (shouldReadFromUnifiedLog, config.disklessManagedReplicasEnabled) match {
-            case (false, _) =>
-              disklessFetchInfosWithoutTopicId += fetchInfo
-            // Cannot read from UnifiedLog on a diskless topic if diskless managed replicas are not enabled.
-            case (true, false) =>
-              immediateFetchResponses += tp -> new FetchPartitionData(
-                Errors.INVALID_REQUEST,
+          getPartitionOrError(tp.topicPartition) match {
+            case Right(partition) => shouldReadFromUnifiedLog = shouldReadFromUnifiedLog || partition.log.exists(partitionData.fetchOffset < _.logEndOffset)
+            case Left(error) =>
+              invalidConsolidatingPartitionFetchResponses += tp -> new FetchPartitionData(
+                error,
                 UnifiedLog.UNKNOWN_OFFSET,
                 UnifiedLog.UNKNOWN_OFFSET,
                 MemoryRecords.EMPTY,
@@ -1965,17 +1938,68 @@ class ReplicaManager(val config: KafkaConfig,
                 OptionalInt.empty(),
                 false
               )
-            case (true, true) =>
-              classicFetchInfos += fetchInfo
+              partitionAlreadyHandled = true
+          }
+        } else {
+          shouldReadFromUnifiedLog = shouldReadFromUnifiedLog ||
+            (classicToDisklessStartOffset >= 0 && partitionData.fetchOffset < classicToDisklessStartOffset)
+        }
+
+        if (!partitionAlreadyHandled) {
+          if (params.isFromFollower && !shouldReadFromUnifiedLog && classicToDisklessStartOffset >= 0) {
+            // The partition has fully migrated to diskless and the follower is asking for an offset at or beyond it.
+            // Followers must never replicate diskless records into their local log. Return
+            // an empty response with HW clamped to the seal offset so the fetcher loop sees the
+            // partition as caught up and goes idle, rather than treating it as out of range.
+            // Deliberately pass logStartOffset=0 (a no-op for the follower since
+            // maybeIncrementLogStartOffset only ever advances) so the follower keeps its classic
+            // local data intact and remains able to serve consumer reads from the local log.
+            immediateFetchResponses += tp -> new FetchPartitionData(
+              Errors.NONE,
+              classicToDisklessStartOffset,
+              0L,
+              MemoryRecords.EMPTY,
+              Optional.empty(),
+              OptionalLong.empty(),
+              Optional.empty(),
+              OptionalInt.empty(),
+              false
+            )
+          } else {
+            (shouldReadFromUnifiedLog, config.disklessManagedReplicasEnabled) match {
+              case (false, _) =>
+                disklessFetchInfosWithoutTopicId += fetchInfo
+              // Cannot read from UnifiedLog on a diskless topic if diskless managed replicas are not enabled.
+              case (true, false) =>
+                immediateFetchResponses += tp -> new FetchPartitionData(
+                  Errors.INVALID_REQUEST,
+                  UnifiedLog.UNKNOWN_OFFSET,
+                  UnifiedLog.UNKNOWN_OFFSET,
+                  MemoryRecords.EMPTY,
+                  Optional.empty(),
+                  OptionalLong.empty(),
+                  Optional.empty(),
+                  OptionalInt.empty(),
+                  false
+                )
+              case (true, true) =>
+                classicFetchInfos += fetchInfo
+            }
           }
         }
       }
     }
 
     def respond(response: Seq[(TopicIdPartition, FetchPartitionData)]): Unit =
-      responseCallback(response ++ immediateFetchResponses)
+      responseCallback(response ++ immediateFetchResponses ++ invalidConsolidatingPartitionFetchResponses)
 
     if (classicFetchInfos.isEmpty && disklessFetchInfosWithoutTopicId.isEmpty && immediateFetchResponses.nonEmpty) {
+      respond(Seq.empty)
+      return
+    }
+
+    if (classicFetchInfos.isEmpty && disklessFetchInfosWithoutTopicId.isEmpty &&
+      invalidDisklessFetchResponses.isEmpty && invalidConsolidatingPartitionFetchResponses.nonEmpty) {
       respond(Seq.empty)
       return
     }

--- a/core/src/test/java/kafka/server/InklessConsolidatedDisklessTopicsTest.java
+++ b/core/src/test/java/kafka/server/InklessConsolidatedDisklessTopicsTest.java
@@ -179,10 +179,8 @@ public class InklessConsolidatedDisklessTopicsTest {
 
     @Test
     public void testNewConsolidatedDisklessTopics() throws Exception {
-        Map<String, Object> clientConfigs = new HashMap<>();
-        clientConfigs.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers());
-        clientConfigs.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
-        clientConfigs.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        Map<String, Object> commonConfigs = new HashMap<>();
+        commonConfigs.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers());
 
         Map<String, String> topicConfigs = Map.of(
             DISKLESS_ENABLE_CONFIG, "true",
@@ -191,7 +189,7 @@ public class InklessConsolidatedDisklessTopicsTest {
             SEGMENT_BYTES_CONFIG, "1048576"
         );
 
-        try (Admin admin = AdminClient.create(clientConfigs)) {
+        try (Admin admin = AdminClient.create(commonConfigs)) {
             final NewTopic topic = new NewTopic(topicName, numPartitions, (short) -1).configs(topicConfigs);
             CreateTopicsResult result = admin.createTopics(Collections.singletonList(topic));
             result.all().get(30, TimeUnit.SECONDS);
@@ -226,7 +224,7 @@ public class InklessConsolidatedDisklessTopicsTest {
 
         int recordsToSendAndReceive = 50;
 
-        var producedValues = produceRecords(clientConfigs, recordsToSendAndReceive, i -> {
+        var producedValues = produceRecords(commonConfigs, recordsToSendAndReceive, i -> {
             String value = TestUtils.randomString(104_857);
             return new ProducerRecord<>(topicName, i % numPartitions, null, value);
         });
@@ -240,14 +238,18 @@ public class InklessConsolidatedDisklessTopicsTest {
                 () -> "Expected at least one tiered object in the Minio bucket after produce");
         }
 
-        consumeAndVerify(clientConfigs, producedValues);
+        consumeAndVerify(commonConfigs, producedValues);
     }
 
-    private List<String> produceRecords(Map<String, Object> configs, int numRecords,
+    private List<String> produceRecords(Map<String, Object> commonConfigs, int numRecords,
                                         IntFunction<ProducerRecord<String, String>> recordFactory) {
+        var producerConfigs = new HashMap<>(commonConfigs);
+        producerConfigs.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        producerConfigs.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+
         long totalSize = 0;
         var producedValues = new ArrayList<String>();
-        try (Producer<String, String> producer = new KafkaProducer<>(configs)) {
+        try (Producer<String, String> producer = new KafkaProducer<>(producerConfigs)) {
             for (int i = 0; i < numRecords; i++) {
                 var record = recordFactory.apply(i);
                 var metadata = producer.send(record).get();
@@ -261,14 +263,16 @@ public class InklessConsolidatedDisklessTopicsTest {
         return producedValues;
     }
 
-    private void consumeAndVerify(Map<String, Object> configs, List<String> producedValues) {
-        configs.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
-        configs.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
-        configs.put(ConsumerConfig.GROUP_ID_CONFIG, "test-group-id");
-        configs.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+    private void consumeAndVerify(Map<String, Object> commonConfigs, List<String> producedValues) {
+        var consumerConfigs = new HashMap<>(commonConfigs);
+        consumerConfigs.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        consumerConfigs.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        consumerConfigs.put(ConsumerConfig.GROUP_ID_CONFIG, "test-group-id");
+        consumerConfigs.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+
         var consumedRecordCount = 0L;
         var recordsToConsumeCount = producedValues.size();
-        try (var consumer = new KafkaConsumer<>(configs)) {
+        try (var consumer = new KafkaConsumer<>(consumerConfigs)) {
             consumer.subscribe(Collections.singletonList(topicName));
             // consume every record to verify that the consumer works
             for  (int i = 0; i < recordsToConsumeCount; i++) {

--- a/core/src/test/java/kafka/server/InklessConsolidatedDisklessTopicsTest.java
+++ b/core/src/test/java/kafka/server/InklessConsolidatedDisklessTopicsTest.java
@@ -60,6 +60,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.IntFunction;
@@ -267,7 +268,7 @@ public class InklessConsolidatedDisklessTopicsTest {
         var consumerConfigs = new HashMap<>(commonConfigs);
         consumerConfigs.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
         consumerConfigs.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
-        consumerConfigs.put(ConsumerConfig.GROUP_ID_CONFIG, "test-group-id");
+        consumerConfigs.put(ConsumerConfig.GROUP_ID_CONFIG, "test-group-id-" + UUID.randomUUID());
         consumerConfigs.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
 
         var consumedRecordCount = 0L;

--- a/core/src/test/java/kafka/server/InklessConsolidatedDisklessTopicsTest.java
+++ b/core/src/test/java/kafka/server/InklessConsolidatedDisklessTopicsTest.java
@@ -22,6 +22,8 @@ import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.CreateTopicsResult;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerConfig;
@@ -29,7 +31,8 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartitionInfo;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
-import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.common.test.KafkaClusterTestKit;
 import org.apache.kafka.common.test.TestKitNodes;
 import org.apache.kafka.coordinator.group.GroupCoordinatorConfig;
@@ -50,8 +53,11 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.nio.file.Files;
+import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
@@ -94,6 +100,8 @@ public class InklessConsolidatedDisklessTopicsTest {
     protected static MinioContainer s3Container = S3TestContainer.minio();
 
     private KafkaClusterTestKit cluster;
+    private String topicName = "consolidated-diskless-topic";
+    private int numPartitions = 2;
 
     @BeforeEach
     public void setup(final TestInfo testInfo) throws Exception {
@@ -173,11 +181,8 @@ public class InklessConsolidatedDisklessTopicsTest {
     public void testNewConsolidatedDisklessTopics() throws Exception {
         Map<String, Object> clientConfigs = new HashMap<>();
         clientConfigs.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers());
-        clientConfigs.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
-        clientConfigs.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
-
-        String topicName = "consolidated-diskless-topic";
-        int numPartitions = 2;
+        clientConfigs.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        clientConfigs.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
 
         Map<String, String> topicConfigs = Map.of(
             DISKLESS_ENABLE_CONFIG, "true",
@@ -219,10 +224,14 @@ public class InklessConsolidatedDisklessTopicsTest {
             }
         }
 
-        produceRecords(clientConfigs, 50, i -> {
-            byte[] value = TestUtils.randomBytes(104_857);
+        int recordsToSendAndReceive = 50;
+
+        var producedValues = produceRecords(clientConfigs, recordsToSendAndReceive, i -> {
+            String value = TestUtils.randomString(104_857);
             return new ProducerRecord<>(topicName, i % numPartitions, null, value);
         });
+
+        assertEquals(recordsToSendAndReceive, producedValues.size());
 
         try (S3Client s3 = s3Container.getS3Client()) {
             final String bucket = s3Container.getBucketName();
@@ -230,21 +239,50 @@ public class InklessConsolidatedDisklessTopicsTest {
                 120_000,
                 () -> "Expected at least one tiered object in the Minio bucket after produce");
         }
+
+        consumeAndVerify(clientConfigs, producedValues);
     }
 
-    private void produceRecords(Map<String, Object> configs, int numRecords,
-                                IntFunction<ProducerRecord<byte[], byte[]>> recordFactory) {
+    private List<String> produceRecords(Map<String, Object> configs, int numRecords,
+                                        IntFunction<ProducerRecord<String, String>> recordFactory) {
         long totalSize = 0;
-        try (Producer<byte[], byte[]> producer = new KafkaProducer<>(configs)) {
+        var producedValues = new ArrayList<String>();
+        try (Producer<String, String> producer = new KafkaProducer<>(configs)) {
             for (int i = 0; i < numRecords; i++) {
                 var record = recordFactory.apply(i);
                 var metadata = producer.send(record).get();
+                producedValues.add(record.value());
                 totalSize += metadata.serializedValueSize();
             }
         } catch (ExecutionException | InterruptedException e) {
             throw new RuntimeException(e);
         }
         log.info("Produced {} records in total size {}", numRecords, totalSize);
+        return producedValues;
+    }
+
+    private void consumeAndVerify(Map<String, Object> configs, List<String> producedValues) {
+        configs.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        configs.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        configs.put(ConsumerConfig.GROUP_ID_CONFIG, "test-group-id");
+        configs.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        var consumedRecordCount = 0L;
+        var recordsToConsumeCount = producedValues.size();
+        try (var consumer = new KafkaConsumer<>(configs)) {
+            consumer.subscribe(Collections.singletonList(topicName));
+            // consume every record to verify that the consumer works
+            for  (int i = 0; i < recordsToConsumeCount; i++) {
+                var records = consumer.poll(Duration.ofMillis(1000));
+                records.forEach(record -> {
+                    producedValues.remove(record.value());
+                });
+                consumedRecordCount += records.count();
+            }
+            // verify that we consumed exactly as much as we needed to, not more, not less
+            assertEquals(recordsToConsumeCount, consumedRecordCount);
+            // verify value-wise correctness
+            assertEquals(0, producedValues.size());
+        }
     }
 
     private static int countObjectsWithPrefix(S3Client s3, String bucket, String prefix) {

--- a/core/src/test/java/kafka/server/InklessConsolidatedDisklessTopicsTest.java
+++ b/core/src/test/java/kafka/server/InklessConsolidatedDisklessTopicsTest.java
@@ -29,6 +29,7 @@ import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.Node;
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.TopicPartitionInfo;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.apache.kafka.common.serialization.StringDeserializer;
@@ -63,6 +64,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.IntFunction;
 import java.util.stream.Collectors;
 
@@ -225,12 +227,10 @@ public class InklessConsolidatedDisklessTopicsTest {
 
         int recordsToSendAndReceive = 50;
 
-        var producedValues = produceRecords(commonConfigs, recordsToSendAndReceive, i -> {
+        produceRecords(commonConfigs, recordsToSendAndReceive, i -> {
             String value = TestUtils.randomString(104_857);
             return new ProducerRecord<>(topicName, i % numPartitions, null, value);
         });
-
-        assertEquals(recordsToSendAndReceive, producedValues.size());
 
         try (S3Client s3 = s3Container.getS3Client()) {
             final String bucket = s3Container.getBucketName();
@@ -239,54 +239,60 @@ public class InklessConsolidatedDisklessTopicsTest {
                 () -> "Expected at least one tiered object in the Minio bucket after produce");
         }
 
-        consumeAndVerify(commonConfigs, producedValues);
+        consumeAndVerify(commonConfigs, recordsToSendAndReceive);
     }
 
-    private List<String> produceRecords(Map<String, Object> commonConfigs, int numRecords,
+    private void produceRecords(Map<String, Object> commonConfigs, int numRecords,
                                         IntFunction<ProducerRecord<String, String>> recordFactory) {
         var producerConfigs = new HashMap<>(commonConfigs);
         producerConfigs.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
         producerConfigs.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
 
         long totalSize = 0;
-        var producedValues = new ArrayList<String>();
         try (Producer<String, String> producer = new KafkaProducer<>(producerConfigs)) {
             for (int i = 0; i < numRecords; i++) {
                 var record = recordFactory.apply(i);
                 var metadata = producer.send(record).get();
-                producedValues.add(record.value());
                 totalSize += metadata.serializedValueSize();
             }
-        } catch (ExecutionException | InterruptedException e) {
+        } catch (ExecutionException e) {
+            throw new RuntimeException(e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             throw new RuntimeException(e);
         }
         log.info("Produced {} records in total size {}", numRecords, totalSize);
-        return producedValues;
     }
 
-    private void consumeAndVerify(Map<String, Object> commonConfigs, List<String> producedValues) {
+    private void consumeAndVerify(Map<String, Object> commonConfigs, int expectedTotalRecords) throws InterruptedException {
         var consumerConfigs = new HashMap<>(commonConfigs);
         consumerConfigs.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
         consumerConfigs.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
         consumerConfigs.put(ConsumerConfig.GROUP_ID_CONFIG, "test-group-id-" + UUID.randomUUID());
         consumerConfigs.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
 
-        var consumedRecordCount = 0L;
-        var recordsToConsumeCount = producedValues.size();
-        try (var consumer = new KafkaConsumer<>(consumerConfigs)) {
+        try (var consumer = new KafkaConsumer<String, String>(consumerConfigs)) {
             consumer.subscribe(Collections.singletonList(topicName));
-            // consume every record to verify that the consumer works
-            for  (int i = 0; i < recordsToConsumeCount; i++) {
+            var offsetsByPartition = new HashMap<TopicPartition, List<Long>>();
+            var consumedCount = new AtomicLong(0);
+            TestUtils.waitForCondition(() -> {
                 var records = consumer.poll(Duration.ofMillis(1000));
-                records.forEach(record -> {
-                    producedValues.remove(record.value());
+                records.forEach(r -> {
+                    var tp = new TopicPartition(r.topic(), r.partition());
+                    offsetsByPartition.computeIfAbsent(tp, __ -> new ArrayList<>()).add(r.offset());
                 });
-                consumedRecordCount += records.count();
-            }
-            // verify that we consumed exactly as much as we needed to, not more, not less
-            assertEquals(recordsToConsumeCount, consumedRecordCount);
-            // verify value-wise correctness
-            assertEquals(0, producedValues.size());
+                consumedCount.addAndGet(records.count());
+                return consumedCount.get() >= expectedTotalRecords;
+            }, 60_000, "Not all records have been consumed");
+            // Monotonicity + no gaps per partition
+            offsetsByPartition.forEach((tp, offsets) -> {
+                offsets.sort(Long::compareTo);
+                for (int i = 1; i < offsets.size(); i++) {
+                    long prev = offsets.get(i - 1);
+                    long cur = offsets.get(i);
+                    assertEquals(prev + 1, cur, "Offset gap or reordering for " + tp);
+                }
+            });
         }
     }
 

--- a/core/src/test/java/kafka/server/InklessConsolidatedDisklessTopicsTest.java
+++ b/core/src/test/java/kafka/server/InklessConsolidatedDisklessTopicsTest.java
@@ -286,7 +286,6 @@ public class InklessConsolidatedDisklessTopicsTest {
             }, 60_000, "Not all records have been consumed");
             // Monotonicity + no gaps per partition
             offsetsByPartition.forEach((tp, offsets) -> {
-                offsets.sort(Long::compareTo);
                 for (int i = 1; i < offsets.size(); i++) {
                     long prev = offsets.get(i - 1);
                     long cur = offsets.get(i);

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -6664,6 +6664,326 @@ class ReplicaManagerTest {
       }
     }
 
+    /** Stubs local UnifiedLog LEO for consolidating diskless fetch routing (uses [[ReplicaManager.getPartitionOrException]]). */
+    private def stubConsolidatingPartitionWithLocalLeo(replicaManager: ReplicaManager, localLeo: Long): Unit = {
+      val mockPartition = mock(classOf[Partition])
+      val mockLog = mock(classOf[UnifiedLog])
+      when(mockLog.logEndOffset).thenReturn(localLeo)
+      when(mockPartition.log).thenReturn(Some(mockLog))
+      doReturn(mockPartition).when(replicaManager).getPartitionOrException(
+        ArgumentMatchers.eq(disklessTopicPartition))
+    }
+
+    private def stubConsolidatingPartitionWithoutLocalLog(replicaManager: ReplicaManager): Unit = {
+      val mockPartition = mock(classOf[Partition])
+      when(mockPartition.log).thenReturn(None)
+      doReturn(mockPartition).when(replicaManager).getPartitionOrException(
+        ArgumentMatchers.eq(disklessTopicPartition))
+    }
+
+    @Test
+    def testFetchConsolidatingDisklessBelowLocalLeoReadsFromUnifiedLogWhenManagedReplicasEnabled(): Unit = {
+      val fetchHandlerCtor = mockFetchHandler(Map.empty)
+      try {
+        val cp = mock(classOf[ControlPlane])
+        val replicaManager = spy(createReplicaManager(
+          List(disklessTopicPartition.topic()),
+          controlPlane = Some(cp),
+          disklessManagedReplicasEnabled = true,
+          disklessRemoteStorageConsolidationEnabled = true,
+          consolidatingDisklessTopics = Set(disklessTopicPartition.topic()),
+        ))
+        when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
+          .thenReturn(100L)
+        stubConsolidatingPartitionWithLocalLeo(replicaManager, localLeo = 200L)
+
+        doReturn(Seq(disklessTopicPartition ->
+          new LogReadResult(
+            new FetchDataInfo(new LogOffsetMetadata(1L, 0L, 0), RECORDS),
+            Optional.empty(), 10L, 0L, 10L, 0L, 0L, OptionalLong.empty(), Errors.NONE
+          ))
+        ).when(replicaManager).readFromLog(any(), any(), any(), any())
+
+        val fetchParams = new FetchParams(
+          -1, -1L,
+          0L, 1, 1024, FetchIsolation.HIGH_WATERMARK, Optional.empty()
+        )
+        val fetchInfos = Seq(
+          disklessTopicPartition -> new PartitionData(disklessTopicPartition.topicId(), 50L, 0L, 1024, Optional.empty())
+        )
+
+        @volatile var responseData: Map[TopicIdPartition, FetchPartitionData] = null
+        val responseCallback = (response: Seq[(TopicIdPartition, FetchPartitionData)]) => {
+          responseData = response.toMap
+        }
+        replicaManager.fetchMessages(fetchParams, fetchInfos, QuotaFactory.UNBOUNDED_QUOTA, responseCallback)
+
+        assertNotNull(responseData)
+        assertEquals(1, responseData.size)
+        assertEquals(RECORDS, responseData(disklessTopicPartition).records)
+        verify(replicaManager, times(1)).readFromLog(any(), any(), any(), any())
+        verify(fetchHandlerCtor.constructed().get(0), never()).handle(any(), any())
+      } finally {
+        fetchHandlerCtor.close()
+      }
+    }
+
+    @Test
+    def testFetchConsolidatingDisklessAboveClassicStartButBelowLocalLeoReadsFromUnifiedLog(): Unit = {
+      val fetchHandlerCtor = mockFetchHandler(Map.empty)
+      try {
+        val cp = mock(classOf[ControlPlane])
+        val replicaManager = spy(createReplicaManager(
+          List(disklessTopicPartition.topic()),
+          controlPlane = Some(cp),
+          disklessManagedReplicasEnabled = true,
+          disklessRemoteStorageConsolidationEnabled = true,
+          consolidatingDisklessTopics = Set(disklessTopicPartition.topic()),
+        ))
+        when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
+          .thenReturn(50L)
+        stubConsolidatingPartitionWithLocalLeo(replicaManager, localLeo = 200L)
+
+        doReturn(Seq(disklessTopicPartition ->
+          new LogReadResult(
+            new FetchDataInfo(new LogOffsetMetadata(1L, 0L, 0), RECORDS),
+            Optional.empty(), 10L, 0L, 10L, 0L, 0L, OptionalLong.empty(), Errors.NONE
+          ))
+        ).when(replicaManager).readFromLog(any(), any(), any(), any())
+
+        val fetchParams = new FetchParams(
+          -1, -1L,
+          0L, 1, 1024, FetchIsolation.HIGH_WATERMARK, Optional.empty()
+        )
+        val fetchInfos = Seq(
+          disklessTopicPartition -> new PartitionData(disklessTopicPartition.topicId(), 75L, 0L, 1024, Optional.empty())
+        )
+
+        @volatile var responseData: Map[TopicIdPartition, FetchPartitionData] = null
+        val responseCallback = (response: Seq[(TopicIdPartition, FetchPartitionData)]) => {
+          responseData = response.toMap
+        }
+        replicaManager.fetchMessages(fetchParams, fetchInfos, QuotaFactory.UNBOUNDED_QUOTA, responseCallback)
+
+        assertNotNull(responseData)
+        assertEquals(1, responseData.size)
+        assertEquals(RECORDS, responseData(disklessTopicPartition).records)
+        verify(replicaManager, times(1)).readFromLog(any(), any(), any(), any())
+        verify(fetchHandlerCtor.constructed().get(0), never()).handle(any(), any())
+      } finally {
+        fetchHandlerCtor.close()
+      }
+    }
+
+    @Test
+    def testFetchConsolidatingDisklessAtOrAboveLocalLeoUsesDisklessPath(): Unit = {
+      val disklessResponse = Map(disklessTopicPartition ->
+        new FetchPartitionData(
+          Errors.NONE,
+          110L, 100L,
+          RECORDS,
+          Optional.empty(), OptionalLong.empty(), Optional.empty(), OptionalInt.empty(), false)
+      )
+      val fetchHandlerCtor = mockFetchHandler(disklessResponse)
+      try {
+        val batchMetadata = mock(classOf[BatchMetadata])
+        when(batchMetadata.topicIdPartition()).thenReturn(disklessTopicPartition)
+        val batch = mock(classOf[BatchInfo])
+        when(batch.metadata()).thenReturn(batchMetadata)
+        val findBatchResponse = mock(classOf[FindBatchResponse])
+        when(findBatchResponse.batches()).thenReturn(util.List.of(batch))
+        when(findBatchResponse.highWatermark()).thenReturn(110L)
+        when(findBatchResponse.estimatedByteSize(100L)).thenReturn(RECORDS.sizeInBytes())
+        when(findBatchResponse.errors()).thenReturn(Errors.NONE)
+        val cp = mock(classOf[ControlPlane])
+        when(cp.findBatches(any(), any(), any())).thenReturn(util.List.of(findBatchResponse))
+
+        val replicaManager = spy(createReplicaManager(
+          List(disklessTopicPartition.topic()),
+          controlPlane = Some(cp),
+          disklessManagedReplicasEnabled = true,
+          disklessRemoteStorageConsolidationEnabled = true,
+          consolidatingDisklessTopics = Set(disklessTopicPartition.topic()),
+        ))
+        when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
+          .thenReturn(100L)
+        stubConsolidatingPartitionWithLocalLeo(replicaManager, localLeo = 100L)
+
+        val fetchParams = new FetchParams(
+          -1, -1L,
+          0L, 1, 1024, FetchIsolation.HIGH_WATERMARK, Optional.empty()
+        )
+        val fetchInfos = Seq(
+          disklessTopicPartition -> new PartitionData(disklessTopicPartition.topicId(), 100L, 0L, 1024, Optional.empty())
+        )
+
+        @volatile var responseData: Map[TopicIdPartition, FetchPartitionData] = null
+        val responseCallback = (response: Seq[(TopicIdPartition, FetchPartitionData)]) => {
+          responseData = response.toMap
+        }
+        replicaManager.fetchMessages(fetchParams, fetchInfos, QuotaFactory.UNBOUNDED_QUOTA, responseCallback)
+
+        assertNotNull(responseData)
+        assertEquals(1, responseData.size)
+        assertEquals(Errors.NONE, responseData(disklessTopicPartition).error)
+        assertEquals(RECORDS, responseData(disklessTopicPartition).records)
+        verify(replicaManager, never()).readFromLog(any(), any(), any(), any())
+        verify(fetchHandlerCtor.constructed().get(0), times(1)).handle(any(), any())
+      } finally {
+        fetchHandlerCtor.close()
+      }
+    }
+
+    @Test
+    def testFetchConsolidatingDisklessWithNoLocalLogUsesDisklessDespiteFetchBelowClassicStart(): Unit = {
+      val disklessResponse = Map(disklessTopicPartition ->
+        new FetchPartitionData(
+          Errors.NONE,
+          110L, 100L,
+          RECORDS,
+          Optional.empty(), OptionalLong.empty(), Optional.empty(), OptionalInt.empty(), false)
+      )
+      val fetchHandlerCtor = mockFetchHandler(disklessResponse)
+      try {
+        val batchMetadata = mock(classOf[BatchMetadata])
+        when(batchMetadata.topicIdPartition()).thenReturn(disklessTopicPartition)
+        val batch = mock(classOf[BatchInfo])
+        when(batch.metadata()).thenReturn(batchMetadata)
+        val findBatchResponse = mock(classOf[FindBatchResponse])
+        when(findBatchResponse.batches()).thenReturn(util.List.of(batch))
+        when(findBatchResponse.highWatermark()).thenReturn(110L)
+        when(findBatchResponse.estimatedByteSize(50L)).thenReturn(RECORDS.sizeInBytes())
+        when(findBatchResponse.errors()).thenReturn(Errors.NONE)
+        val cp = mock(classOf[ControlPlane])
+        when(cp.findBatches(any(), any(), any())).thenReturn(util.List.of(findBatchResponse))
+
+        val replicaManager = spy(createReplicaManager(
+          List(disklessTopicPartition.topic()),
+          controlPlane = Some(cp),
+          disklessManagedReplicasEnabled = true,
+          disklessRemoteStorageConsolidationEnabled = true,
+          consolidatingDisklessTopics = Set(disklessTopicPartition.topic()),
+        ))
+        when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
+          .thenReturn(100L)
+        stubConsolidatingPartitionWithoutLocalLog(replicaManager)
+
+        val fetchParams = new FetchParams(
+          -1, -1L,
+          0L, 1, 1024, FetchIsolation.HIGH_WATERMARK, Optional.empty()
+        )
+        val fetchInfos = Seq(
+          disklessTopicPartition -> new PartitionData(disklessTopicPartition.topicId(), 50L, 0L, 1024, Optional.empty())
+        )
+
+        @volatile var responseData: Map[TopicIdPartition, FetchPartitionData] = null
+        val responseCallback = (response: Seq[(TopicIdPartition, FetchPartitionData)]) => {
+          responseData = response.toMap
+        }
+        replicaManager.fetchMessages(fetchParams, fetchInfos, QuotaFactory.UNBOUNDED_QUOTA, responseCallback)
+
+        assertNotNull(responseData)
+        assertEquals(1, responseData.size)
+        assertEquals(Errors.NONE, responseData(disklessTopicPartition).error)
+        verify(replicaManager, never()).readFromLog(any(), any(), any(), any())
+        verify(fetchHandlerCtor.constructed().get(0), times(1)).handle(any(), any())
+      } finally {
+        fetchHandlerCtor.close()
+      }
+    }
+
+    @Test
+    def testFetchConsolidatingMetadataButConsolidationDisabledUsesClassicStartOffsetRule(): Unit = {
+      val fetchHandlerCtor = mockFetchHandler(Map.empty)
+      try {
+        val cp = mock(classOf[ControlPlane])
+        val replicaManager = spy(createReplicaManager(
+          List(disklessTopicPartition.topic()),
+          controlPlane = Some(cp),
+          disklessManagedReplicasEnabled = true,
+          disklessRemoteStorageConsolidationEnabled = false,
+          consolidatingDisklessTopics = Set(disklessTopicPartition.topic()),
+        ))
+        when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
+          .thenReturn(100L)
+
+        doReturn(Seq(disklessTopicPartition ->
+          new LogReadResult(
+            new FetchDataInfo(new LogOffsetMetadata(1L, 0L, 0), RECORDS),
+            Optional.empty(), 10L, 0L, 10L, 0L, 0L, OptionalLong.empty(), Errors.NONE
+          ))
+        ).when(replicaManager).readFromLog(any(), any(), any(), any())
+
+        val fetchParams = new FetchParams(
+          -1, -1L,
+          0L, 1, 1024, FetchIsolation.HIGH_WATERMARK, Optional.empty()
+        )
+        val fetchInfos = Seq(
+          disklessTopicPartition -> new PartitionData(disklessTopicPartition.topicId(), 50L, 0L, 1024, Optional.empty())
+        )
+
+        @volatile var responseData: Map[TopicIdPartition, FetchPartitionData] = null
+        val responseCallback = (response: Seq[(TopicIdPartition, FetchPartitionData)]) => {
+          responseData = response.toMap
+        }
+        replicaManager.fetchMessages(fetchParams, fetchInfos, QuotaFactory.UNBOUNDED_QUOTA, responseCallback)
+
+        assertNotNull(responseData)
+        assertEquals(1, responseData.size)
+        assertEquals(RECORDS, responseData(disklessTopicPartition).records)
+        verify(replicaManager, times(1)).readFromLog(any(), any(), any(), any())
+        verify(fetchHandlerCtor.constructed().get(0), never()).handle(any(), any())
+      } finally {
+        fetchHandlerCtor.close()
+      }
+    }
+
+    @Test
+    def testFetchConsolidatingDisklessMigrationPendingReadsFromUnifiedLogWhenConsolidationEnabled(): Unit = {
+      val fetchHandlerCtor = mockFetchHandler(Map.empty)
+      try {
+        val cp = mock(classOf[ControlPlane])
+        val replicaManager = spy(createReplicaManager(
+          List(disklessTopicPartition.topic()),
+          controlPlane = Some(cp),
+          disklessManagedReplicasEnabled = true,
+          disklessRemoteStorageConsolidationEnabled = true,
+          consolidatingDisklessTopics = Set(disklessTopicPartition.topic()),
+        ))
+        when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
+          .thenReturn(PartitionRegistration.CLASSIC_TO_DISKLESS_MIGRATION_PENDING)
+
+        doReturn(Seq(disklessTopicPartition ->
+          new LogReadResult(
+            new FetchDataInfo(new LogOffsetMetadata(1L, 0L, 0), RECORDS),
+            Optional.empty(), 10L, 0L, 10L, 0L, 0L, OptionalLong.empty(), Errors.NONE
+          ))
+        ).when(replicaManager).readFromLog(any(), any(), any(), any())
+
+        val fetchParams = new FetchParams(
+          -1, -1L,
+          0L, 1, 1024, FetchIsolation.HIGH_WATERMARK, Optional.empty()
+        )
+        val fetchInfos = Seq(
+          disklessTopicPartition -> new PartitionData(disklessTopicPartition.topicId(), 50L, 0L, 1024, Optional.empty())
+        )
+
+        @volatile var responseData: Map[TopicIdPartition, FetchPartitionData] = null
+        val responseCallback = (response: Seq[(TopicIdPartition, FetchPartitionData)]) => {
+          responseData = response.toMap
+        }
+        replicaManager.fetchMessages(fetchParams, fetchInfos, QuotaFactory.UNBOUNDED_QUOTA, responseCallback)
+
+        assertNotNull(responseData)
+        assertEquals(1, responseData.size)
+        assertEquals(RECORDS, responseData(disklessTopicPartition).records)
+        verify(replicaManager, times(1)).readFromLog(any(), any(), any(), any())
+        verify(fetchHandlerCtor.constructed().get(0), never()).handle(any(), any())
+      } finally {
+        fetchHandlerCtor.close()
+      }
+    }
+
     @Test
     def testFindBatches(): Unit = {
       // Given

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -6664,21 +6664,33 @@ class ReplicaManagerTest {
       }
     }
 
-    /** Stubs local UnifiedLog LEO for consolidating diskless fetch routing (uses [[ReplicaManager.getPartitionOrException]]). */
     private def stubConsolidatingPartitionWithLocalLeo(replicaManager: ReplicaManager, localLeo: Long): Unit = {
+      stubConsolidatingPartitionWithLocalLeoFor(replicaManager, disklessTopicPartition, localLeo)
+    }
+
+    private def stubConsolidatingPartitionWithLocalLeoFor(replicaManager: ReplicaManager, tp: TopicIdPartition, localLeo: Long): Unit = {
       val mockPartition = mock(classOf[Partition])
       val mockLog = mock(classOf[UnifiedLog])
       when(mockLog.logEndOffset).thenReturn(localLeo)
       when(mockPartition.log).thenReturn(Some(mockLog))
-      doReturn(mockPartition).when(replicaManager).getPartitionOrException(
-        ArgumentMatchers.eq(disklessTopicPartition))
+      doReturn(Right(mockPartition)).when(replicaManager).getPartitionOrError(
+        ArgumentMatchers.eq(tp.topicPartition()))
     }
 
     private def stubConsolidatingPartitionWithoutLocalLog(replicaManager: ReplicaManager): Unit = {
       val mockPartition = mock(classOf[Partition])
       when(mockPartition.log).thenReturn(None)
-      doReturn(mockPartition).when(replicaManager).getPartitionOrException(
-        ArgumentMatchers.eq(disklessTopicPartition))
+      doReturn(Right(mockPartition)).when(replicaManager).getPartitionOrError(
+        ArgumentMatchers.eq(disklessTopicPartition.topicPartition()))
+    }
+
+    private def stubConsolidatingPartitionAsError(replicaManager: ReplicaManager, error: Errors): Unit = {
+      doReturn(Left(error)).when(replicaManager).getPartitionOrError(
+        ArgumentMatchers.eq(disklessTopicPartition.topicPartition()))
+    }
+
+    private def waitForFetchResponse(responseData: => Map[TopicIdPartition, FetchPartitionData]): Unit = {
+      TestUtils.waitUntilTrue(() => responseData != null, "Expected fetch response", 10_000)
     }
 
     @Test
@@ -6718,9 +6730,199 @@ class ReplicaManagerTest {
         }
         replicaManager.fetchMessages(fetchParams, fetchInfos, QuotaFactory.UNBOUNDED_QUOTA, responseCallback)
 
-        assertNotNull(responseData)
+        waitForFetchResponse(responseData)
         assertEquals(1, responseData.size)
         assertEquals(RECORDS, responseData(disklessTopicPartition).records)
+        verify(replicaManager, times(1)).readFromLog(any(), any(), any(), any())
+        verify(fetchHandlerCtor.constructed().get(0), never()).handle(any(), any())
+      } finally {
+        fetchHandlerCtor.close()
+      }
+    }
+
+    @Test
+    def testFetchConsolidatingDisklessPartitionOfflineReturnsKafkaStorageError(): Unit = {
+      val disklessResponse = Map(disklessTopicPartition ->
+        new FetchPartitionData(
+          Errors.NONE,
+          110L, 100L,
+          RECORDS,
+          Optional.empty(), OptionalLong.empty(), Optional.empty(), OptionalInt.empty(), false)
+      )
+      val fetchHandlerCtor = mockFetchHandler(disklessResponse)
+      try {
+        val replicaManager = spy(createReplicaManager(
+          List(disklessTopicPartition.topic()),
+          disklessManagedReplicasEnabled = true,
+          disklessRemoteStorageConsolidationEnabled = true,
+          consolidatingDisklessTopics = Set(disklessTopicPartition.topic()),
+        ))
+        when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
+          .thenReturn(PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET)
+        stubConsolidatingPartitionAsError(replicaManager, Errors.KAFKA_STORAGE_ERROR)
+
+        val fetchParams = new FetchParams(
+          -1, -1L,
+          0L, 1, 1024, FetchIsolation.HIGH_WATERMARK, Optional.empty()
+        )
+        val fetchInfos = Seq(
+          disklessTopicPartition -> new PartitionData(disklessTopicPartition.topicId(), 50L, 0L, 1024, Optional.empty())
+        )
+
+        @volatile var responseData: Map[TopicIdPartition, FetchPartitionData] = null
+        val responseCallback = (response: Seq[(TopicIdPartition, FetchPartitionData)]) => responseData = response.toMap
+        replicaManager.fetchMessages(fetchParams, fetchInfos, QuotaFactory.UNBOUNDED_QUOTA, responseCallback)
+
+        waitForFetchResponse(responseData)
+        assertEquals(1, responseData.size)
+        assertEquals(Errors.KAFKA_STORAGE_ERROR, responseData(disklessTopicPartition).error)
+        assertEquals(MemoryRecords.EMPTY, responseData(disklessTopicPartition).records)
+        verify(fetchHandlerCtor.constructed().get(0), never()).handle(any(), any())
+        verify(replicaManager, never()).readFromLog(any(), any(), any(), any())
+      } finally {
+        fetchHandlerCtor.close()
+      }
+    }
+
+    @Test
+    def testFetchConsolidatingDisklessPartitionMissingReplicaReturnsNotLeaderOrFollower(): Unit = {
+      val disklessResponse = Map(disklessTopicPartition ->
+        new FetchPartitionData(
+          Errors.NONE,
+          110L, 100L,
+          RECORDS,
+          Optional.empty(), OptionalLong.empty(), Optional.empty(), OptionalInt.empty(), false)
+      )
+      val fetchHandlerCtor = mockFetchHandler(disklessResponse)
+      try {
+        val replicaManager = spy(createReplicaManager(
+          List(disklessTopicPartition.topic()),
+          disklessManagedReplicasEnabled = true,
+          disklessRemoteStorageConsolidationEnabled = true,
+          consolidatingDisklessTopics = Set(disklessTopicPartition.topic()),
+        ))
+        when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
+          .thenReturn(PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET)
+        stubConsolidatingPartitionAsError(replicaManager, Errors.NOT_LEADER_OR_FOLLOWER)
+
+        val fetchParams = new FetchParams(
+          -1, -1L,
+          0L, 1, 1024, FetchIsolation.HIGH_WATERMARK, Optional.empty()
+        )
+        val fetchInfos = Seq(
+          disklessTopicPartition -> new PartitionData(disklessTopicPartition.topicId(), 50L, 0L, 1024, Optional.empty())
+        )
+
+        @volatile var responseData: Map[TopicIdPartition, FetchPartitionData] = null
+        val responseCallback = (response: Seq[(TopicIdPartition, FetchPartitionData)]) => responseData = response.toMap
+        replicaManager.fetchMessages(fetchParams, fetchInfos, QuotaFactory.UNBOUNDED_QUOTA, responseCallback)
+
+        waitForFetchResponse(responseData)
+        assertEquals(1, responseData.size)
+        assertEquals(Errors.NOT_LEADER_OR_FOLLOWER, responseData(disklessTopicPartition).error)
+        assertEquals(MemoryRecords.EMPTY, responseData(disklessTopicPartition).records)
+        verify(fetchHandlerCtor.constructed().get(0), never()).handle(any(), any())
+        verify(replicaManager, never()).readFromLog(any(), any(), any(), any())
+      } finally {
+        fetchHandlerCtor.close()
+      }
+    }
+
+    @Test
+    def testFetchConsolidatingDisklessUnknownPartitionReturnsUnknownTopicOrPartition(): Unit = {
+      val disklessResponse = Map(disklessTopicPartition ->
+        new FetchPartitionData(
+          Errors.NONE,
+          110L, 100L,
+          RECORDS,
+          Optional.empty(), OptionalLong.empty(), Optional.empty(), OptionalInt.empty(), false)
+      )
+      val fetchHandlerCtor = mockFetchHandler(disklessResponse)
+      try {
+        val replicaManager = spy(createReplicaManager(
+          List(disklessTopicPartition.topic()),
+          disklessManagedReplicasEnabled = true,
+          disklessRemoteStorageConsolidationEnabled = true,
+          consolidatingDisklessTopics = Set(disklessTopicPartition.topic()),
+        ))
+        when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
+          .thenReturn(PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET)
+        stubConsolidatingPartitionAsError(replicaManager, Errors.UNKNOWN_TOPIC_OR_PARTITION)
+
+        val fetchParams = new FetchParams(
+          -1, -1L,
+          0L, 1, 1024, FetchIsolation.HIGH_WATERMARK, Optional.empty()
+        )
+        val fetchInfos = Seq(
+          disklessTopicPartition -> new PartitionData(disklessTopicPartition.topicId(), 50L, 0L, 1024, Optional.empty())
+        )
+
+        @volatile var responseData: Map[TopicIdPartition, FetchPartitionData] = null
+        val responseCallback = (response: Seq[(TopicIdPartition, FetchPartitionData)]) => responseData = response.toMap
+        replicaManager.fetchMessages(fetchParams, fetchInfos, QuotaFactory.UNBOUNDED_QUOTA, responseCallback)
+
+        waitForFetchResponse(responseData)
+        assertEquals(1, responseData.size)
+        assertEquals(Errors.UNKNOWN_TOPIC_OR_PARTITION, responseData(disklessTopicPartition).error)
+        assertEquals(MemoryRecords.EMPTY, responseData(disklessTopicPartition).records)
+        verify(fetchHandlerCtor.constructed().get(0), never()).handle(any(), any())
+        verify(replicaManager, never()).readFromLog(any(), any(), any(), any())
+      } finally {
+        fetchHandlerCtor.close()
+      }
+    }
+
+    @Test
+    def testFetchConsolidatingDisklessErrorAppendedWhenOtherPartitionReadsFromUnifiedLog(): Unit = {
+      val disklessTopicPartition2 = new TopicIdPartition(Uuid.randomUuid(), 0, "diskless2")
+      val fetchHandlerCtor = mockFetchHandler(Map.empty)
+      try {
+        val cp = mock(classOf[ControlPlane])
+        val replicaManager = spy(createReplicaManager(
+          List(disklessTopicPartition.topic(), disklessTopicPartition2.topic()),
+          controlPlane = Some(cp),
+          disklessManagedReplicasEnabled = true,
+          disklessRemoteStorageConsolidationEnabled = true,
+          consolidatingDisklessTopics = Set(disklessTopicPartition.topic(), disklessTopicPartition2.topic()),
+          topicIdMapping = Map(disklessTopicPartition2.topic() -> disklessTopicPartition2.topicId()),
+        ))
+        when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
+          .thenReturn(PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET)
+        when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition2.topicPartition()))
+          .thenReturn(100L)
+
+        doReturn(Left(Errors.KAFKA_STORAGE_ERROR)).when(replicaManager).getPartitionOrError(
+          ArgumentMatchers.eq(disklessTopicPartition.topicPartition()))
+        stubConsolidatingPartitionWithLocalLeoFor(replicaManager, disklessTopicPartition2, localLeo = 200L)
+
+        doReturn(Seq(disklessTopicPartition2 ->
+          new LogReadResult(
+            new FetchDataInfo(new LogOffsetMetadata(1L, 0L, 0), RECORDS),
+            Optional.empty(), 10L, 0L, 10L, 0L, 0L, OptionalLong.empty(), Errors.NONE
+          ))
+        ).when(replicaManager).readFromLog(any(), any(), any(), any())
+
+        val fetchParams = new FetchParams(
+          -1, -1L,
+          0L, 1, 1024, FetchIsolation.HIGH_WATERMARK, Optional.empty()
+        )
+        val fetchInfos = Seq(
+          disklessTopicPartition -> new PartitionData(disklessTopicPartition.topicId(), 50L, 0L, 1024, Optional.empty()),
+          disklessTopicPartition2 -> new PartitionData(disklessTopicPartition2.topicId(), 50L, 0L, 1024, Optional.empty())
+        )
+
+        @volatile var responseData: Map[TopicIdPartition, FetchPartitionData] = null
+        val responseCallback = (response: Seq[(TopicIdPartition, FetchPartitionData)]) => {
+          responseData = response.toMap
+        }
+        replicaManager.fetchMessages(fetchParams, fetchInfos, QuotaFactory.UNBOUNDED_QUOTA, responseCallback)
+
+        waitForFetchResponse(responseData)
+        assertEquals(2, responseData.size)
+        assertEquals(Errors.KAFKA_STORAGE_ERROR, responseData(disklessTopicPartition).error)
+        assertEquals(MemoryRecords.EMPTY, responseData(disklessTopicPartition).records)
+        assertEquals(Errors.NONE, responseData(disklessTopicPartition2).error)
+        assertEquals(RECORDS, responseData(disklessTopicPartition2).records)
         verify(replicaManager, times(1)).readFromLog(any(), any(), any(), any())
         verify(fetchHandlerCtor.constructed().get(0), never()).handle(any(), any())
       } finally {
@@ -6765,7 +6967,7 @@ class ReplicaManagerTest {
         }
         replicaManager.fetchMessages(fetchParams, fetchInfos, QuotaFactory.UNBOUNDED_QUOTA, responseCallback)
 
-        assertNotNull(responseData)
+        waitForFetchResponse(responseData)
         assertEquals(1, responseData.size)
         assertEquals(RECORDS, responseData(disklessTopicPartition).records)
         verify(replicaManager, times(1)).readFromLog(any(), any(), any(), any())
@@ -6823,7 +7025,7 @@ class ReplicaManagerTest {
         }
         replicaManager.fetchMessages(fetchParams, fetchInfos, QuotaFactory.UNBOUNDED_QUOTA, responseCallback)
 
-        assertNotNull(responseData)
+        waitForFetchResponse(responseData)
         assertEquals(1, responseData.size)
         assertEquals(Errors.NONE, responseData(disklessTopicPartition).error)
         assertEquals(RECORDS, responseData(disklessTopicPartition).records)
@@ -6882,7 +7084,7 @@ class ReplicaManagerTest {
         }
         replicaManager.fetchMessages(fetchParams, fetchInfos, QuotaFactory.UNBOUNDED_QUOTA, responseCallback)
 
-        assertNotNull(responseData)
+        waitForFetchResponse(responseData)
         assertEquals(1, responseData.size)
         assertEquals(Errors.NONE, responseData(disklessTopicPartition).error)
         verify(replicaManager, never()).readFromLog(any(), any(), any(), any())
@@ -6901,7 +7103,6 @@ class ReplicaManagerTest {
           List(disklessTopicPartition.topic()),
           controlPlane = Some(cp),
           disklessManagedReplicasEnabled = true,
-          disklessRemoteStorageConsolidationEnabled = false,
           consolidatingDisklessTopics = Set(disklessTopicPartition.topic()),
         ))
         when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
@@ -6928,7 +7129,7 @@ class ReplicaManagerTest {
         }
         replicaManager.fetchMessages(fetchParams, fetchInfos, QuotaFactory.UNBOUNDED_QUOTA, responseCallback)
 
-        assertNotNull(responseData)
+        waitForFetchResponse(responseData)
         assertEquals(1, responseData.size)
         assertEquals(RECORDS, responseData(disklessTopicPartition).records)
         verify(replicaManager, times(1)).readFromLog(any(), any(), any(), any())
@@ -6952,6 +7153,8 @@ class ReplicaManagerTest {
         ))
         when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
           .thenReturn(PartitionRegistration.CLASSIC_TO_DISKLESS_MIGRATION_PENDING)
+        // Ensure we don't generate an additional invalid response from the consolidating-partition check.
+        stubConsolidatingPartitionWithoutLocalLog(replicaManager)
 
         doReturn(Seq(disklessTopicPartition ->
           new LogReadResult(
@@ -6974,7 +7177,7 @@ class ReplicaManagerTest {
         }
         replicaManager.fetchMessages(fetchParams, fetchInfos, QuotaFactory.UNBOUNDED_QUOTA, responseCallback)
 
-        assertNotNull(responseData)
+        waitForFetchResponse(responseData)
         assertEquals(1, responseData.size)
         assertEquals(RECORDS, responseData(disklessTopicPartition).records)
         verify(replicaManager, times(1)).readFromLog(any(), any(), any(), any())


### PR DESCRIPTION
Consolidated read will be done by prioritizing local logs whenever possible. This means that if the log is consolidating and if the fetched offset falls in the local offset space, meaning fetched offset < localLog.logEndOffset, then read from local logs. Otherwise read from diskless.

In case of diskless partitions that aren't consolidaing, read should be decided based on disklessStartOffset. That means that if there is a diskless offset, then read from the diskless offsets, otherwise read from the local log.
