### PR TITLE
fix(inkless): POD-1965 Use local log start in DisklessLeaderEndPoint

### DIFF
--- a/core/src/main/scala/io/aiven/inkless/consolidation/DisklessLeaderEndPoint.scala
+++ b/core/src/main/scala/io/aiven/inkless/consolidation/DisklessLeaderEndPoint.scala
@@ -119,7 +119,9 @@ class DisklessLeaderEndPoint(
         case Right(partition) =>
           val logStartOffset = Try(partition.localLogOrException).toOption match {
             case Some(localLog) => localLog.logStartOffset
-            case None => UnifiedLog.UNKNOWN_OFFSET
+            case None => 
+                    logger.warn("Local log unavailable for topic-partition {}, returning unknown log start offset", tp.topicPartition)
+                    UnifiedLog.UNKNOWN_OFFSET
           }
           if (fetchResponseData.errorCode == Errors.NONE.code) {
             // in case of an inconsistency log an error, set an unknown offset and also return unknown server error

--- a/core/src/main/scala/io/aiven/inkless/consolidation/DisklessLeaderEndPoint.scala
+++ b/core/src/main/scala/io/aiven/inkless/consolidation/DisklessLeaderEndPoint.scala
@@ -124,7 +124,7 @@ class DisklessLeaderEndPoint(
           if (fetchResponseData.errorCode == Errors.NONE.code) {
             // in case of an inconsistency log an error, set an unknown offset and also return unknown server error
             if (logStartOffset > data.highWatermark) {
-              logger.error("Local log start offset ({}) is higher than high watermark ({}) for topic-partition {}",
+              logger.error("Local log start offset ({}) is higher than high watermark ({}) for topic-partition {}, this may indicate a transient inconsistency during migration",
                 logStartOffset, data.highWatermark, partition.topicPartition)
               fetchResponseData.setLogStartOffset(UnifiedLog.UNKNOWN_OFFSET)
               fetchResponseData.setErrorCode(Errors.UNKNOWN_SERVER_ERROR.code)

--- a/core/src/main/scala/io/aiven/inkless/consolidation/DisklessLeaderEndPoint.scala
+++ b/core/src/main/scala/io/aiven/inkless/consolidation/DisklessLeaderEndPoint.scala
@@ -20,6 +20,7 @@ package io.aiven.inkless.consolidation
 
 import io.aiven.inkless.consume.{FetchHandler, FetchOffsetHandler}
 import kafka.server.{KafkaConfig, ReplicaManager, ReplicaQuota}
+import kafka.utils.Logging
 import org.apache.kafka.common.Uuid
 import org.apache.kafka.common.errors.KafkaStorageException
 import org.apache.kafka.common.message.{FetchResponseData, OffsetForLeaderEpochRequestData}
@@ -35,12 +36,14 @@ import org.apache.kafka.server.network.BrokerEndPoint
 import org.apache.kafka.server.storage.log.{FetchIsolation, FetchParams}
 import org.apache.kafka.server.{LeaderEndPoint, PartitionFetchState, ReplicaFetch, ResultWithPartitions}
 import org.apache.kafka.storage.internals.log.OffsetResultHolder.FileRecordsOrError
+import org.apache.kafka.storage.internals.log.UnifiedLog
 
 import java.util
 import java.util.Optional
 import java.util.concurrent.CompletableFuture
 import scala.collection.mutable
 import scala.jdk.CollectionConverters._
+import scala.util.Try
 
 /**
  * Leader endpoint for consolidation fetching from Inkless (object storage) on this broker.
@@ -58,7 +61,7 @@ class DisklessLeaderEndPoint(
   quota: ReplicaQuota,
   metadataVersionSupplier: () => MetadataVersion,
   brokerEpochSupplier: () => Long
-) extends LeaderEndPoint {
+) extends LeaderEndPoint with Logging {
 
   private val replicaId = brokerConfig.brokerId
   private val maxWait = brokerConfig.replicaFetchWaitMaxMs
@@ -96,14 +99,43 @@ class DisklessLeaderEndPoint(
     response.asScala.map { case (tp, data) =>
       val abortedTransactions = data.abortedTransactions.orElse(null)
       val lastStableOffset: Long = data.lastStableOffset.orElse(FetchResponse.INVALID_LAST_STABLE_OFFSET)
-      tp.topicPartition -> new FetchResponseData.PartitionData()
+      val fetchResponseData = new FetchResponseData.PartitionData()
         .setPartitionIndex(tp.topicPartition.partition)
         .setErrorCode(data.error.code)
         .setHighWatermark(data.highWatermark)
         .setLastStableOffset(lastStableOffset)
-        .setLogStartOffset(data.logStartOffset)
         .setAbortedTransactions(abortedTransactions)
         .setRecords(data.records)
+      // set local LSO if possible instead of the diskless start offset that is data.logStartOffset
+      replicaManager.getPartitionOrError(tp.topicPartition) match {
+        case Left(error) =>
+          // If we couldn't read the partition, then we won't be able to set the log start offset
+          // of the unified log. If there is no error coming from diskless, then we can propagate
+          // the error in the partition, but otherwise don't mask it.
+          if (fetchResponseData.errorCode == Errors.NONE.code) {
+            fetchResponseData.setErrorCode(error.code)
+          }
+          fetchResponseData.setLogStartOffset(UnifiedLog.UNKNOWN_OFFSET)
+        case Right(partition) =>
+          val logStartOffset = Try(partition.localLogOrException).toOption match {
+            case Some(localLog) => localLog.logStartOffset
+            case None => UnifiedLog.UNKNOWN_OFFSET
+          }
+          if (fetchResponseData.errorCode == Errors.NONE.code) {
+            // in case of an inconsistency log an error, set an unknown offset and also return unknown server error
+            if (logStartOffset > data.highWatermark) {
+              logger.error("Local log start offset ({}) is higher than high watermark ({}) for topic-partition {}",
+                logStartOffset, data.highWatermark, partition.topicPartition)
+              fetchResponseData.setLogStartOffset(UnifiedLog.UNKNOWN_OFFSET)
+              fetchResponseData.setErrorCode(Errors.UNKNOWN_SERVER_ERROR.code)
+            } else {
+              fetchResponseData.setLogStartOffset(logStartOffset)
+            }
+          } else {
+            fetchResponseData.setLogStartOffset(data.logStartOffset)
+          }
+      }
+      tp.topicPartition -> fetchResponseData
     }.toMap.asJava
   }
 

--- a/core/src/main/scala/io/aiven/inkless/consolidation/DisklessLeaderEndPoint.scala
+++ b/core/src/main/scala/io/aiven/inkless/consolidation/DisklessLeaderEndPoint.scala
@@ -132,7 +132,7 @@ class DisklessLeaderEndPoint(
               fetchResponseData.setLogStartOffset(logStartOffset)
             }
           } else {
-            fetchResponseData.setLogStartOffset(data.logStartOffset)
+            fetchResponseData.setLogStartOffset(UnifiedLog.UNKNOWN_OFFSET)
           }
       }
       tp.topicPartition -> fetchResponseData

--- a/core/src/test/scala/io/aiven/inkless/consolidation/DisklessLeaderEndPointTest.scala
+++ b/core/src/test/scala/io/aiven/inkless/consolidation/DisklessLeaderEndPointTest.scala
@@ -19,9 +19,10 @@
 package io.aiven.inkless.consolidation
 
 import io.aiven.inkless.consume.{FetchHandler, FetchOffsetHandler}
+import kafka.cluster.Partition
 import kafka.server.{KafkaConfig, QuotaFactory, ReplicaManager, ReplicaQuota}
 import kafka.utils.TestUtils
-import org.apache.kafka.common.errors.{KafkaStorageException, UnknownTopicOrPartitionException}
+import org.apache.kafka.common.errors.{KafkaStorageException, NotLeaderOrFollowerException, UnknownTopicOrPartitionException}
 import org.apache.kafka.common.message.FetchResponseData
 import org.apache.kafka.common.message.OffsetForLeaderEpochRequestData.OffsetForLeaderPartition
 import org.apache.kafka.common.message.OffsetForLeaderEpochResponseData.EpochEndOffset
@@ -48,6 +49,7 @@ import java.util.OptionalInt
 import java.util.OptionalLong
 import java.util.concurrent.CompletableFuture
 import scala.jdk.CollectionConverters._
+import scala.util.{Left, Right}
 
 class DisklessLeaderEndPointTest {
 
@@ -113,6 +115,11 @@ class DisklessLeaderEndPointTest {
     val fetchHandler = mock(classOf[FetchHandler])
     val fetchOffsetHandler = mock(classOf[FetchOffsetHandler])
     val replicaManager = mock(classOf[ReplicaManager])
+    val partition = mock(classOf[Partition])
+    val localLog = mock(classOf[UnifiedLog])
+    when(partition.localLogOrException).thenReturn(localLog)
+    when(localLog.logStartOffset).thenReturn(55L)
+    when(replicaManager.getPartitionOrError(topicPartition)).thenReturn(Right(partition))
 
     val aborted = util.List.of(new FetchResponseData.AbortedTransaction())
     val fetchData = new FetchPartitionData(
@@ -140,7 +147,7 @@ class DisklessLeaderEndPointTest {
     assertEquals(Errors.NONE.code, pd.errorCode)
     assertEquals(99L, pd.highWatermark)
     assertEquals(88L, pd.lastStableOffset)
-    assertEquals(1L, pd.logStartOffset)
+    assertEquals(55L, pd.logStartOffset)
     assertEquals(aborted, pd.abortedTransactions)
     assertEquals(MemoryRecords.EMPTY, pd.records)
   }
@@ -150,6 +157,11 @@ class DisklessLeaderEndPointTest {
     val fetchHandler = mock(classOf[FetchHandler])
     val fetchOffsetHandler = mock(classOf[FetchOffsetHandler])
     val replicaManager = mock(classOf[ReplicaManager])
+    val partition = mock(classOf[Partition])
+    val localLog = mock(classOf[UnifiedLog])
+    when(partition.localLogOrException).thenReturn(localLog)
+    when(localLog.logStartOffset).thenReturn(0L)
+    when(replicaManager.getPartitionOrError(topicPartition)).thenReturn(Right(partition))
 
     val fetchData = new FetchPartitionData(
       Errors.NONE,
@@ -477,5 +489,160 @@ class DisklessLeaderEndPointTest {
 
     assertTrue(result.result.isEmpty)
     assertTrue(result.partitionsWithError.isEmpty)
+  }
+
+  @Test
+  def testFetchLeavesDisklessLogStartOffsetWhenDisklessErrorEvenIfPartitionAvailable(): Unit = {
+    val fetchHandler = mock(classOf[FetchHandler])
+    val fetchOffsetHandler = mock(classOf[FetchOffsetHandler])
+    val replicaManager = mock(classOf[ReplicaManager])
+    val partition = mock(classOf[Partition])
+    val localLog = mock(classOf[UnifiedLog])
+    when(partition.localLogOrException).thenReturn(localLog)
+    when(localLog.logStartOffset).thenReturn(0L)
+    when(replicaManager.getPartitionOrError(topicPartition)).thenReturn(Right(partition))
+
+    val fetchData = new FetchPartitionData(
+      Errors.OFFSET_OUT_OF_RANGE,
+      50L,
+      7L,
+      MemoryRecords.EMPTY,
+      Optional.empty(),
+      OptionalLong.empty(),
+      Optional.empty(),
+      OptionalInt.empty(),
+      false
+    )
+    when(fetchHandler.handle(any(), any())).thenReturn(CompletableFuture.completedFuture(Map(topicIdPartition -> fetchData).asJava))
+
+    val endPoint = newEndPoint(fetchHandler, fetchOffsetHandler, replicaManager)
+    val partitionData = new util.HashMap[TopicPartition, FetchRequest.PartitionData]()
+    val fetchBuilder = FetchRequest.Builder.forReplica(12, 1, 1L, 100, 1, partitionData).setMaxBytes(100_000)
+
+    val pd = endPoint.fetch(fetchBuilder).get(topicPartition)
+    assertEquals(Errors.OFFSET_OUT_OF_RANGE.code, pd.errorCode)
+    assertEquals(7L, pd.logStartOffset)
+  }
+
+  @Test
+  def testFetchOverlaysPartitionErrorAndUnknownLogStartWhenLookupFailsAndDisklessWasOk(): Unit = {
+    val fetchHandler = mock(classOf[FetchHandler])
+    val fetchOffsetHandler = mock(classOf[FetchOffsetHandler])
+    val replicaManager = mock(classOf[ReplicaManager])
+    when(replicaManager.getPartitionOrError(topicPartition)).thenReturn(Left(Errors.NOT_LEADER_OR_FOLLOWER))
+
+    val fetchData = new FetchPartitionData(
+      Errors.NONE,
+      50L,
+      3L,
+      MemoryRecords.EMPTY,
+      Optional.empty(),
+      OptionalLong.empty(),
+      Optional.empty(),
+      OptionalInt.empty(),
+      false
+    )
+    when(fetchHandler.handle(any(), any())).thenReturn(CompletableFuture.completedFuture(Map(topicIdPartition -> fetchData).asJava))
+
+    val endPoint = newEndPoint(fetchHandler, fetchOffsetHandler, replicaManager)
+    val partitionData = new util.HashMap[TopicPartition, FetchRequest.PartitionData]()
+    val fetchBuilder = FetchRequest.Builder.forReplica(12, 1, 1L, 100, 1, partitionData).setMaxBytes(100_000)
+
+    val pd = endPoint.fetch(fetchBuilder).get(topicPartition)
+    assertEquals(Errors.NOT_LEADER_OR_FOLLOWER.code, pd.errorCode)
+    assertEquals(UnifiedLog.UNKNOWN_OFFSET, pd.logStartOffset)
+  }
+
+  @Test
+  def testFetchKeepsDisklessErrorWhenLookupFailsButDisklessAlreadyFailed(): Unit = {
+    val fetchHandler = mock(classOf[FetchHandler])
+    val fetchOffsetHandler = mock(classOf[FetchOffsetHandler])
+    val replicaManager = mock(classOf[ReplicaManager])
+    when(replicaManager.getPartitionOrError(topicPartition)).thenReturn(Left(Errors.KAFKA_STORAGE_ERROR))
+
+    val fetchData = new FetchPartitionData(
+      Errors.OFFSET_OUT_OF_RANGE,
+      50L,
+      12L,
+      MemoryRecords.EMPTY,
+      Optional.empty(),
+      OptionalLong.empty(),
+      Optional.empty(),
+      OptionalInt.empty(),
+      false
+    )
+    when(fetchHandler.handle(any(), any())).thenReturn(CompletableFuture.completedFuture(Map(topicIdPartition -> fetchData).asJava))
+
+    val endPoint = newEndPoint(fetchHandler, fetchOffsetHandler, replicaManager)
+    val partitionData = new util.HashMap[TopicPartition, FetchRequest.PartitionData]()
+    val fetchBuilder = FetchRequest.Builder.forReplica(12, 1, 1L, 100, 1, partitionData).setMaxBytes(100_000)
+
+    val pd = endPoint.fetch(fetchBuilder).get(topicPartition)
+    assertEquals(Errors.OFFSET_OUT_OF_RANGE.code, pd.errorCode)
+    assertEquals(UnifiedLog.UNKNOWN_OFFSET, pd.logStartOffset)
+  }
+
+  @Test
+  def testFetchSetsUnknownServerErrorAndUnknownLogStartWhenLocalLogStartAheadOfHighWatermark(): Unit = {
+    val fetchHandler = mock(classOf[FetchHandler])
+    val fetchOffsetHandler = mock(classOf[FetchOffsetHandler])
+    val replicaManager = mock(classOf[ReplicaManager])
+    val partition = mock(classOf[Partition])
+    val localLog = mock(classOf[UnifiedLog])
+    when(partition.localLogOrException).thenReturn(localLog)
+    when(localLog.logStartOffset).thenReturn(200L)
+    when(replicaManager.getPartitionOrError(topicPartition)).thenReturn(Right(partition))
+
+    val fetchData = new FetchPartitionData(
+      Errors.NONE,
+      99L,
+      1L,
+      MemoryRecords.EMPTY,
+      Optional.empty(),
+      OptionalLong.empty(),
+      Optional.empty(),
+      OptionalInt.empty(),
+      false
+    )
+    when(fetchHandler.handle(any(), any())).thenReturn(CompletableFuture.completedFuture(Map(topicIdPartition -> fetchData).asJava))
+
+    val endPoint = newEndPoint(fetchHandler, fetchOffsetHandler, replicaManager)
+    val partitionData = new util.HashMap[TopicPartition, FetchRequest.PartitionData]()
+    val fetchBuilder = FetchRequest.Builder.forReplica(12, 1, 1L, 100, 1, partitionData).setMaxBytes(100_000)
+
+    val pd = endPoint.fetch(fetchBuilder).get(topicPartition)
+    assertEquals(Errors.UNKNOWN_SERVER_ERROR.code, pd.errorCode)
+    assertEquals(UnifiedLog.UNKNOWN_OFFSET, pd.logStartOffset)
+  }
+
+  @Test
+  def testFetchSetsUnknownLogStartWhenLocalLogUnavailable(): Unit = {
+    val fetchHandler = mock(classOf[FetchHandler])
+    val fetchOffsetHandler = mock(classOf[FetchOffsetHandler])
+    val replicaManager = mock(classOf[ReplicaManager])
+    val partition = mock(classOf[Partition])
+    when(partition.localLogOrException).thenThrow(new NotLeaderOrFollowerException("no local log"))
+    when(replicaManager.getPartitionOrError(topicPartition)).thenReturn(Right(partition))
+
+    val fetchData = new FetchPartitionData(
+      Errors.NONE,
+      99L,
+      1L,
+      MemoryRecords.EMPTY,
+      Optional.empty(),
+      OptionalLong.empty(),
+      Optional.empty(),
+      OptionalInt.empty(),
+      false
+    )
+    when(fetchHandler.handle(any(), any())).thenReturn(CompletableFuture.completedFuture(Map(topicIdPartition -> fetchData).asJava))
+
+    val endPoint = newEndPoint(fetchHandler, fetchOffsetHandler, replicaManager)
+    val partitionData = new util.HashMap[TopicPartition, FetchRequest.PartitionData]()
+    val fetchBuilder = FetchRequest.Builder.forReplica(12, 1, 1L, 100, 1, partitionData).setMaxBytes(100_000)
+
+    val pd = endPoint.fetch(fetchBuilder).get(topicPartition)
+    assertEquals(Errors.NONE.code, pd.errorCode)
+    assertEquals(UnifiedLog.UNKNOWN_OFFSET, pd.logStartOffset)
   }
 }

--- a/core/src/test/scala/io/aiven/inkless/consolidation/DisklessLeaderEndPointTest.scala
+++ b/core/src/test/scala/io/aiven/inkless/consolidation/DisklessLeaderEndPointTest.scala
@@ -492,7 +492,7 @@ class DisklessLeaderEndPointTest {
   }
 
   @Test
-  def testFetchLeavesDisklessLogStartOffsetWhenDisklessErrorEvenIfPartitionAvailable(): Unit = {
+  def testFetchReturnsUnknownLogStartOffsetWhenDisklessErrorEvenIfPartitionAvailable(): Unit = {
     val fetchHandler = mock(classOf[FetchHandler])
     val fetchOffsetHandler = mock(classOf[FetchOffsetHandler])
     val replicaManager = mock(classOf[ReplicaManager])
@@ -521,7 +521,7 @@ class DisklessLeaderEndPointTest {
 
     val pd = endPoint.fetch(fetchBuilder).get(topicPartition)
     assertEquals(Errors.OFFSET_OUT_OF_RANGE.code, pd.errorCode)
-    assertEquals(7L, pd.logStartOffset)
+    assertEquals(-1L, pd.logStartOffset)
   }
 
   @Test


### PR DESCRIPTION
Fetching with FetchHandler returns the log_start_offset from the coordinator which is actually the diskless start offset. If we pass this on, then ReplicaManager will believe that log_start_offset is the first offset and therefore enforces retention.
Instead of this behavior we should use the local log start offset to properly respect the offset boundaries and retention.
