### PR TITLE
feat(inkless): extended metrics for diskless migration states tracking

### DIFF
--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -372,7 +372,8 @@ class BrokerServer(
           controlPlane = controlPlane,
           scheduler = kafkaScheduler,
           brokerId = config.brokerId,
-          brokerEpochSupplier = () => lifecycleManager.brokerEpoch
+          brokerEpochSupplier = () => lifecycleManager.brokerEpoch,
+          time = time,
         )
       }
 

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -880,6 +880,8 @@ class BrokerServer(
       if (replicaManager != null)
         CoreUtils.swallow(replicaManager.shutdown(), this)
 
+      maybeInitDisklessLogManager.foreach(m => CoreUtils.swallow(m.shutdown(), this))
+
       if (initDisklessLogChannelManager != null)
         CoreUtils.swallow(initDisklessLogChannelManager.shutdown(), this)
 

--- a/core/src/main/scala/kafka/server/InitDisklessLogBatchQueue.scala
+++ b/core/src/main/scala/kafka/server/InitDisklessLogBatchQueue.scala
@@ -61,7 +61,8 @@ abstract class RetriableInitDisklessLogBatchQueue[S <: InitDisklessLogState](
   brokerEpochSupplier: () => Long,
   lingerMs: Long,
   retryPeriodMs: Long,
-  maxRetryTimeMs: Long
+  maxRetryTimeMs: Long,
+  onRetry: () => Unit = () => ()
 ) extends Logging {
   import InitDisklessLogBatchQueue._
 
@@ -226,15 +227,18 @@ abstract class RetriableInitDisklessLogBatchQueue[S <: InitDisklessLogState](
     taskStatus = TaskScheduled(scheduler.scheduleOnce("init-diskless-log-batch-queue", () => task(), delayMs))
   }
 
-  private def enqueueRetryOrFail(tp: TopicPartition, attempt: Attempt): Unit = withQueueLock {
-    val retryAttemptNumber = attempt.attemptNumber + 1
-    Option(queuedByTp.get(tp)) match {
-      case Some(existing) =>
-        // Keep the already queued state (it may be fresher), but ensure retry progression is not lost.
-        queuedByTp.put(tp, Attempt(existing.state, Math.max(existing.attemptNumber, retryAttemptNumber)))
-      case None =>
-        queuedByTp.put(tp, Attempt(attempt.state, retryAttemptNumber))
+  private def enqueueRetryOrFail(tp: TopicPartition, attempt: Attempt): Unit = {
+    withQueueLock {
+      val retryAttemptNumber = attempt.attemptNumber + 1
+      Option(queuedByTp.get(tp)) match {
+        case Some(existing) =>
+          // Keep the already queued state (it may be fresher), but ensure retry progression is not lost.
+          queuedByTp.put(tp, Attempt(existing.state, Math.max(existing.attemptNumber, retryAttemptNumber)))
+        case None =>
+          queuedByTp.put(tp, Attempt(attempt.state, retryAttemptNumber))
+      }
     }
+    onRetry()
   }
 
   private def completeAndRemovePromise(tp: TopicPartition, accepted: Boolean): Unit = {
@@ -267,14 +271,16 @@ class SendingToControllerBatchQueue(
   brokerEpochSupplier: () => Long,
   lingerMs: Long,
   retryPeriodMs: Long,
-  maxRetryTimeMs: Long
+  maxRetryTimeMs: Long,
+  onRetry: () => Unit = () => ()
 ) extends RetriableInitDisklessLogBatchQueue[SendingToController](
   scheduler = scheduler,
   brokerId = brokerId,
   brokerEpochSupplier = brokerEpochSupplier,
   lingerMs = lingerMs,
   retryPeriodMs = retryPeriodMs,
-  maxRetryTimeMs = maxRetryTimeMs
+  maxRetryTimeMs = maxRetryTimeMs,
+  onRetry = onRetry
 ) {
   logIdent = s"[SendingToControllerBatchQueue] "
 
@@ -328,14 +334,16 @@ class AwaitingMetadataBatchQueue(
   brokerEpochSupplier: () => Long,
   lingerMs: Long,
   retryPeriodMs: Long,
-  maxRetryTimeMs: Long
+  maxRetryTimeMs: Long,
+  onRetry: () => Unit = () => ()
 ) extends RetriableInitDisklessLogBatchQueue[AwaitingMetadata](
   scheduler = scheduler,
   brokerId = brokerId,
   brokerEpochSupplier = brokerEpochSupplier,
   lingerMs = lingerMs,
   retryPeriodMs = retryPeriodMs,
-  maxRetryTimeMs = maxRetryTimeMs
+  maxRetryTimeMs = maxRetryTimeMs,
+  onRetry = onRetry
 ) {
   logIdent = s"[AwaitingMetadataBatchQueue] "
 

--- a/core/src/main/scala/kafka/server/InitDisklessLogBatchQueue.scala
+++ b/core/src/main/scala/kafka/server/InitDisklessLogBatchQueue.scala
@@ -228,17 +228,27 @@ abstract class RetriableInitDisklessLogBatchQueue[S <: InitDisklessLogState](
   }
 
   private def enqueueRetryOrFail(tp: TopicPartition, attempt: Attempt): Unit = {
-    withQueueLock {
-      val retryAttemptNumber = attempt.attemptNumber + 1
-      Option(queuedByTp.get(tp)) match {
-        case Some(existing) =>
-          // Keep the already queued state (it may be fresher), but ensure retry progression is not lost.
-          queuedByTp.put(tp, Attempt(existing.state, Math.max(existing.attemptNumber, retryAttemptNumber)))
-        case None =>
-          queuedByTp.put(tp, Attempt(attempt.state, retryAttemptNumber))
+    val retried = withQueueLock {
+      // If the tp's promise is gone, it was cancelled via `remove(tp)` (e.g.,
+      // `removePartition` on leadership loss / shutdown) while this batch was
+      // in flight. Re-queueing would produce orphan controller traffic that
+      // no caller is awaiting -- and, for repeated retriable failures, would
+      // keep firing indefinitely.
+      if (!resultPromiseByTp.containsKey(tp)) {
+        false
+      } else {
+        val retryAttemptNumber = attempt.attemptNumber + 1
+        Option(queuedByTp.get(tp)) match {
+          case Some(existing) =>
+            // Keep the already queued state (it may be fresher), but ensure retry progression is not lost.
+            queuedByTp.put(tp, Attempt(existing.state, Math.max(existing.attemptNumber, retryAttemptNumber)))
+          case None =>
+            queuedByTp.put(tp, Attempt(attempt.state, retryAttemptNumber))
+        }
+        true
       }
     }
-    onRetry()
+    if (retried) onRetry()
   }
 
   private def completeAndRemovePromise(tp: TopicPartition, accepted: Boolean): Unit = {

--- a/core/src/main/scala/kafka/server/InitDisklessLogManager.scala
+++ b/core/src/main/scala/kafka/server/InitDisklessLogManager.scala
@@ -18,12 +18,15 @@ package kafka.server
 
 import io.aiven.inkless.control_plane.{ControlPlane, InitDisklessLogProducerState => CpProducerState}
 import kafka.cluster.Partition
+import kafka.server.InitDisklessLogManager._
 import kafka.utils.Logging
 import org.apache.kafka.common.{TopicPartition, Uuid}
+import org.apache.kafka.common.utils.Time
 import org.apache.kafka.server.common.NodeToControllerChannelManager
+import org.apache.kafka.server.metrics.KafkaMetricsGroup
 import org.apache.kafka.server.util.Scheduler
 
-import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.{ConcurrentHashMap, TimeUnit}
 import scala.concurrent.ExecutionContext
 import scala.jdk.CollectionConverters._
 
@@ -32,12 +35,19 @@ class InitDisklessLogManager(
   controlPlane: ControlPlane,
   scheduler: Scheduler,
   brokerId: Int,
-  brokerEpochSupplier: () => Long
+  brokerEpochSupplier: () => Long,
+  time: Time = Time.SYSTEM
 ) extends Logging {
 
   this.logIdent = s"[InitDisklessLogManager broker=$brokerId] "
 
   private val tracked = new ConcurrentHashMap[TopicPartition, InitDisklessLogState]()
+  private val metrics = new Metrics(time, () => tracked.size)
+
+  // Notify metrics that `tp`'s tracked state has changed. Call after every
+  // mutation of `tracked`. Best-effort: a tiny race with concurrent mutations
+  // is tolerated.
+  private def refreshMetrics(tp: TopicPartition): Unit = metrics.onStateChange(tp, tracked.get(tp))
 
   // Delay before firing a batch send, allowing multiple partitions that become ready
   // around the same time (e.g., when an entire topic is sealed) to be coalesced into one request.
@@ -53,7 +63,8 @@ class InitDisklessLogManager(
     brokerEpochSupplier = brokerEpochSupplier,
     lingerMs = lingerMs,
     retryPeriodMs = retryPeriodMs,
-    maxRetryTimeMs = maxRetryTimeMs
+    maxRetryTimeMs = maxRetryTimeMs,
+    onRetry = () => metrics.markRetried()
   )
   private val awaitingMetadataQueue = new AwaitingMetadataBatchQueue(
     controlPlane = controlPlane,
@@ -62,7 +73,8 @@ class InitDisklessLogManager(
     brokerEpochSupplier = brokerEpochSupplier,
     lingerMs = lingerMs,
     retryPeriodMs = retryPeriodMs,
-    maxRetryTimeMs = maxRetryTimeMs
+    maxRetryTimeMs = maxRetryTimeMs,
+    onRetry = () => metrics.markRetried()
   )
 
   private[server] def getTrackedPartitions: Set[TopicPartition] = tracked.keySet().asScala.toSet
@@ -92,6 +104,7 @@ class InitDisklessLogManager(
     if (tracked.putIfAbsent(tp, newState) != null) {
       tracked.computeIfPresent(tp, (_, _) => newState)
     }
+    refreshMetrics(tp)
     enqueueAwaitingMetadata(tp, newState)
   }
 
@@ -107,6 +120,7 @@ class InitDisklessLogManager(
         case _: WaitingForReplication => handleWaitingOutcome(tp, outcome)
         case other => other
       })
+      refreshMetrics(tp)
     })
 
     val tp = partition.topicPartition
@@ -125,6 +139,7 @@ class InitDisklessLogManager(
       case done: Done => done
       case _: Failed => null
     })
+    refreshMetrics(tp)
 
     if (inserted) {
       Option(tracked.get(tp)).foreach {
@@ -136,6 +151,7 @@ class InitDisklessLogManager(
             case w: WaitingForReplication => handleWaitingOutcome(tp, w.maybeAdvanceState())
             case other => other
           })
+          refreshMetrics(tp)
         case _ =>
       }
     }
@@ -147,7 +163,10 @@ class InitDisklessLogManager(
       case sendingToController: SendingToController =>
         enqueueSendingToController(tp, sendingToController)
         sendingToController
-      case _: Failed => null // remove from tracking
+      case _: Failed =>
+        // remove from tracking and count as a failed migration.
+        metrics.markFailed()
+        null
       case waitingForReplication: WaitingForReplication => waitingForReplication
     }
   }
@@ -162,8 +181,13 @@ class InitDisklessLogManager(
           }
         )
       } else {
+        // PermanentFailure on controller call (e.g. FENCED_LEADER_EPOCH /
+        // INVALID_REQUEST) or local pre-flight rejection (leader/log lost):
+        // the migration won't progress, so drop it and record the failure.
+        metrics.markFailed()
         tracked.remove(tp)
       }
+      refreshMetrics(tp)
     }(ExecutionContext.parasitic)
   }
 
@@ -176,10 +200,13 @@ class InitDisklessLogManager(
             case other => other
           }
         )
+        metrics.markCompleted()
         tracked.remove(tp)
       } else {
+        metrics.markFailed()
         tracked.remove(tp)
       }
+      refreshMetrics(tp)
     }(ExecutionContext.parasitic)
   }
 
@@ -190,7 +217,106 @@ class InitDisklessLogManager(
     if (tracked.remove(tp) != null) {
       sendingToControllerQueue.remove(tp)
       awaitingMetadataQueue.remove(tp)
+      refreshMetrics(tp)
       info(s"Removed partition $tp from diskless init tracking")
+    }
+  }
+
+  def removeMetrics(): Unit = metrics.removeMetrics()
+}
+
+object InitDisklessLogManager {
+  private val MetricsPackage = "kafka.server"
+  private val MetricsClassName = "InitDisklessLogManager"
+
+  private[server] val MigrationsInFlightMetricName = "ClassicToDisklessMigrationsInFlight"
+  private[server] val WaitingForReplicationCountMetricName = "ClassicToDisklessMigrationsWaitingForReplicationCount"
+  private[server] val SendingToControllerCountMetricName = "ClassicToDisklessMigrationsSendingToControllerCount"
+  private[server] val AwaitingMetadataCountMetricName ="ClassicToDisklessMigrationsAwaitingMetadataCount"
+
+  // Oldest-age-per-state gauges. Reads 0 when no partition is currently in the corresponding state.
+  private[server] val OldestWaitingForReplicationAgeMsMetricName = "ClassicToDisklessMigrationOldestWaitingForReplicationAgeMs"
+  private[server] val OldestSendingToControllerAgeMsMetricName = "ClassicToDisklessMigrationOldestSendingToControllerAgeMs"
+  private[server] val OldestAwaitingMetadataAgeMsMetricName = "ClassicToDisklessMigrationOldestAwaitingMetadataAgeMs"
+
+  private[server] val MigrationsCompletedPerSecMetricName = "ClassicToDisklessMigrationsCompletedPerSec"
+  private[server] val MigrationsFailedPerSecMetricName = "ClassicToDisklessMigrationsFailedPerSec"
+  private[server] val MigrationsRetriedPerSecMetricName = "ClassicToDisklessMigrationsRetriedPerSec"
+
+  private[server] val GaugeMetricNames = Set(
+    MigrationsInFlightMetricName,
+    WaitingForReplicationCountMetricName,
+    SendingToControllerCountMetricName,
+    AwaitingMetadataCountMetricName,
+    OldestWaitingForReplicationAgeMsMetricName,
+    OldestSendingToControllerAgeMsMetricName,
+    OldestAwaitingMetadataAgeMsMetricName,
+  )
+
+  private[server] val MeterMetricNames = Set(
+    MigrationsCompletedPerSecMetricName,
+    MigrationsFailedPerSecMetricName,
+    MigrationsRetriedPerSecMetricName,
+  )
+
+  private[server] val MetricNames: Set[String] = GaugeMetricNames union MeterMetricNames
+
+  private final case class EnteredAtEntry(stateClass: Class[_], enteredAtMs: Long)
+
+  // All JMX wiring for InitDisklessLogManager: per-state count / oldest-age
+  // gauges, completed/failed/retried meters, plus a small per-partition
+  // bookkeeping map used to back the gauges. The manager calls `onStateChange`
+  // after every mutation of its `tracked` map and `markCompleted` /
+  // `markFailed` / `markRetried` at the relevant points in the state machine.
+  private[server] final class Metrics(time: Time, trackedSize: () => Int) {
+    private val enteredAtByTp = new ConcurrentHashMap[TopicPartition, EnteredAtEntry]()
+    private val metricsGroup = new KafkaMetricsGroup(MetricsPackage, MetricsClassName)
+
+    metricsGroup.newGauge(MigrationsInFlightMetricName, () => trackedSize())
+    metricsGroup.newGauge(WaitingForReplicationCountMetricName, () => enteredAtByTp.values().asScala.count(_.stateClass eq classOf[WaitingForReplication]))
+    metricsGroup.newGauge(SendingToControllerCountMetricName,   () => enteredAtByTp.values().asScala.count(_.stateClass eq classOf[SendingToController]))
+    metricsGroup.newGauge(AwaitingMetadataCountMetricName,      () => enteredAtByTp.values().asScala.count(_.stateClass eq classOf[AwaitingMetadata]))
+
+    metricsGroup.newGauge(OldestWaitingForReplicationAgeMsMetricName, () => oldestAgeMs(classOf[WaitingForReplication]))
+    metricsGroup.newGauge(OldestSendingToControllerAgeMsMetricName,   () => oldestAgeMs(classOf[SendingToController]))
+    metricsGroup.newGauge(OldestAwaitingMetadataAgeMsMetricName,      () => oldestAgeMs(classOf[AwaitingMetadata]))
+
+    private val completedMeter = metricsGroup.newMeter(MigrationsCompletedPerSecMetricName, "migrations", TimeUnit.SECONDS)
+    private val failedMeter    = metricsGroup.newMeter(MigrationsFailedPerSecMetricName,    "migrations", TimeUnit.SECONDS)
+    private val retriedMeter   = metricsGroup.newMeter(MigrationsRetriedPerSecMetricName,   "retries",    TimeUnit.SECONDS)
+
+    def markCompleted(): Unit = completedMeter.mark()
+    def markFailed(): Unit    = failedMeter.mark()
+    def markRetried(): Unit   = retriedMeter.mark()
+
+    // Update the gauge view of `tp`'s state. Pass `state == null` when the partition is no longer tracked.
+    def onStateChange(tp: TopicPartition, state: InitDisklessLogState): Unit = {
+      if (state == null) {
+        enteredAtByTp.remove(tp)
+      } else {
+        val newClass: Class[_] = state.getClass
+        val nowMs = time.milliseconds()
+        enteredAtByTp.compute(tp, (_, existing) =>
+          if (existing == null || existing.stateClass != newClass) EnteredAtEntry(newClass, nowMs)
+          else existing
+        )
+      }
+    }
+
+    def removeMetrics(): Unit = MetricNames.foreach(metricsGroup.removeMetric)
+
+    private def oldestAgeMs(stateClass: Class[_]): Long = {
+      val nowMs = time.milliseconds()
+      var oldest = 0L
+      val it = enteredAtByTp.values().iterator()
+      while (it.hasNext) {
+        val e = it.next()
+        if (e.stateClass eq stateClass) {
+          val age = nowMs - e.enteredAtMs
+          if (age > oldest) oldest = age
+        }
+      }
+      oldest
     }
   }
 }

--- a/core/src/main/scala/kafka/server/InitDisklessLogManager.scala
+++ b/core/src/main/scala/kafka/server/InitDisklessLogManager.scala
@@ -26,6 +26,7 @@ import org.apache.kafka.server.common.NodeToControllerChannelManager
 import org.apache.kafka.server.metrics.KafkaMetricsGroup
 import org.apache.kafka.server.util.Scheduler
 
+import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.{ConcurrentHashMap, TimeUnit}
 import scala.concurrent.ExecutionContext
 import scala.jdk.CollectionConverters._
@@ -183,9 +184,15 @@ class InitDisklessLogManager(
       } else {
         // PermanentFailure on controller call (e.g. FENCED_LEADER_EPOCH /
         // INVALID_REQUEST) or local pre-flight rejection (leader/log lost):
-        // the migration won't progress, so drop it and record the failure.
-        metrics.markFailed()
-        tracked.remove(tp)
+        // the migration won't progress.
+        // Only count a failure when this callback observed `tp` as still
+        // tracked. `removePartition` completes the queue promise with `false`
+        // (via `queue.remove`) AFTER clearing `tracked`, so the cancellation
+        // path lands here with `tracked.remove(tp) == null` and must not
+        // increment the failed meter.
+        if (tracked.remove(tp) != null) {
+          metrics.markFailed()
+        }
       }
       refreshMetrics(tp)
     }(ExecutionContext.parasitic)
@@ -200,11 +207,18 @@ class InitDisklessLogManager(
             case other => other
           }
         )
-        metrics.markCompleted()
-        tracked.remove(tp)
+        // Only count completion when this callback observed `tp` as still
+        // tracked. If `removePartition` cleared `tracked` (and/or the queue
+        // promise) concurrently, the migration was cancelled externally and
+        // we must not inflate the completed meter.
+        if (tracked.remove(tp) != null) {
+          metrics.markCompleted()
+        }
       } else {
-        metrics.markFailed()
-        tracked.remove(tp)
+        if (tracked.remove(tp) != null) {
+          // Only count failure when this callback observed `tp` as still tracked
+          metrics.markFailed()
+        }
       }
       refreshMetrics(tp)
     }(ExecutionContext.parasitic)
@@ -220,6 +234,11 @@ class InitDisklessLogManager(
       refreshMetrics(tp)
       info(s"Removed partition $tp from diskless init tracking")
     }
+  }
+
+  def shutdown(): Unit = {
+    tracked.keySet().asScala.toList.foreach(removePartition)
+    removeMetrics()
   }
 
   def removeMetrics(): Unit = metrics.removeMetrics()
@@ -261,22 +280,32 @@ object InitDisklessLogManager {
 
   private[server] val MetricNames: Set[String] = GaugeMetricNames union MeterMetricNames
 
-  private final case class EnteredAtEntry(stateClass: Class[_], enteredAtMs: Long)
-
-  // All JMX wiring for InitDisklessLogManager: per-state count / oldest-age
-  // gauges, completed/failed/retried meters, plus a small per-partition
-  // bookkeeping map used to back the gauges. The manager calls `onStateChange`
-  // after every mutation of its `tracked` map and `markCompleted` /
-  // `markFailed` / `markRetried` at the relevant points in the state machine.
+  // JMX wiring: per-state count and oldest-age gauges plus completed/failed/
+  // retried meters. The manager calls `onStateChange` after every mutation of
+  // its `tracked` map and `markCompleted` / `markFailed` / `markRetried` at
+  // the relevant state-machine transitions.
   private[server] final class Metrics(time: Time, trackedSize: () => Int) {
-    private val enteredAtByTp = new ConcurrentHashMap[TopicPartition, EnteredAtEntry]()
     private val metricsGroup = new KafkaMetricsGroup(MetricsPackage, MetricsClassName)
 
-    metricsGroup.newGauge(MigrationsInFlightMetricName, () => trackedSize())
-    metricsGroup.newGauge(WaitingForReplicationCountMetricName, () => enteredAtByTp.values().asScala.count(_.stateClass eq classOf[WaitingForReplication]))
-    metricsGroup.newGauge(SendingToControllerCountMetricName,   () => enteredAtByTp.values().asScala.count(_.stateClass eq classOf[SendingToController]))
-    metricsGroup.newGauge(AwaitingMetadataCountMetricName,      () => enteredAtByTp.values().asScala.count(_.stateClass eq classOf[AwaitingMetadata]))
+    // Per-state counters incrementally maintained by `onStateChange`
+    private val counters: Map[Class[_], AtomicInteger] = Map(
+      classOf[WaitingForReplication] -> new AtomicInteger(0),
+      classOf[SendingToController]   -> new AtomicInteger(0),
+      classOf[AwaitingMetadata]      -> new AtomicInteger(0)
+    )
 
+    // Per-state TP -> enteredAtMs registry; walked by `oldestAgeMs` on read.
+    // Scan cost is negligible: same pattern as `AbstractFetcherManager.MaxLag`.
+    private val enteredAtByState: Map[Class[_], ConcurrentHashMap[TopicPartition, java.lang.Long]] = Map(
+      classOf[WaitingForReplication] -> new ConcurrentHashMap[TopicPartition, java.lang.Long](),
+      classOf[SendingToController]   -> new ConcurrentHashMap[TopicPartition, java.lang.Long](),
+      classOf[AwaitingMetadata]      -> new ConcurrentHashMap[TopicPartition, java.lang.Long]()
+    )
+
+    metricsGroup.newGauge(MigrationsInFlightMetricName, () => trackedSize())
+    metricsGroup.newGauge(WaitingForReplicationCountMetricName, () => counters(classOf[WaitingForReplication]).get)
+    metricsGroup.newGauge(SendingToControllerCountMetricName,   () => counters(classOf[SendingToController]).get)
+    metricsGroup.newGauge(AwaitingMetadataCountMetricName,      () => counters(classOf[AwaitingMetadata]).get)
     metricsGroup.newGauge(OldestWaitingForReplicationAgeMsMetricName, () => oldestAgeMs(classOf[WaitingForReplication]))
     metricsGroup.newGauge(OldestSendingToControllerAgeMsMetricName,   () => oldestAgeMs(classOf[SendingToController]))
     metricsGroup.newGauge(OldestAwaitingMetadataAgeMsMetricName,      () => oldestAgeMs(classOf[AwaitingMetadata]))
@@ -289,17 +318,15 @@ object InitDisklessLogManager {
     def markFailed(): Unit    = failedMeter.mark()
     def markRetried(): Unit   = retriedMeter.mark()
 
-    // Update the gauge view of `tp`'s state. Pass `state == null` when the partition is no longer tracked.
+    // Update metrics for `tp` in `state`, or remove it from tracking when `state == null`.
     def onStateChange(tp: TopicPartition, state: InitDisklessLogState): Unit = {
-      if (state == null) {
-        enteredAtByTp.remove(tp)
-      } else {
-        val newClass: Class[_] = state.getClass
-        val nowMs = time.milliseconds()
-        enteredAtByTp.compute(tp, (_, existing) =>
-          if (existing == null || existing.stateClass != newClass) EnteredAtEntry(newClass, nowMs)
-          else existing
-        )
+      val newClass: Class[_] = if (state == null) null else state.getClass
+      val nowMs = time.milliseconds()
+      enteredAtByState.foreach { case (cls, m) =>
+        if (cls eq newClass) {
+          // Keep the original timestamp on same-class re-entries.
+          if (m.putIfAbsent(tp, nowMs) == null) counters(cls).incrementAndGet()
+        } else if (m.remove(tp) != null) counters(cls).decrementAndGet()
       }
     }
 
@@ -308,13 +335,10 @@ object InitDisklessLogManager {
     private def oldestAgeMs(stateClass: Class[_]): Long = {
       val nowMs = time.milliseconds()
       var oldest = 0L
-      val it = enteredAtByTp.values().iterator()
+      val it = enteredAtByState(stateClass).values().iterator()
       while (it.hasNext) {
-        val e = it.next()
-        if (e.stateClass eq stateClass) {
-          val age = nowMs - e.enteredAtMs
-          if (age > oldest) oldest = age
-        }
+        val age = nowMs - it.next().longValue()
+        if (age > oldest) oldest = age
       }
       oldest
     }

--- a/core/src/test/scala/unit/kafka/server/InitDisklessLogManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/InitDisklessLogManagerTest.scala
@@ -24,6 +24,7 @@ import org.apache.kafka.common.message.{InitDisklessLogRequestData, InitDiskless
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.requests.{AbstractRequest, InitDisklessLogRequest, InitDisklessLogResponse, RequestHeader}
 import org.apache.kafka.common.protocol.ApiKeys
+import org.apache.kafka.server.metrics.KafkaYammerMetrics
 import org.apache.kafka.server.partition.PartitionListener
 import org.apache.kafka.server.common.{ControllerRequestCompletionHandler, NodeToControllerChannelManager}
 import org.apache.kafka.server.util.MockScheduler
@@ -362,6 +363,179 @@ class InitDisklessLogManagerTest {
     // Then it is no longer tracked
     assertTrue(manager.getTrackedPartitions.isEmpty)
     assertEquals(None, manager.getInitState(tp0))
+  }
+
+  @Test
+  def testShutdownDrainsTrackedAndUnregistersMetrics(): Unit = {
+    // Given several partitions across different states
+    val tp1 = new TopicPartition("test-topic", 1)
+    val tp2 = new TopicPartition("test-topic", 2)
+    val p0 = mockPartition(tp = tp0, hw = 100, leo = 100)
+    val p1 = mockPartition(tp = tp1, hw = 50, leo = 100)
+    val p2 = mockPartition(tp = tp2, hw = 200, leo = 200)
+    manager.registerPartition(p0, topicId)
+    manager.registerPartition(p1, topicId)
+    manager.registerPartition(p2, topicId)
+    fireLinger()
+    // p0 and p2 are in-flight to the controller; p1 is parked waiting for HW.
+    assertEquals(1, channelManager.requests.size())
+    assertEquals(Set(tp0, tp1, tp2), manager.getTrackedPartitions)
+    assertTrue(initDisklessMetricsRegistered, "metrics should be registered while manager is alive")
+
+    val failedBefore = meterCount(InitDisklessLogManager.MigrationsFailedPerSecMetricName)
+    val completedBefore = meterCount(InitDisklessLogManager.MigrationsCompletedPerSecMetricName)
+
+    // When the manager is shut down
+    manager.shutdown()
+
+    // Then tracked is drained, no meters are inflated (cancellation is not a
+    // failure or completion), and all Yammer metrics are unregistered so the
+    // next broker start in the same JVM can re-register them.
+    assertTrue(manager.getTrackedPartitions.isEmpty)
+    assertEquals(
+      failedBefore,
+      meterCount(
+        InitDisklessLogManager.MigrationsFailedPerSecMetricName,
+        defaultIfMissing = failedBefore
+      )
+    )
+    assertEquals(
+      completedBefore,
+      meterCount(
+        InitDisklessLogManager.MigrationsCompletedPerSecMetricName,
+        defaultIfMissing = completedBefore
+      )
+    )
+    assertFalse(initDisklessMetricsRegistered,
+      "all InitDisklessLogManager metrics should be unregistered after shutdown")
+
+    // And shutdown is idempotent
+    manager.shutdown()
+    assertTrue(manager.getTrackedPartitions.isEmpty)
+    assertFalse(initDisklessMetricsRegistered)
+  }
+
+  @Test
+  def testRemovePartitionBeforeRetriableResponseDoesNotEnqueueOrphanRetry(): Unit = {
+    // Given a partition with an in-flight controller request
+    val partition = mockPartition(hw = 100, leo = 100)
+    manager.registerPartition(partition, topicId)
+    fireLinger()
+    assertEquals(1, channelManager.requests.size())
+
+    val retriedBefore = meterCount(InitDisklessLogManager.MigrationsRetriedPerSecMetricName)
+
+    // When the partition is removed (e.g., leadership loss) and the
+    // controller subsequently responds with a retriable error
+    manager.removePartition(tp0)
+    pollAndComplete(makeErrorResponse(topicId, 0, Errors.NOT_CONTROLLER))
+
+    // Then no retry is enqueued: the queue's `enqueueRetryOrFail` must
+    // observe the now-removed promise and skip both re-queueing and the
+    // onRetry callback. Otherwise the queue would keep firing orphan
+    // controller requests on every backoff tick.
+    assertTrue(manager.getTrackedPartitions.isEmpty)
+    assertEquals(
+      retriedBefore,
+      meterCount(InitDisklessLogManager.MigrationsRetriedPerSecMetricName),
+      "removed partition's retriable response must not increment the retried meter"
+    )
+
+    // Advance well past the maximum backoff to confirm no retry task fires.
+    mockTime.sleep(manager.maxRetryTimeMs + 1)
+    scheduler.tick()
+    assertTrue(channelManager.requests.isEmpty,
+      "no request should be issued for a partition that was removed before the response")
+  }
+
+  @Test
+  def testRemovePartitionBeforeTransportFailureDoesNotEnqueueOrphanRetry(): Unit = {
+    // Same race as above, but exercising the `Left(reason)` path of
+    // `enqueueRetryOrFail` (transport-level failure -- here, a request
+    // timeout) which iterates over every in-flight entry.
+    val partition = mockPartition(hw = 100, leo = 100)
+    manager.registerPartition(partition, topicId)
+    fireLinger()
+    assertEquals(1, channelManager.requests.size())
+
+    val retriedBefore = meterCount(InitDisklessLogManager.MigrationsRetriedPerSecMetricName)
+
+    manager.removePartition(tp0)
+    channelManager.requests.poll().timeout()
+
+    assertTrue(manager.getTrackedPartitions.isEmpty)
+    assertEquals(
+      retriedBefore,
+      meterCount(InitDisklessLogManager.MigrationsRetriedPerSecMetricName)
+    )
+
+    mockTime.sleep(manager.maxRetryTimeMs + 1)
+    scheduler.tick()
+    assertTrue(channelManager.requests.isEmpty)
+  }
+
+  @Test
+  def testRemovePartitionDuringInFlightSendIsNotCountedAsFailure(): Unit = {
+    // Given a partition with an in-flight controller request
+    val partition = mockPartition(hw = 100, leo = 100)
+    manager.registerPartition(partition, topicId)
+    fireLinger()
+    assertEquals(1, channelManager.requests.size())
+
+    val failedBefore = meterCount(InitDisklessLogManager.MigrationsFailedPerSecMetricName)
+
+    // When the partition is removed before the response arrives
+    // (e.g. on leadership loss), `removePartition` calls `queue.remove(tp)`
+    // which completes the pending promise with `false`.
+    manager.removePartition(tp0)
+
+    // Then the migration is no longer tracked and is NOT counted as a failure:
+    // the parasitic callback's `accepted = false` branch must distinguish a
+    // cancellation (tracked already cleared) from a permanent failure.
+    assertTrue(manager.getTrackedPartitions.isEmpty)
+    assertEquals(
+      failedBefore,
+      meterCount(InitDisklessLogManager.MigrationsFailedPerSecMetricName),
+      "removePartition during in-flight send must not increment the failed meter"
+    )
+
+    // And a late-arriving controller response remains a no-op for metrics:
+    // the queue's promise is already completed, so `completeAndRemovePromise`
+    // finds no promise to fulfill.
+    pollAndComplete(makeSuccessResponse(topicId, 0))
+    assertEquals(
+      failedBefore,
+      meterCount(InitDisklessLogManager.MigrationsFailedPerSecMetricName)
+    )
+    assertEquals(
+      0L,
+      meterCount(InitDisklessLogManager.MigrationsCompletedPerSecMetricName)
+    )
+  }
+
+  private def meterCount(name: String): Long = {
+    val (_, metric) = KafkaYammerMetrics.defaultRegistry.allMetrics.asScala
+      .find { case (mn, _) => mn.getType == "InitDisklessLogManager" && mn.getName == name }
+      .getOrElse(throw new AssertionError(
+        s"Meter $name not registered on InitDisklessLogManager"))
+    metric.asInstanceOf[com.yammer.metrics.core.Meter].count()
+  }
+
+  // Variant used after shutdown(), when the meter may already have been removed
+  // from the registry. Returns `defaultIfMissing` when the metric is gone.
+  private def meterCount(name: String, defaultIfMissing: Long): Long = {
+    KafkaYammerMetrics.defaultRegistry.allMetrics.asScala
+      .find { case (mn, _) => mn.getType == "InitDisklessLogManager" && mn.getName == name }
+      .map { case (_, metric) => metric.asInstanceOf[com.yammer.metrics.core.Meter].count() }
+      .getOrElse(defaultIfMissing)
+  }
+
+  private def initDisklessMetricsRegistered: Boolean = {
+    val expected = InitDisklessLogManager.MetricNames
+    val present = KafkaYammerMetrics.defaultRegistry.allMetrics.asScala.collect {
+      case (mn, _) if mn.getType == "InitDisklessLogManager" => mn.getName
+    }.toSet
+    expected.subsetOf(present)
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/server/InitDisklessLogManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/InitDisklessLogManagerTest.scala
@@ -30,7 +30,7 @@ import org.apache.kafka.server.util.MockScheduler
 import org.apache.kafka.common.utils.MockTime
 import org.apache.kafka.storage.internals.log.{ProducerStateEntry, ProducerStateManager, UnifiedLog}
 import org.junit.jupiter.api.Assertions._
-import org.junit.jupiter.api.{BeforeEach, Test}
+import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
 
@@ -66,8 +66,14 @@ class InitDisklessLogManagerTest {
       controlPlane = controlPlane,
       scheduler = scheduler,
       brokerId = brokerId,
-      brokerEpochSupplier = () => brokerEpoch
+      brokerEpochSupplier = () => brokerEpoch,
+      time = mockTime
     )
+  }
+
+  @AfterEach
+  def tearDown(): Unit = {
+    if (manager != null) manager.removeMetrics()
   }
 
   private def fireLinger(): Unit = {

--- a/core/src/test/scala/unit/kafka/server/metadata/InitDisklessLogFlowTest.scala
+++ b/core/src/test/scala/unit/kafka/server/metadata/InitDisklessLogFlowTest.scala
@@ -17,6 +17,7 @@
 
 package kafka.server.metadata
 
+import com.yammer.metrics.core.Gauge
 import io.aiven.inkless.control_plane.{ControlPlane, InitDisklessLogResponse => CpInitResponse}
 import kafka.coordinator.transaction.TransactionCoordinator
 import kafka.log.LogManager
@@ -34,6 +35,7 @@ import org.apache.kafka.metadata.publisher.{AclPublisher, DelegationTokenPublish
 import org.apache.kafka.raft.LeaderAndEpoch
 import org.apache.kafka.server.common.MetadataVersion
 import org.apache.kafka.server.fault.FaultHandler
+import org.apache.kafka.server.metrics.KafkaYammerMetrics
 import org.apache.kafka.server.util.{MockScheduler, MockTime}
 import org.apache.kafka.storage.internals.log.{LogConfig, LogDirFailureChannel}
 import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertTrue}
@@ -125,6 +127,108 @@ class InitDisklessLogFlowTest {
 
       // Final check: metadata-triggered control-plane init executed.
       verify(ctx.controlPlane, times(1)).initDisklessLog(any())
+    } finally {
+      shutdown(ctx)
+    }
+  }
+
+  @Test
+  def testPerStateGaugesReflectMigrationProgress(): Unit = {
+    // Walks a single partition through the full state machine and asserts that
+    // the per-state JMX gauges and meters advance, and the oldest-age-per-state
+    // gauges reset on transitions and return to 0 once the partition leaves
+    // tracking. WaitingForReplication is left at 0 for the whole flow because
+    // the mock log has HW == LEO == 0 from the start, so registerPartition
+    // transitions directly to SendingToController without parking there.
+    val ctx = newContext()
+    val topicName = "integration-gauge-progression"
+    val topicId = Uuid.randomUuid()
+    val tp = new TopicPartition(topicName, 0)
+
+    when(ctx.replicaManager.inklessMetadataView().isDisklessTopic(anyString())).thenReturn(false)
+
+    try {
+      // Initially: no partitions sealed, no entries tracked, every gauge is 0
+      // and no migrations have completed/failed/retried yet.
+      val createDelta = new TopicsDelta(TopicsImage.EMPTY)
+      createDelta.replay(new TopicRecord().setName(topicName).setTopicId(topicId))
+      createDelta.replay(new PartitionRecord()
+        .setTopicId(topicId).setPartitionId(0).setReplicas(util.Arrays.asList(0, 1))
+        .setIsr(util.Arrays.asList(0, 1)).setLeader(ctx.config.brokerId)
+        .setLeaderEpoch(0).setPartitionEpoch(0))
+      val createImage = imageFromTopics(createDelta.apply())
+      ctx.replicaManager.applyDelta(createDelta, createImage)
+      assertCountGaugesAllZero()
+      assertOldestAgesAllZero()
+      assertMeterCount(InitDisklessLogManager.MigrationsCompletedPerSecMetricName, 0L)
+      assertMeterCount(InitDisklessLogManager.MigrationsFailedPerSecMetricName, 0L)
+
+      // After alter -> diskless=true: the partition is sealed and registered.
+      // With a fresh mock log (HW == LEO == 0), the state machine immediately
+      // transitions out of WaitingForReplication and parks in SendingToController.
+      ctx.metadataPublisher._firstPublish = false
+      when(ctx.replicaManager.inklessMetadataView().isDisklessTopic(topicName)).thenReturn(true)
+      val disklessDelta = new MetadataDelta(createImage)
+      disklessDelta.replay(new ConfigRecord()
+        .setResourceType(ConfigResource.Type.TOPIC.id())
+        .setResourceName(topicName)
+        .setName(TopicConfig.DISKLESS_ENABLE_CONFIG)
+        .setValue("true"))
+      val disklessImage = withClusterBrokers(disklessDelta.apply(MetadataProvenance.EMPTY))
+      ctx.metadataPublisher.onMetadataUpdate(disklessDelta, disklessImage, metadataManifest())
+
+      assertGauge(InitDisklessLogManager.MigrationsInFlightMetricName, 1)
+      assertGauge(InitDisklessLogManager.WaitingForReplicationCountMetricName, 0)
+      assertGauge(InitDisklessLogManager.SendingToControllerCountMetricName, 1)
+      assertGauge(InitDisklessLogManager.AwaitingMetadataCountMetricName, 0)
+      assertLongGauge(InitDisklessLogManager.OldestSendingToControllerAgeMsMetricName, 0L)
+
+      // Age advances when virtual clock advances while the state class is unchanged.
+      ctx.time.sleep(50)
+      assertLongGauge(InitDisklessLogManager.OldestSendingToControllerAgeMsMetricName, 50L)
+
+      // After linger elapses + RPC completes: state advances to AwaitingMetadata.
+      ctx.time.sleep(ctx.initDisklessLogManager.lingerMs)
+      ctx.scheduler.tick()
+      ctx.channelManager.requests.poll().complete(new org.apache.kafka.common.message.InitDisklessLogResponseData().setTopics(util.List.of(
+        new org.apache.kafka.common.message.InitDisklessLogResponseData.TopicResponse()
+          .setTopicId(topicId)
+          .setPartitions(util.List.of(
+            new org.apache.kafka.common.message.InitDisklessLogResponseData.PartitionResponse()
+              .setPartitionId(0)
+              .setErrorCode(org.apache.kafka.common.protocol.Errors.NONE.code())
+          ))
+      )))
+
+      assertTrackedStates(ctx, Map(tp -> classOf[AwaitingMetadata]))
+      assertGauge(InitDisklessLogManager.MigrationsInFlightMetricName, 1)
+      assertGauge(InitDisklessLogManager.SendingToControllerCountMetricName, 0)
+      assertGauge(InitDisklessLogManager.AwaitingMetadataCountMetricName, 1)
+      // The oldest SendingToController age must reset to 0 (no partitions
+      // remain in that state) while AwaitingMetadata's age starts at 0.
+      assertLongGauge(InitDisklessLogManager.OldestSendingToControllerAgeMsMetricName, 0L)
+      assertLongGauge(InitDisklessLogManager.OldestAwaitingMetadataAgeMsMetricName, 0L)
+
+      // After PartitionChangeRecord with diskless tagged fields replays: control-plane
+      // init runs and the partition is removed from tracking. All gauges return to 0
+      // and the completed meter increments by 1.
+      val pcrDelta = new MetadataDelta(disklessImage)
+      val pcr = new PartitionChangeRecord()
+        .setTopicId(topicId)
+        .setPartitionId(0)
+        .setIsr(util.Arrays.asList(0, 1))
+      pcr.unknownTaggedFields().add(InitDisklessLogFields.encodeClassicToDisklessStartOffset(100L))
+      pcr.unknownTaggedFields().add(InitDisklessLogFields.encodeProducerStates(util.List.of()))
+      pcrDelta.replay(pcr)
+      val pcrImage = withClusterBrokers(pcrDelta.apply(MetadataProvenance.EMPTY))
+      ctx.metadataPublisher.onMetadataUpdate(pcrDelta, pcrImage, metadataManifest())
+      ctx.time.sleep(ctx.initDisklessLogManager.lingerMs)
+      ctx.scheduler.tick()
+
+      assertCountGaugesAllZero()
+      assertOldestAgesAllZero()
+      assertMeterCount(InitDisklessLogManager.MigrationsCompletedPerSecMetricName, 1L)
+      assertMeterCount(InitDisklessLogManager.MigrationsFailedPerSecMetricName, 0L)
     } finally {
       shutdown(ctx)
     }
@@ -707,7 +811,8 @@ class InitDisklessLogFlowTest {
       controlPlane = controlPlane,
       scheduler = scheduler,
       brokerId = config.brokerId,
-      brokerEpochSupplier = () => 1L
+      brokerEpochSupplier = () => 1L,
+      time = time
     )
 
     val logManager = TestUtils.createLogManager(
@@ -752,6 +857,52 @@ class InitDisklessLogFlowTest {
   private def shutdown(ctx: TestContext): Unit = {
     ctx.replicaManager.shutdown(checkpointHW = false)
     ctx.logManager.shutdown(-1L)
+    ctx.initDisklessLogManager.removeMetrics()
+  }
+
+  private def gaugeValue[T](name: String): T = {
+    val (_, metric) = KafkaYammerMetrics.defaultRegistry.allMetrics.asScala
+      .find { case (mn, _) => mn.getType == "InitDisklessLogManager" && mn.getName == name }
+      .getOrElse(throw new AssertionError(
+        s"Gauge $name not registered on InitDisklessLogManager"))
+    metric.asInstanceOf[Gauge[T]].value()
+  }
+
+  private def meterCount(name: String): Long = {
+    val (_, metric) = KafkaYammerMetrics.defaultRegistry.allMetrics.asScala
+      .find { case (mn, _) => mn.getType == "InitDisklessLogManager" && mn.getName == name }
+      .getOrElse(throw new AssertionError(
+        s"Meter $name not registered on InitDisklessLogManager"))
+    metric.asInstanceOf[com.yammer.metrics.core.Meter].count()
+  }
+
+  private def assertGauge(name: String, expected: Int): Unit = {
+    assertEquals(expected, gaugeValue[Int](name), s"Unexpected value for gauge $name")
+  }
+
+  private def assertLongGauge(name: String, expected: Long): Unit = {
+    assertEquals(expected, gaugeValue[Long](name), s"Unexpected value for gauge $name")
+  }
+
+  private def assertMeterCount(name: String, expected: Long): Unit = {
+    assertEquals(expected, meterCount(name), s"Unexpected meter count for $name")
+  }
+
+  private def assertCountGaugesAllZero(): Unit = {
+    Set(
+      InitDisklessLogManager.MigrationsInFlightMetricName,
+      InitDisklessLogManager.WaitingForReplicationCountMetricName,
+      InitDisklessLogManager.SendingToControllerCountMetricName,
+      InitDisklessLogManager.AwaitingMetadataCountMetricName,
+    ).foreach(name => assertGauge(name, 0))
+  }
+
+  private def assertOldestAgesAllZero(): Unit = {
+    Set(
+      InitDisklessLogManager.OldestWaitingForReplicationAgeMsMetricName,
+      InitDisklessLogManager.OldestSendingToControllerAgeMsMetricName,
+      InitDisklessLogManager.OldestAwaitingMetadataAgeMsMetricName,
+    ).foreach(name => assertLongGauge(name, 0L))
   }
 
   private def assertTrackedStates(


### PR DESCRIPTION
Add the following metrics:
- `ClassicToDisklessMigrationsInFlight`
- `ClassicToDisklessMigrationsWaitingForReplicationCount`
- `ClassicToDisklessMigrationsSendingToControllerCount`
- `ClassicToDisklessMigrationsAwaitingMetadataCount`
- `ClassicToDisklessMigrationOldestWaitingForReplicationAgeMs`
- `ClassicToDisklessMigrationOldestSendingToControllerAgeMs`
- `ClassicToDisklessMigrationOldestAwaitingMetadataAgeMs`
- `ClassicToDisklessMigrationsCompletedPerSec`
- `ClassicToDisklessMigrationsFailedPerSec`
- `ClassicToDisklessMigrationsRetriedPerSec`