### PR TITLE
feat(inkless): Always allow fetching from replicas for migrated partitions

### DIFF
--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -1321,10 +1321,15 @@ class Partition(val topicPartition: TopicPartition,
    * @param maxBytes the maximum bytes to return
    * @param minOneMessage whether to ensure that at least one complete message is returned
    * @param updateFetchState true if the Fetch should update replica state (only applies to follower fetches)
+   * @param allowReplica if true, override `fetchParams.fetchOnlyLeader` and let this node serve the
+   *                     read even when it is not the leader (e.g. for hybrid diskless partitions where
+   *                     any in-sync replica may serve the classic portion of the log). Defaults to
+   *                     `false`, in which case the standard `fetchParams.fetchOnlyLeader` rule applies.
    * @return [[LogReadInfo]] containing the fetched records or the diverging epoch if present
-   * @throws NotLeaderOrFollowerException if this node is not the current leader and `FetchParams.fetchOnlyLeader`
-   *                                      is enabled, or if this is a follower fetch with an older request version
-   *                                      and the replicaId is not recognized among the current valid replicas
+   * @throws NotLeaderOrFollowerException if this node is not the current leader, `fetchParams.fetchOnlyLeader`
+   *                                      is enabled, and `allowReplica` is `false`; or if this is a follower
+   *                                      fetch with an older request version and the replicaId is not
+   *                                      recognized among the current valid replicas
    * @throws FencedLeaderEpochException if the leader epoch in the `Fetch` request is lower than the current
    *                                    leader epoch
    * @throws UnknownLeaderEpochException if the leader epoch in the `Fetch` request is higher than the current
@@ -1342,7 +1347,8 @@ class Partition(val topicPartition: TopicPartition,
     fetchTimeMs: Long,
     maxBytes: Int,
     minOneMessage: Boolean,
-    updateFetchState: Boolean
+    updateFetchState: Boolean,
+    allowReplica: Boolean = false
   ): LogReadInfo = {
     def readFromLocalLog(log: UnifiedLog): LogReadInfo = {
       readRecords(
@@ -1361,7 +1367,7 @@ class Partition(val topicPartition: TopicPartition,
       val (replica, logReadInfo) = inReadLock(leaderIsrUpdateLock) {
         val localLog = localLogWithEpochOrThrow(
           fetchPartitionData.currentLeaderEpoch,
-          fetchParams.fetchOnlyLeader
+          fetchParams.fetchOnlyLeader && !allowReplica
         )
         val replica = followerReplicaOrThrow(
           fetchParams.replicaId,
@@ -1387,7 +1393,7 @@ class Partition(val topicPartition: TopicPartition,
       inReadLock(leaderIsrUpdateLock) {
         val localLog = localLogWithEpochOrThrow(
           fetchPartitionData.currentLeaderEpoch,
-          fetchParams.fetchOnlyLeader
+          fetchParams.fetchOnlyLeader && !allowReplica
         )
         readFromLocalLog(localLog)
       }

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -2246,12 +2246,17 @@ class ReplicaManager(val config: KafkaConfig,
             if (preferredReadReplica.isDefined) OptionalInt.of(preferredReadReplica.get) else OptionalInt.empty(),
             Errors.NONE)
         } else {
-          // For hybrid diskless partitions (classicToDisklessStartOffset >= 0, i.e. the partition
-          // was migrated from classic to diskless and still has classic local/remote data to read),
-          // relax the leader-only requirement so any in-sync replica can serve the classic portion
-          // of the read. This enables follower fetching for older FETCH versions (no rackId / empty
-          // clientMetadata) that would otherwise get NOT_LEADER_OR_FOLLOWER when targeting a non-leader broker.
-          val allowReplica = !params.fetchOnlyLeader() || isMigratedPartitionFromClassicToDiskless(tp)
+          // For partitions that were migrated from classic to diskless and still have classic
+          // local/remote data to read (classicToDisklessStartOffset >= 0), relax the leader-only
+          // requirement so any in-sync replica can serve the classic portion of the read. This is
+          // scoped to older consumer fetches that don't supply clientMetadata (pre-KIP-392 / no
+          // rackId), which would otherwise get NOT_LEADER_OR_FOLLOWER on a non-leader broker.
+          // Broker-to-broker follower replication and share fetches are intentionally excluded.
+          // The check is ordered so that the metadata lookup is only performed when the override
+          // could actually apply.
+          val isOlderConsumer = params.isFromConsumer && params.clientMetadata.isEmpty
+          val allowReplica = !params.fetchOnlyLeader() ||
+            (isOlderConsumer && isMigratedPartitionFromClassicToDiskless(tp))
           log = partition.localLogWithEpochOrThrow(fetchInfo.currentLeaderEpoch, !allowReplica)
 
           // Try the read first, this tells us whether we need all of adjustedFetchSize for this partition

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -2166,6 +2166,20 @@ class ReplicaManager(val config: KafkaConfig,
   }
 
   /**
+   * Returns true for a partition that has been migrated from a classic topic to a diskless one
+   * (`diskless.enable=true`) and whose `classicToDisklessStartOffset` has been sealed at a
+   * non-negative offset. For these partitions every replica still can host the classic local/remote
+   * log below the seal offset. Migration-pending (`-2`) and never-migrated (`-1`) partitions are excluded.
+   *
+   * The `isDisklessTopic` check is also a guard against unnecessary metadata-image lookups in the
+   * hot fetch path for the non-diskless case.
+   */
+  private[server] def isMigratedPartitionFromClassicToDiskless(tp: TopicIdPartition): Boolean = {
+    _inklessMetadataView.isDisklessTopic(tp.topic) &&
+      _inklessMetadataView.getClassicToDisklessStartOffset(tp.topicPartition) >= 0L
+  }
+
+  /**
    * Read from multiple topic partitions at the given offset up to maxSize bytes
    */
   def readFromLog(
@@ -2232,7 +2246,13 @@ class ReplicaManager(val config: KafkaConfig,
             if (preferredReadReplica.isDefined) OptionalInt.of(preferredReadReplica.get) else OptionalInt.empty(),
             Errors.NONE)
         } else {
-          log = partition.localLogWithEpochOrThrow(fetchInfo.currentLeaderEpoch, params.fetchOnlyLeader())
+          // For hybrid diskless partitions (classicToDisklessStartOffset >= 0, i.e. the partition
+          // was migrated from classic to diskless and still has classic local/remote data to read),
+          // relax the leader-only requirement so any in-sync replica can serve the classic portion
+          // of the read. This enables follower fetching for older FETCH versions (no rackId / empty
+          // clientMetadata) that would otherwise get NOT_LEADER_OR_FOLLOWER when targeting a non-leader broker.
+          val allowReplica = !params.fetchOnlyLeader() || isMigratedPartitionFromClassicToDiskless(tp)
+          log = partition.localLogWithEpochOrThrow(fetchInfo.currentLeaderEpoch, !allowReplica)
 
           // Try the read first, this tells us whether we need all of adjustedFetchSize for this partition
           val readInfo: LogReadInfo = partition.fetchRecords(
@@ -2241,7 +2261,8 @@ class ReplicaManager(val config: KafkaConfig,
             fetchTimeMs = fetchTimeMs,
             maxBytes = adjustedMaxBytes,
             minOneMessage = minOneMessage,
-            updateFetchState = !readFromPurgatory)
+            updateFetchState = !readFromPurgatory,
+            allowReplica = allowReplica)
 
           val fetchDataInfo = checkFetchDataInfo(partition, readInfo.fetchedData)
 

--- a/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
@@ -1471,7 +1471,7 @@ class PartitionTest extends AbstractPartitionTest {
       val replica = new Replica(remoteBrokerId, topicPartition, metadataCache)
       partition.updateFollowerFetchState(replica, mock(classOf[LogOffsetMetadata]), 0, initializeTimeMs, 0, defaultBrokerEpoch(remoteBrokerId))
       mock(classOf[LogReadInfo])
-    }).when(partition).fetchRecords(any(), any(), anyLong(), anyInt(), anyBoolean(), anyBoolean())
+    }).when(partition).fetchRecords(any(), any(), anyLong(), anyInt(), anyBoolean(), anyBoolean(), anyBoolean())
 
     assertDoesNotThrow(() => fetchFollower(partition, replicaId = remoteBrokerId, fetchOffset = 3L))
   }

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -1698,17 +1698,47 @@ class ReplicaManagerTest {
       val followerImage = imageFromTopics(followerDelta.apply())
       replicaManager.applyDelta(followerDelta, followerImage)
 
-      // Mark this partition as hybrid diskless (classicToDisklessStartOffset >= 0).
+      // Mark this partition as migrated from classic to diskless (classicToDisklessStartOffset >= 0).
       doReturn(true).when(replicaManager).isMigratedPartitionFromClassicToDiskless(tidp0)
 
-      // Fetch from follower with empty ClientMetadata (older FETCH versions, no rackId).
-      // Without the hybrid override this would fail with NOT_LEADER_OR_FOLLOWER (see
-      // testFetchFollowerNotAllowedForOlderClients). For hybrid partitions every replica
-      // can serve the classic portion of the log, so the read should succeed.
+      // Consumer fetch with empty ClientMetadata (older FETCH versions, no rackId) targeting
+      // a non-leader broker. Without the override this would fail with NOT_LEADER_OR_FOLLOWER
+      // (see testFetchFollowerNotAllowedForOlderClients); migrated partitions allow any
+      // in-sync replica to serve the classic portion of the log, so the read should succeed.
       val partitionData = new FetchRequest.PartitionData(Uuid.ZERO_UUID, 0L, 0L, 100,
         Optional.of(0))
       val fetchResult = fetchPartitionAsConsumer(replicaManager, tidp0, partitionData)
       assertEquals(Errors.NONE, fetchResult.assertFired.error)
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
+  def testFetchFromFollowerStillRequiresLeaderOnMigratedPartition(): Unit = {
+    // Regression test: the migrated-partition override must NOT relax leader-only for
+    // broker-to-broker follower replication. Replication semantics (ISR/HWM) require
+    // followers to fetch from the leader.
+    val replicaManager = spy(setupReplicaManagerWithMockedPurgatories(new MockTimer(time), aliveBrokerIds = Seq(0, 1)))
+
+    try {
+      val tp0 = new TopicPartition(topic, 0)
+      val tidp0 = new TopicIdPartition(topicId, tp0)
+      val offsetCheckpoints = new LazyOffsetCheckpoints(replicaManager.highWatermarkCheckpoints.asJava)
+      replicaManager.createPartition(tp0).createLogIfNotExists(isNew = false, isFutureReplica = false, offsetCheckpoints, None)
+
+      // Make broker 0 a follower of broker 1 (i.e. this broker is NOT the leader).
+      val followerDelta = createFollowerDelta(topicId, tp0, 0, 1)
+      val followerImage = imageFromTopics(followerDelta.apply())
+      replicaManager.applyDelta(followerDelta, followerImage)
+
+      // Even if the partition is marked as migrated, follower fetches must keep failing.
+      doReturn(true).when(replicaManager).isMigratedPartitionFromClassicToDiskless(tidp0)
+
+      val partitionData = new FetchRequest.PartitionData(Uuid.ZERO_UUID, 0L, 0L, 100,
+        Optional.of(0))
+      val fetchResult = fetchPartitionAsFollower(replicaManager, tidp0, partitionData, replicaId = 1)
+      assertEquals(Errors.NOT_LEADER_OR_FOLLOWER, fetchResult.assertFired.error)
     } finally {
       replicaManager.shutdown(checkpointHW = false)
     }
@@ -9418,7 +9448,12 @@ class ReplicaManagerTest {
       try {
         val tp = disklessTopicPartition.topicPartition()
 
-        // Never-migrated (or non-diskless) partition: classicToDisklessStartOffset == -1.
+        val classicTp = classicTopicPartition.topicPartition()
+        when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(classicTp))
+          .thenReturn(100L)
+        assertFalse(replicaManager.isMigratedPartitionFromClassicToDiskless(classicTopicPartition))
+
+        // Diskless but never-migrated partition: classicToDisklessStartOffset == -1.
         when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(tp))
           .thenReturn(PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET)
         assertFalse(replicaManager.isMigratedPartitionFromClassicToDiskless(disklessTopicPartition))

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -1685,6 +1685,36 @@ class ReplicaManagerTest {
   }
 
   @Test
+  def testFetchFollowerAllowedForOlderClientsOnHybridDisklessPartition(): Unit = {
+    val replicaManager = spy(setupReplicaManagerWithMockedPurgatories(new MockTimer(time), aliveBrokerIds = Seq(0, 1)))
+
+    try {
+      val tp0 = new TopicPartition(topic, 0)
+      val tidp0 = new TopicIdPartition(topicId, tp0)
+      val offsetCheckpoints = new LazyOffsetCheckpoints(replicaManager.highWatermarkCheckpoints.asJava)
+      replicaManager.createPartition(tp0).createLogIfNotExists(isNew = false, isFutureReplica = false, offsetCheckpoints, None)
+
+      val followerDelta = createFollowerDelta(topicId, tp0, 0, 1)
+      val followerImage = imageFromTopics(followerDelta.apply())
+      replicaManager.applyDelta(followerDelta, followerImage)
+
+      // Mark this partition as hybrid diskless (classicToDisklessStartOffset >= 0).
+      doReturn(true).when(replicaManager).isMigratedPartitionFromClassicToDiskless(tidp0)
+
+      // Fetch from follower with empty ClientMetadata (older FETCH versions, no rackId).
+      // Without the hybrid override this would fail with NOT_LEADER_OR_FOLLOWER (see
+      // testFetchFollowerNotAllowedForOlderClients). For hybrid partitions every replica
+      // can serve the classic portion of the log, so the read should succeed.
+      val partitionData = new FetchRequest.PartitionData(Uuid.ZERO_UUID, 0L, 0L, 100,
+        Optional.of(0))
+      val fetchResult = fetchPartitionAsConsumer(replicaManager, tidp0, partitionData)
+      assertEquals(Errors.NONE, fetchResult.assertFired.error)
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
   def testFetchRequestRateMetrics(): Unit = {
     val localId = 0
     val mockTimer = new MockTimer(time)
@@ -9379,6 +9409,36 @@ class ReplicaManagerTest {
         verify(cp, never()).findBatches(any(), any(), any())
       } finally {
         fetchHandlerCtor.close()
+      }
+    }
+
+    @Test
+    def testIsMigratedPartitionFromClassicToDiskless(): Unit = {
+      val replicaManager = spy(createReplicaManager(List(disklessTopicPartition.topic())))
+      try {
+        val tp = disklessTopicPartition.topicPartition()
+
+        // Never-migrated (or non-diskless) partition: classicToDisklessStartOffset == -1.
+        when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(tp))
+          .thenReturn(PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET)
+        assertFalse(replicaManager.isMigratedPartitionFromClassicToDiskless(disklessTopicPartition))
+
+        // Migration pending: classicToDisklessStartOffset == -2 (sealed but offset not committed).
+        when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(tp))
+          .thenReturn(PartitionRegistration.CLASSIC_TO_DISKLESS_MIGRATION_PENDING)
+        assertFalse(replicaManager.isMigratedPartitionFromClassicToDiskless(disklessTopicPartition))
+
+        // Migrated (just sealed, seal at offset 0).
+        when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(tp))
+          .thenReturn(0L)
+        assertTrue(replicaManager.isMigratedPartitionFromClassicToDiskless(disklessTopicPartition))
+
+        // Migrated (seal at a later offset).
+        when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(tp))
+          .thenReturn(100L)
+        assertTrue(replicaManager.isMigratedPartitionFromClassicToDiskless(disklessTopicPartition))
+      } finally {
+        replicaManager.shutdown(checkpointHW = false)
       }
     }
 


### PR DESCRIPTION
Partitions migrated from classic to diskless are handled like full diskless partitions from the metadata point of view. This means that a replica can be advertised as a leader from the `InklessTopicMetadataTransformer`.
Allow fetching from replicas for all types of fetch requests that want to read from a migrated partition so the unified log can be read also when a client request does not support follower fetching.