### PR TITLE
feat(inkless): POD-2456 Enable offset fetch in consolidating partitions

### DIFF
--- a/core/src/main/scala/io/aiven/inkless/consolidation/DisklessLeaderEndPoint.scala
+++ b/core/src/main/scala/io/aiven/inkless/consolidation/DisklessLeaderEndPoint.scala
@@ -119,7 +119,7 @@ class DisklessLeaderEndPoint(
         case Right(partition) =>
           val logStartOffset = Try(partition.localLogOrException).toOption match {
             case Some(localLog) => localLog.logStartOffset
-            case None => 
+            case None =>
                     logger.warn("Local log unavailable for topic-partition {}, returning unknown log start offset", tp.topicPartition)
                     UnifiedLog.UNKNOWN_OFFSET
           }

--- a/core/src/main/scala/kafka/server/DisklessFetchOffsetRouter.scala
+++ b/core/src/main/scala/kafka/server/DisklessFetchOffsetRouter.scala
@@ -40,13 +40,16 @@ import scala.jdk.OptionConverters.RichOptional
  * the diskless control-plane path, and hybrid configurations that can answer from either.
  *
  * Distinguishes among:
- *   1. Pure diskless partition (`classicToDisklessStartOffset <= 0` or managed replicas disabled):
- *      fetch offset in the diskless path.
- *   2. Hybrid diskless partition (`classicToDisklessStartOffset > 0` and managed replicas enabled):
- *      fetch offset in classic and/or diskless path, depending on the requested timestamp.
+ *   1. Pure diskless partition (`classicToDisklessStartOffset <= 0` and managed replicas disabled
+ *      and not consolidating diskless topics): fetch offset in the diskless path.
+ *   2. Hybrid diskless partition (`classicToDisklessStartOffset > 0` and managed replicas enabled,
+ *      or a consolidating diskless topic): fetch offset in classic and/or diskless path, depending
+ *      on the requested timestamp. Consolidating topics also allow followers on the classic leg
+ *      (same rationale as sealed migrated replicas: clients may be routed to any ISR replica).
  *   3. Partition that is being migrated from classic to diskless
  *      (`classicToDisklessStartOffset == CLASSIC_TO_DISKLESS_MIGRATION_PENDING` and managed
- *      replicas enabled): fetch offset only in the classic path.
+ *      replicas enabled, and not a consolidating diskless topic): fetch offset only in the
+ *      classic path.
  *   4. Follower requests on a migrated partition: ListOffsets requests (used by ReplicaFetcher
  *      for truncation / initial offset bootstrap) must never see diskless offsets, otherwise the
  *      follower would try to truncate to or fetch from offsets that live only in object storage:
@@ -59,6 +62,7 @@ import scala.jdk.OptionConverters.RichOptional
 class DisklessFetchOffsetRouter(
   inklessMetadataView: InklessMetadataView,
   disklessManagedReplicasEnabled: Boolean,
+  disklessConsolidationEnabled: Boolean,
   delayedRemoteListOffsetsPurgatory: DelayedOperationPurgatory[DelayedRemoteListOffsets]
 ) {
   import DisklessFetchOffsetRouter._
@@ -90,26 +94,33 @@ class DisklessFetchOffsetRouter(
   ): ListOffsetsPartitionStatus = {
     val classicToDisklessStartOffset = inklessMetadataView.getClassicToDisklessStartOffset(topicPartition)
     val migrationPending = classicToDisklessStartOffset == PartitionRegistration.CLASSIC_TO_DISKLESS_MIGRATION_PENDING
-    val isMigratedWithClassicAccess = classicToDisklessStartOffset > 0 && disklessManagedReplicasEnabled
+    val isMigratedWithClassicAccess = (classicToDisklessStartOffset > 0 && disklessManagedReplicasEnabled)
+    val isConsolidatingPartition = disklessConsolidationEnabled && inklessMetadataView.isConsolidatingDisklessTopic(topicPartition.topic)
 
     // Migrated partitions seal their classic local log: once classicToDisklessStartOffset is
     // committed the LEO can no longer grow and every ISR replica has the same data on disk.
     // Any replica can therefore safely answer ListOffsets from its local log, so we let
     // followers serve the classic-side query as well.
-    val allowFromFollower = isMigratedWithClassicAccess
+    // Since consolidating partitions contain only data that has been stored in the diskless
+    // coordinator and its offsets won't change, we can allow follower requests.
+    val allowFromFollower = isMigratedWithClassicAccess || isConsolidatingPartition
     val isFollowerRequest = replicaId >= 0
 
     def classicLookup(): ListOffsetsPartitionStatus = classicFetchOffset(topicPartition, partition, allowFromFollower)
     def disklessLookup: Lookup = disklessLookupOnJob(job, topicPartition, partition)
     def disklessLookupOnNewJob: Lookup = disklessLookupOnJob(newJob(), topicPartition, partition, startNow = true)
 
-    if (migrationPending && disklessManagedReplicasEnabled) {
+    // Consolidating diskless topics can still carry CLASSIC_TO_DISKLESS_MIGRATION_PENDING in
+    // metadata while the leader serves (or is catching up) from object storage; ListOffsets must
+    // not be forced down the classic-only path in that case (see ReplicaManager diskless fetch
+    // routing for the analogous consolidating carve-out).
+    if (migrationPending && disklessManagedReplicasEnabled && !isConsolidatingPartition) {
       // Case 3.
       classicFetchOffset(topicPartition, partition, false)
     } else if (isMigratedWithClassicAccess && isFollowerRequest) {
       // Case 4.
       classicLookup()
-    } else if (isMigratedWithClassicAccess) {
+    } else if (isMigratedWithClassicAccess || isConsolidatingPartition) {
       // Case 2: hybrid, route by timestamp.
       partition.timestamp() match {
         case ListOffsetsRequest.EARLIEST_LOCAL_TIMESTAMP | ListOffsetsRequest.LATEST_TIERED_TIMESTAMP =>
@@ -117,27 +128,19 @@ class DisklessFetchOffsetRouter(
           classicLookup()
 
         case ListOffsetsRequest.EARLIEST_TIMESTAMP =>
+          // Always do classic first and then fall back to diskless with consolidating partitions
+          if (isConsolidatingPartition) {
+            classicWithDisklessFallbackLookup(topicPartition, version, classicLookup _, disklessLookup _, disklessLookupOnNewJob _)
           // Try classic first when classic data is still on disk, otherwise go straight to diskless.
-          if (classicLogStartOffsetProvider(topicPartition).exists(_ < classicToDisklessStartOffset)) classicLookup()
-          else asStatus(topicPartition, disklessLookup)
+          } else if (classicLogStartOffsetProvider(topicPartition).exists(_ < classicToDisklessStartOffset)) {
+            classicLookup()
+          } else {
+            asStatus(topicPartition, disklessLookup)
+          }
 
         case t if t >= 0 =>
           // Specific timestamp: classic first, fall back to diskless on a "no match".
-          val classic = classicLookup()
-          if (classic.responseOpt.isPresent) {
-            if (isSyncNoMatch(classic.responseOpt.get)) asStatus(topicPartition, disklessLookup)
-            else classic
-          } else if (classic.futureHolderOpt.isPresent) {
-            // If the classic future is already complete at routing time, withFallback's thenCompose
-            // invokes the fallback factory synchronously on this thread, i.e. inside route(), which
-            // runs before the caller calls job.start() (see ReplicaManager.fetchOffset). So we can
-            // still batch the diskless lookup into the per-request job. Otherwise the fallback
-            // fires asynchronously after start(), and must use a fresh, immediately-started job.
-            val fallback: () => Lookup =
-              if (classic.futureHolderOpt.get.taskFuture.isDone) () => disklessLookup
-              else                                               () => disklessLookupOnNewJob
-            withFallback(topicPartition, classicLookupOf(classic, version), fallback)
-          } else classic
+          classicWithDisklessFallbackLookup(topicPartition, version, classicLookup _, disklessLookup _, disklessLookupOnNewJob _)
 
         case _ =>
           // LATEST_TIMESTAMP / MAX_TIMESTAMP: diskless first, classic fallback on empty.
@@ -147,6 +150,28 @@ class DisklessFetchOffsetRouter(
       // Case 1.
       asStatus(topicPartition, disklessLookup)
     }
+  }
+
+  private def classicWithDisklessFallbackLookup(topicPartition: TopicPartition,
+                                                version: Short,
+                                                classicLookup: () => ListOffsetsPartitionStatus,
+                                                disklessLookup: () => Lookup,
+                                                disklessLookupOnNewJob: () => Lookup) = {
+    val classic = classicLookup()
+    if (classic.responseOpt.isPresent) {
+      if (isSyncNoMatch(classic.responseOpt.get)) asStatus(topicPartition, disklessLookup())
+      else classic
+    } else if (classic.futureHolderOpt.isPresent) {
+      // If the classic future is already complete at routing time, withFallback's thenCompose
+      // invokes the fallback factory synchronously on this thread, i.e. inside route(), which
+      // runs before the caller calls job.start() (see ReplicaManager.fetchOffset). So we can
+      // still batch the diskless lookup into the per-request job. Otherwise the fallback
+      // fires asynchronously after start(), and must use a fresh, immediately-started job.
+      val fallback: () => Lookup =
+        if (classic.futureHolderOpt.get.taskFuture.isDone) () => disklessLookup()
+        else () => disklessLookupOnNewJob()
+      withFallback(topicPartition, classicLookupOf(classic, version), fallback)
+    } else classic
   }
 
   /**

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -277,6 +277,7 @@ class ReplicaManager(val config: KafkaConfig,
   private val disklessFetchOffsetRouter = new DisklessFetchOffsetRouter(
     _inklessMetadataView,
     config.disklessManagedReplicasEnabled,
+    config.disklessRemoteStorageConsolidationEnabled,
     delayedRemoteListOffsetsPurgatory
   )
   private val inklessDeleteRecordsInterceptor: Option[DeleteRecordsInterceptor] = inklessSharedState.map(new DeleteRecordsInterceptor(_))

--- a/core/src/test/scala/unit/kafka/server/DisklessFetchOffsetRouterTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DisklessFetchOffsetRouterTest.scala
@@ -65,8 +65,11 @@ class DisklessFetchOffsetRouterTest {
   // Default classic-side answer for tests that don't care about the response shape.
   private val defaultClassicResult: ListOffsetsPartitionStatus = resolvedStatus(makeResponse(offset = 0L, timestamp = 0L))
   
-  private def newRouter(disklessManagedReplicasEnabled: Boolean = true): DisklessFetchOffsetRouter =
-    new DisklessFetchOffsetRouter(inklessMetadataView, disklessManagedReplicasEnabled, purgatory)
+  private def newRouter(
+    disklessManagedReplicasEnabled: Boolean = true,
+    disklessConsolidationEnabled: Boolean = false
+  ): DisklessFetchOffsetRouter =
+    new DisklessFetchOffsetRouter(inklessMetadataView, disklessManagedReplicasEnabled, disklessConsolidationEnabled, purgatory)
 
   private def makePartition(timestamp: Long, partitionIndex: Int): ListOffsetsPartition =
     new ListOffsetsPartition().setPartitionIndex(partitionIndex).setTimestamp(timestamp)
@@ -394,5 +397,102 @@ class DisklessFetchOffsetRouterTest {
     val ex = assertThrows(classOf[ExecutionException],
       () => status.futureHolderOpt.get.taskFuture.get(1, TimeUnit.SECONDS))
     assertSame(controlPlaneFailure, ex.getCause)
+  }
+
+  @Test
+  def routesToDisklessWhenMigrationPendingButConsolidatingTopic(): Unit = {
+    when(inklessMetadataView.getClassicToDisklessStartOffset(tp)).thenReturn(PartitionRegistration.CLASSIC_TO_DISKLESS_MIGRATION_PENDING)
+    when(inklessMetadataView.isConsolidatingDisklessTopic(tp.topic)).thenReturn(true)
+
+    val status = route(
+      newRouter(disklessManagedReplicasEnabled = true, disklessConsolidationEnabled = true),
+      timestamp = ListOffsetsRequest.LATEST_TIMESTAMP
+    )
+
+    assertTrue(classicCalls.isEmpty, "consolidating topics must not use migration-pending classic-only ListOffsets")
+    verify(job).add(eqTo(tp), any())
+    assertTrue(status.futureHolderOpt.isPresent)
+    assertFalse(status.responseOpt.isPresent)
+  }
+
+  @Test
+  def hybridConsolidatingWithoutCommittedBoundaryAllowsFollowerOnEarliestLocal(): Unit = {
+    when(inklessMetadataView.getClassicToDisklessStartOffset(tp)).thenReturn(PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET)
+    when(inklessMetadataView.isConsolidatingDisklessTopic(tp.topic)).thenReturn(true)
+
+    val status = route(
+      newRouter(disklessManagedReplicasEnabled = true, disklessConsolidationEnabled = true),
+      timestamp = ListOffsetsRequest.EARLIEST_LOCAL_TIMESTAMP
+    )
+
+    assertSame(defaultClassicResult, status)
+    assertClassicCalledWith(allowFromFollower = true)
+    verify(job, never()).add(any(), any())
+  }
+
+  @Test
+  def hybridConsolidatingWithoutCommittedBoundaryAllowsFollowerOnLatestTiered(): Unit = {
+    when(inklessMetadataView.getClassicToDisklessStartOffset(tp)).thenReturn(PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET)
+    when(inklessMetadataView.isConsolidatingDisklessTopic(tp.topic)).thenReturn(true)
+
+    val status = route(
+      newRouter(disklessManagedReplicasEnabled = true, disklessConsolidationEnabled = true),
+      timestamp = ListOffsetsRequest.LATEST_TIERED_TIMESTAMP
+    )
+
+    assertSame(defaultClassicResult, status)
+    assertClassicCalledWith(allowFromFollower = true)
+    verify(job, never()).add(any(), any())
+  }
+
+  @Test
+  def hybridConsolidatingEarliestAlwaysTriesClassicFirstWithDisklessFallback(): Unit = {
+    when(inklessMetadataView.getClassicToDisklessStartOffset(tp)).thenReturn(PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET)
+    when(inklessMetadataView.isConsolidatingDisklessTopic(tp.topic)).thenReturn(true)
+
+    val status = route(
+      newRouter(disklessManagedReplicasEnabled = true, disklessConsolidationEnabled = true),
+      timestamp = ListOffsetsRequest.EARLIEST_TIMESTAMP,
+      classicLogStartOffset = Some(100L)
+    )
+
+    assertSame(defaultClassicResult, status)
+    assertClassicCalledWith(allowFromFollower = true)
+    verify(job, never()).add(any(), any())
+  }
+
+  @Test
+  def hybridConsolidatingEarliestFallsBackToDisklessWhenClassicReturnsNoMatchEvenIfLogPastBoundary(): Unit = {
+    when(inklessMetadataView.getClassicToDisklessStartOffset(tp)).thenReturn(100L)
+    when(inklessMetadataView.isConsolidatingDisklessTopic(tp.topic)).thenReturn(true)
+    val noMatch = resolvedStatus(makeResponse(offset = -1L, errorCode = Errors.NONE.code))
+
+    val status = route(
+      newRouter(disklessConsolidationEnabled = true),
+      timestamp = ListOffsetsRequest.EARLIEST_TIMESTAMP,
+      classicLogStartOffset = Some(100L),
+      classicResult = noMatch
+    )
+
+    assertClassicCalledWith(allowFromFollower = true)
+    verify(job).add(eqTo(tp), any())
+    assertTrue(status.futureHolderOpt.isPresent, "fallback to diskless surfaces an async holder")
+    assertNotSame(noMatch, status)
+  }
+
+  @Test
+  def hybridConsolidatingEarliestReturnsClassicWhenClassicHitsEvenIfLogPastBoundary(): Unit = {
+    when(inklessMetadataView.getClassicToDisklessStartOffset(tp)).thenReturn(100L)
+    when(inklessMetadataView.isConsolidatingDisklessTopic(tp.topic)).thenReturn(true)
+
+    val status = route(
+      newRouter(disklessConsolidationEnabled = true),
+      timestamp = ListOffsetsRequest.EARLIEST_TIMESTAMP,
+      classicLogStartOffset = Some(100L)
+    )
+
+    assertSame(defaultClassicResult, status)
+    assertClassicCalledWith(allowFromFollower = true)
+    verify(job, never()).add(any(), any())
   }
 }

--- a/core/src/test/scala/unit/kafka/server/DisklessFetchOffsetRouterTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DisklessFetchOffsetRouterTest.scala
@@ -495,4 +495,21 @@ class DisklessFetchOffsetRouterTest {
     assertClassicCalledWith(allowFromFollower = true)
     verify(job, never()).add(any(), any())
   }
+  
+  @Test
+  def consolidatingFollowerOnLatestTimestampRoutesThroughDisklessFirst(): Unit = {
+    when(inklessMetadataView.getClassicToDisklessStartOffset(tp)).thenReturn(PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET)
+    when(inklessMetadataView.isConsolidatingDisklessTopic(tp.topic)).thenReturn(true)
+
+    val status = route(
+      newRouter(disklessManagedReplicasEnabled = true, disklessConsolidationEnabled = true),
+      timestamp = ListOffsetsRequest.LATEST_TIMESTAMP,
+      replicaId = followerReplicaId
+    )
+
+    // Should go through hybrid Case 2 LATEST_TIMESTAMP path (diskless first, classic fallback)
+    verify(job).add(eqTo(tp), any())
+    assertTrue(status.futureHolderOpt.isPresent)
+  }
+
 }


### PR DESCRIPTION
Enable list offsets API for consolidating partitions. When they fetch offsets, the decision should be similar to what is already done for diskless partitions that have classic log tails.