### PR TITLE
fix(inkless:migration): reschedule fetcher on leader change during pending migration

### DIFF
--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -3146,14 +3146,22 @@ class ReplicaManager(val config: KafkaConfig,
           getOrCreatePartition(tp, delta, info.topicId).foreach { case (partition, isNew) =>
             try {
               val partitionAssignedDirectoryId = directoryIds.find(_._1.topicPartition() == tp).map(_._2)
-              partition.makeFollower(info.partition, isNew, offsetCheckpoints, Some(info.topicId), partitionAssignedDirectoryId)
+              val isNewLeaderEpoch = partition.makeFollower(info.partition, isNew, offsetCheckpoints, Some(info.topicId), partitionAssignedDirectoryId)
               partition.seal()
               changedPartitions.add(partition)
-              // Schedule a catch-up fetch when the local HW is below the seal -- either
-              // because we restarted with a stale HW (unclean shutdown) or because we
-              // were just added as a replica and have an empty local log. The
-              // ReplicaFetcher self-evicts once the follower has read past the seal.
               if (seal >= 0 && partition.localLogOrException.highWatermark < seal) {
+                // Schedule a catch-up fetch when the local HW is below the seal -- either
+                // because we restarted with a stale HW (unclean shutdown) or because we
+                // were just added as a replica and have an empty local log. The
+                // ReplicaFetcher self-evicts once the follower has read past the seal.
+                partitionsToStartFetching.put(tp, partition)
+              } else if (seal == PartitionRegistration.CLASSIC_TO_DISKLESS_MIGRATION_PENDING && isNewLeaderEpoch) {
+                // Migration is in flight: the leader has already sealed its log and
+                // frozen the LEO, but the controller has not yet committed the seal
+                // offset. Followers must keep replicating up to that frozen LEO via the
+                // classic ReplicaFetcher. Reschedule on any leader-epoch change so a
+                // leader move during PENDING doesn't strand replication on a fetcher
+                // still pointing at the previous leader.
                 partitionsToStartFetching.put(tp, partition)
               }
             } catch {

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -9600,12 +9600,46 @@ class ReplicaManagerTest {
       }
     }
 
-    @ParameterizedTest
-    @ValueSource(longs = Array(
-      PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET,
-      PartitionRegistration.CLASSIC_TO_DISKLESS_MIGRATION_PENDING
-    ))
-    def testApplyDeltaDoesNotStartCatchUpFetcherWhenSealOffsetUnset(sealOffset: Long): Unit = {
+    @Test
+    def testApplyDeltaDoesNotStartCatchUpFetcherForNeverMigratedDisklessFollower(): Unit = {
+      // Never-migrated diskless topic (seal == -1) on a broker that has no on-disk
+      // classic data: there is nothing here to expose to consumers below a seal, and
+      // there is no upper bound to fetch up to. Nothing should be done on this path.
+      val topicName = "fully-diskless-topic"
+      val topicId = Uuid.randomUuid()
+      val tp = new TopicPartition(topicName, 0)
+      val brokerId = 1
+      val leaderId = 2
+
+      val mockFetcherManager = mock(classOf[ReplicaFetcherManager])
+      when(mockFetcherManager.removeFetcherForPartitions(any())).thenReturn(Map.empty[TopicPartition, PartitionFetchState])
+
+      val replicaManager = spy(createReplicaManager(
+        List(topicName),
+        mockReplicaFetcherManager = Some(mockFetcherManager)
+      ))
+      try {
+        assertTrue(replicaManager.logManager.getLog(tp).isEmpty)
+        when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(tp))
+          .thenReturn(PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET)
+
+        val delta = disklessFollowerDelta(topicName, topicId, brokerId, leaderId)
+        replicaManager.applyDelta(delta, imageFromTopics(delta.apply()))
+
+        assertEquals(HostedPartition.None, replicaManager.getPartition(tp))
+        verify(mockFetcherManager, never()).addFetcherForPartitions(any())
+      } finally {
+        replicaManager.shutdown(checkpointHW = false)
+      }
+    }
+
+    @Test
+    def testApplyDeltaSchedulesFetcherForDisklessFollowerDuringMigrationPending(): Unit = {
+      // PENDING window: the topic is already flagged diskless but the controller has
+      // not yet committed the seal offset (-2). The leader has already sealed its log
+      // and frozen its LEO; followers must keep replicating up to that frozen LEO
+      // with a normal ReplicaFetcher. Verify that the first follower-side applyDelta
+      // during PENDING arms a fetcher pointing at the leader from the follower's LEO.
       val topicName = "migrated-topic"
       val topicId = Uuid.randomUuid()
       val tp = new TopicPartition(topicName, 0)
@@ -9620,20 +9654,123 @@ class ReplicaManagerTest {
         mockReplicaFetcherManager = Some(mockFetcherManager)
       ))
       try {
-        // HW lags LEO, but the seal offset is not yet committed by the controller.
         val log = replicaManager.logManager.getOrCreateLog(tp, isNew = true, topicId = Optional.of(topicId))
         populateLocalLogAtLeoAndCheckpointedHwm(replicaManager, tp, log, leo = 10L, hw = 5L)
 
-        when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(tp)).thenReturn(sealOffset)
+        when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(tp))
+          .thenReturn(PartitionRegistration.CLASSIC_TO_DISKLESS_MIGRATION_PENDING)
 
         val delta = disklessFollowerDelta(topicName, topicId, brokerId, leaderId)
         replicaManager.applyDelta(delta, imageFromTopics(delta.apply()))
 
-        // Without a committed seal offset we have no upper bound to fetch up to,
-        // so no catch-up fetcher should be started yet. The follower will start
-        // catching up once the controller publishes the seal (which bumps the
-        // partitionEpoch and re-triggers applyLocalFollowersDelta).
-        verify(mockFetcherManager, never()).addFetcherForPartitions(any())
+        val leaderEndpoint = ClusterImageTest.IMAGE1.broker(leaderId).listeners().get("PLAINTEXT")
+        verify(mockFetcherManager).addFetcherForPartitions(Map(tp -> InitialFetchState(
+          topicId = Some(topicId),
+          leader = new BrokerEndPoint(leaderId, leaderEndpoint.host(), leaderEndpoint.port()),
+          currentLeaderEpoch = 0,
+          initOffset = 10L
+        )))
+      } finally {
+        replicaManager.shutdown(checkpointHW = false)
+      }
+    }
+
+    @Test
+    def testApplyDeltaReschedulesFetcherForDisklessFollowerOnLeaderChangeDuringMigrationPending(): Unit = {
+      // PENDING + leader change: if the original leader crashes mid-migration and a
+      // new leader is elected, the follower's existing fetcher would still target the
+      // dead broker and replication would stall (the leader can never commit the seal
+      // because it sees no follower fetch traffic). This test pins down that a new
+      // leader epoch during PENDING reschedules the fetcher onto the new leader.
+      val topicName = "migrated-topic"
+      val topicId = Uuid.randomUuid()
+      val tp = new TopicPartition(topicName, 0)
+      val brokerId = 1
+      val firstLeaderId = 2
+      val secondLeaderId = 0
+
+      val mockFetcherManager = mock(classOf[ReplicaFetcherManager])
+      when(mockFetcherManager.removeFetcherForPartitions(any())).thenReturn(Map.empty[TopicPartition, PartitionFetchState])
+
+      val replicaManager = spy(createReplicaManager(
+        List(topicName),
+        mockReplicaFetcherManager = Some(mockFetcherManager)
+      ))
+      try {
+        val log = replicaManager.logManager.getOrCreateLog(tp, isNew = true, topicId = Optional.of(topicId))
+        populateLocalLogAtLeoAndCheckpointedHwm(replicaManager, tp, log, leo = 10L, hw = 5L)
+
+        when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(tp))
+          .thenReturn(PartitionRegistration.CLASSIC_TO_DISKLESS_MIGRATION_PENDING)
+
+        // First apply: leader == firstLeaderId, leaderEpoch == 0.
+        val delta1 = disklessFollowerDelta(topicName, topicId, brokerId, firstLeaderId)
+        replicaManager.applyDelta(delta1, imageFromTopics(delta1.apply()))
+
+        val firstEndpoint = ClusterImageTest.IMAGE1.broker(firstLeaderId).listeners().get("PLAINTEXT")
+        verify(mockFetcherManager).addFetcherForPartitions(Map(tp -> InitialFetchState(
+          topicId = Some(topicId),
+          leader = new BrokerEndPoint(firstLeaderId, firstEndpoint.host(), firstEndpoint.port()),
+          currentLeaderEpoch = 0,
+          initOffset = 10L
+        )))
+
+        // Second apply: leader moves to secondLeaderId, leaderEpoch bumps to 1.
+        val delta2 = new TopicsDelta(TopicsImage.EMPTY)
+        delta2.replay(new TopicRecord().setName(topicName).setTopicId(topicId))
+        delta2.replay(new PartitionRecord()
+          .setPartitionId(0)
+          .setTopicId(topicId)
+          .setReplicas(util.Arrays.asList(brokerId, firstLeaderId, secondLeaderId))
+          .setIsr(util.Arrays.asList(brokerId, firstLeaderId, secondLeaderId))
+          .setLeader(secondLeaderId)
+          .setLeaderEpoch(1)
+          .setPartitionEpoch(1)
+        )
+        replicaManager.applyDelta(delta2, imageFromTopics(delta2.apply()))
+
+        val secondEndpoint = ClusterImageTest.IMAGE1.broker(secondLeaderId).listeners().get("PLAINTEXT")
+        verify(mockFetcherManager).addFetcherForPartitions(Map(tp -> InitialFetchState(
+          topicId = Some(topicId),
+          leader = new BrokerEndPoint(secondLeaderId, secondEndpoint.host(), secondEndpoint.port()),
+          currentLeaderEpoch = 1,
+          initOffset = 10L
+        )))
+      } finally {
+        replicaManager.shutdown(checkpointHW = false)
+      }
+    }
+
+    @Test
+    def testApplyDeltaDoesNotRescheduleFetcherForDisklessFollowerDuringMigrationPendingOnSameEpoch(): Unit = {
+      // Same leader, same leader epoch: the existing fetcher is still valid, so a
+      // second applyDelta during PENDING must not redundantly reschedule it.
+      val topicName = "migrated-topic"
+      val topicId = Uuid.randomUuid()
+      val tp = new TopicPartition(topicName, 0)
+      val brokerId = 1
+      val leaderId = 2
+
+      val mockFetcherManager = mock(classOf[ReplicaFetcherManager])
+      when(mockFetcherManager.removeFetcherForPartitions(any())).thenReturn(Map.empty[TopicPartition, PartitionFetchState])
+
+      val replicaManager = spy(createReplicaManager(
+        List(topicName),
+        mockReplicaFetcherManager = Some(mockFetcherManager)
+      ))
+      try {
+        val log = replicaManager.logManager.getOrCreateLog(tp, isNew = true, topicId = Optional.of(topicId))
+        populateLocalLogAtLeoAndCheckpointedHwm(replicaManager, tp, log, leo = 10L, hw = 5L)
+
+        when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(tp))
+          .thenReturn(PartitionRegistration.CLASSIC_TO_DISKLESS_MIGRATION_PENDING)
+
+        val delta = disklessFollowerDelta(topicName, topicId, brokerId, leaderId)
+        replicaManager.applyDelta(delta, imageFromTopics(delta.apply()))
+        replicaManager.applyDelta(delta, imageFromTopics(delta.apply()))
+
+        // Only the first apply should have armed the fetcher.
+        verify(mockFetcherManager, times(1)).addFetcherForPartitions(any())
       } finally {
         replicaManager.shutdown(checkpointHW = false)
       }


### PR DESCRIPTION
During the classic-to-diskless pending window (topic flagged diskless but seal not yet committed) the leader has already sealed its log and frozen its LEO; followers must keep replicating up to that LEO. The diskless branch of applyLocalFollowersDelta only armed a fetcher post-seal, so a leader change mid-PENDING left followers stuck on the previous leader, the new leader saw no follower fetch traffic, and the seal could never be committed.

Capture isNewLeaderEpoch from makeFollower and, for `seal == -2`, reschedule the ReplicaFetcher on any leader-epoch bump. Once the seal commits, the existing `seal >= 0` branch takes over as a bounded catch-up.
