### PR TITLE
feat(inkless): Support ListOffsets for all cases of diskless partitions

### DIFF
--- a/core/src/main/scala/kafka/server/DisklessFetchOffsetRouter.scala
+++ b/core/src/main/scala/kafka/server/DisklessFetchOffsetRouter.scala
@@ -1,0 +1,348 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.server
+
+import io.aiven.inkless.consume.FetchOffsetHandler
+import kafka.server.metadata.InklessMetadataView
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.errors.ApiException
+import org.apache.kafka.common.message.ListOffsetsRequestData.ListOffsetsPartition
+import org.apache.kafka.common.message.ListOffsetsResponseData.ListOffsetsPartitionResponse
+import org.apache.kafka.common.protocol.Errors
+import org.apache.kafka.common.record.{FileRecords, RecordBatch}
+import org.apache.kafka.common.requests.ListOffsetsRequest
+import org.apache.kafka.metadata.PartitionRegistration
+import org.apache.kafka.server.purgatory.{DelayedOperationPurgatory, DelayedRemoteListOffsets, ListOffsetsPartitionStatus, TopicPartitionOperationKey}
+import org.apache.kafka.storage.internals.log.AsyncOffsetReadFutureHolder
+import org.apache.kafka.storage.internals.log.OffsetResultHolder.FileRecordsOrError
+
+import java.util.Optional
+import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.{CompletableFuture, CopyOnWriteArrayList, Future}
+import scala.jdk.OptionConverters.RichOptional
+
+/**
+ * Routes ListOffsets queries for diskless-managed topics among the classic UnifiedLog path,
+ * the diskless control-plane path, and hybrid configurations that can answer from either.
+ *
+ * Distinguishes among:
+ *   1. Pure diskless partition (`classicToDisklessStartOffset <= 0` or managed replicas disabled):
+ *      fetch offset in the diskless path.
+ *   2. Hybrid diskless partition (`classicToDisklessStartOffset > 0` and managed replicas enabled):
+ *      fetch offset in classic and/or diskless path, depending on the requested timestamp.
+ *   3. Partition that is being migrated from classic to diskless
+ *      (`classicToDisklessStartOffset == CLASSIC_TO_DISKLESS_MIGRATION_PENDING` and managed
+ *      replicas enabled): fetch offset only in the classic path.
+ *   4. Follower requests on a migrated partition: ListOffsets requests (used by ReplicaFetcher
+ *      for truncation / initial offset bootstrap) must never see diskless offsets, otherwise the
+ *      follower would try to truncate to or fetch from offsets that live only in object storage:
+ *      fetch offset only in the classic path.
+ *
+ * Per request, the caller obtains a per-request `FetchOffsetHandler.Job` via [[createJob]],
+ * routes each diskless-managed partition through [[route]] (passing classic-side callbacks),
+ * and finally calls `job.start()` to fire the underlying control plane job.
+ */
+class DisklessFetchOffsetRouter(
+  inklessFetchOffsetHandler: Option[FetchOffsetHandler],
+  inklessMetadataView: InklessMetadataView,
+  disklessManagedReplicasEnabled: Boolean,
+  delayedRemoteListOffsetsPurgatory: DelayedOperationPurgatory[DelayedRemoteListOffsets]
+) {
+  import DisklessFetchOffsetRouter._
+
+  /**
+   * Create a per-request control-plane job. Returns `None` if diskless is not configured for
+   * this broker, in which case the caller should fall through to the standard classic path for
+   * all partitions.
+   */
+  def createJob(): Option[FetchOffsetHandler.Job] =
+    inklessFetchOffsetHandler.map(_.createJob())
+
+  /**
+   * Route a single partition.
+   *
+   * @param job                           the per-request job from [[createJob]]; partitions that
+   *                                      go to the diskless path are added to it (and the caller
+   *                                      starts it once after routing all partitions).
+   * @param classicLogStartOffsetProvider returns the local UnifiedLog's `logStartOffset` for the
+   *                                      given partition, used to decide whether the EARLIEST
+   *                                      timestamp can be served by the classic path.
+   * @param classicFetchOffset            runs the standard Kafka classic-path lookup for the
+   *                                      given `(topicPartition, partition, allowFromFollower)`.
+   */
+  def route(
+    job: FetchOffsetHandler.Job,
+    topicPartition: TopicPartition,
+    partition: ListOffsetsPartition,
+    replicaId: Int,
+    version: Short,
+    classicLogStartOffsetProvider: TopicPartition => Option[Long],
+    classicFetchOffset: (TopicPartition, ListOffsetsPartition, Boolean) => ListOffsetsPartitionStatus
+  ): ListOffsetsPartitionStatus = {
+    val classicToDisklessStartOffset = inklessMetadataView.getClassicToDisklessStartOffset(topicPartition)
+    val migrationPending = classicToDisklessStartOffset == PartitionRegistration.CLASSIC_TO_DISKLESS_MIGRATION_PENDING
+    val isMigratedWithClassicAccess = classicToDisklessStartOffset > 0 && disklessManagedReplicasEnabled
+
+    // Migrated partitions seal their classic local log: once classicToDisklessStartOffset is
+    // committed the LEO can no longer grow and every ISR replica has the same data on disk.
+    // Any replica can therefore safely answer ListOffsets from its local log, so we let
+    // followers serve the classic-side query as well.
+    val allowFromFollower = isMigratedWithClassicAccess
+    val isFollowerRequest = replicaId >= 0
+
+    def classicLookup(): ListOffsetsPartitionStatus = classicFetchOffset(topicPartition, partition, allowFromFollower)
+    def disklessLookup: Lookup = disklessLookupOnJob(job, topicPartition, partition)
+    def disklessLookupOnNewJob: Lookup = disklessLookupOnJob(inklessFetchOffsetHandler.get.createJob(), topicPartition, partition, startNow = true)
+
+    if (migrationPending && disklessManagedReplicasEnabled) {
+      // Case 3.
+      classicFetchOffset(topicPartition, partition, false)
+    } else if (isMigratedWithClassicAccess && isFollowerRequest) {
+      // Case 4.
+      classicLookup()
+    } else if (isMigratedWithClassicAccess) {
+      // Case 2: hybrid, route by timestamp.
+      partition.timestamp() match {
+        case ListOffsetsRequest.EARLIEST_LOCAL_TIMESTAMP | ListOffsetsRequest.LATEST_TIERED_TIMESTAMP =>
+          // These timestamps reference the local UnifiedLog / tiered storage; never route to diskless.
+          classicLookup()
+
+        case ListOffsetsRequest.EARLIEST_TIMESTAMP =>
+          // Try classic first when classic data is still on disk, otherwise go straight to diskless.
+          if (classicLogStartOffsetProvider(topicPartition).exists(_ < classicToDisklessStartOffset)) classicLookup()
+          else asStatus(topicPartition, disklessLookup)
+
+        case t if t >= 0 =>
+          // Specific timestamp: classic first, fall back to diskless on a "no match".
+          val classic = classicLookup()
+          if (classic.responseOpt.isPresent) {
+            if (isSyncNoMatch(classic.responseOpt.get)) asStatus(topicPartition, disklessLookup)
+            else classic
+          } else if (classic.futureHolderOpt.isPresent) {
+            // If the classic future is already complete at routing time, withFallback's thenCompose
+            // invokes the fallback factory synchronously on this thread, i.e. inside route(), which
+            // runs before the caller calls job.start() (see ReplicaManager.fetchOffset). So we can
+            // still batch the diskless lookup into the per-request job. Otherwise the fallback
+            // fires asynchronously after start(), and must use a fresh, immediately-started job.
+            val fallback: () => Lookup =
+              if (classic.futureHolderOpt.get.taskFuture.isDone) () => disklessLookup
+              else                                               () => disklessLookupOnNewJob
+            withFallback(topicPartition, classicLookupOf(classic, version), fallback)
+          } else classic
+
+        case _ =>
+          // LATEST_TIMESTAMP / MAX_TIMESTAMP: diskless first, classic fallback on empty.
+          withFallback(topicPartition, disklessLookup, () => classicLookupOf(classicLookup(), version))
+      }
+    } else {
+      // Case 1.
+      asStatus(topicPartition, disklessLookup)
+    }
+  }
+
+  /**
+   * Wrap a single async lookup as a `ListOffsetsPartitionStatus`, ensuring the purgatory wakes
+   * up to deliver the response when the lookup completes.
+   */
+  private def asStatus(tp: TopicPartition, lookup: Lookup): ListOffsetsPartitionStatus = {
+    lookup.taskFuture.whenComplete { (_, _) =>
+      delayedRemoteListOffsetsPurgatory.checkAndComplete(new TopicPartitionOperationKey(tp.topic, tp.partition))
+    }
+    ListOffsetsPartitionStatus.builder().futureHolderOpt(Optional.of(lookup)).build()
+  }
+
+  /**
+   * Run `primary`; if it returns a "no match" (no exception, no timestamp+offset), invoke
+   * `fallback` and forward its outcome instead. The purgatory's single cancel hook is fanned
+   * out to both legs so an expiration cancels whichever underlying job(s) are still in flight,
+   * forwarding the original `mayInterruptIfRunning` flag (the purgatory uses `cancel(false)` on
+   * the in-flight-error path and `cancel(true)` on expiration; both must reach the underlying
+   * remote-storage / inkless job futures unchanged).
+   */
+  private def withFallback(
+    tp: TopicPartition,
+    primary: Lookup,
+    fallback: () => Lookup
+  ): ListOffsetsPartitionStatus = {
+    val cancelSignal = new FanOutCancelFuture
+    cancelSignal.addTarget(primary.jobFuture)
+
+    val combined = primary.taskFuture.thenCompose[FileRecordsOrError] { result =>
+      if (result.hasException || result.hasTimestampAndOffset) {
+        // Primary answered authoritatively (hit or error). No fallback needed.
+        CompletableFuture.completedFuture(result)
+      } else {
+        try {
+          val secondary = fallback()
+          cancelSignal.addTarget(secondary.jobFuture)
+          secondary.taskFuture
+        } catch {
+          case e: Exception =>
+            CompletableFuture.completedFuture(new FileRecordsOrError(Optional.of(e), Optional.empty()))
+        }
+      }
+    }
+
+    asStatus(tp, new AsyncOffsetReadFutureHolder(cancelSignal, combined))
+  }
+}
+
+private[server] object DisklessFetchOffsetRouter {
+
+  /**
+   * The shape every code path produces: a result future plus a cancel hook the purgatory can
+   * pull on. This is the same record `ListOffsetsPartitionStatus` carries around, which means
+   * we don't need a separate intermediate type and `asStatus` doesn't have to convert.
+   */
+  private type Lookup = AsyncOffsetReadFutureHolder[FileRecordsOrError]
+
+  /**
+   * A `CompletableFuture[Void]` used as a single cancel hook for several underlying job futures.
+   * When `cancel(mayInterruptIfRunning)` is invoked the same flag is forwarded to every target,
+   * preserving the purgatory's choice between `cancel(true)` (expiration: interrupt the running
+   * worker) and `cancel(false)` (in-flight error: just mark cancelled, don't interrupt). Targets
+   * added after a cancel has already fired are cancelled immediately with the recorded flag, so
+   * the chained-in fallback leg cannot leak past a cancellation that races with it.
+   *
+   * Concurrent `cancel(...)` calls are made deterministic with a single CAS on `cancelFlag`:
+   * the first caller atomically transitions it from `null` to its own `mayInterruptIfRunning`
+   * and is the unique fan-out winner; later callers (and `addTarget` after the fact) read back
+   * that same flag, so every target is cancelled exactly once with the winner's value.
+   */
+  private final class FanOutCancelFuture extends CompletableFuture[Void] {
+    // Use CopyOnWriteArrayList because addTarget() and cancel()'s forEach can race on different threads,
+    // and we need iteration to be snapshot-safe (no ConcurrentModificationException) and
+    // lock-free, so a target's `cancel(...)` callback can't deadlock us by reentering. Writes
+    // are tiny and rare (typically 1-2 targets per request), so the copy-on-write cost is negligible.
+    private val targets = new CopyOnWriteArrayList[Future[_]]()
+    // Records the mayInterruptIfRunning flag of the first cancel() to land; `null` while no cancel has run yet.
+    private val cancelFlag = new AtomicReference[java.lang.Boolean]()
+
+    def addTarget(target: Future[_]): Unit = {
+      targets.add(target)
+      // Add first, *then* read cancelFlag. A racing cancel either already
+      // published its flag (we observe it here and cancel ourselves) or will iterate `targets` in `cancel()`
+      // next and find us there. So no concurrent cancel can leave us un-cancelled.
+      val f = cancelFlag.get
+      if (f != null) target.cancel(f)
+    }
+
+    override def cancel(mayInterruptIfRunning: Boolean): Boolean = {
+      // `won` == true if this call is the first cancel() and its flag is the one now stored.
+      val won = cancelFlag.compareAndSet(null, java.lang.Boolean.valueOf(mayInterruptIfRunning))
+      // Always propagate the *winning* flag (never our own arg) so a losing caller's
+      // mayInterruptIfRunning cannot leak through to targets and contradict the winner's choice.
+      val flag = cancelFlag.get.booleanValue
+      val result = super.cancel(flag)
+      // Only the CAS winner fans out: Future#cancel is idempotent, but a second fan-out from a
+      // losing caller would still re-invoke targets unnecessarily.
+      if (won) targets.forEach(_.cancel(flag))
+      result
+    }
+  }
+
+  private val EmptyResult = new FileRecordsOrError(Optional.empty(), Optional.empty())
+  private val NoOpCancel: CompletableFuture[Void] = CompletableFuture.completedFuture(null)
+
+  /**
+   * Diskless lookup against the given job. Set `startNow = true` for a one-off fallback job
+   * (for fallbacks discovered after the caller's job has already been started); leave it
+   * `false` when adding to the caller's per-request job (the caller will start it).
+   */
+  private def disklessLookupOnJob(job: FetchOffsetHandler.Job,
+                                  tp: TopicPartition,
+                                  partition: ListOffsetsPartition,
+                                  startNow: Boolean = false): Lookup = {
+    val task = job.add(tp, partition)
+    if (startNow) job.start()
+    new AsyncOffsetReadFutureHolder(job.cancelHandler(), task)
+  }
+
+  /**
+   * Wrap a `ListOffsetsPartitionStatus` produced by the classic path. For async (tiered storage)
+   * results, applies the `lastFetchableOffset` / `maybeOffsetsError` translation up-front so the
+   * resulting future already accounts for clamp / pending error and the status we eventually
+   * hand to the purgatory does not need to carry classic metadata.
+   */
+  private def classicLookupOf(status: ListOffsetsPartitionStatus, version: Short): Lookup = {
+    if (status.responseOpt.isPresent) {
+      new AsyncOffsetReadFutureHolder(NoOpCancel, CompletableFuture.completedFuture(syncResponseToResult(status.responseOpt.get)))
+    } else if (status.futureHolderOpt.isPresent) {
+      val holder = status.futureHolderOpt.get
+      val translated = holder.taskFuture.thenApply[FileRecordsOrError](r => translateClassicRemoteResult(r, status, version))
+      new AsyncOffsetReadFutureHolder(holder.jobFuture, translated)
+    } else {
+      new AsyncOffsetReadFutureHolder(NoOpCancel, CompletableFuture.completedFuture(EmptyResult))
+    }
+  }
+
+  /** Sync classic responses with `errorCode == NONE && offset < 0` are the "no match" sentinel. */
+  private def isSyncNoMatch(r: ListOffsetsPartitionResponse): Boolean =
+    r.errorCode == Errors.NONE.code && r.offset < 0
+
+  private def syncResponseToResult(r: ListOffsetsPartitionResponse): FileRecordsOrError = {
+    if (r.errorCode != Errors.NONE.code) {
+      new FileRecordsOrError(Optional.of(Errors.forCode(r.errorCode).exception()), Optional.empty())
+    } else if (r.offset >= 0) {
+      val leaderEpoch =
+        if (r.leaderEpoch == RecordBatch.NO_PARTITION_LEADER_EPOCH) Optional.empty[Integer]()
+        else Optional.of[Integer](r.leaderEpoch)
+      new FileRecordsOrError(
+        Optional.empty(),
+        Optional.of(new FileRecords.TimestampAndOffset(r.timestamp, r.offset, leaderEpoch)))
+    } else {
+      EmptyResult
+    }
+  }
+
+  /**
+   * Apply the same `lastFetchableOffset` / `maybeOffsetsError` evaluation that
+   * [[org.apache.kafka.server.purgatory.DelayedRemoteListOffsets]] performs when it inspects a
+   * partition status that carries classic-side metadata.
+   *
+   *   - exception → forward as-is.
+   *   - empty taskFuture → if `maybeOffsetsError` is set, surface the version-mapped error; else
+   *     forward the empty result so the consumer reports NONE+UNKNOWN.
+   *   - hit with offset >= lastFetchableOffset → if `maybeOffsetsError` is set, surface the
+   *     version-mapped error; otherwise treat as empty (the original behaviour returns
+   *     NONE+UNKNOWN, encoded here as an empty `FileRecordsOrError`).
+   *   - hit otherwise → forward as-is.
+   *
+   * The version mapping mirrors classicFetchOffset's catch on `OffsetNotAvailableException`:
+   * v>=5 surfaces the exception's actual error code, older versions collapse to
+   * `LEADER_NOT_AVAILABLE` for back-compat.
+   */
+  private def translateClassicRemoteResult(remoteResult: FileRecordsOrError,
+                                           classic: ListOffsetsPartitionStatus,
+                                           version: Short): FileRecordsOrError = {
+    def mapPendingError(e: ApiException): FileRecordsOrError = {
+      val mapped: Exception = if (version >= 5) e else Errors.LEADER_NOT_AVAILABLE.exception()
+      new FileRecordsOrError(Optional.of(mapped), Optional.empty())
+    }
+
+    if (remoteResult.hasException) remoteResult
+    else if (!remoteResult.hasTimestampAndOffset) {
+      classic.maybeOffsetsError.toScala.map(mapPendingError).getOrElse(remoteResult)
+    } else {
+      val found = remoteResult.timestampAndOffset.get
+      // Clamped == true: found offset is at/past the visibility boundary (LSO/HW/LEO per isolation level), so it isn't readable yet.
+      val clamped = classic.lastFetchableOffset.toScala.exists(found.offset >= _)
+      if (!clamped) remoteResult
+      else classic.maybeOffsetsError.toScala.map(mapPendingError).getOrElse(EmptyResult)
+    }
+  }
+}

--- a/core/src/main/scala/kafka/server/DisklessFetchOffsetRouter.scala
+++ b/core/src/main/scala/kafka/server/DisklessFetchOffsetRouter.scala
@@ -57,7 +57,6 @@ import scala.jdk.OptionConverters.RichOptional
  * and finally calls `job.start()` to fire the underlying control plane job.
  */
 class DisklessFetchOffsetRouter(
-  inklessFetchOffsetHandler: Option[FetchOffsetHandler],
   inklessMetadataView: InklessMetadataView,
   disklessManagedReplicasEnabled: Boolean,
   delayedRemoteListOffsetsPurgatory: DelayedOperationPurgatory[DelayedRemoteListOffsets]
@@ -65,19 +64,14 @@ class DisklessFetchOffsetRouter(
   import DisklessFetchOffsetRouter._
 
   /**
-   * Create a per-request control-plane job. Returns `None` if diskless is not configured for
-   * this broker, in which case the caller should fall through to the standard classic path for
-   * all partitions.
-   */
-  def createJob(): Option[FetchOffsetHandler.Job] =
-    inklessFetchOffsetHandler.map(_.createJob())
-
-  /**
    * Route a single partition.
    *
-   * @param job                           the per-request job from [[createJob]]; partitions that
-   *                                      go to the diskless path are added to it (and the caller
+   * @param job                           the per-request control-plane job; partitions that go
+   *                                      to the diskless path are added to it (and the caller
    *                                      starts it once after routing all partitions).
+   * @param newJob                        factory for a fresh, immediately-started job used by
+   *                                      async fallbacks that fire after the caller has already
+   *                                      started `job`.
    * @param classicLogStartOffsetProvider returns the local UnifiedLog's `logStartOffset` for the
    *                                      given partition, used to decide whether the EARLIEST
    *                                      timestamp can be served by the classic path.
@@ -86,6 +80,7 @@ class DisklessFetchOffsetRouter(
    */
   def route(
     job: FetchOffsetHandler.Job,
+    newJob: () => FetchOffsetHandler.Job,
     topicPartition: TopicPartition,
     partition: ListOffsetsPartition,
     replicaId: Int,
@@ -106,7 +101,7 @@ class DisklessFetchOffsetRouter(
 
     def classicLookup(): ListOffsetsPartitionStatus = classicFetchOffset(topicPartition, partition, allowFromFollower)
     def disklessLookup: Lookup = disklessLookupOnJob(job, topicPartition, partition)
-    def disklessLookupOnNewJob: Lookup = disklessLookupOnJob(inklessFetchOffsetHandler.get.createJob(), topicPartition, partition, startNow = true)
+    def disklessLookupOnNewJob: Lookup = disklessLookupOnJob(newJob(), topicPartition, partition, startNow = true)
 
     if (migrationPending && disklessManagedReplicasEnabled) {
       // Case 3.

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -275,7 +275,6 @@ class ReplicaManager(val config: KafkaConfig,
   private val inklessFetchHandler: Option[FetchHandler] = inklessSharedState.map(new FetchHandler(_))
   private val inklessFetchOffsetHandler: Option[FetchOffsetHandler] = inklessSharedState.map(new FetchOffsetHandler(_))
   private val disklessFetchOffsetRouter = new DisklessFetchOffsetRouter(
-    inklessFetchOffsetHandler,
     _inklessMetadataView,
     config.disklessManagedReplicasEnabled,
     delayedRemoteListOffsetsPurgatory
@@ -1621,7 +1620,7 @@ class ReplicaManager(val config: KafkaConfig,
                   buildErrorResponse: (Errors, ListOffsetsPartition) => ListOffsetsPartitionResponse,
                   responseCallback: Consumer[util.Collection[ListOffsetsTopicResponse]],
                   timeoutMs: Int = 0): Unit = {
-    val maybeFetchOffsetJob: Option[FetchOffsetHandler.Job] = disklessFetchOffsetRouter.createJob()
+    val maybeFetchOffsetJob: Option[FetchOffsetHandler.Job] = inklessFetchOffsetHandler.map(_.createJob())
     val statusByPartition = mutable.Map[TopicPartition, ListOffsetsPartitionStatus]()
 
     val classicFetch: (TopicPartition, ListOffsetsPartition, Boolean) => ListOffsetsPartitionStatus =
@@ -1643,8 +1642,8 @@ class ReplicaManager(val config: KafkaConfig,
             ListOffsetsPartitionStatus.builder().responseOpt(Optional.of(buildErrorResponse(Errors.UNSUPPORTED_VERSION, partition))).build()
         } else if (maybeFetchOffsetJob.exists(_.mustHandle(topic.name))) {
           statusByPartition += topicPartition ->
-            disklessFetchOffsetRouter.route(maybeFetchOffsetJob.get, topicPartition, partition, replicaId, version,
-              classicLogStart, classicFetch)
+            disklessFetchOffsetRouter.route(maybeFetchOffsetJob.get, () => inklessFetchOffsetHandler.get.createJob(),
+              topicPartition, partition, replicaId, version, classicLogStart, classicFetch)
         } else {
           statusByPartition += topicPartition -> classicFetch(topicPartition, partition, false)
         }

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -76,7 +76,7 @@ import org.apache.kafka.server.util.timer.{SystemTimer, TimerTask}
 import org.apache.kafka.server.util.{Scheduler, ShutdownableThread}
 import org.apache.kafka.server.{ActionQueue, DelayedActionQueue, common}
 import org.apache.kafka.storage.internals.checkpoint.{LazyOffsetCheckpoints, OffsetCheckpointFile, OffsetCheckpoints}
-import org.apache.kafka.storage.internals.log.{AppendOrigin, AsyncOffsetReadFutureHolder, FetchDataInfo, FetchPartitionStatus, LeaderHwChange, LogAppendInfo, LogConfig, LogDirFailureChannel, LogOffsetMetadata, LogReadInfo, LogReadResult, OffsetResultHolder, RecordValidationException, RemoteLogReadResult, RemoteStorageFetchInfo, UnifiedLog, VerificationGuard}
+import org.apache.kafka.storage.internals.log.{AppendOrigin, FetchDataInfo, FetchPartitionStatus, LeaderHwChange, LogAppendInfo, LogConfig, LogDirFailureChannel, LogOffsetMetadata, LogReadInfo, LogReadResult, OffsetResultHolder, RecordValidationException, RemoteLogReadResult, RemoteStorageFetchInfo, UnifiedLog, VerificationGuard}
 import org.apache.kafka.storage.log.metrics.BrokerTopicStats
 
 import java.io.File
@@ -274,6 +274,12 @@ class ReplicaManager(val config: KafkaConfig,
   private val inklessAppendHandler: Option[AppendHandler] = inklessSharedState.map(new AppendHandler(_))
   private val inklessFetchHandler: Option[FetchHandler] = inklessSharedState.map(new FetchHandler(_))
   private val inklessFetchOffsetHandler: Option[FetchOffsetHandler] = inklessSharedState.map(new FetchOffsetHandler(_))
+  private val disklessFetchOffsetRouter = new DisklessFetchOffsetRouter(
+    inklessFetchOffsetHandler,
+    _inklessMetadataView,
+    config.disklessManagedReplicasEnabled,
+    delayedRemoteListOffsetsPurgatory
+  )
   private val inklessDeleteRecordsInterceptor: Option[DeleteRecordsInterceptor] = inklessSharedState.map(new DeleteRecordsInterceptor(_))
   private val inklessRetentionEnforcer: Option[RetentionEnforcer] = inklessSharedState.map(new RetentionEnforcer(_))
   private val inklessFileCleaner: Option[FileCleaner] = inklessSharedState.map(new FileCleaner(_))
@@ -1615,8 +1621,15 @@ class ReplicaManager(val config: KafkaConfig,
                   buildErrorResponse: (Errors, ListOffsetsPartition) => ListOffsetsPartitionResponse,
                   responseCallback: Consumer[util.Collection[ListOffsetsTopicResponse]],
                   timeoutMs: Int = 0): Unit = {
-    val maybeFetchOffsetJob: Option[FetchOffsetHandler.Job] = inklessFetchOffsetHandler.map(_.createJob())
+    val maybeFetchOffsetJob: Option[FetchOffsetHandler.Job] = disklessFetchOffsetRouter.createJob()
     val statusByPartition = mutable.Map[TopicPartition, ListOffsetsPartitionStatus]()
+
+    val classicFetch: (TopicPartition, ListOffsetsPartition, Boolean) => ListOffsetsPartitionStatus =
+      (tp, p, allowFromFollower) =>
+        classicFetchOffset(tp, p, replicaId, isolationLevel, version,
+          correlationId, clientId, buildErrorResponse, allowFromFollower = allowFromFollower)
+    val classicLogStart: TopicPartition => Option[Long] = tp => logManager.getLog(tp).map(_.logStartOffset)
+
     topics.foreach { topic =>
       topic.partitions.asScala.foreach { partition =>
         val topicPartition = new TopicPartition(topic.name, partition.partitionIndex)
@@ -1628,22 +1641,12 @@ class ReplicaManager(val config: KafkaConfig,
         } else if (isListOffsetsTimestampUnsupported(partition.timestamp(), version)) {
           statusByPartition += topicPartition ->
             ListOffsetsPartitionStatus.builder().responseOpt(Optional.of(buildErrorResponse(Errors.UNSUPPORTED_VERSION, partition))).build()
-        } else if (maybeFetchOffsetJob.exists(_.mustHandle(topic.name()))) {
-          val migrationPending =
-            _inklessMetadataView.getClassicToDisklessStartOffset(topicPartition) == PartitionRegistration.CLASSIC_TO_DISKLESS_MIGRATION_PENDING
-
-          if (migrationPending) {
-            statusByPartition += topicPartition ->
-              classicFetchOffset(topicPartition, partition, replicaId, isolationLevel, version,
-                correlationId, clientId, buildErrorResponse)
-          } else {
-            statusByPartition += topicPartition ->
-              disklessFetchOffset(maybeFetchOffsetJob.get, topicPartition, partition)
-          }
-        } else {
+        } else if (maybeFetchOffsetJob.exists(_.mustHandle(topic.name))) {
           statusByPartition += topicPartition ->
-            classicFetchOffset(topicPartition, partition, replicaId, isolationLevel, version,
-              correlationId, clientId, buildErrorResponse)
+            disklessFetchOffsetRouter.route(maybeFetchOffsetJob.get, topicPartition, partition, replicaId, version,
+              classicLogStart, classicFetch)
+        } else {
+          statusByPartition += topicPartition -> classicFetch(topicPartition, partition, false)
         }
       }
     }
@@ -1668,23 +1671,6 @@ class ReplicaManager(val config: KafkaConfig,
     }
   }
 
-  private def disklessFetchOffset(fetchOffsetJob: FetchOffsetHandler.Job,
-                                 topicPartition: TopicPartition,
-                                 partition: ListOffsetsPartition): ListOffsetsPartitionStatus = {
-    val taskFuture = fetchOffsetJob.add(topicPartition, partition)
-    taskFuture.handle((_ignoredValue, _ignoredError) => {
-      val key = new TopicPartitionOperationKey(topicPartition.topic, topicPartition.partition)
-      delayedRemoteListOffsetsPurgatory.checkAndComplete(key)
-    })
-    val futureHolder = new AsyncOffsetReadFutureHolder[OffsetResultHolder.FileRecordsOrError](
-      fetchOffsetJob.cancelHandler(),
-      taskFuture
-    )
-    ListOffsetsPartitionStatus.builder()
-      .futureHolderOpt(Optional.of(futureHolder))
-      .build()
-  }
-
   private def classicFetchOffset(topicPartition: TopicPartition,
                                  partition: ListOffsetsPartition,
                                  replicaId: Int,
@@ -1692,10 +1678,11 @@ class ReplicaManager(val config: KafkaConfig,
                                  version: Short,
                                  correlationId: Int,
                                  clientId: String,
-                                 buildErrorResponse: (Errors, ListOffsetsPartition) => ListOffsetsPartitionResponse
+                                 buildErrorResponse: (Errors, ListOffsetsPartition) => ListOffsetsPartitionResponse,
+                                 allowFromFollower: Boolean
                                 ): ListOffsetsPartitionStatus = {
     try {
-      val fetchOnlyFromLeader = replicaId != ListOffsetsRequest.DEBUGGING_REPLICA_ID
+      val fetchOnlyFromLeader = replicaId != ListOffsetsRequest.DEBUGGING_REPLICA_ID && !allowFromFollower
       val isClientRequest = replicaId == ListOffsetsRequest.CONSUMER_REPLICA_ID
       val isolationLevelOpt = if (isClientRequest)
         Some(isolationLevel)

--- a/core/src/test/scala/unit/kafka/server/DisklessFetchOffsetRouterTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DisklessFetchOffsetRouterTest.scala
@@ -34,7 +34,7 @@ import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito._
 
 import java.util.Optional
-import java.util.concurrent.{CompletableFuture, TimeUnit}
+import java.util.concurrent.{CompletableFuture, ExecutionException, TimeUnit}
 import scala.collection.mutable
 
 class DisklessFetchOffsetRouterTest {
@@ -371,5 +371,28 @@ class DisklessFetchOffsetRouterTest {
       verify(fresh).add(eqTo(p), any())
       verify(fresh).start()
     }
+  }
+
+  @Test
+  def routesToDisklessAndForwardsControlPlaneFailureWhenMigrationPendingAndManagedReplicasDisabled(): Unit = {
+    // Migration to diskless is pending while managed replicas are disabled. Migration can only have been 
+    // initiated with managed replicas enabled, so this is a misconfiguration.
+    // The control plane is not expected to have a committed diskless start offset for the partition yet, so we
+    // simulate the realistic outcome by completing the diskless task future exceptionally and
+    // assert the router forwards that failure verbatim.
+    
+    when(inklessMetadataView.getClassicToDisklessStartOffset(tp)).thenReturn(PartitionRegistration.CLASSIC_TO_DISKLESS_MIGRATION_PENDING)
+    val controlPlaneFailure = new RuntimeException("partition not found in the diskless control plane")
+    disklessTaskFuture.completeExceptionally(controlPlaneFailure)
+
+    val status = route(newRouter(disklessManagedReplicasEnabled = false), timestamp = ListOffsetsRequest.LATEST_TIMESTAMP)
+
+    assertTrue(classicCalls.isEmpty, "classic path must not be invoked")
+    verify(job).add(eqTo(tp), any())
+    assertTrue(status.futureHolderOpt.isPresent, "must surface an async holder backed by the diskless control plane")
+    assertFalse(status.responseOpt.isPresent)
+    val ex = assertThrows(classOf[ExecutionException],
+      () => status.futureHolderOpt.get.taskFuture.get(1, TimeUnit.SECONDS))
+    assertSame(controlPlaneFailure, ex.getCause)
   }
 }

--- a/core/src/test/scala/unit/kafka/server/DisklessFetchOffsetRouterTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DisklessFetchOffsetRouterTest.scala
@@ -1,0 +1,375 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.server
+
+import io.aiven.inkless.consume.FetchOffsetHandler
+import kafka.server.metadata.InklessMetadataView
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.message.ListOffsetsRequestData.ListOffsetsPartition
+import org.apache.kafka.common.message.ListOffsetsResponseData.ListOffsetsPartitionResponse
+import org.apache.kafka.common.protocol.Errors
+import org.apache.kafka.common.record.{FileRecords, RecordBatch}
+import org.apache.kafka.common.requests.ListOffsetsRequest
+import org.apache.kafka.metadata.PartitionRegistration
+import org.apache.kafka.server.purgatory.{DelayedOperationPurgatory, DelayedRemoteListOffsets, ListOffsetsPartitionStatus}
+import org.apache.kafka.storage.internals.log.AsyncOffsetReadFutureHolder
+import org.apache.kafka.storage.internals.log.OffsetResultHolder.FileRecordsOrError
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
+import org.mockito.Mockito._
+
+import java.util.Optional
+import java.util.concurrent.{CompletableFuture, TimeUnit}
+import scala.collection.mutable
+
+class DisklessFetchOffsetRouterTest {
+
+  private val tp = new TopicPartition("diskless-topic", 0)
+  private val consumerReplicaId = ListOffsetsRequest.CONSUMER_REPLICA_ID
+  private val followerReplicaId = 1
+
+  private val inklessMetadataView: InklessMetadataView = mock(classOf[InklessMetadataView])
+  private val purgatory: DelayedOperationPurgatory[DelayedRemoteListOffsets] =
+    mock(classOf[DelayedOperationPurgatory[DelayedRemoteListOffsets]])
+
+  // Diskless task future we hand back from job.add(...). Stays incomplete by default;
+  // tests that need a result complete this future before invoking route().
+  private val disklessTaskFuture: CompletableFuture[FileRecordsOrError] = new CompletableFuture[FileRecordsOrError]()
+
+  private val job: FetchOffsetHandler.Job = {
+    val m = mock(classOf[FetchOffsetHandler.Job])
+    when(m.add(any(), any())).thenAnswer(_ => disklessTaskFuture)
+    when(m.cancelHandler()).thenReturn(new CompletableFuture[Void]())
+    m
+  }
+
+  // Records the (topicPartition, partition, allowFromFollower) tuple the router passes to the
+  // classic path on each call, so tests can assert on call count and call shape.
+  private val classicCalls = mutable.ListBuffer.empty[(TopicPartition, ListOffsetsPartition, Boolean)]
+
+  // Default classic-side answer for tests that don't care about the response shape.
+  private val defaultClassicResult: ListOffsetsPartitionStatus = resolvedStatus(makeResponse(offset = 0L, timestamp = 0L))
+  
+  private def newRouter(disklessManagedReplicasEnabled: Boolean = true): DisklessFetchOffsetRouter =
+    new DisklessFetchOffsetRouter(inklessMetadataView, disklessManagedReplicasEnabled, purgatory)
+
+  private def makePartition(timestamp: Long, partitionIndex: Int): ListOffsetsPartition =
+    new ListOffsetsPartition().setPartitionIndex(partitionIndex).setTimestamp(timestamp)
+
+  private def makeResponse(offset: Long,
+                           timestamp: Long = RecordBatch.NO_TIMESTAMP,
+                           errorCode: Short = Errors.NONE.code): ListOffsetsPartitionResponse =
+    new ListOffsetsPartitionResponse()
+      .setPartitionIndex(tp.partition)
+      .setOffset(offset)
+      .setTimestamp(timestamp)
+      .setErrorCode(errorCode)
+
+  // Status with the answer already resolved.
+  private def resolvedStatus(response: ListOffsetsPartitionResponse): ListOffsetsPartitionStatus =
+    ListOffsetsPartitionStatus.builder().responseOpt(Optional.of(response)).build()
+
+  // Invoke `route()` with the standard test wiring.
+  private def route(router: DisklessFetchOffsetRouter,
+                    timestamp: Long,
+                    topicPartition: TopicPartition = tp,
+                    replicaId: Int = consumerReplicaId,
+                    version: Short = 7,
+                    classicLogStartOffset: Option[Long] = None,
+                    classicResult: ListOffsetsPartitionStatus = defaultClassicResult,
+                    newJob: () => FetchOffsetHandler.Job = () =>
+                      throw new AssertionError("newJob() should not be called by this routing path")): ListOffsetsPartitionStatus = {
+    router.route(
+      job = job,
+      newJob = newJob,
+      topicPartition = topicPartition,
+      partition = makePartition(timestamp, topicPartition.partition),
+      replicaId = replicaId,
+      version = version,
+      classicLogStartOffsetProvider = _ => classicLogStartOffset,
+      classicFetchOffset = (tpArg, partition, allow) => {
+        classicCalls += ((tpArg, partition, allow))
+        classicResult
+      }
+    )
+  }
+
+  private def assertClassicCalledWith(allowFromFollower: Boolean): Unit = {
+    assertEquals(1, classicCalls.size, "classic path should have been invoked exactly once")
+    val (calledTp, _, allow) = classicCalls.head
+    assertEquals(tp, calledTp)
+    assertEquals(allowFromFollower, allow, "unexpected allowFromFollower")
+  }
+
+  // ---------------------------------------------------------------------------
+  // Case 1: pure diskless partition.
+  // ---------------------------------------------------------------------------
+
+  @Test
+  def routesToDisklessWhenNotMigrated(): Unit = {
+    when(inklessMetadataView.getClassicToDisklessStartOffset(tp)).thenReturn(PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET)
+
+    val status = route(newRouter(), timestamp = ListOffsetsRequest.LATEST_TIMESTAMP)
+
+    assertTrue(classicCalls.isEmpty, "classic path should not have been invoked")
+    verify(job).add(eqTo(tp), any())
+    assertTrue(status.futureHolderOpt.isPresent, "pure-diskless routing returns an async holder")
+    assertFalse(status.responseOpt.isPresent)
+  }
+
+  @Test
+  def routesToDisklessWhenManagedReplicasDisabledEvenWithCommittedBoundary(): Unit = {
+    // classicToDisklessStartOffset > 0 but managed replicas are disabled: we treat the partition
+    // as pure diskless (case 1) and never consult the classic local log.
+    when(inklessMetadataView.getClassicToDisklessStartOffset(tp)).thenReturn(100L)
+
+    val status = route(newRouter(disklessManagedReplicasEnabled = false), timestamp = 123L)
+
+    assertTrue(classicCalls.isEmpty, "classic path should not have been invoked")
+    verify(job).add(eqTo(tp), any())
+    assertTrue(status.futureHolderOpt.isPresent)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Case 3: partition is being migrated from classic to diskless.
+  // ---------------------------------------------------------------------------
+
+  @Test
+  def routesToClassicWithoutFollowerAccessWhenMigrationPending(): Unit = {
+    when(inklessMetadataView.getClassicToDisklessStartOffset(tp)).thenReturn(PartitionRegistration.CLASSIC_TO_DISKLESS_MIGRATION_PENDING)
+
+    val status = route(newRouter(), timestamp = ListOffsetsRequest.LATEST_TIMESTAMP)
+
+    assertSame(defaultClassicResult, status, "migration-pending must return the classic status as-is")
+    assertClassicCalledWith(allowFromFollower = false)
+    verify(job, never()).add(any(), any())
+  }
+
+  // ---------------------------------------------------------------------------
+  // Case 4: follower request on a migrated partition.
+  // ---------------------------------------------------------------------------
+
+  @Test
+  def routesToClassicWithFollowerAccessWhenMigratedAndFollowerRequest(): Unit = {
+    when(inklessMetadataView.getClassicToDisklessStartOffset(tp)).thenReturn(100L)
+
+    val status = route(newRouter(), timestamp = ListOffsetsRequest.LATEST_TIMESTAMP, replicaId = followerReplicaId)
+
+    assertSame(defaultClassicResult, status)
+    // followers may serve from their local log on a sealed (migrated) partition.
+    assertClassicCalledWith(allowFromFollower = true)
+    verify(job, never()).add(any(), any())
+  }
+
+  // ---------------------------------------------------------------------------
+  // Case 2: hybrid routing by timestamp.
+  // ---------------------------------------------------------------------------
+
+  @Test
+  def hybridEarliestLocalAlwaysGoesToClassic(): Unit = {
+    when(inklessMetadataView.getClassicToDisklessStartOffset(tp)).thenReturn(100L)
+
+    val status = route(newRouter(), timestamp = ListOffsetsRequest.EARLIEST_LOCAL_TIMESTAMP)
+
+    assertSame(defaultClassicResult, status)
+    assertClassicCalledWith(allowFromFollower = true)
+    verify(job, never()).add(any(), any())
+  }
+
+  @Test
+  def hybridLatestTieredAlwaysGoesToClassic(): Unit = {
+    when(inklessMetadataView.getClassicToDisklessStartOffset(tp)).thenReturn(100L)
+
+    val status = route(newRouter(), timestamp = ListOffsetsRequest.LATEST_TIERED_TIMESTAMP)
+
+    assertSame(defaultClassicResult, status)
+    assertClassicCalledWith(allowFromFollower = true)
+    verify(job, never()).add(any(), any())
+  }
+
+  @Test
+  def hybridEarliestUsesClassicWhenClassicStillHasData(): Unit = {
+    // logStartOffset (0) < classicToDisklessStartOffset (100), so classic side still owns the
+    // earliest offset.
+    when(inklessMetadataView.getClassicToDisklessStartOffset(tp)).thenReturn(100L)
+
+    val status = route(newRouter(), timestamp = ListOffsetsRequest.EARLIEST_TIMESTAMP, classicLogStartOffset = Some(0L))
+
+    assertSame(defaultClassicResult, status)
+    assertClassicCalledWith(allowFromFollower = true)
+    verify(job, never()).add(any(), any())
+  }
+
+  @Test
+  def hybridEarliestFallsThroughToDisklessWhenClassicLogIsEmpty(): Unit = {
+    // logStartOffset (100) >= classicToDisklessStartOffset (100): no classic data left to scan.
+    when(inklessMetadataView.getClassicToDisklessStartOffset(tp)).thenReturn(100L)
+
+    val status = route(newRouter(), timestamp = ListOffsetsRequest.EARLIEST_TIMESTAMP, classicLogStartOffset = Some(100L))
+
+    assertTrue(classicCalls.isEmpty, "classic path should not have been invoked")
+    verify(job).add(eqTo(tp), any())
+    assertTrue(status.futureHolderOpt.isPresent)
+  }
+
+  @Test
+  def hybridSpecificTimestampReturnsClassicResultOnSyncMatch(): Unit = {
+    when(inklessMetadataView.getClassicToDisklessStartOffset(tp)).thenReturn(100L)
+    val matched = resolvedStatus(makeResponse(offset = 42L, timestamp = 123L))
+
+    val status = route(newRouter(), timestamp = 123L, classicResult = matched)
+
+    assertSame(matched, status, "classic must be returned verbatim on a sync match")
+    assertClassicCalledWith(allowFromFollower = true)
+    verify(job, never()).add(any(), any())
+  }
+
+  @Test
+  def hybridSpecificTimestampFallsBackToDisklessOnSyncNoMatch(): Unit = {
+    when(inklessMetadataView.getClassicToDisklessStartOffset(tp)).thenReturn(100L)
+    // errorCode == NONE && offset < 0  =>  classic "no match" sentinel.
+    val noMatch = resolvedStatus(makeResponse(offset = -1L, errorCode = Errors.NONE.code))
+
+    val status = route(newRouter(), timestamp = 123L, classicResult = noMatch)
+
+    assertClassicCalledWith(allowFromFollower = true)
+    verify(job).add(eqTo(tp), any())
+    assertTrue(status.futureHolderOpt.isPresent, "fallback to diskless surfaces an async holder")
+    assertNotSame(noMatch, status)
+  }
+
+  @Test
+  def hybridLatestPrefersDisklessAndDoesNotConsultClassicWhenDisklessHits(): Unit = {
+    when(inklessMetadataView.getClassicToDisklessStartOffset(tp)).thenReturn(100L)
+    // The diskless task must already be done so withFallback's thenCompose can resolve while we
+    // assert the result.
+    val disklessHit = new FileRecordsOrError(
+      Optional.empty(),
+      Optional.of(new FileRecords.TimestampAndOffset(456L, 200L, Optional.of[Integer](1))))
+    disklessTaskFuture.complete(disklessHit)
+
+    val status = route(newRouter(), timestamp = ListOffsetsRequest.LATEST_TIMESTAMP)
+
+    assertTrue(classicCalls.isEmpty, "classic path should not have been invoked")
+    verify(job).add(eqTo(tp), any())
+    assertTrue(status.futureHolderOpt.isPresent)
+    val result = status.futureHolderOpt.get.taskFuture.get(1, TimeUnit.SECONDS)
+    assertSame(disklessHit, result)
+  }
+
+  @Test
+  def hybridLatestFallsBackToClassicWhenDisklessIsEmpty(): Unit = {
+    when(inklessMetadataView.getClassicToDisklessStartOffset(tp)).thenReturn(100L)
+    // Empty FileRecordsOrError: neither exception nor offset => withFallback should fire its
+    // fallback factory and consult the classic path.
+    disklessTaskFuture.complete(new FileRecordsOrError(Optional.empty(), Optional.empty()))
+    val classicHit = resolvedStatus(makeResponse(offset = 7L, timestamp = 999L))
+
+    val status = route(newRouter(), timestamp = ListOffsetsRequest.LATEST_TIMESTAMP, classicResult = classicHit)
+
+    verify(job).add(eqTo(tp), any())
+    assertClassicCalledWith(allowFromFollower = true)
+    assertTrue(status.futureHolderOpt.isPresent)
+    val result = status.futureHolderOpt.get.taskFuture.get(1, TimeUnit.SECONDS)
+    assertFalse(result.hasException)
+    assertTrue(result.hasTimestampAndOffset)
+    assertEquals(7L, result.timestampAndOffset.get.offset)
+    assertEquals(999L, result.timestampAndOffset.get.timestamp)
+  }
+
+  @Test
+  def batchesMultipleDisklessPartitionsIntoTheSameJob(): Unit = {
+    val tp1 = new TopicPartition("diskless-topic", 0)
+    val tp2 = new TopicPartition("diskless-topic", 1)
+    val tp3 = new TopicPartition("diskless-topic", 2)
+    Seq(tp1, tp2, tp3).foreach { p =>
+      when(inklessMetadataView.getClassicToDisklessStartOffset(p)).thenReturn(PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET)
+    }
+
+    val router = newRouter()
+    val statuses = Seq(tp1, tp2, tp3).map { p =>
+      route(router, timestamp = ListOffsetsRequest.LATEST_TIMESTAMP, topicPartition = p)
+    }
+
+    // Each routed partition must show up on the shared job exactly once, and there must be no
+    // other adds (so no stray duplicates or extra calls) and no start (the caller is responsible
+    // for invoking start()).
+    verify(job, times(3)).add(any(), any())
+    Seq(tp1, tp2, tp3).foreach { p => verify(job).add(eqTo(p), any()) }
+    verify(job, never()).start()
+
+    assertTrue(statuses.forall(_.futureHolderOpt.isPresent))
+    assertTrue(classicCalls.isEmpty, "classic path should not have been invoked")
+  }
+
+  @Test
+  def mixesBatchedAndFreshJobsInTheSameRequest(): Unit = {
+    // batchedTp: case 1 (pure diskless). fallbackTps: case 2 (t >= 0) with async-incomplete classic.
+    val batchedTp = new TopicPartition("diskless-topic", 0)
+    val fallbackTps = Seq(new TopicPartition("diskless-topic", 1), new TopicPartition("diskless-topic", 2))
+    when(inklessMetadataView.getClassicToDisklessStartOffset(batchedTp))
+      .thenReturn(PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET)
+    fallbackTps.foreach(p => when(inklessMetadataView.getClassicToDisklessStartOffset(p)).thenReturn(100L))
+
+    val emptyResult = new FileRecordsOrError(Optional.empty(), Optional.empty())
+
+    val freshJobs = mutable.ListBuffer.empty[FetchOffsetHandler.Job]
+    def newFreshJob(): FetchOffsetHandler.Job = {
+      val m = mock(classOf[FetchOffsetHandler.Job])
+      when(m.add(any(), any())).thenReturn(CompletableFuture.completedFuture(emptyResult))
+      when(m.cancelHandler()).thenReturn(new CompletableFuture[Void]())
+      freshJobs += m
+      m
+    }
+
+    // Wraps a still-pending classic future as a `futureHolderOpt`-shaped status.
+    def asyncClassicStatus(f: CompletableFuture[FileRecordsOrError]): ListOffsetsPartitionStatus =
+      ListOffsetsPartitionStatus.builder().futureHolderOpt(Optional.of(
+        new AsyncOffsetReadFutureHolder[FileRecordsOrError](new CompletableFuture[Void](), f))).build()
+
+    val router = newRouter()
+
+    // batchedTp routes through case 1 → adds directly to the batched `job`.
+    route(router, timestamp = ListOffsetsRequest.LATEST_TIMESTAMP, topicPartition = batchedTp)
+
+    // Each fallbackTp routes through case 2 (t >= 0) with an incomplete classic future, priming
+    // a fresh-job fallback factory. The fallback only fires when the classic future completes.
+    val classicFutures = fallbackTps.map(_ => new CompletableFuture[FileRecordsOrError]())
+    fallbackTps.zip(classicFutures).foreach { case (p, f) =>
+      route(router, timestamp = 123L, topicPartition = p,
+        classicResult = asyncClassicStatus(f), newJob = () => newFreshJob())
+    }
+
+    // Trigger each fallback (empty FileRecordsOrError = primary missed → run fallback).
+    classicFutures.foreach(_.complete(emptyResult))
+
+    // The batched `job` got exactly one add (for batchedTp) and was not started by the router.
+    verify(job).add(eqTo(batchedTp), any())
+    verify(job, times(1)).add(any(), any())
+    verify(job, never()).start()
+
+    // Each fallback created its own distinct fresh job, started by the router, and carrying
+    // its own partition. No spillover between fresh jobs or onto the batched `job`.
+    assertEquals(fallbackTps.size, freshJobs.size, "each async-classic fallback must create its own fresh job")
+    assertNotSame(freshJobs(0), freshJobs(1), "fallbacks must not share a fresh job")
+    fallbackTps.zip(freshJobs).foreach { case (p, fresh) =>
+      verify(fresh).add(eqTo(p), any())
+      verify(fresh).start()
+    }
+  }
+}

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -87,7 +87,7 @@ import org.apache.kafka.server.util.timer.{MockTimer, SystemTimer}
 import org.apache.kafka.server.util.{MockScheduler, MockTime, Scheduler}
 import org.apache.kafka.storage.internals.checkpoint.LazyOffsetCheckpoints
 import org.apache.kafka.storage.internals.epoch.LeaderEpochFileCache
-import org.apache.kafka.storage.internals.log.{AppendOrigin, CleanerConfig, FetchDataInfo, LocalLog, LogAppendInfo, LogConfig, LogDirFailureChannel, LogLoader, LogOffsetMetadata, LogOffsetSnapshot, LogOffsetsListener, LogReadResult, LogSegments, OffsetResultHolder, ProducerStateManager, ProducerStateManagerConfig, RemoteLogReadResult, RemoteStorageFetchInfo, UnifiedLog, VerificationGuard}
+import org.apache.kafka.storage.internals.log.{AppendOrigin, AsyncOffsetReadFutureHolder, CleanerConfig, FetchDataInfo, LocalLog, LogAppendInfo, LogConfig, LogDirFailureChannel, LogLoader, LogOffsetMetadata, LogOffsetSnapshot, LogOffsetsListener, LogReadResult, LogSegments, OffsetResultHolder, ProducerStateManager, ProducerStateManagerConfig, RemoteLogReadResult, RemoteStorageFetchInfo, UnifiedLog, VerificationGuard}
 import org.apache.kafka.storage.log.metrics.BrokerTopicStats
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{AfterAll, AfterEach, BeforeEach, Nested, Test}
@@ -7988,6 +7988,906 @@ class ReplicaManagerTest {
 
       verify(jobMock).add(ArgumentMatchers.eq(disklessTopicPartition.topicPartition()), any())
       verify(replicaManager, never()).fetchOffsetForTimestamp(any(), anyLong(), any(), any(), anyBoolean())
+    }
+
+    @Test
+    def testFetchOffsetEarliestUsesClassicPathWhenMigrationCompleteAndClassicHasData(): Unit = {
+      val jobMock = Mockito.mock(classOf[FetchOffsetHandler.Job])
+      when(jobMock.mustHandle(any())).thenReturn(true)
+      doNothing().when(jobMock).start()
+
+      val fetchOffsetHandlerCtorInit: MockedConstruction.MockInitializer[FetchOffsetHandler] = {
+        case (handlerMock, _) =>
+          when(handlerMock.createJob()).thenReturn(jobMock)
+      }
+      val fetchOffsetHandlerCtor = mockConstruction(classOf[FetchOffsetHandler], fetchOffsetHandlerCtorInit)
+
+      val replicaManager = try {
+        spy(createReplicaManager(List(disklessTopicPartition.topic()), disklessManagedReplicasEnabled = true))
+      } finally {
+        fetchOffsetHandlerCtor.close()
+      }
+
+      when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
+        .thenReturn(100L)
+
+      // Stub the local log so classicHasData is true (logStartOffset < classicToDisklessStartOffset).
+      val unifiedLogMock = mock(classOf[UnifiedLog])
+      when(unifiedLogMock.logStartOffset).thenReturn(0L)
+      val logManagerMock = mock(classOf[LogManager])
+      when(logManagerMock.getLog(ArgumentMatchers.eq(disklessTopicPartition.topicPartition()), anyBoolean()))
+        .thenReturn(Some(unifiedLogMock))
+      doReturn(logManagerMock).when(replicaManager).logManager
+
+      val resultHolder = new OffsetResultHolder(
+        Optional.of(new FileRecords.TimestampAndOffset(RecordBatch.NO_TIMESTAMP, 0L, Optional.of[Integer](0))))
+      doReturn(resultHolder).when(replicaManager).fetchOffsetForTimestamp(
+        ArgumentMatchers.eq(disklessTopicPartition.topicPartition()), anyLong(), any(), any(), anyBoolean())
+
+      val topics = Seq(new ListOffsetsTopic()
+        .setName(disklessTopicPartition.topic())
+        .setPartitions(util.List.of(new ListOffsetsPartition()
+          .setPartitionIndex(disklessTopicPartition.partition())
+          .setTimestamp(ListOffsetsRequest.EARLIEST_TIMESTAMP)
+          .setCurrentLeaderEpoch(0))))
+
+      @volatile var responseTopics: util.Collection[ListOffsetsTopicResponse] = null
+      val callback: Consumer[util.Collection[ListOffsetsTopicResponse]] = (r: util.Collection[ListOffsetsTopicResponse]) => responseTopics = r
+
+      replicaManager.fetchOffset(topics, Set.empty, IsolationLevel.READ_UNCOMMITTED,
+        ListOffsetsRequest.CONSUMER_REPLICA_ID, "client", 0, 1.toShort,
+        (e, p) => new ListOffsetsPartitionResponse().setPartitionIndex(p.partitionIndex).setErrorCode(e.code),
+        callback)
+
+      assertNotNull(responseTopics)
+      val partitionResponse = responseTopics.asScala.head.partitions().get(0)
+      assertEquals(Errors.NONE.code, partitionResponse.errorCode())
+      assertEquals(0L, partitionResponse.offset())
+
+      verify(replicaManager).fetchOffsetForTimestamp(
+        ArgumentMatchers.eq(disklessTopicPartition.topicPartition()), anyLong(), any(), any(), anyBoolean())
+      verify(jobMock, never()).add(any(), any())
+    }
+
+    @Test
+    def testFetchOffsetEarliestLocalAlwaysUsesClassicWhenMigrationComplete(): Unit = {
+      val jobMock = Mockito.mock(classOf[FetchOffsetHandler.Job])
+      when(jobMock.mustHandle(any())).thenReturn(true)
+      doNothing().when(jobMock).start()
+
+      val fetchOffsetHandlerCtorInit: MockedConstruction.MockInitializer[FetchOffsetHandler] = {
+        case (handlerMock, _) =>
+          when(handlerMock.createJob()).thenReturn(jobMock)
+      }
+      val fetchOffsetHandlerCtor = mockConstruction(classOf[FetchOffsetHandler], fetchOffsetHandlerCtorInit)
+
+      val replicaManager = try {
+        spy(createReplicaManager(List(disklessTopicPartition.topic()), disklessManagedReplicasEnabled = true))
+      } finally {
+        fetchOffsetHandlerCtor.close()
+      }
+
+      when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
+        .thenReturn(100L)
+
+      val resultHolder = new OffsetResultHolder(
+        Optional.of(new FileRecords.TimestampAndOffset(RecordBatch.NO_TIMESTAMP, 0L, Optional.of[Integer](0))))
+      doReturn(resultHolder).when(replicaManager).fetchOffsetForTimestamp(
+        ArgumentMatchers.eq(disklessTopicPartition.topicPartition()), anyLong(), any(), any(), anyBoolean())
+
+      val topics = Seq(new ListOffsetsTopic()
+        .setName(disklessTopicPartition.topic())
+        .setPartitions(util.List.of(new ListOffsetsPartition()
+          .setPartitionIndex(disklessTopicPartition.partition())
+          .setTimestamp(ListOffsetsRequest.EARLIEST_LOCAL_TIMESTAMP)
+          .setCurrentLeaderEpoch(0))))
+
+      @volatile var responseTopics: util.Collection[ListOffsetsTopicResponse] = null
+      val callback: Consumer[util.Collection[ListOffsetsTopicResponse]] = (r: util.Collection[ListOffsetsTopicResponse]) => responseTopics = r
+
+      replicaManager.fetchOffset(topics, Set.empty, IsolationLevel.READ_UNCOMMITTED,
+        ListOffsetsRequest.CONSUMER_REPLICA_ID, "client", 0, 8.toShort,
+        (e, p) => new ListOffsetsPartitionResponse().setPartitionIndex(p.partitionIndex).setErrorCode(e.code),
+        callback)
+
+      assertNotNull(responseTopics)
+      val partitionResponse = responseTopics.asScala.head.partitions().get(0)
+      assertEquals(Errors.NONE.code, partitionResponse.errorCode())
+      assertEquals(0L, partitionResponse.offset())
+
+      verify(replicaManager).fetchOffsetForTimestamp(
+        ArgumentMatchers.eq(disklessTopicPartition.topicPartition()), anyLong(), any(), any(), anyBoolean())
+      verify(jobMock, never()).add(any(), any())
+    }
+
+    @Test
+    def testFetchOffsetLatestTieredAlwaysUsesClassicWhenMigrationComplete(): Unit = {
+      val jobMock = Mockito.mock(classOf[FetchOffsetHandler.Job])
+      when(jobMock.mustHandle(any())).thenReturn(true)
+      doNothing().when(jobMock).start()
+
+      val fetchOffsetHandlerCtorInit: MockedConstruction.MockInitializer[FetchOffsetHandler] = {
+        case (handlerMock, _) =>
+          when(handlerMock.createJob()).thenReturn(jobMock)
+      }
+      val fetchOffsetHandlerCtor = mockConstruction(classOf[FetchOffsetHandler], fetchOffsetHandlerCtorInit)
+
+      val replicaManager = try {
+        spy(createReplicaManager(List(disklessTopicPartition.topic()), disklessManagedReplicasEnabled = true))
+      } finally {
+        fetchOffsetHandlerCtor.close()
+      }
+
+      when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
+        .thenReturn(100L)
+
+      val resultHolder = new OffsetResultHolder(
+        Optional.of(new FileRecords.TimestampAndOffset(RecordBatch.NO_TIMESTAMP, 0L, Optional.of[Integer](0))))
+      doReturn(resultHolder).when(replicaManager).fetchOffsetForTimestamp(
+        ArgumentMatchers.eq(disklessTopicPartition.topicPartition()), anyLong(), any(), any(), anyBoolean())
+
+      val topics = Seq(new ListOffsetsTopic()
+        .setName(disklessTopicPartition.topic())
+        .setPartitions(util.List.of(new ListOffsetsPartition()
+          .setPartitionIndex(disklessTopicPartition.partition())
+          .setTimestamp(ListOffsetsRequest.LATEST_TIERED_TIMESTAMP)
+          .setCurrentLeaderEpoch(0))))
+
+      @volatile var responseTopics: util.Collection[ListOffsetsTopicResponse] = null
+      val callback: Consumer[util.Collection[ListOffsetsTopicResponse]] = (r: util.Collection[ListOffsetsTopicResponse]) => responseTopics = r
+
+      replicaManager.fetchOffset(topics, Set.empty, IsolationLevel.READ_UNCOMMITTED,
+        ListOffsetsRequest.CONSUMER_REPLICA_ID, "client", 0, 9.toShort,
+        (e, p) => new ListOffsetsPartitionResponse().setPartitionIndex(p.partitionIndex).setErrorCode(e.code),
+        callback)
+
+      assertNotNull(responseTopics)
+      val partitionResponse = responseTopics.asScala.head.partitions().get(0)
+      assertEquals(Errors.NONE.code, partitionResponse.errorCode())
+      assertEquals(0L, partitionResponse.offset())
+
+      verify(replicaManager).fetchOffsetForTimestamp(
+        ArgumentMatchers.eq(disklessTopicPartition.topicPartition()), anyLong(), any(), any(), anyBoolean())
+      verify(jobMock, never()).add(any(), any())
+    }
+
+    @Test
+    def testFetchOffsetSpecificTimestampUsesClassicPathOnMatch(): Unit = {
+      val jobMock = Mockito.mock(classOf[FetchOffsetHandler.Job])
+      when(jobMock.mustHandle(any())).thenReturn(true)
+      doNothing().when(jobMock).start()
+
+      val fetchOffsetHandlerCtorInit: MockedConstruction.MockInitializer[FetchOffsetHandler] = {
+        case (handlerMock, _) =>
+          when(handlerMock.createJob()).thenReturn(jobMock)
+      }
+      val fetchOffsetHandlerCtor = mockConstruction(classOf[FetchOffsetHandler], fetchOffsetHandlerCtorInit)
+
+      val replicaManager = try {
+        spy(createReplicaManager(List(disklessTopicPartition.topic()), disklessManagedReplicasEnabled = true))
+      } finally {
+        fetchOffsetHandlerCtor.close()
+      }
+
+      when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
+        .thenReturn(100L)
+
+      // Classic returns a real match at offset 42 for the requested timestamp.
+      val resultHolder = new OffsetResultHolder(
+        Optional.of(new FileRecords.TimestampAndOffset(123L, 42L, Optional.of[Integer](0))))
+      doReturn(resultHolder).when(replicaManager).fetchOffsetForTimestamp(
+        ArgumentMatchers.eq(disklessTopicPartition.topicPartition()), anyLong(), any(), any(), anyBoolean())
+
+      val topics = Seq(new ListOffsetsTopic()
+        .setName(disklessTopicPartition.topic())
+        .setPartitions(util.List.of(new ListOffsetsPartition()
+          .setPartitionIndex(disklessTopicPartition.partition())
+          .setTimestamp(123L)
+          .setCurrentLeaderEpoch(0))))
+
+      @volatile var responseTopics: util.Collection[ListOffsetsTopicResponse] = null
+      val callback: Consumer[util.Collection[ListOffsetsTopicResponse]] = (r: util.Collection[ListOffsetsTopicResponse]) => responseTopics = r
+
+      replicaManager.fetchOffset(topics, Set.empty, IsolationLevel.READ_UNCOMMITTED,
+        ListOffsetsRequest.CONSUMER_REPLICA_ID, "client", 0, 1.toShort,
+        (e, p) => new ListOffsetsPartitionResponse().setPartitionIndex(p.partitionIndex).setErrorCode(e.code),
+        callback)
+
+      assertNotNull(responseTopics)
+      val partitionResponse = responseTopics.asScala.head.partitions().get(0)
+      assertEquals(Errors.NONE.code, partitionResponse.errorCode())
+      assertEquals(42L, partitionResponse.offset())
+
+      verify(replicaManager).fetchOffsetForTimestamp(
+        ArgumentMatchers.eq(disklessTopicPartition.topicPartition()), anyLong(), any(), any(), anyBoolean())
+      verify(jobMock, never()).add(any(), any())
+    }
+
+    @Test
+    def testFetchOffsetSpecificTimestampFallsBackToDisklessOnNoMatch(): Unit = {
+      val disklessSuccess = new OffsetResultHolder.FileRecordsOrError(
+        Optional.empty(),
+        Optional.of(new FileRecords.TimestampAndOffset(456L, 200L, Optional.of[Integer](1))))
+
+      val jobMock = Mockito.mock(classOf[FetchOffsetHandler.Job])
+      when(jobMock.mustHandle(any())).thenReturn(true)
+      when(jobMock.add(any(), any())).thenReturn(CompletableFuture.completedFuture(disklessSuccess))
+      when(jobMock.cancelHandler()).thenReturn(new CompletableFuture[Void]())
+      doNothing().when(jobMock).start()
+
+      val fetchOffsetHandlerCtorInit: MockedConstruction.MockInitializer[FetchOffsetHandler] = {
+        case (handlerMock, _) =>
+          when(handlerMock.createJob()).thenReturn(jobMock)
+      }
+      val fetchOffsetHandlerCtor = mockConstruction(classOf[FetchOffsetHandler], fetchOffsetHandlerCtorInit)
+
+      val replicaManager = try {
+        spy(createReplicaManager(List(disklessTopicPartition.topic()), disklessManagedReplicasEnabled = true))
+      } finally {
+        fetchOffsetHandlerCtor.close()
+      }
+
+      when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
+        .thenReturn(100L)
+
+      // Classic returns no match (empty result, no error).
+      val emptyResultHolder = new OffsetResultHolder(Optional.empty[FileRecords.TimestampAndOffset]())
+      doReturn(emptyResultHolder).when(replicaManager).fetchOffsetForTimestamp(
+        ArgumentMatchers.eq(disklessTopicPartition.topicPartition()), anyLong(), any(), any(), anyBoolean())
+
+      val topics = Seq(new ListOffsetsTopic()
+        .setName(disklessTopicPartition.topic())
+        .setPartitions(util.List.of(new ListOffsetsPartition()
+          .setPartitionIndex(disklessTopicPartition.partition())
+          .setTimestamp(123L)
+          .setCurrentLeaderEpoch(0))))
+
+      @volatile var responseTopics: util.Collection[ListOffsetsTopicResponse] = null
+      val callback: Consumer[util.Collection[ListOffsetsTopicResponse]] = (r: util.Collection[ListOffsetsTopicResponse]) => responseTopics = r
+
+      replicaManager.fetchOffset(topics, Set.empty, IsolationLevel.READ_UNCOMMITTED,
+        ListOffsetsRequest.CONSUMER_REPLICA_ID, "client", 0, 1.toShort,
+        (e, p) => new ListOffsetsPartitionResponse().setPartitionIndex(p.partitionIndex).setErrorCode(e.code),
+        callback)
+
+      assertNotNull(responseTopics)
+      val partitionResponse = responseTopics.asScala.head.partitions().get(0)
+      assertEquals(Errors.NONE.code, partitionResponse.errorCode())
+      assertEquals(200L, partitionResponse.offset())
+      assertEquals(456L, partitionResponse.timestamp())
+
+      verify(replicaManager).fetchOffsetForTimestamp(
+        ArgumentMatchers.eq(disklessTopicPartition.topicPartition()), anyLong(), any(), any(), anyBoolean())
+      verify(jobMock).add(ArgumentMatchers.eq(disklessTopicPartition.topicPartition()), any())
+    }
+
+    @Test
+    def testFetchOffsetSpecificTimestampPropagatesClassicError(): Unit = {
+      val jobMock = Mockito.mock(classOf[FetchOffsetHandler.Job])
+      when(jobMock.mustHandle(any())).thenReturn(true)
+      doNothing().when(jobMock).start()
+
+      val fetchOffsetHandlerCtorInit: MockedConstruction.MockInitializer[FetchOffsetHandler] = {
+        case (handlerMock, _) =>
+          when(handlerMock.createJob()).thenReturn(jobMock)
+      }
+      val fetchOffsetHandlerCtor = mockConstruction(classOf[FetchOffsetHandler], fetchOffsetHandlerCtorInit)
+
+      val replicaManager = try {
+        spy(createReplicaManager(List(disklessTopicPartition.topic()), disklessManagedReplicasEnabled = true))
+      } finally {
+        fetchOffsetHandlerCtor.close()
+      }
+
+      when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
+        .thenReturn(100L)
+
+      // Classic raises NotLeaderOrFollower (a real error). classicFetchOffset converts it to a
+      // response with errorCode = NOT_LEADER_OR_FOLLOWER which must be propagated to the client.
+      doThrow(new org.apache.kafka.common.errors.NotLeaderOrFollowerException("not leader"))
+        .when(replicaManager).fetchOffsetForTimestamp(
+          ArgumentMatchers.eq(disklessTopicPartition.topicPartition()), anyLong(), any(), any(), anyBoolean())
+
+      val topics = Seq(new ListOffsetsTopic()
+        .setName(disklessTopicPartition.topic())
+        .setPartitions(util.List.of(new ListOffsetsPartition()
+          .setPartitionIndex(disklessTopicPartition.partition())
+          .setTimestamp(123L)
+          .setCurrentLeaderEpoch(0))))
+
+      @volatile var responseTopics: util.Collection[ListOffsetsTopicResponse] = null
+      val callback: Consumer[util.Collection[ListOffsetsTopicResponse]] = (r: util.Collection[ListOffsetsTopicResponse]) => responseTopics = r
+
+      replicaManager.fetchOffset(topics, Set.empty, IsolationLevel.READ_UNCOMMITTED,
+        ListOffsetsRequest.CONSUMER_REPLICA_ID, "client", 0, 1.toShort,
+        (e, p) => new ListOffsetsPartitionResponse().setPartitionIndex(p.partitionIndex).setErrorCode(e.code),
+        callback)
+
+      assertNotNull(responseTopics)
+      val partitionResponse = responseTopics.asScala.head.partitions().get(0)
+      assertEquals(Errors.NOT_LEADER_OR_FOLLOWER.code, partitionResponse.errorCode())
+
+      verify(replicaManager).fetchOffsetForTimestamp(
+        ArgumentMatchers.eq(disklessTopicPartition.topicPartition()), anyLong(), any(), any(), anyBoolean())
+      verify(jobMock, never()).add(any(), any())
+    }
+
+    @Test
+    def testFetchOffsetSpecificTimestampBatchesDisklessFallbackWhenClassicRemoteSyncEmpty(): Unit = {
+      // Classic delegates to a remote/tiered lookup whose taskFuture is *already complete* by the
+      // time route() inspects it (e.g. RLM short-circuits or hits a metadata cache). withFallback's
+      // thenCompose then runs the fallback factory synchronously on the request thread, before
+      // ReplicaManager.fetchOffset has called job.start(), so the diskless fallback can be added
+      // to the existing per-request job and batched with the rest of the request — no fresh job
+      // and no extra control-plane RPC are needed.
+      val emptyClassicRemoteResult = new OffsetResultHolder.FileRecordsOrError(
+        Optional.empty(),
+        Optional.empty())
+      val classicRemoteTaskFuture =
+        CompletableFuture.completedFuture[OffsetResultHolder.FileRecordsOrError](emptyClassicRemoteResult)
+      val classicRemoteJobFuture = new CompletableFuture[Void]()
+      val classicRemoteHolder = new AsyncOffsetReadFutureHolder[OffsetResultHolder.FileRecordsOrError](
+        classicRemoteJobFuture, classicRemoteTaskFuture)
+
+      val disklessSuccess = new OffsetResultHolder.FileRecordsOrError(
+        Optional.empty(),
+        Optional.of(new FileRecords.TimestampAndOffset(456L, 200L, Optional.of[Integer](1))))
+
+      val batchJobMock = Mockito.mock(classOf[FetchOffsetHandler.Job])
+      when(batchJobMock.mustHandle(any())).thenReturn(true)
+      when(batchJobMock.add(any(), any())).thenReturn(CompletableFuture.completedFuture(disklessSuccess))
+      when(batchJobMock.cancelHandler()).thenReturn(new CompletableFuture[Void]())
+      doNothing().when(batchJobMock).start()
+
+      val fetchOffsetHandlerCtorInit: MockedConstruction.MockInitializer[FetchOffsetHandler] = {
+        case (handlerMock, _) =>
+          when(handlerMock.createJob()).thenReturn(batchJobMock)
+      }
+      val fetchOffsetHandlerCtor = mockConstruction(classOf[FetchOffsetHandler], fetchOffsetHandlerCtorInit)
+
+      val replicaManager = try {
+        spy(createReplicaManager(List(disklessTopicPartition.topic()), disklessManagedReplicasEnabled = true))
+      } finally {
+        fetchOffsetHandlerCtor.close()
+      }
+
+      when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
+        .thenReturn(100L)
+
+      // Classic returns a holder pointing at a pre-completed async remote-storage lookup.
+      val resultHolder = new OffsetResultHolder(
+        Optional.empty[FileRecords.TimestampAndOffset](),
+        Optional.of(classicRemoteHolder))
+      doReturn(resultHolder).when(replicaManager).fetchOffsetForTimestamp(
+        ArgumentMatchers.eq(disklessTopicPartition.topicPartition()), anyLong(), any(), any(), anyBoolean())
+
+      val topics = Seq(new ListOffsetsTopic()
+        .setName(disklessTopicPartition.topic())
+        .setPartitions(util.List.of(new ListOffsetsPartition()
+          .setPartitionIndex(disklessTopicPartition.partition())
+          .setTimestamp(123L)
+          .setCurrentLeaderEpoch(0))))
+
+      @volatile var responseTopics: util.Collection[ListOffsetsTopicResponse] = null
+      val callback: Consumer[util.Collection[ListOffsetsTopicResponse]] = (r: util.Collection[ListOffsetsTopicResponse]) => responseTopics = r
+
+      replicaManager.fetchOffset(topics, Set.empty, IsolationLevel.READ_UNCOMMITTED,
+        ListOffsetsRequest.CONSUMER_REPLICA_ID, "client", 0, 7.toShort,
+        (e, p) => new ListOffsetsPartitionResponse().setPartitionIndex(p.partitionIndex).setErrorCode(e.code),
+        callback)
+
+      assertNotNull(responseTopics)
+      val partitionResponse = responseTopics.asScala.head.partitions().get(0)
+      assertEquals(Errors.NONE.code, partitionResponse.errorCode())
+      assertEquals(200L, partitionResponse.offset())
+      assertEquals(456L, partitionResponse.timestamp())
+
+      verify(replicaManager).fetchOffsetForTimestamp(
+        ArgumentMatchers.eq(disklessTopicPartition.topicPartition()), anyLong(), any(), any(), anyBoolean())
+      // The diskless fallback was batched into the per-request job rather than into a fresh one;
+      // exactly one job (the outer batch) was created and started exactly once.
+      verify(batchJobMock).add(ArgumentMatchers.eq(disklessTopicPartition.topicPartition()), any())
+      verify(batchJobMock).start()
+    }
+
+    @Test
+    def testFetchOffsetSpecificTimestampFallsBackToDisklessOnNewJobWhenClassicRemoteAsync(): Unit = {
+      // Classic delegates to an async remote/tiered lookup whose taskFuture is *not yet complete*
+      // when route() inspects it. withFallback's thenCompose lambda will therefore fire later, on
+      // the thread that completes the classic future, by which point the per-request job has
+      // already been started by ReplicaManager.fetchOffset. The diskless fallback must use a
+      // fresh, independently-started job.
+      val classicRemoteTaskFuture = new CompletableFuture[OffsetResultHolder.FileRecordsOrError]()
+      val classicRemoteJobFuture = new CompletableFuture[Void]()
+      val classicRemoteHolder = new AsyncOffsetReadFutureHolder[OffsetResultHolder.FileRecordsOrError](
+        classicRemoteJobFuture, classicRemoteTaskFuture)
+
+      val disklessSuccess = new OffsetResultHolder.FileRecordsOrError(
+        Optional.empty(),
+        Optional.of(new FileRecords.TimestampAndOffset(456L, 200L, Optional.of[Integer](1))))
+
+      val batchJobMock = Mockito.mock(classOf[FetchOffsetHandler.Job])
+      when(batchJobMock.mustHandle(any())).thenReturn(true)
+      doNothing().when(batchJobMock).start()
+
+      // Fallback job created on demand once the async classic future completes empty.
+      val fallbackJobMock = Mockito.mock(classOf[FetchOffsetHandler.Job])
+      when(fallbackJobMock.add(any(), any())).thenReturn(CompletableFuture.completedFuture(disklessSuccess))
+      when(fallbackJobMock.cancelHandler()).thenReturn(new CompletableFuture[Void]())
+      doNothing().when(fallbackJobMock).start()
+
+      val fetchOffsetHandlerCtorInit: MockedConstruction.MockInitializer[FetchOffsetHandler] = {
+        case (handlerMock, _) =>
+          // First createJob() is the outer batch; second is the diskless fallback created when
+          // the async classic remote future eventually completes empty.
+          when(handlerMock.createJob()).thenReturn(batchJobMock, fallbackJobMock)
+      }
+      val fetchOffsetHandlerCtor = mockConstruction(classOf[FetchOffsetHandler], fetchOffsetHandlerCtorInit)
+
+      val replicaManager = try {
+        spy(createReplicaManager(List(disklessTopicPartition.topic()), disklessManagedReplicasEnabled = true))
+      } finally {
+        fetchOffsetHandlerCtor.close()
+      }
+
+      when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
+        .thenReturn(100L)
+
+      val resultHolder = new OffsetResultHolder(
+        Optional.empty[FileRecords.TimestampAndOffset](),
+        Optional.of(classicRemoteHolder))
+      doReturn(resultHolder).when(replicaManager).fetchOffsetForTimestamp(
+        ArgumentMatchers.eq(disklessTopicPartition.topicPartition()), anyLong(), any(), any(), anyBoolean())
+
+      val topics = Seq(new ListOffsetsTopic()
+        .setName(disklessTopicPartition.topic())
+        .setPartitions(util.List.of(new ListOffsetsPartition()
+          .setPartitionIndex(disklessTopicPartition.partition())
+          .setTimestamp(123L)
+          .setCurrentLeaderEpoch(0))))
+
+      @volatile var responseTopics: util.Collection[ListOffsetsTopicResponse] = null
+      val callback: Consumer[util.Collection[ListOffsetsTopicResponse]] = (r: util.Collection[ListOffsetsTopicResponse]) => responseTopics = r
+
+      replicaManager.fetchOffset(topics, Set.empty, IsolationLevel.READ_UNCOMMITTED,
+        ListOffsetsRequest.CONSUMER_REPLICA_ID, "client", 0, 7.toShort,
+        (e, p) => new ListOffsetsPartitionResponse().setPartitionIndex(p.partitionIndex).setErrorCode(e.code),
+        callback)
+
+      // Classic future hasn't completed yet → response is parked in the purgatory and the
+      // fallback hasn't fired. The outer batch job was started; the fallback job has not been
+      // created yet.
+      assertNull(responseTopics)
+      verify(batchJobMock, never()).add(any(), any())
+      verify(batchJobMock).start()
+      verify(fallbackJobMock, never()).add(any(), any())
+      verify(fallbackJobMock, never()).start()
+
+      // Now complete the classic remote future as empty. This drives the fallback chain
+      // synchronously on this thread, which creates and starts the fresh fallback job and
+      // ultimately fires the response callback via the purgatory's checkAndComplete hook.
+      val emptyClassicRemoteResult = new OffsetResultHolder.FileRecordsOrError(
+        Optional.empty(),
+        Optional.empty())
+      classicRemoteTaskFuture.complete(emptyClassicRemoteResult)
+
+      assertNotNull(responseTopics)
+      val partitionResponse = responseTopics.asScala.head.partitions().get(0)
+      assertEquals(Errors.NONE.code, partitionResponse.errorCode())
+      assertEquals(200L, partitionResponse.offset())
+      assertEquals(456L, partitionResponse.timestamp())
+
+      verify(replicaManager).fetchOffsetForTimestamp(
+        ArgumentMatchers.eq(disklessTopicPartition.topicPartition()), anyLong(), any(), any(), anyBoolean())
+      // The outer batch job was never used to add a partition because classic returned async.
+      verify(batchJobMock, never()).add(any(), any())
+      // The diskless fallback was issued on a fresh job created on demand.
+      verify(fallbackJobMock).add(ArgumentMatchers.eq(disklessTopicPartition.topicPartition()), any())
+      verify(fallbackJobMock).start()
+    }
+
+    @Test
+    def testFetchOffsetSpecificTimestampForwardsClassicRemoteHit(): Unit = {
+      // Classic delegates to an async (remote/tiered) lookup that resolves with a real
+      // timestamp/offset hit. The wrapper must forward it as-is and never touch diskless.
+      val classicRemoteHit = new OffsetResultHolder.FileRecordsOrError(
+        Optional.empty(),
+        Optional.of(new FileRecords.TimestampAndOffset(789L, 42L, Optional.of[Integer](3))))
+      val classicRemoteTaskFuture =
+        CompletableFuture.completedFuture[OffsetResultHolder.FileRecordsOrError](classicRemoteHit)
+      val classicRemoteJobFuture = new CompletableFuture[Void]()
+      val classicRemoteHolder = new AsyncOffsetReadFutureHolder[OffsetResultHolder.FileRecordsOrError](
+        classicRemoteJobFuture, classicRemoteTaskFuture)
+
+      val batchJobMock = Mockito.mock(classOf[FetchOffsetHandler.Job])
+      when(batchJobMock.mustHandle(any())).thenReturn(true)
+      doNothing().when(batchJobMock).start()
+
+      val fetchOffsetHandlerCtorInit: MockedConstruction.MockInitializer[FetchOffsetHandler] = {
+        case (handlerMock, _) =>
+          when(handlerMock.createJob()).thenReturn(batchJobMock)
+      }
+      val fetchOffsetHandlerCtor = mockConstruction(classOf[FetchOffsetHandler], fetchOffsetHandlerCtorInit)
+
+      val replicaManager = try {
+        spy(createReplicaManager(List(disklessTopicPartition.topic()), disklessManagedReplicasEnabled = true))
+      } finally {
+        fetchOffsetHandlerCtor.close()
+      }
+
+      when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
+        .thenReturn(100L)
+
+      val resultHolder = new OffsetResultHolder(
+        Optional.empty[FileRecords.TimestampAndOffset](),
+        Optional.of(classicRemoteHolder))
+      doReturn(resultHolder).when(replicaManager).fetchOffsetForTimestamp(
+        ArgumentMatchers.eq(disklessTopicPartition.topicPartition()), anyLong(), any(), any(), anyBoolean())
+
+      val topics = Seq(new ListOffsetsTopic()
+        .setName(disklessTopicPartition.topic())
+        .setPartitions(util.List.of(new ListOffsetsPartition()
+          .setPartitionIndex(disklessTopicPartition.partition())
+          .setTimestamp(123L)
+          .setCurrentLeaderEpoch(0))))
+
+      @volatile var responseTopics: util.Collection[ListOffsetsTopicResponse] = null
+      val callback: Consumer[util.Collection[ListOffsetsTopicResponse]] = (r: util.Collection[ListOffsetsTopicResponse]) => responseTopics = r
+
+      replicaManager.fetchOffset(topics, Set.empty, IsolationLevel.READ_UNCOMMITTED,
+        ListOffsetsRequest.CONSUMER_REPLICA_ID, "client", 0, 7.toShort,
+        (e, p) => new ListOffsetsPartitionResponse().setPartitionIndex(p.partitionIndex).setErrorCode(e.code),
+        callback)
+
+      assertNotNull(responseTopics)
+      val partitionResponse = responseTopics.asScala.head.partitions().get(0)
+      assertEquals(Errors.NONE.code, partitionResponse.errorCode())
+      assertEquals(42L, partitionResponse.offset())
+      assertEquals(789L, partitionResponse.timestamp())
+
+      verify(replicaManager).fetchOffsetForTimestamp(
+        ArgumentMatchers.eq(disklessTopicPartition.topicPartition()), anyLong(), any(), any(), anyBoolean())
+      // No diskless fallback should fire when classic remote answered authoritatively.
+      verify(batchJobMock, never()).add(any(), any())
+    }
+
+    @Test
+    def testFetchOffsetMaxTimestampFallsBackToClassicWhenDisklessEmpty(): Unit = {
+      // Diskless reports a genuine empty result (no exception, no offset) → fall back to classic.
+      val emptyDisklessResult = new OffsetResultHolder.FileRecordsOrError(
+        Optional.empty(),
+        Optional.empty())
+
+      val jobMock = Mockito.mock(classOf[FetchOffsetHandler.Job])
+      when(jobMock.mustHandle(any())).thenReturn(true)
+      when(jobMock.add(any(), any())).thenReturn(CompletableFuture.completedFuture(emptyDisklessResult))
+      when(jobMock.cancelHandler()).thenReturn(new CompletableFuture[Void]())
+      doNothing().when(jobMock).start()
+
+      val fetchOffsetHandlerCtorInit: MockedConstruction.MockInitializer[FetchOffsetHandler] = {
+        case (handlerMock, _) =>
+          when(handlerMock.createJob()).thenReturn(jobMock)
+      }
+      val fetchOffsetHandlerCtor = mockConstruction(classOf[FetchOffsetHandler], fetchOffsetHandlerCtorInit)
+
+      val replicaManager = try {
+        spy(createReplicaManager(List(disklessTopicPartition.topic()), disklessManagedReplicasEnabled = true))
+      } finally {
+        fetchOffsetHandlerCtor.close()
+      }
+
+      when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
+        .thenReturn(100L)
+
+      // Classic returns a successful timestamp/offset that the helper substitutes into the
+      // wrapped diskless future before completing the purgatory.
+      val resultHolder = new OffsetResultHolder(
+        Optional.of(new FileRecords.TimestampAndOffset(123L, 7L, Optional.of[Integer](2))))
+      doReturn(resultHolder).when(replicaManager).fetchOffsetForTimestamp(
+        ArgumentMatchers.eq(disklessTopicPartition.topicPartition()), anyLong(), any(), any(), anyBoolean())
+
+      val topics = Seq(new ListOffsetsTopic()
+        .setName(disklessTopicPartition.topic())
+        .setPartitions(util.List.of(new ListOffsetsPartition()
+          .setPartitionIndex(disklessTopicPartition.partition())
+          .setTimestamp(ListOffsetsRequest.MAX_TIMESTAMP)
+          .setCurrentLeaderEpoch(0))))
+
+      @volatile var responseTopics: util.Collection[ListOffsetsTopicResponse] = null
+      val callback: Consumer[util.Collection[ListOffsetsTopicResponse]] = (r: util.Collection[ListOffsetsTopicResponse]) => responseTopics = r
+
+      replicaManager.fetchOffset(topics, Set.empty, IsolationLevel.READ_UNCOMMITTED,
+        ListOffsetsRequest.CONSUMER_REPLICA_ID, "client", 0, 7.toShort,
+        (e, p) => new ListOffsetsPartitionResponse().setPartitionIndex(p.partitionIndex).setErrorCode(e.code),
+        callback)
+
+      assertNotNull(responseTopics)
+      val partitionResponse = responseTopics.asScala.head.partitions().get(0)
+      assertEquals(Errors.NONE.code, partitionResponse.errorCode())
+      assertEquals(7L, partitionResponse.offset())
+      assertEquals(123L, partitionResponse.timestamp())
+
+      verify(replicaManager).fetchOffsetForTimestamp(
+        ArgumentMatchers.eq(disklessTopicPartition.topicPartition()), anyLong(), any(), any(), anyBoolean())
+      verify(jobMock).add(ArgumentMatchers.eq(disklessTopicPartition.topicPartition()), any())
+    }
+
+    @Test
+    def testFetchOffsetFallsBackToClassicRemoteStorageWhenDisklessEmpty(): Unit = {
+      // Diskless reports a genuine empty result. Classic delegates to an async remote-storage lookup
+      // (e.g. the matching offset has been tiered). The wrapper must chain the remote future into
+      // the wrapped future so the offset is surfaced to the client.
+      val emptyDisklessResult = new OffsetResultHolder.FileRecordsOrError(
+        Optional.empty(),
+        Optional.empty())
+
+      val jobMock = Mockito.mock(classOf[FetchOffsetHandler.Job])
+      when(jobMock.mustHandle(any())).thenReturn(true)
+      when(jobMock.add(any(), any())).thenReturn(CompletableFuture.completedFuture(emptyDisklessResult))
+      when(jobMock.cancelHandler()).thenReturn(new CompletableFuture[Void]())
+      doNothing().when(jobMock).start()
+
+      val fetchOffsetHandlerCtorInit: MockedConstruction.MockInitializer[FetchOffsetHandler] = {
+        case (handlerMock, _) =>
+          when(handlerMock.createJob()).thenReturn(jobMock)
+      }
+      val fetchOffsetHandlerCtor = mockConstruction(classOf[FetchOffsetHandler], fetchOffsetHandlerCtorInit)
+
+      val replicaManager = try {
+        spy(createReplicaManager(List(disklessTopicPartition.topic()), disklessManagedReplicasEnabled = true))
+      } finally {
+        fetchOffsetHandlerCtor.close()
+      }
+
+      when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
+        .thenReturn(100L)
+
+      // Classic returns a holder that points at an async remote-storage task already resolved with a
+      // successful timestamp/offset; the wrapper must chain it through.
+      val remoteResult = new OffsetResultHolder.FileRecordsOrError(
+        Optional.empty(),
+        Optional.of(new FileRecords.TimestampAndOffset(789L, 42L, Optional.of[Integer](3))))
+      val remoteTaskFuture = CompletableFuture.completedFuture[OffsetResultHolder.FileRecordsOrError](remoteResult)
+      val remoteJobFuture = new CompletableFuture[Void]()
+      val remoteHolder = new AsyncOffsetReadFutureHolder[OffsetResultHolder.FileRecordsOrError](
+        remoteJobFuture, remoteTaskFuture)
+      val resultHolder = new OffsetResultHolder(
+        Optional.empty[FileRecords.TimestampAndOffset](),
+        Optional.of(remoteHolder))
+      doReturn(resultHolder).when(replicaManager).fetchOffsetForTimestamp(
+        ArgumentMatchers.eq(disklessTopicPartition.topicPartition()), anyLong(), any(), any(), anyBoolean())
+
+      val topics = Seq(new ListOffsetsTopic()
+        .setName(disklessTopicPartition.topic())
+        .setPartitions(util.List.of(new ListOffsetsPartition()
+          .setPartitionIndex(disklessTopicPartition.partition())
+          .setTimestamp(ListOffsetsRequest.MAX_TIMESTAMP)
+          .setCurrentLeaderEpoch(0))))
+
+      @volatile var responseTopics: util.Collection[ListOffsetsTopicResponse] = null
+      val callback: Consumer[util.Collection[ListOffsetsTopicResponse]] = (r: util.Collection[ListOffsetsTopicResponse]) => responseTopics = r
+
+      replicaManager.fetchOffset(topics, Set.empty, IsolationLevel.READ_UNCOMMITTED,
+        ListOffsetsRequest.CONSUMER_REPLICA_ID, "client", 0, 7.toShort,
+        (e, p) => new ListOffsetsPartitionResponse().setPartitionIndex(p.partitionIndex).setErrorCode(e.code),
+        callback)
+
+      assertNotNull(responseTopics)
+      val partitionResponse = responseTopics.asScala.head.partitions().get(0)
+      assertEquals(Errors.NONE.code, partitionResponse.errorCode())
+      assertEquals(42L, partitionResponse.offset())
+      assertEquals(789L, partitionResponse.timestamp())
+
+      verify(replicaManager).fetchOffsetForTimestamp(
+        ArgumentMatchers.eq(disklessTopicPartition.topicPartition()), anyLong(), any(), any(), anyBoolean())
+      verify(jobMock).add(ArgumentMatchers.eq(disklessTopicPartition.topicPartition()), any())
+    }
+
+    @Test
+    def testFetchOffsetMaxTimestampClassicRemoteEmptyWithMaybeOffsetsErrorSurfacesError(): Unit = {
+      // Diskless empty → fall back to classic. Classic delegates to an async remote-storage lookup
+      // that completes empty AND carries a pending maybeOffsetsError. The wrapper must apply the
+      // same semantics as DelayedRemoteListOffsets and surface the version-mapped error in the
+      // response, even though the classic metadata is no longer attached to the wrapped status.
+      val emptyDisklessResult = new OffsetResultHolder.FileRecordsOrError(
+        Optional.empty(), Optional.empty())
+      val emptyClassicRemoteResult = new OffsetResultHolder.FileRecordsOrError(
+        Optional.empty(), Optional.empty())
+
+      val jobMock = Mockito.mock(classOf[FetchOffsetHandler.Job])
+      when(jobMock.mustHandle(any())).thenReturn(true)
+      when(jobMock.add(any(), any())).thenReturn(CompletableFuture.completedFuture(emptyDisklessResult))
+      when(jobMock.cancelHandler()).thenReturn(new CompletableFuture[Void]())
+      doNothing().when(jobMock).start()
+
+      val fetchOffsetHandlerCtorInit: MockedConstruction.MockInitializer[FetchOffsetHandler] = {
+        case (handlerMock, _) =>
+          when(handlerMock.createJob()).thenReturn(jobMock)
+      }
+      val fetchOffsetHandlerCtor = mockConstruction(classOf[FetchOffsetHandler], fetchOffsetHandlerCtorInit)
+
+      val replicaManager = try {
+        spy(createReplicaManager(List(disklessTopicPartition.topic()), disklessManagedReplicasEnabled = true))
+      } finally {
+        fetchOffsetHandlerCtor.close()
+      }
+
+      when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
+        .thenReturn(100L)
+
+      val classicRemoteTaskFuture =
+        CompletableFuture.completedFuture[OffsetResultHolder.FileRecordsOrError](emptyClassicRemoteResult)
+      val classicRemoteHolder = new AsyncOffsetReadFutureHolder[OffsetResultHolder.FileRecordsOrError](
+        new CompletableFuture[Void](), classicRemoteTaskFuture)
+
+      val pendingError = new org.apache.kafka.common.errors.OffsetNotAvailableException("retry later")
+      val resultHolder = new OffsetResultHolder(
+        Optional.empty[FileRecords.TimestampAndOffset](),
+        Optional.of(classicRemoteHolder))
+      resultHolder.maybeOffsetsError(Optional.of(pendingError))
+      doReturn(resultHolder).when(replicaManager).fetchOffsetForTimestamp(
+        ArgumentMatchers.eq(disklessTopicPartition.topicPartition()), anyLong(), any(), any(), anyBoolean())
+
+      val topics = Seq(new ListOffsetsTopic()
+        .setName(disklessTopicPartition.topic())
+        .setPartitions(util.List.of(new ListOffsetsPartition()
+          .setPartitionIndex(disklessTopicPartition.partition())
+          .setTimestamp(ListOffsetsRequest.MAX_TIMESTAMP)
+          .setCurrentLeaderEpoch(0))))
+
+      @volatile var responseTopics: util.Collection[ListOffsetsTopicResponse] = null
+      val callback: Consumer[util.Collection[ListOffsetsTopicResponse]] = (r: util.Collection[ListOffsetsTopicResponse]) => responseTopics = r
+
+      replicaManager.fetchOffset(topics, Set.empty, IsolationLevel.READ_UNCOMMITTED,
+        ListOffsetsRequest.CONSUMER_REPLICA_ID, "client", 0, 7.toShort,
+        (e, p) => new ListOffsetsPartitionResponse().setPartitionIndex(p.partitionIndex).setErrorCode(e.code),
+        callback)
+
+      assertNotNull(responseTopics)
+      val partitionResponse = responseTopics.asScala.head.partitions().get(0)
+      assertEquals(Errors.OFFSET_NOT_AVAILABLE.code, partitionResponse.errorCode())
+    }
+
+    @Test
+    def testFetchOffsetMaxTimestampClassicRemoteHitBeyondLastFetchableOffsetSurfacesError(): Unit = {
+      // Diskless empty → fall back to classic. Classic returns a remote async lookup with a
+      // lastFetchableOffset clamp AND a pending maybeOffsetsError. The remote completes with a hit
+      // beyond the clamp, which must be surfaced as the pending error rather than as the offset.
+      val emptyDisklessResult = new OffsetResultHolder.FileRecordsOrError(
+        Optional.empty(), Optional.empty())
+      // Classic remote returns a hit at offset 100, but lastFetchableOffset is 50 → clamped.
+      val classicRemoteHit = new OffsetResultHolder.FileRecordsOrError(
+        Optional.empty(),
+        Optional.of(new FileRecords.TimestampAndOffset(123L, 100L, Optional.of[Integer](2))))
+
+      val jobMock = Mockito.mock(classOf[FetchOffsetHandler.Job])
+      when(jobMock.mustHandle(any())).thenReturn(true)
+      when(jobMock.add(any(), any())).thenReturn(CompletableFuture.completedFuture(emptyDisklessResult))
+      when(jobMock.cancelHandler()).thenReturn(new CompletableFuture[Void]())
+      doNothing().when(jobMock).start()
+
+      val fetchOffsetHandlerCtorInit: MockedConstruction.MockInitializer[FetchOffsetHandler] = {
+        case (handlerMock, _) =>
+          when(handlerMock.createJob()).thenReturn(jobMock)
+      }
+      val fetchOffsetHandlerCtor = mockConstruction(classOf[FetchOffsetHandler], fetchOffsetHandlerCtorInit)
+
+      val replicaManager = try {
+        spy(createReplicaManager(List(disklessTopicPartition.topic()), disklessManagedReplicasEnabled = true))
+      } finally {
+        fetchOffsetHandlerCtor.close()
+      }
+
+      when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
+        .thenReturn(100L)
+
+      val classicRemoteTaskFuture =
+        CompletableFuture.completedFuture[OffsetResultHolder.FileRecordsOrError](classicRemoteHit)
+      val classicRemoteHolder = new AsyncOffsetReadFutureHolder[OffsetResultHolder.FileRecordsOrError](
+        new CompletableFuture[Void](), classicRemoteTaskFuture)
+
+      val pendingError = new org.apache.kafka.common.errors.OffsetNotAvailableException("not yet")
+      val resultHolder = new OffsetResultHolder(
+        Optional.empty[FileRecords.TimestampAndOffset](),
+        Optional.of(classicRemoteHolder))
+      resultHolder.lastFetchableOffset(Optional.of(50L))
+      resultHolder.maybeOffsetsError(Optional.of(pendingError))
+      doReturn(resultHolder).when(replicaManager).fetchOffsetForTimestamp(
+        ArgumentMatchers.eq(disklessTopicPartition.topicPartition()), anyLong(), any(), any(), anyBoolean())
+
+      val topics = Seq(new ListOffsetsTopic()
+        .setName(disklessTopicPartition.topic())
+        .setPartitions(util.List.of(new ListOffsetsPartition()
+          .setPartitionIndex(disklessTopicPartition.partition())
+          .setTimestamp(ListOffsetsRequest.MAX_TIMESTAMP)
+          .setCurrentLeaderEpoch(0))))
+
+      @volatile var responseTopics: util.Collection[ListOffsetsTopicResponse] = null
+      val callback: Consumer[util.Collection[ListOffsetsTopicResponse]] = (r: util.Collection[ListOffsetsTopicResponse]) => responseTopics = r
+
+      replicaManager.fetchOffset(topics, Set.empty, IsolationLevel.READ_UNCOMMITTED,
+        ListOffsetsRequest.CONSUMER_REPLICA_ID, "client", 0, 7.toShort,
+        (e, p) => new ListOffsetsPartitionResponse().setPartitionIndex(p.partitionIndex).setErrorCode(e.code),
+        callback)
+
+      assertNotNull(responseTopics)
+      val partitionResponse = responseTopics.asScala.head.partitions().get(0)
+      assertEquals(Errors.OFFSET_NOT_AVAILABLE.code, partitionResponse.errorCode())
+    }
+
+    @Test
+    def testFetchOffsetSpecificTimestampClassicRemoteHitBeyondLastFetchableOffsetFallsBackToDiskless(): Unit = {
+      // Specific timestamp: classic delegates to an async remote-storage lookup with a
+      // lastFetchableOffset clamp but no pending maybeOffsetsError. The remote returns a hit
+      // beyond the clamp, which translates to "no match" — and the wrapper must then fall back to
+      // diskless instead of returning the clamped offset. The classic remote future is already
+      // complete at routing time, so the diskless fallback batches into the per-request job
+      // rather than creating a fresh one.
+      val disklessSuccess = new OffsetResultHolder.FileRecordsOrError(
+        Optional.empty(),
+        Optional.of(new FileRecords.TimestampAndOffset(456L, 200L, Optional.of[Integer](1))))
+      // Classic remote returns a hit at offset 100, but lastFetchableOffset is 50 → clamped.
+      val classicRemoteHit = new OffsetResultHolder.FileRecordsOrError(
+        Optional.empty(),
+        Optional.of(new FileRecords.TimestampAndOffset(123L, 100L, Optional.of[Integer](2))))
+
+      val batchJobMock = Mockito.mock(classOf[FetchOffsetHandler.Job])
+      when(batchJobMock.mustHandle(any())).thenReturn(true)
+      when(batchJobMock.add(any(), any())).thenReturn(CompletableFuture.completedFuture(disklessSuccess))
+      when(batchJobMock.cancelHandler()).thenReturn(new CompletableFuture[Void]())
+      doNothing().when(batchJobMock).start()
+
+      val fetchOffsetHandlerCtorInit: MockedConstruction.MockInitializer[FetchOffsetHandler] = {
+        case (handlerMock, _) =>
+          when(handlerMock.createJob()).thenReturn(batchJobMock)
+      }
+      val fetchOffsetHandlerCtor = mockConstruction(classOf[FetchOffsetHandler], fetchOffsetHandlerCtorInit)
+
+      val replicaManager = try {
+        spy(createReplicaManager(List(disklessTopicPartition.topic()), disklessManagedReplicasEnabled = true))
+      } finally {
+        fetchOffsetHandlerCtor.close()
+      }
+
+      when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
+        .thenReturn(100L)
+
+      val classicRemoteTaskFuture =
+        CompletableFuture.completedFuture[OffsetResultHolder.FileRecordsOrError](classicRemoteHit)
+      val classicRemoteHolder = new AsyncOffsetReadFutureHolder[OffsetResultHolder.FileRecordsOrError](
+        new CompletableFuture[Void](), classicRemoteTaskFuture)
+
+      val resultHolder = new OffsetResultHolder(
+        Optional.empty[FileRecords.TimestampAndOffset](),
+        Optional.of(classicRemoteHolder))
+      resultHolder.lastFetchableOffset(Optional.of(50L))
+      doReturn(resultHolder).when(replicaManager).fetchOffsetForTimestamp(
+        ArgumentMatchers.eq(disklessTopicPartition.topicPartition()), anyLong(), any(), any(), anyBoolean())
+
+      val topics = Seq(new ListOffsetsTopic()
+        .setName(disklessTopicPartition.topic())
+        .setPartitions(util.List.of(new ListOffsetsPartition()
+          .setPartitionIndex(disklessTopicPartition.partition())
+          .setTimestamp(123L)
+          .setCurrentLeaderEpoch(0))))
+
+      @volatile var responseTopics: util.Collection[ListOffsetsTopicResponse] = null
+      val callback: Consumer[util.Collection[ListOffsetsTopicResponse]] = (r: util.Collection[ListOffsetsTopicResponse]) => responseTopics = r
+
+      replicaManager.fetchOffset(topics, Set.empty, IsolationLevel.READ_UNCOMMITTED,
+        ListOffsetsRequest.CONSUMER_REPLICA_ID, "client", 0, 7.toShort,
+        (e, p) => new ListOffsetsPartitionResponse().setPartitionIndex(p.partitionIndex).setErrorCode(e.code),
+        callback)
+
+      assertNotNull(responseTopics)
+      val partitionResponse = responseTopics.asScala.head.partitions().get(0)
+      assertEquals(Errors.NONE.code, partitionResponse.errorCode())
+      // The diskless fallback's hit must be surfaced (offset 200 / timestamp 456), not the
+      // clamped classic remote hit (offset 100 / timestamp 123).
+      assertEquals(200L, partitionResponse.offset())
+      assertEquals(456L, partitionResponse.timestamp())
+      verify(batchJobMock).add(ArgumentMatchers.eq(disklessTopicPartition.topicPartition()), any())
+      verify(batchJobMock).start()
     }
 
     @Test

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -7688,8 +7688,6 @@ class ReplicaManagerTest {
       assertEquals(RECORDS, classicPartitionResponse.records)
     }
 
-    // TODO: Add more fetch tests combinations, edge cases ara not covered yet.
-
     @Test
     def testLastOffsetForLeaderEpochDisklessWithControlPlaneError(): Unit = {
       val errorResult = new OffsetResultHolder.FileRecordsOrError(
@@ -7733,6 +7731,64 @@ class ReplicaManagerTest {
       val partitionResult = topicResult.partitions().get(0)
       assertEquals(Errors.UNKNOWN_TOPIC_OR_PARTITION.code, partitionResult.errorCode())
       assertEquals(OffsetsForLeaderEpochResponse.UNDEFINED_EPOCH_OFFSET, partitionResult.endOffset())
+    }
+
+    @Test
+    def testFetchOffsetPureDisklessRoutesToDisklessPathWhenNoMigration(): Unit = {
+      val jobMock = Mockito.mock(classOf[FetchOffsetHandler.Job])
+      when(jobMock.mustHandle(any())).thenReturn(true)
+      doNothing().when(jobMock).start()
+
+      val taskFuture = new CompletableFuture[OffsetResultHolder.FileRecordsOrError]()
+      when(jobMock.add(any[TopicPartition], any[ListOffsetsPartition])).thenReturn(taskFuture)
+      when(jobMock.cancelHandler()).thenReturn(CompletableFuture.completedFuture(null))
+
+      val fetchOffsetHandlerCtorInit: MockedConstruction.MockInitializer[FetchOffsetHandler] = {
+        case (handlerMock, _) =>
+          when(handlerMock.createJob()).thenReturn(jobMock)
+      }
+      val fetchOffsetHandlerCtor = mockConstruction(classOf[FetchOffsetHandler], fetchOffsetHandlerCtorInit)
+
+      val replicaManager = try {
+        spy(createReplicaManager(List(disklessTopicPartition.topic()), disklessManagedReplicasEnabled = false))
+      } finally {
+        fetchOffsetHandlerCtor.close()
+      }
+
+      // No migration — pure diskless: classicToDisklessStartOffset == -1. Combined with managed
+      // replicas disabled, the router falls into case 1 and routes the lookup to the diskless
+      // control plane.
+      when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
+        .thenReturn(PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET)
+
+      // Complete the diskless task with a successful offset before invoking fetchOffset so the
+      // callback can resolve synchronously.
+      taskFuture.complete(new OffsetResultHolder.FileRecordsOrError(
+        Optional.empty(),
+        Optional.of(new FileRecords.TimestampAndOffset(RecordBatch.NO_TIMESTAMP, 200L, Optional.of[Integer](0)))))
+
+      val topics = Seq(new ListOffsetsTopic()
+        .setName(disklessTopicPartition.topic())
+        .setPartitions(util.List.of(new ListOffsetsPartition()
+          .setPartitionIndex(disklessTopicPartition.partition())
+          .setTimestamp(ListOffsetsRequest.LATEST_TIMESTAMP)
+          .setCurrentLeaderEpoch(0))))
+
+      @volatile var responseTopics: util.Collection[ListOffsetsTopicResponse] = null
+      val callback: Consumer[util.Collection[ListOffsetsTopicResponse]] = (r: util.Collection[ListOffsetsTopicResponse]) => responseTopics = r
+
+      replicaManager.fetchOffset(topics, Set.empty, IsolationLevel.READ_UNCOMMITTED,
+        ListOffsetsRequest.CONSUMER_REPLICA_ID, "client", 0, 1.toShort,
+        (e, p) => new ListOffsetsPartitionResponse().setPartitionIndex(p.partitionIndex).setErrorCode(e.code),
+        callback)
+
+      assertNotNull(responseTopics)
+      val partitionResponse = responseTopics.asScala.head.partitions().get(0)
+      assertEquals(Errors.NONE.code, partitionResponse.errorCode())
+      assertEquals(200L, partitionResponse.offset())
+
+      verify(jobMock).add(ArgumentMatchers.eq(disklessTopicPartition.topicPartition()), any())
+      verify(replicaManager, never()).fetchOffsetForTimestamp(any(), anyLong(), any(), any(), anyBoolean())
     }
 
     @Test


### PR DESCRIPTION
Introduce DisklessFetchOffsetRouter to dispatch ListOffsets queries between the classic UnifiedLog path and the diskless control plane, covering all four diskless-managed partition states:
  1. Pure diskless: answer from the diskless control plane.
  2. Hybrid (classic data still present alongside diskless): route by requested timestamp, with classic↔diskless fallback on no-match or empty results.
  3. Migration pending: classic path only.
  4. Follower ListOffsets on a migrated partition: classic path only.