### PR TITLE
fix(inkless): Stop replicating after migration to diskless is completed

### DIFF
--- a/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
@@ -47,6 +47,10 @@ class ReplicaFetcherThread(name: String,
   // Visible for testing
   private[server] val partitionsWithNewHighWatermark = mutable.Buffer[TopicPartition]()
 
+  // Partitions that have caught up to a fully-migrated diskless topic's classicToDisklessStartOffset
+  // and should be evicted from this fetcher.
+  private[server] val partitionsToEvictAfterDisklessMigration = mutable.Buffer[TopicPartition]()
+
   override protected def latestEpoch(topicPartition: TopicPartition): Optional[Integer] = {
     replicaMgr.localLogOrException(topicPartition).latestEpoch
   }
@@ -95,6 +99,7 @@ class ReplicaFetcherThread(name: String,
   override def doWork(): Unit = {
     super.doWork()
     completeDelayedFetchRequests()
+    evictFullyMigratedDisklessPartitions()
   }
 
   // process fetched data
@@ -148,6 +153,14 @@ class ReplicaFetcherThread(name: String,
 
     brokerTopicStats.updateReplicationBytesIn(records.sizeInBytes)
 
+    // Stop fetching after the migration from classic to diskless is completed: once the controller
+    // has committed a classicToDisklessStartOffset for this partition AND our local LEO has reached it,
+    // the follower is fully caught up to the leader's frozen classic log and must not keep fetching.
+    val classicToDisklessStartOffset = replicaMgr.inklessMetadataView().getClassicToDisklessStartOffset(topicPartition)
+    if (classicToDisklessStartOffset >= 0 && log.logEndOffset >= classicToDisklessStartOffset) {
+      partitionsToEvictAfterDisklessMigration += topicPartition
+    }
+
     logAppendInfo
   }
 
@@ -155,6 +168,16 @@ class ReplicaFetcherThread(name: String,
     if (partitionsWithNewHighWatermark.nonEmpty) {
       replicaMgr.completeDelayedFetchRequests(partitionsWithNewHighWatermark.toSeq)
       partitionsWithNewHighWatermark.clear()
+    }
+  }
+
+  private def evictFullyMigratedDisklessPartitions(): Unit = {
+    if (partitionsToEvictAfterDisklessMigration.nonEmpty) {
+      val toEvict = partitionsToEvictAfterDisklessMigration.toSet
+      partitionsToEvictAfterDisklessMigration.clear()
+      info(s"Evicting partitions from this replica fetcher because they have completed the " +
+        s"classic-to-diskless migration and the local log has caught up to the seal offset: $toEvict")
+      replicaMgr.replicaFetcherManager.removeFetcherForPartitions(toEvict)
     }
   }
 

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1908,7 +1908,7 @@ class ReplicaManager(val config: KafkaConfig,
 
     val disklessFetchInfosWithoutTopicId = new mutable.ArrayBuffer[(TopicIdPartition, PartitionData)]()
     val classicFetchInfos = new mutable.ArrayBuffer[(TopicIdPartition, PartitionData)]()
-    val invalidDisklessFetchResponses = new mutable.ArrayBuffer[(TopicIdPartition, FetchPartitionData)]()
+    val immediateFetchResponses = new mutable.ArrayBuffer[(TopicIdPartition, FetchPartitionData)]()
 
     fetchInfos.foreach { case (tp, partitionData) =>
       val fetchInfo = tp -> partitionData
@@ -1921,32 +1921,53 @@ class ReplicaManager(val config: KafkaConfig,
         val shouldReadFromUnifiedLog = migrationPending || (
           classicToDisklessStartOffset >= 0 && partitionData.fetchOffset < classicToDisklessStartOffset)
 
-        (shouldReadFromUnifiedLog, config.disklessManagedReplicasEnabled) match {
-          case (false, _) =>
-            disklessFetchInfosWithoutTopicId += fetchInfo
-          // Cannot read from UnifiedLog on a diskless topic if diskless managed replicas are not enabled.
-          case (true, false) =>
-            invalidDisklessFetchResponses += tp -> new FetchPartitionData(
-              Errors.INVALID_REQUEST,
-              UnifiedLog.UNKNOWN_OFFSET,
-              UnifiedLog.UNKNOWN_OFFSET,
-              MemoryRecords.EMPTY,
-              Optional.empty(),
-              OptionalLong.empty(),
-              Optional.empty(),
-              OptionalInt.empty(),
-              false
-            )
-          case (true, true) =>
-            classicFetchInfos += fetchInfo
+        if (params.isFromFollower && !shouldReadFromUnifiedLog && classicToDisklessStartOffset >= 0) {
+          // The partition has fully migrated to diskless and the follower is asking for an offset at or beyond it.
+          // Followers must never replicate diskless records into their local log. Return
+          // an empty response with HW clamped to the seal offset so the fetcher loop sees the
+          // partition as caught up and goes idle, rather than treating it as out of range.
+          // Deliberately pass logStartOffset=0 (a no-op for the follower since
+          // maybeIncrementLogStartOffset only ever advances) so the follower keeps its classic
+          // local data intact and remains able to serve consumer reads from the local log.
+          immediateFetchResponses += tp -> new FetchPartitionData(
+            Errors.NONE,
+            classicToDisklessStartOffset,
+            0L,
+            MemoryRecords.EMPTY,
+            Optional.empty(),
+            OptionalLong.empty(),
+            Optional.empty(),
+            OptionalInt.empty(),
+            false
+          )
+        } else {
+          (shouldReadFromUnifiedLog, config.disklessManagedReplicasEnabled) match {
+            case (false, _) =>
+              disklessFetchInfosWithoutTopicId += fetchInfo
+            // Cannot read from UnifiedLog on a diskless topic if diskless managed replicas are not enabled.
+            case (true, false) =>
+              immediateFetchResponses += tp -> new FetchPartitionData(
+                Errors.INVALID_REQUEST,
+                UnifiedLog.UNKNOWN_OFFSET,
+                UnifiedLog.UNKNOWN_OFFSET,
+                MemoryRecords.EMPTY,
+                Optional.empty(),
+                OptionalLong.empty(),
+                Optional.empty(),
+                OptionalInt.empty(),
+                false
+              )
+            case (true, true) =>
+              classicFetchInfos += fetchInfo
+          }
         }
       }
     }
 
     def respond(response: Seq[(TopicIdPartition, FetchPartitionData)]): Unit =
-      responseCallback(response ++ invalidDisklessFetchResponses)
+      responseCallback(response ++ immediateFetchResponses)
 
-    if (classicFetchInfos.isEmpty && disklessFetchInfosWithoutTopicId.isEmpty && invalidDisklessFetchResponses.nonEmpty) {
+    if (classicFetchInfos.isEmpty && disklessFetchInfosWithoutTopicId.isEmpty && immediateFetchResponses.nonEmpty) {
       respond(Seq.empty)
       return
     }

--- a/core/src/test/scala/unit/kafka/server/ReplicaFetcherThreadTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaFetcherThreadTest.scala
@@ -21,7 +21,7 @@ import kafka.log.LogManager
 
 import kafka.server.QuotaFactory.UNBOUNDED_QUOTA
 import kafka.server.epoch.util.MockBlockingSender
-import kafka.server.metadata.KRaftMetadataCache
+import kafka.server.metadata.{InklessMetadataView, KRaftMetadataCache}
 import kafka.utils.TestUtils
 import org.apache.kafka.clients.FetchSessionHandler
 import org.apache.kafka.common.compress.Compression
@@ -34,6 +34,7 @@ import org.apache.kafka.common.record.{CompressionType, MemoryRecords, RecordBat
 import org.apache.kafka.common.requests.OffsetsForLeaderEpochResponse.{UNDEFINED_EPOCH, UNDEFINED_EPOCH_OFFSET}
 import org.apache.kafka.common.requests.{FetchRequest, FetchResponse}
 import org.apache.kafka.common.utils.{LogContext, Time}
+import org.apache.kafka.metadata.PartitionRegistration
 import org.apache.kafka.server.common.{KRaftVersion, MetadataVersion, OffsetAndEpoch}
 import org.apache.kafka.server.network.BrokerEndPoint
 import org.apache.kafka.server.ReplicaState
@@ -393,6 +394,7 @@ class ReplicaFetcherThreadTest {
 
     when(replicaManager.localLogOrException(t1p0)).thenReturn(log)
     when(replicaManager.getPartitionOrException(t1p0)).thenReturn(partition)
+    stubInklessMetadataView(replicaManager)
 
     when(partition.localLogOrException).thenReturn(log)
     when(partition.appendRecordsToFollowerOrFutureReplica(any(), any(), any())).thenReturn(None)
@@ -473,6 +475,7 @@ class ReplicaFetcherThreadTest {
     when(replicaManager.localLogOrException(t1p0)).thenReturn(log)
     when(replicaManager.getPartitionOrException(t1p0)).thenReturn(partition)
     when(replicaManager.brokerTopicStats).thenReturn(mock(classOf[BrokerTopicStats]))
+    stubInklessMetadataView(replicaManager)
 
     when(partition.localLogOrException).thenReturn(log)
     when(partition.appendRecordsToFollowerOrFutureReplica(any(), any(), any())).thenReturn(Some(new LogAppendInfo(
@@ -705,6 +708,7 @@ class ReplicaFetcherThreadTest {
     )
     val brokerTopicStats = new BrokerTopicStats
     when(replicaManager.brokerTopicStats).thenReturn(brokerTopicStats)
+    stubInklessMetadataView(replicaManager)
 
     val replicaQuota: ReplicaQuota = mock(classOf[ReplicaQuota])
 
@@ -737,6 +741,112 @@ class ReplicaFetcherThreadTest {
       verify(replicaManager, times(0)).completeDelayedFetchRequests(any[Seq[TopicPartition]])
     }
     assertEquals(mutable.Buffer.empty, thread.partitionsWithNewHighWatermark)
+  }
+
+  @Test
+  def shouldEvictPartitionWhenLogEndOffsetReachesClassicToDisklessSealOffset(): Unit = {
+    verifyDisklessMigrationEviction(
+      classicToDisklessStartOffset = 100L,
+      logEndOffsetAfterAppend = 100L,
+      expectEviction = true)
+  }
+
+  @Test
+  def shouldEvictPartitionWhenLogEndOffsetExceedsClassicToDisklessSealOffset(): Unit = {
+    verifyDisklessMigrationEviction(
+      classicToDisklessStartOffset = 100L,
+      logEndOffsetAfterAppend = 150L,
+      expectEviction = true)
+  }
+
+  @Test
+  def shouldNotEvictPartitionWhenLogEndOffsetBelowClassicToDisklessSealOffset(): Unit = {
+    verifyDisklessMigrationEviction(
+      classicToDisklessStartOffset = 100L,
+      logEndOffsetAfterAppend = 50L,
+      expectEviction = false)
+  }
+
+  @Test
+  def shouldNotEvictPartitionWhenNoClassicToDisklessMigration(): Unit = {
+    verifyDisklessMigrationEviction(
+      classicToDisklessStartOffset = PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET,
+      logEndOffsetAfterAppend = 100L,
+      expectEviction = false)
+  }
+
+  @Test
+  def shouldNotEvictPartitionWhenClassicToDisklessMigrationPending(): Unit = {
+    verifyDisklessMigrationEviction(
+      classicToDisklessStartOffset = PartitionRegistration.CLASSIC_TO_DISKLESS_MIGRATION_PENDING,
+      logEndOffsetAfterAppend = 100L,
+      expectEviction = false)
+  }
+
+  private def verifyDisklessMigrationEviction(
+    classicToDisklessStartOffset: Long,
+    logEndOffsetAfterAppend: Long,
+    expectEviction: Boolean
+  ): Unit = {
+    val props = TestUtils.createBrokerConfig(1)
+    val config = KafkaConfig.fromProps(props)
+
+    val mockBlockingSend: BlockingSend = mock(classOf[BlockingSend])
+    when(mockBlockingSend.brokerEndPoint()).thenReturn(brokerEndPoint)
+
+    // Pin LEO to the post-append value so it satisfies both the offset-mismatch check at the
+    // top of processPartitionData and the seal-offset comparison at the bottom.
+    val log: UnifiedLog = mock(classOf[UnifiedLog])
+    when(log.logEndOffset).thenReturn(logEndOffsetAfterAppend)
+    when(log.maybeUpdateHighWatermark(anyLong())).thenReturn(Optional.empty)
+
+    val partition: Partition = mock(classOf[Partition])
+    when(partition.localLogOrException).thenReturn(log)
+    when(partition.appendRecordsToFollowerOrFutureReplica(any[MemoryRecords], any[Boolean], any[Int]))
+      .thenReturn(Some(mock(classOf[LogAppendInfo])))
+
+    val inklessMetadataView: InklessMetadataView = mock(classOf[InklessMetadataView])
+    when(inklessMetadataView.getClassicToDisklessStartOffset(t1p0)).thenReturn(classicToDisklessStartOffset)
+
+    val replicaFetcherManager: ReplicaFetcherManager = mock(classOf[ReplicaFetcherManager])
+
+    val replicaManager: ReplicaManager = mock(classOf[ReplicaManager])
+    when(replicaManager.getPartitionOrException(any[TopicPartition])).thenReturn(partition)
+    when(replicaManager.brokerTopicStats).thenReturn(new BrokerTopicStats)
+    when(replicaManager.inklessMetadataView()).thenReturn(inklessMetadataView)
+    when(replicaManager.replicaFetcherManager).thenReturn(replicaFetcherManager)
+
+    val replicaQuota: ReplicaQuota = mock(classOf[ReplicaQuota])
+
+    val thread = createReplicaFetcherThread(
+      name = "replica-fetcher",
+      fetcherId = 0,
+      brokerConfig = config,
+      failedPartitions = failedPartitions,
+      replicaMgr = replicaManager,
+      quota = replicaQuota,
+      leaderEndpointBlockingSend = mockBlockingSend)
+
+    val records = MemoryRecords.withRecords(Compression.NONE,
+      new SimpleRecord(1000, "foo".getBytes(StandardCharsets.UTF_8)))
+    val partitionData = new FetchResponseData.PartitionData()
+      .setPartitionIndex(t1p0.partition)
+      .setRecords(records)
+
+    // fetchOffset must equal log.logEndOffset to avoid the offset-mismatch IllegalStateException.
+    thread.processPartitionData(t1p0, logEndOffsetAfterAppend, Int.MaxValue, partitionData)
+
+    // processPartitionData only buffers the eviction; the actual fetcher removal is deferred to doWork().
+    verify(replicaFetcherManager, times(0)).removeFetcherForPartitions(any())
+
+    thread.doWork()
+
+    if (expectEviction) {
+      verify(replicaFetcherManager, times(1)).removeFetcherForPartitions(Set(t1p0))
+    } else {
+      verify(replicaFetcherManager, times(0)).removeFetcherForPartitions(any())
+    }
+    assertEquals(mutable.Buffer.empty, thread.partitionsToEvictAfterDisklessMigration)
   }
 
   private def newOffsetForLeaderPartitionResult(
@@ -782,6 +892,7 @@ class ReplicaFetcherThreadTest {
     when(replicaManager.getPartitionOrException(any[TopicPartition])).thenReturn(partition)
     val brokerTopicStats = new BrokerTopicStats
     when(replicaManager.brokerTopicStats).thenReturn(brokerTopicStats)
+    stubInklessMetadataView(replicaManager)
 
     val replicaQuota: ReplicaQuota = mock(classOf[ReplicaQuota])
 
@@ -817,5 +928,12 @@ class ReplicaFetcherThreadTest {
     when(replicaManager.getPartitionOrException(t1p1)).thenReturn(partition)
     when(replicaManager.localLogOrException(t2p1)).thenReturn(log)
     when(replicaManager.getPartitionOrException(t2p1)).thenReturn(partition)
+  }
+
+  private def stubInklessMetadataView(replicaManager: ReplicaManager): Unit = {
+    val view: InklessMetadataView = mock(classOf[InklessMetadataView])
+    when(view.getClassicToDisklessStartOffset(any[TopicPartition]))
+      .thenReturn(PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET)
+    when(replicaManager.inklessMetadataView()).thenReturn(view)
   }
 }

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -6575,8 +6575,10 @@ class ReplicaManagerTest {
     def testFetchFailDisklessWhenFromReplicaAndUnmanagedReplicas(): Unit = {
       val fetchHandlerCtor = mockFetchHandler(Map.empty)
       try {
-        // Given a topic partition that is diskless and managed replicas are disabled
-        val replicaManager = createReplicaManager(List(disklessTopicPartition.topic()), disklessManagedReplicasEnabled = false)
+        // Given a topic partition that is fully diskless (never migrated) and managed replicas are disabled
+        val replicaManager = spy(createReplicaManager(List(disklessTopicPartition.topic()), disklessManagedReplicasEnabled = false))
+        when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
+          .thenReturn(PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET)
         val fetchParams = new FetchParams(
           1, 1L, // follower fetch
           10L, 100, 200, FetchIsolation.HIGH_WATERMARK, Optional.empty()
@@ -7760,6 +7762,144 @@ class ReplicaManagerTest {
         assertTrue(onlinePartition.isSealed, "Partition should be sealed")
       } finally {
         replicaManager.shutdown(checkpointHW = false)
+      }
+    }
+
+    @Test
+    def testFollowerFetchAtClassicToDisklessStartOffsetReturnsEmptyAndIdle(): Unit = {
+      val fetchHandlerCtor = mockFetchHandler(Map.empty)
+      try {
+        val cp = mock(classOf[ControlPlane])
+        val replicaManager = spy(createReplicaManager(
+          List(disklessTopicPartition.topic()),
+          controlPlane = Some(cp),
+          disklessManagedReplicasEnabled = true,
+        ))
+
+        // Given a fully-migrated diskless topic with classicToDisklessStartOffset = 100
+        when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
+          .thenReturn(100L)
+
+        // When a follower fetches at offset >= classicToDisklessStartOffset
+        val fetchParams = new FetchParams(
+          1, 1L, // follower fetch
+          0L, 1, 1024, FetchIsolation.HIGH_WATERMARK, Optional.empty()
+        )
+        val fetchInfos = Seq(
+          disklessTopicPartition -> new PartitionData(disklessTopicPartition.topicId(), 100L, 0L, 1024, Optional.empty())
+        )
+
+        @volatile var responseData: Map[TopicIdPartition, FetchPartitionData] = null
+        val responseCallback = (response: Seq[(TopicIdPartition, FetchPartitionData)]) => {
+          responseData = response.toMap
+        }
+        replicaManager.fetchMessages(fetchParams, fetchInfos, QuotaFactory.UNBOUNDED_QUOTA, responseCallback)
+
+        // Then the response is empty with HW clamped to the seal offset and we never touched
+        // diskless storage or the local log on behalf of the follower.
+        assertNotNull(responseData)
+        assertEquals(1, responseData.size)
+        val data = responseData(disklessTopicPartition)
+        assertEquals(Errors.NONE, data.error)
+        assertEquals(MemoryRecords.EMPTY, data.records)
+        assertEquals(100L, data.highWatermark)
+        // logStartOffset must NOT advance the follower's local log start offset (would delete classic data).
+        assertEquals(0L, data.logStartOffset)
+        verify(replicaManager, never()).readFromLog(any(), any(), any(), any())
+        verify(fetchHandlerCtor.constructed().get(0), never()).handle(any(), any())
+        verify(cp, never()).findBatches(any(), any(), any())
+      } finally {
+        fetchHandlerCtor.close()
+      }
+    }
+
+    @Test
+    def testFollowerFetchAtClassicToDisklessStartOffsetEmptyEvenWhenManagedReplicasDisabled(): Unit = {
+      val fetchHandlerCtor = mockFetchHandler(Map.empty)
+      try {
+        val cp = mock(classOf[ControlPlane])
+        val replicaManager = spy(createReplicaManager(
+          List(disklessTopicPartition.topic()),
+          controlPlane = Some(cp),
+          disklessManagedReplicasEnabled = false,
+        ))
+
+        when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
+          .thenReturn(100L)
+
+        val fetchParams = new FetchParams(
+          1, 1L, // follower fetch
+          0L, 1, 1024, FetchIsolation.HIGH_WATERMARK, Optional.empty()
+        )
+        val fetchInfos = Seq(
+          disklessTopicPartition -> new PartitionData(disklessTopicPartition.topicId(), 150L, 0L, 1024, Optional.empty())
+        )
+
+        @volatile var responseData: Map[TopicIdPartition, FetchPartitionData] = null
+        val responseCallback = (response: Seq[(TopicIdPartition, FetchPartitionData)]) => {
+          responseData = response.toMap
+        }
+        replicaManager.fetchMessages(fetchParams, fetchInfos, QuotaFactory.UNBOUNDED_QUOTA, responseCallback)
+
+        // Same outcome regardless of managedReplicasEnabled: follower never sees diskless data.
+        assertNotNull(responseData)
+        assertEquals(1, responseData.size)
+        val data = responseData(disklessTopicPartition)
+        assertEquals(Errors.NONE, data.error)
+        assertEquals(MemoryRecords.EMPTY, data.records)
+        assertEquals(100L, data.highWatermark)
+        verify(replicaManager, never()).readFromLog(any(), any(), any(), any())
+        verify(fetchHandlerCtor.constructed().get(0), never()).handle(any(), any())
+        verify(cp, never()).findBatches(any(), any(), any())
+      } finally {
+        fetchHandlerCtor.close()
+      }
+    }
+
+    @Test
+    def testFollowerFetchBelowClassicToDisklessStartOffsetReadsFromClassicLog(): Unit = {
+      val fetchHandlerCtor = mockFetchHandler(Map.empty)
+      try {
+        val cp = mock(classOf[ControlPlane])
+        val replicaManager = spy(createReplicaManager(
+          List(disklessTopicPartition.topic()),
+          controlPlane = Some(cp),
+          disklessManagedReplicasEnabled = true,
+        ))
+
+        when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
+          .thenReturn(100L)
+
+        // Below the seal offset the follower should still be able to catch up via classic.
+        doReturn(Seq(disklessTopicPartition ->
+          new LogReadResult(
+            new FetchDataInfo(new LogOffsetMetadata(50L, 0L, 0), RECORDS),
+            Optional.empty(), 100L, 0L, 100L, 0L, 0L, OptionalLong.empty(), Errors.NONE
+          ))
+        ).when(replicaManager).readFromLog(any(), any(), any(), any())
+
+        val fetchParams = new FetchParams(
+          1, 1L, // follower fetch
+          0L, 1, 1024, FetchIsolation.LOG_END, Optional.empty()
+        )
+        val fetchInfos = Seq(
+          disklessTopicPartition -> new PartitionData(disklessTopicPartition.topicId(), 50L, 0L, 1024, Optional.empty())
+        )
+
+        @volatile var responseData: Map[TopicIdPartition, FetchPartitionData] = null
+        val responseCallback = (response: Seq[(TopicIdPartition, FetchPartitionData)]) => {
+          responseData = response.toMap
+        }
+        replicaManager.fetchMessages(fetchParams, fetchInfos, QuotaFactory.UNBOUNDED_QUOTA, responseCallback)
+
+        assertNotNull(responseData)
+        assertEquals(1, responseData.size)
+        assertEquals(RECORDS, responseData(disklessTopicPartition).records)
+        verify(replicaManager, times(1)).readFromLog(any(), any(), any(), any())
+        verify(fetchHandlerCtor.constructed().get(0), never()).handle(any(), any())
+        verify(cp, never()).findBatches(any(), any(), any())
+      } finally {
+        fetchHandlerCtor.close()
       }
     }
 


### PR DESCRIPTION
Diskless offsets should never be replicated to followers. Avoid this in two ways:
1. Do not respond with diskless offsets on fetch requests coming from followers
2. In case of diskless migration from classic, stop ReplicaFetcher as soon as they have caught up to `classicToDisklessStartOffset`.
