### PR TITLE
refactor(inkless): Rename diskless migration to diskless switch

### DIFF
--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -195,7 +195,7 @@ class Partition(val topicPartition: TopicPartition,
   @volatile private[cluster] var partitionState: PartitionState = new CommittedPartitionState(util.Set.of(), LeaderRecoveryState.RECOVERED)
   @volatile var assignmentState: AssignmentState = new SimpleAssignmentState(util.List.of())
 
-  // When true, the partition is sealed for classic-to-diskless migration.
+  // When true, the partition is sealed for classic-to-diskless switch.
   // A sealed partition rejects all produce requests via appendRecordsToLeader.
   // Set under the write lock to guarantee that once sealed, LEO cannot increase.
   @volatile private var _sealed: Boolean = false
@@ -272,14 +272,14 @@ class Partition(val topicPartition: TopicPartition,
         abortOngoingTransactions(leaderLog)
       }
       _sealed = true
-      stateChangeLogger.info(s"Sealed partition $topicPartition for diskless migration with LEO ${leaderLog.logEndOffset}")
+      stateChangeLogger.info(s"Sealed partition $topicPartition for diskless switch with LEO ${leaderLog.logEndOffset}")
     }
   }
 
   /**
    * Abort all ongoing transactions by appending ABORT markers directly to the log.
    * Diskless topics do not support transactions, so any in-flight transaction must
-   * be resolved before migration proceeds.
+   * be resolved before the switch from classic to diskless proceeds.
    * @throws KafkaStorageException If transaction abortion fails due to an I/O error.
    */
   private def abortOngoingTransactions(leaderLog: UnifiedLog): Unit = {
@@ -304,7 +304,7 @@ class Partition(val topicPartition: TopicPartition,
         RequestLocal.noCaching(), VerificationGuard.SENTINEL, TransactionVersion.TV_0.featureLevel())
       stateChangeLogger.info(s"Aborted ongoing transaction for producer $producerId " +
         s"(epoch=$producerEpoch, txnFirstOffset=$txnFirstOffset) " +
-        s"on partition $topicPartition before sealing for diskless migration")
+        s"on partition $topicPartition before sealing for diskless switch")
     }
   }
 
@@ -1281,9 +1281,9 @@ class Partition(val topicPartition: TopicPartition,
   ): LogAppendInfo = {
     val (info, leaderHWIncremented) = inReadLock(leaderIsrUpdateLock) {
       if (_sealed) {
-        // Force metadata refresh and client retries while the migration from classic to diskless is still ongoing.
+        // Force metadata refresh and client retries while the switch from classic to diskless is still ongoing.
         throw new ReplicaNotAvailableException(
-          s"Partition $topicPartition is sealed for diskless migration on broker $localBrokerId")
+          s"Partition $topicPartition is sealed for diskless switch on broker $localBrokerId")
       }
 
       leaderLogIfLocal match {

--- a/core/src/main/scala/kafka/server/DisklessFetchOffsetRouter.scala
+++ b/core/src/main/scala/kafka/server/DisklessFetchOffsetRouter.scala
@@ -93,7 +93,7 @@ class DisklessFetchOffsetRouter(
     classicFetchOffset: (TopicPartition, ListOffsetsPartition, Boolean) => ListOffsetsPartitionStatus
   ): ListOffsetsPartitionStatus = {
     val classicToDisklessStartOffset = inklessMetadataView.getClassicToDisklessStartOffset(topicPartition)
-    val migrationPending = classicToDisklessStartOffset == PartitionRegistration.CLASSIC_TO_DISKLESS_MIGRATION_PENDING
+    val migrationPending = classicToDisklessStartOffset == PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING
     val isMigratedWithClassicAccess = (classicToDisklessStartOffset > 0 && disklessManagedReplicasEnabled)
     val isConsolidatingPartition = disklessConsolidationEnabled && inklessMetadataView.isConsolidatingDisklessTopic(topicPartition.topic)
 

--- a/core/src/main/scala/kafka/server/DisklessFetchOffsetRouter.scala
+++ b/core/src/main/scala/kafka/server/DisklessFetchOffsetRouter.scala
@@ -45,12 +45,12 @@ import scala.jdk.OptionConverters.RichOptional
  *   2. Hybrid diskless partition (`classicToDisklessStartOffset > 0` and managed replicas enabled,
  *      or a consolidating diskless topic): fetch offset in classic and/or diskless path, depending
  *      on the requested timestamp. Consolidating topics also allow followers on the classic leg
- *      (same rationale as sealed migrated replicas: clients may be routed to any ISR replica).
- *   3. Partition that is being migrated from classic to diskless
- *      (`classicToDisklessStartOffset == CLASSIC_TO_DISKLESS_MIGRATION_PENDING` and managed
+ *      (same rationale as sealed switched replicas: clients may be routed to any ISR replica).
+ *   3. Partition that is being switched from classic to diskless
+ *      (`classicToDisklessStartOffset == CLASSIC_TO_DISKLESS_SWITCH_PENDING` and managed
  *      replicas enabled, and not a consolidating diskless topic): fetch offset only in the
  *      classic path.
- *   4. Follower requests on a migrated partition: ListOffsets requests (used by ReplicaFetcher
+ *   4. Follower requests on a switched partition: ListOffsets requests (used by ReplicaFetcher
  *      for truncation / initial offset bootstrap) must never see diskless offsets, otherwise the
  *      follower would try to truncate to or fetch from offsets that live only in object storage:
  *      fetch offset only in the classic path.
@@ -93,34 +93,34 @@ class DisklessFetchOffsetRouter(
     classicFetchOffset: (TopicPartition, ListOffsetsPartition, Boolean) => ListOffsetsPartitionStatus
   ): ListOffsetsPartitionStatus = {
     val classicToDisklessStartOffset = inklessMetadataView.getClassicToDisklessStartOffset(topicPartition)
-    val migrationPending = classicToDisklessStartOffset == PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING
-    val isMigratedWithClassicAccess = (classicToDisklessStartOffset > 0 && disklessManagedReplicasEnabled)
+    val switchPending = classicToDisklessStartOffset == PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING
+    val isSwitchedWithClassicAccess = (classicToDisklessStartOffset > 0 && disklessManagedReplicasEnabled)
     val isConsolidatingPartition = disklessConsolidationEnabled && inklessMetadataView.isConsolidatingDisklessTopic(topicPartition.topic)
 
-    // Migrated partitions seal their classic local log: once classicToDisklessStartOffset is
+    // Switched partitions seal their classic local log: once classicToDisklessStartOffset is
     // committed the LEO can no longer grow and every ISR replica has the same data on disk.
     // Any replica can therefore safely answer ListOffsets from its local log, so we let
     // followers serve the classic-side query as well.
     // Since consolidating partitions contain only data that has been stored in the diskless
     // coordinator and its offsets won't change, we can allow follower requests.
-    val allowFromFollower = isMigratedWithClassicAccess || isConsolidatingPartition
+    val allowFromFollower = isSwitchedWithClassicAccess || isConsolidatingPartition
     val isFollowerRequest = replicaId >= 0
 
     def classicLookup(): ListOffsetsPartitionStatus = classicFetchOffset(topicPartition, partition, allowFromFollower)
     def disklessLookup: Lookup = disklessLookupOnJob(job, topicPartition, partition)
     def disklessLookupOnNewJob: Lookup = disklessLookupOnJob(newJob(), topicPartition, partition, startNow = true)
 
-    // Consolidating diskless topics can still carry CLASSIC_TO_DISKLESS_MIGRATION_PENDING in
+    // Consolidating diskless topics can still carry CLASSIC_TO_DISKLESS_SWITCH_PENDING in
     // metadata while the leader serves (or is catching up) from object storage; ListOffsets must
     // not be forced down the classic-only path in that case (see ReplicaManager diskless fetch
     // routing for the analogous consolidating carve-out).
-    if (migrationPending && disklessManagedReplicasEnabled && !isConsolidatingPartition) {
+    if (switchPending && disklessManagedReplicasEnabled && !isConsolidatingPartition) {
       // Case 3.
       classicFetchOffset(topicPartition, partition, false)
-    } else if (isMigratedWithClassicAccess && isFollowerRequest) {
+    } else if (isSwitchedWithClassicAccess && isFollowerRequest) {
       // Case 4.
       classicLookup()
-    } else if (isMigratedWithClassicAccess || isConsolidatingPartition) {
+    } else if (isSwitchedWithClassicAccess || isConsolidatingPartition) {
       // Case 2: hybrid, route by timestamp.
       partition.timestamp() match {
         case ListOffsetsRequest.EARLIEST_LOCAL_TIMESTAMP | ListOffsetsRequest.LATEST_TIERED_TIMESTAMP =>

--- a/core/src/main/scala/kafka/server/InitDisklessLogManager.scala
+++ b/core/src/main/scala/kafka/server/InitDisklessLogManager.scala
@@ -248,34 +248,34 @@ object InitDisklessLogManager {
   private val MetricsPackage = "kafka.server"
   private val MetricsClassName = "InitDisklessLogManager"
 
-  private[server] val InitDisklessLogInFlightMetricName = "InitDisklessLogInFlight"
-  private[server] val WaitingForReplicationCountMetricName = "InitDisklessLogWaitingForReplicationCount"
-  private[server] val SendingToControllerCountMetricName = "InitDisklessLogSendingToControllerCount"
-  private[server] val AwaitingMetadataCountMetricName = "InitDisklessLogAwaitingMetadataCount"
+  private[server] val InFlightPartitionsMetricName = "InFlightPartitions"
+  private[server] val WaitingForReplicationPartitionsMetricName = "WaitingForReplicationPartitions"
+  private[server] val SendingToControllerPartitionsMetricName = "SendingToControllerPartitions"
+  private[server] val AwaitingMetadataPartitionsMetricName = "AwaitingMetadataPartitions"
 
   // Oldest-age-per-state gauges. Reads 0 when no partition is currently in the corresponding state.
-  private[server] val OldestWaitingForReplicationAgeMsMetricName = "InitDisklessLogOldestWaitingForReplicationAgeMs"
-  private[server] val OldestSendingToControllerAgeMsMetricName = "InitDisklessLogOldestSendingToControllerAgeMs"
-  private[server] val OldestAwaitingMetadataAgeMsMetricName = "InitDisklessLogOldestAwaitingMetadataAgeMs"
+  private[server] val OldestWaitingForReplicationAgeMsMetricName = "OldestWaitingForReplicationAgeMs"
+  private[server] val OldestSendingToControllerAgeMsMetricName = "OldestSendingToControllerAgeMs"
+  private[server] val OldestAwaitingMetadataAgeMsMetricName = "OldestAwaitingMetadataAgeMs"
 
-  private[server] val InitDisklessLogCompletedPerSecMetricName = "InitDisklessLogCompletedPerSec"
-  private[server] val InitDisklessLogFailedPerSecMetricName = "InitDisklessLogFailedPerSec"
-  private[server] val InitDisklessLogRetriedPerSecMetricName = "InitDisklessLogRetriedPerSec"
+  private[server] val InitCompletedPerSecMetricName = "InitCompletedPerSec"
+  private[server] val InitFailedPerSecMetricName = "InitFailedPerSec"
+  private[server] val InitRetriedPerSecMetricName = "InitRetriedPerSec"
 
   private[server] val GaugeMetricNames = Set(
-    InitDisklessLogInFlightMetricName,
-    WaitingForReplicationCountMetricName,
-    SendingToControllerCountMetricName,
-    AwaitingMetadataCountMetricName,
+    InFlightPartitionsMetricName,
+    WaitingForReplicationPartitionsMetricName,
+    SendingToControllerPartitionsMetricName,
+    AwaitingMetadataPartitionsMetricName,
     OldestWaitingForReplicationAgeMsMetricName,
     OldestSendingToControllerAgeMsMetricName,
     OldestAwaitingMetadataAgeMsMetricName,
   )
 
   private[server] val MeterMetricNames = Set(
-    InitDisklessLogCompletedPerSecMetricName,
-    InitDisklessLogFailedPerSecMetricName,
-    InitDisklessLogRetriedPerSecMetricName,
+    InitCompletedPerSecMetricName,
+    InitFailedPerSecMetricName,
+    InitRetriedPerSecMetricName,
   )
 
   private[server] val MetricNames: Set[String] = GaugeMetricNames union MeterMetricNames
@@ -302,17 +302,17 @@ object InitDisklessLogManager {
       classOf[AwaitingMetadata]      -> new ConcurrentHashMap[TopicPartition, java.lang.Long]()
     )
 
-    metricsGroup.newGauge(InitDisklessLogInFlightMetricName, () => trackedSize())
-    metricsGroup.newGauge(WaitingForReplicationCountMetricName, () => counters(classOf[WaitingForReplication]).get)
-    metricsGroup.newGauge(SendingToControllerCountMetricName,   () => counters(classOf[SendingToController]).get)
-    metricsGroup.newGauge(AwaitingMetadataCountMetricName,      () => counters(classOf[AwaitingMetadata]).get)
+    metricsGroup.newGauge(InFlightPartitionsMetricName, () => trackedSize())
+    metricsGroup.newGauge(WaitingForReplicationPartitionsMetricName, () => counters(classOf[WaitingForReplication]).get)
+    metricsGroup.newGauge(SendingToControllerPartitionsMetricName, () => counters(classOf[SendingToController]).get)
+    metricsGroup.newGauge(AwaitingMetadataPartitionsMetricName, () => counters(classOf[AwaitingMetadata]).get)
     metricsGroup.newGauge(OldestWaitingForReplicationAgeMsMetricName, () => oldestAgeMs(classOf[WaitingForReplication]))
     metricsGroup.newGauge(OldestSendingToControllerAgeMsMetricName,   () => oldestAgeMs(classOf[SendingToController]))
     metricsGroup.newGauge(OldestAwaitingMetadataAgeMsMetricName,      () => oldestAgeMs(classOf[AwaitingMetadata]))
 
-    private val completedMeter = metricsGroup.newMeter(InitDisklessLogCompletedPerSecMetricName, "completed", TimeUnit.SECONDS)
-    private val failedMeter    = metricsGroup.newMeter(InitDisklessLogFailedPerSecMetricName,    "failed",    TimeUnit.SECONDS)
-    private val retriedMeter   = metricsGroup.newMeter(InitDisklessLogRetriedPerSecMetricName,   "retries",   TimeUnit.SECONDS)
+    private val completedMeter = metricsGroup.newMeter(InitCompletedPerSecMetricName, "inits", TimeUnit.SECONDS)
+    private val failedMeter    = metricsGroup.newMeter(InitFailedPerSecMetricName,    "inits", TimeUnit.SECONDS)
+    private val retriedMeter   = metricsGroup.newMeter(InitRetriedPerSecMetricName,   "inits", TimeUnit.SECONDS)
 
     def markCompleted(): Unit = completedMeter.mark()
     def markFailed(): Unit    = failedMeter.mark()

--- a/core/src/main/scala/kafka/server/InitDisklessLogManager.scala
+++ b/core/src/main/scala/kafka/server/InitDisklessLogManager.scala
@@ -110,7 +110,7 @@ class InitDisklessLogManager(
   }
 
   /**
-   * Register a sealed partition for migration. Registers this manager as a
+   * Register a sealed partition for init diskless log. Registers this manager as a
    * PartitionListener to receive HW advancement notifications. If HW already
    * equals LEO, immediately marks the partition ready and schedules a batch
    * send. Otherwise, waits for HW advancement notifications.
@@ -165,7 +165,7 @@ class InitDisklessLogManager(
         enqueueSendingToController(tp, sendingToController)
         sendingToController
       case _: Failed =>
-        // remove from tracking and count as a failed migration.
+        // remove from tracking and count as a failed init diskless log operation.
         metrics.markFailed()
         null
       case waitingForReplication: WaitingForReplication => waitingForReplication
@@ -184,7 +184,7 @@ class InitDisklessLogManager(
       } else {
         // PermanentFailure on controller call (e.g. FENCED_LEADER_EPOCH /
         // INVALID_REQUEST) or local pre-flight rejection (leader/log lost):
-        // the migration won't progress.
+        // the init diskless log operation won't progress.
         // Only count a failure when this callback observed `tp` as still
         // tracked. `removePartition` completes the queue promise with `false`
         // (via `queue.remove`) AFTER clearing `tracked`, so the cancellation
@@ -209,7 +209,7 @@ class InitDisklessLogManager(
         )
         // Only count completion when this callback observed `tp` as still
         // tracked. If `removePartition` cleared `tracked` (and/or the queue
-        // promise) concurrently, the migration was cancelled externally and
+        // promise) concurrently, the init diskless log operation was cancelled externally and
         // we must not inflate the completed meter.
         if (tracked.remove(tp) != null) {
           metrics.markCompleted()
@@ -248,22 +248,22 @@ object InitDisklessLogManager {
   private val MetricsPackage = "kafka.server"
   private val MetricsClassName = "InitDisklessLogManager"
 
-  private[server] val MigrationsInFlightMetricName = "ClassicToDisklessMigrationsInFlight"
-  private[server] val WaitingForReplicationCountMetricName = "ClassicToDisklessMigrationsWaitingForReplicationCount"
-  private[server] val SendingToControllerCountMetricName = "ClassicToDisklessMigrationsSendingToControllerCount"
-  private[server] val AwaitingMetadataCountMetricName ="ClassicToDisklessMigrationsAwaitingMetadataCount"
+  private[server] val InitDisklessLogInFlightMetricName = "InitDisklessLogInFlight"
+  private[server] val WaitingForReplicationCountMetricName = "InitDisklessLogWaitingForReplicationCount"
+  private[server] val SendingToControllerCountMetricName = "InitDisklessLogSendingToControllerCount"
+  private[server] val AwaitingMetadataCountMetricName = "InitDisklessLogAwaitingMetadataCount"
 
   // Oldest-age-per-state gauges. Reads 0 when no partition is currently in the corresponding state.
-  private[server] val OldestWaitingForReplicationAgeMsMetricName = "ClassicToDisklessMigrationOldestWaitingForReplicationAgeMs"
-  private[server] val OldestSendingToControllerAgeMsMetricName = "ClassicToDisklessMigrationOldestSendingToControllerAgeMs"
-  private[server] val OldestAwaitingMetadataAgeMsMetricName = "ClassicToDisklessMigrationOldestAwaitingMetadataAgeMs"
+  private[server] val OldestWaitingForReplicationAgeMsMetricName = "InitDisklessLogOldestWaitingForReplicationAgeMs"
+  private[server] val OldestSendingToControllerAgeMsMetricName = "InitDisklessLogOldestSendingToControllerAgeMs"
+  private[server] val OldestAwaitingMetadataAgeMsMetricName = "InitDisklessLogOldestAwaitingMetadataAgeMs"
 
-  private[server] val MigrationsCompletedPerSecMetricName = "ClassicToDisklessMigrationsCompletedPerSec"
-  private[server] val MigrationsFailedPerSecMetricName = "ClassicToDisklessMigrationsFailedPerSec"
-  private[server] val MigrationsRetriedPerSecMetricName = "ClassicToDisklessMigrationsRetriedPerSec"
+  private[server] val InitDisklessLogCompletedPerSecMetricName = "InitDisklessLogCompletedPerSec"
+  private[server] val InitDisklessLogFailedPerSecMetricName = "InitDisklessLogFailedPerSec"
+  private[server] val InitDisklessLogRetriedPerSecMetricName = "InitDisklessLogRetriedPerSec"
 
   private[server] val GaugeMetricNames = Set(
-    MigrationsInFlightMetricName,
+    InitDisklessLogInFlightMetricName,
     WaitingForReplicationCountMetricName,
     SendingToControllerCountMetricName,
     AwaitingMetadataCountMetricName,
@@ -273,9 +273,9 @@ object InitDisklessLogManager {
   )
 
   private[server] val MeterMetricNames = Set(
-    MigrationsCompletedPerSecMetricName,
-    MigrationsFailedPerSecMetricName,
-    MigrationsRetriedPerSecMetricName,
+    InitDisklessLogCompletedPerSecMetricName,
+    InitDisklessLogFailedPerSecMetricName,
+    InitDisklessLogRetriedPerSecMetricName,
   )
 
   private[server] val MetricNames: Set[String] = GaugeMetricNames union MeterMetricNames
@@ -302,7 +302,7 @@ object InitDisklessLogManager {
       classOf[AwaitingMetadata]      -> new ConcurrentHashMap[TopicPartition, java.lang.Long]()
     )
 
-    metricsGroup.newGauge(MigrationsInFlightMetricName, () => trackedSize())
+    metricsGroup.newGauge(InitDisklessLogInFlightMetricName, () => trackedSize())
     metricsGroup.newGauge(WaitingForReplicationCountMetricName, () => counters(classOf[WaitingForReplication]).get)
     metricsGroup.newGauge(SendingToControllerCountMetricName,   () => counters(classOf[SendingToController]).get)
     metricsGroup.newGauge(AwaitingMetadataCountMetricName,      () => counters(classOf[AwaitingMetadata]).get)
@@ -310,9 +310,9 @@ object InitDisklessLogManager {
     metricsGroup.newGauge(OldestSendingToControllerAgeMsMetricName,   () => oldestAgeMs(classOf[SendingToController]))
     metricsGroup.newGauge(OldestAwaitingMetadataAgeMsMetricName,      () => oldestAgeMs(classOf[AwaitingMetadata]))
 
-    private val completedMeter = metricsGroup.newMeter(MigrationsCompletedPerSecMetricName, "migrations", TimeUnit.SECONDS)
-    private val failedMeter    = metricsGroup.newMeter(MigrationsFailedPerSecMetricName,    "migrations", TimeUnit.SECONDS)
-    private val retriedMeter   = metricsGroup.newMeter(MigrationsRetriedPerSecMetricName,   "retries",    TimeUnit.SECONDS)
+    private val completedMeter = metricsGroup.newMeter(InitDisklessLogCompletedPerSecMetricName, "completed", TimeUnit.SECONDS)
+    private val failedMeter    = metricsGroup.newMeter(InitDisklessLogFailedPerSecMetricName,    "failed",    TimeUnit.SECONDS)
+    private val retriedMeter   = metricsGroup.newMeter(InitDisklessLogRetriedPerSecMetricName,   "retries",   TimeUnit.SECONDS)
 
     def markCompleted(): Unit = completedMeter.mark()
     def markFailed(): Unit    = failedMeter.mark()

--- a/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
@@ -47,9 +47,9 @@ class ReplicaFetcherThread(name: String,
   // Visible for testing
   private[server] val partitionsWithNewHighWatermark = mutable.Buffer[TopicPartition]()
 
-  // Partitions that have caught up to a fully-migrated diskless topic's classicToDisklessStartOffset
+  // Partitions that have caught up to a fully-switch diskless topic's classicToDisklessStartOffset
   // and should be evicted from this fetcher.
-  private[server] val partitionsToEvictAfterDisklessMigration = mutable.Buffer[TopicPartition]()
+  private[server] val partitionsToEvictAfterDisklessSwitch = mutable.Buffer[TopicPartition]()
 
   override protected def latestEpoch(topicPartition: TopicPartition): Optional[Integer] = {
     replicaMgr.localLogOrException(topicPartition).latestEpoch
@@ -99,7 +99,7 @@ class ReplicaFetcherThread(name: String,
   override def doWork(): Unit = {
     super.doWork()
     completeDelayedFetchRequests()
-    evictFullyMigratedDisklessPartitions()
+    evictFullySwitchedDisklessPartitions()
   }
 
   // process fetched data
@@ -153,12 +153,12 @@ class ReplicaFetcherThread(name: String,
 
     brokerTopicStats.updateReplicationBytesIn(records.sizeInBytes)
 
-    // Stop fetching after the migration from classic to diskless is completed: once the controller
+    // Stop fetching after the switch from classic to diskless is completed: once the controller
     // has committed a classicToDisklessStartOffset for this partition AND our local LEO has reached it,
     // the follower is fully caught up to the leader's frozen classic log and must not keep fetching.
     val classicToDisklessStartOffset = replicaMgr.inklessMetadataView().getClassicToDisklessStartOffset(topicPartition)
     if (classicToDisklessStartOffset >= 0 && log.logEndOffset >= classicToDisklessStartOffset) {
-      partitionsToEvictAfterDisklessMigration += topicPartition
+      partitionsToEvictAfterDisklessSwitch += topicPartition
     }
 
     logAppendInfo
@@ -171,12 +171,12 @@ class ReplicaFetcherThread(name: String,
     }
   }
 
-  private def evictFullyMigratedDisklessPartitions(): Unit = {
-    if (partitionsToEvictAfterDisklessMigration.nonEmpty) {
-      val toEvict = partitionsToEvictAfterDisklessMigration.toSet
-      partitionsToEvictAfterDisklessMigration.clear()
+  private def evictFullySwitchedDisklessPartitions(): Unit = {
+    if (partitionsToEvictAfterDisklessSwitch.nonEmpty) {
+      val toEvict = partitionsToEvictAfterDisklessSwitch.toSet
+      partitionsToEvictAfterDisklessSwitch.clear()
       info(s"Evicting partitions from this replica fetcher because they have completed the " +
-        s"classic-to-diskless migration and the local log has caught up to the seal offset: $toEvict")
+        s"classic-to-diskless switch and the local log has caught up to the seal offset: $toEvict")
       replicaMgr.replicaFetcherManager.removeFetcherForPartitions(toEvict)
     }
   }

--- a/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
@@ -47,7 +47,7 @@ class ReplicaFetcherThread(name: String,
   // Visible for testing
   private[server] val partitionsWithNewHighWatermark = mutable.Buffer[TopicPartition]()
 
-  // Partitions that have caught up to a fully-switch diskless topic's classicToDisklessStartOffset
+  // Partitions that have caught up to a fully-switched diskless topic's classicToDisklessStartOffset
   // and should be evicted from this fetcher.
   private[server] val partitionsToEvictAfterDisklessSwitch = mutable.Buffer[TopicPartition]()
 

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -607,11 +607,11 @@ class ReplicaManager(val config: KafkaConfig,
                 } catch {
                   case e: KafkaStorageException =>
                     stateChangeLogger.error(s"Failed to seal partition ${partition.topicPartition} " +
-                      s"for diskless migration due to a storage error ${e.getMessage}")
+                      s"for diskless switch due to a storage error ${e.getMessage}")
                     markPartitionOffline(tp)
                 }
               case None =>
-                error(s"Partition ${partition.topicPartition} has no topic ID, skipping seal and migration registration")
+                error(s"Partition ${partition.topicPartition} has no topic ID, skipping seal and switch registration")
             }
           case _ =>
         }
@@ -619,7 +619,7 @@ class ReplicaManager(val config: KafkaConfig,
     }
   }
 
-  def sealExistingLeadersOfTopicsMigratedToDiskless(delta: MetadataDelta, newImage: MetadataImage): Unit = {
+  def sealExistingLeadersOfTopicsSwitchedToDiskless(delta: MetadataDelta, newImage: MetadataImage): Unit = {
     Option(delta.configsDelta()).foreach { configsDelta =>
       configsDelta.changes().forEach { (resource, _) =>
         if (resource.`type`() == ConfigResource.Type.TOPIC) {
@@ -810,11 +810,11 @@ class ReplicaManager(val config: KafkaConfig,
 
     val (disklessEntries, classicEntries) = entriesPerPartition.partition { case (k, _) => _inklessMetadataView.isDisklessTopic(k.topic()) }
 
-    val (pendingMigrationToDisklessEntries, readyDisklessEntries) = disklessEntries.partition { case (topicIdPartition, _) =>
+    val (pendingSwitchToDisklessEntries, readyDisklessEntries) = disklessEntries.partition { case (topicIdPartition, _) =>
       _inklessMetadataView.getClassicToDisklessStartOffset(topicIdPartition.topicPartition()) ==
-        PartitionRegistration.CLASSIC_TO_DISKLESS_MIGRATION_PENDING
+        PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING
     }
-    val pendingDisklessMigrationResult = pendingMigrationToDisklessEntries.map { case (tp, _) =>
+    val pendingDisklessSwitchResult = pendingSwitchToDisklessEntries.map { case (tp, _) =>
       tp -> new PartitionResponse(Errors.REPLICA_NOT_AVAILABLE)
     }
 
@@ -835,7 +835,7 @@ class ReplicaManager(val config: KafkaConfig,
         }
         // Diskless append results do not complete purgatory actions to avoid overloading the control-plane.
         // only classic append results complete purgatory actions.
-        responseCallback(disklessResult ++ pendingDisklessMigrationResult ++ classicResult)
+        responseCallback(disklessResult ++ pendingDisklessSwitchResult ++ classicResult)
       }
     }
 
@@ -1924,7 +1924,7 @@ class ReplicaManager(val config: KafkaConfig,
         classicFetchInfos += fetchInfo
       } else {
         val classicToDisklessStartOffset = _inklessMetadataView.getClassicToDisklessStartOffset(tp.topicPartition())
-        var shouldReadFromUnifiedLog = classicToDisklessStartOffset == PartitionRegistration.CLASSIC_TO_DISKLESS_MIGRATION_PENDING
+        var shouldReadFromUnifiedLog = classicToDisklessStartOffset == PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING
         val isConsolidatingPartition =
           _inklessMetadataView.isConsolidatingDisklessTopic(tp.topic) &&
             config.disklessRemoteStorageConsolidationEnabled
@@ -1952,7 +1952,7 @@ class ReplicaManager(val config: KafkaConfig,
 
         if (!partitionAlreadyHandled) {
           if (params.isFromFollower && !shouldReadFromUnifiedLog && classicToDisklessStartOffset >= 0) {
-            // The partition has fully migrated to diskless and the follower is asking for an offset at or beyond it.
+            // The partition has fully switched to diskless and the follower is asking for an offset at or beyond it.
             // Followers must never replicate diskless records into their local log. Return
             // an empty response with HW clamped to the seal offset so the fetcher loop sees the
             // partition as caught up and goes idle, rather than treating it as out of range.
@@ -2185,15 +2185,15 @@ class ReplicaManager(val config: KafkaConfig,
   }
 
   /**
-   * Returns true for a partition that has been migrated from a classic topic to a diskless one
+   * Returns true for a partition that has been switched from a classic topic to a diskless one
    * (`diskless.enable=true`) and whose `classicToDisklessStartOffset` has been sealed at a
    * non-negative offset. For these partitions every replica still can host the classic local/remote
-   * log below the seal offset. Migration-pending (`-2`) and never-migrated (`-1`) partitions are excluded.
+   * log below the seal offset. Switch-pending (`-2`) and never-switched (`-1`) partitions are excluded.
    *
    * The `isDisklessTopic` check is also a guard against unnecessary metadata-image lookups in the
    * hot fetch path for the non-diskless case.
    */
-  private[server] def isMigratedPartitionFromClassicToDiskless(tp: TopicIdPartition): Boolean = {
+  private[server] def isPartitionSwitchedFromClassicToDiskless(tp: TopicIdPartition): Boolean = {
     _inklessMetadataView.isDisklessTopic(tp.topic) &&
       _inklessMetadataView.getClassicToDisklessStartOffset(tp.topicPartition) >= 0L
   }
@@ -2265,7 +2265,7 @@ class ReplicaManager(val config: KafkaConfig,
             if (preferredReadReplica.isDefined) OptionalInt.of(preferredReadReplica.get) else OptionalInt.empty(),
             Errors.NONE)
         } else {
-          // For partitions that were migrated from classic to diskless and still have classic
+          // For partitions that were switched from classic to diskless and still have classic
           // local/remote data to read (classicToDisklessStartOffset >= 0), relax the leader-only
           // requirement so any in-sync replica can serve the classic portion of the read. This is
           // scoped to older consumer fetches that don't supply clientMetadata (pre-KIP-392 / no
@@ -2275,7 +2275,7 @@ class ReplicaManager(val config: KafkaConfig,
           // could actually apply.
           val isOlderConsumer = params.isFromConsumer && params.clientMetadata.isEmpty
           val allowReplica = !params.fetchOnlyLeader() ||
-            (isOlderConsumer && isMigratedPartitionFromClassicToDiskless(tp))
+            (isOlderConsumer && isPartitionSwitchedFromClassicToDiskless(tp))
           log = partition.localLogWithEpochOrThrow(fetchInfo.currentLeaderEpoch, !allowReplica)
 
           // Try the read first, this tells us whether we need all of adjustedFetchSize for this partition
@@ -3071,7 +3071,7 @@ class ReplicaManager(val config: KafkaConfig,
             changedPartitions.add(partition)
           } catch {
             case e: KafkaStorageException =>
-              stateChangeLogger.info(s"Skipped the become-leader state change for migrated partition $tp " +
+              stateChangeLogger.info(s"Skipped the become-leader state change for switched partition $tp " +
                 s"with topic id ${info.topicId} due to a storage error ${e.getMessage}")
               markPartitionOffline(tp)
           }
@@ -3129,17 +3129,17 @@ class ReplicaManager(val config: KafkaConfig,
         config.disklessRemoteStorageConsolidationEnabled &&
           _inklessMetadataView.isConsolidatingDisklessTopic(tp.topic)
       if (_inklessMetadataView.isDisklessTopic(tp.topic())) {
-        // Clean up migration tracking since only the leader drives classic -> diskless migration.
+        // Clean up classic-to-diskless switch tracking since only the leader drives classic-to-diskless switch.
         initDisklessLogManager.foreach(_.removePartition(tp))
         val seal = _inklessMetadataView.getClassicToDisklessStartOffset(tp)
         // Create the Partition (and a local log on the fly if missing) when either:
         //   (a) the broker already has classic data on disk -- typical post-restart case
         //       for a pre-existing replica; or
-        //   (b) the topic has already been migrated (seal >= 0) and this broker has been
+        //   (b) the topic has already been switched (seal >= 0) and this broker has been
         //       newly added to the replica set -- it needs a local log so it can fetch
         //       the classic-era prefix from another replica and serve reads below the
         //       seal if it ever takes over leadership.
-        // For never-migrated diskless topics (seal == -1) and migrations still in
+        // For never-switched diskless topics (seal == -1) and switches still in
         // progress without a committed seal (seal == -2), a missing local log means
         // there is no classic data to expose on this broker, so we leave the partition
         // unmanaged here.
@@ -3156,8 +3156,8 @@ class ReplicaManager(val config: KafkaConfig,
                 // were just added as a replica and have an empty local log. The
                 // ReplicaFetcher self-evicts once the follower has read past the seal.
                 partitionsToStartFetching.put(tp, partition)
-              } else if (seal == PartitionRegistration.CLASSIC_TO_DISKLESS_MIGRATION_PENDING && isNewLeaderEpoch) {
-                // Migration is in flight: the leader has already sealed its log and
+              } else if (seal == PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING && isNewLeaderEpoch) {
+                // Switch is in flight: the leader has already sealed its log and
                 // frozen the LEO, but the controller has not yet committed the seal
                 // offset. Followers must keep replicating up to that frozen LEO via the
                 // classic ReplicaFetcher. Reschedule on any leader-epoch change so a
@@ -3167,7 +3167,7 @@ class ReplicaManager(val config: KafkaConfig,
               }
             } catch {
               case e: KafkaStorageException =>
-                stateChangeLogger.error(s"Unable to create follower for migrated partition $tp " +
+                stateChangeLogger.error(s"Unable to create follower for switched partition $tp " +
                   s"with topic ID ${info.topicId} due to a storage error ${e.getMessage}", e)
                 markPartitionOffline(tp)
             }

--- a/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
+++ b/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
@@ -145,7 +145,7 @@ class BrokerMetadataPublisher(
 
       // Seal existing leader partitions for topics transitioning from classic to diskless.
       // New leaders elected are instead sealed inside ReplicaManager.applyLocalLeadersDelta.
-      replicaManager.sealExistingLeadersOfTopicsMigratedToDiskless(delta, newImage)
+      replicaManager.sealExistingLeadersOfTopicsSwitchedToDiskless(delta, newImage)
       // Apply topic deltas.
       Option(delta.topicsDelta()).foreach { topicsDelta =>
         try {

--- a/core/src/test/java/kafka/server/DisklessAndRemoteStorageConfigsTest.java
+++ b/core/src/test/java/kafka/server/DisklessAndRemoteStorageConfigsTest.java
@@ -71,7 +71,7 @@ public class DisklessAndRemoteStorageConfigsTest {
 
     private static final String ENABLE_DISKLESS_ERROR = "It is invalid to enable diskless on an already existing topic.";
     private static final String DISABLE_DISKLESS_ERROR = "It is invalid to disable diskless.";
-    private static final String DISKLESS_REMOTE_SET_ERROR = "It is not valid to set a value for both diskless.enable and remote.storage.enable unless it's for diskless migration or consolidation.";
+    private static final String DISKLESS_REMOTE_SET_ERROR = "It is not valid to set a value for both diskless.enable and remote.storage.enable unless it's for diskless switch or consolidation.";
     private static final String DISABLE_REMOTE_WITHOUT_DELETE_ERROR = "It is invalid to disable remote storage without deleting remote data. "
         + "If you want to keep the remote data and turn to read only, please set `remote.storage.enable=true,remote.log.copy.disable=true`. "
         + "If you want to disable remote storage and delete all remote data, please set `remote.storage.enable=false,remote.log.delete.on.disable=true`.";

--- a/core/src/test/scala/unit/kafka/log/LogConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogConfigTest.scala
@@ -434,7 +434,7 @@ class LogConfigTest {
   def testDisklessAndRemoteStorageAtCreation(): Unit = {
     val kafkaConfig = KafkaConfig.fromProps(TestUtils.createDummyBrokerConfig())
     val noExisting: util.Map[String, String] = util.Map.of()
-    val mutualExclusionError = "It is not valid to set a value for both diskless.enable and remote.storage.enable unless it's for diskless migration or consolidation."
+    val mutualExclusionError = "It is not valid to set a value for both diskless.enable and remote.storage.enable unless it's for diskless switch or consolidation."
 
     // Allowed to set diskless.enable=true at creation
     assertValid(noExisting, topicProps(TopicConfig.DISKLESS_ENABLE_CONFIG -> "true"), kafkaConfig)
@@ -514,7 +514,7 @@ class LogConfigTest {
           kafkaConfig.disklessStorageSystemEnabled,
           kafkaConfig.disklessRemoteStorageConsolidationEnabled
         ))
-      assertEquals("It is not valid to set a value for both diskless.enable and remote.storage.enable unless it's for diskless migration or consolidation.",
+      assertEquals("It is not valid to set a value for both diskless.enable and remote.storage.enable unless it's for diskless switch or consolidation.",
         ex.getMessage)
     } else {
       LogConfig.validate(
@@ -534,7 +534,7 @@ class LogConfigTest {
   def testRemoteStorageConsolidationAtCreation(): Unit = {
     val kafkaConfig = KafkaConfig.fromProps(TestUtils.createDummyBrokerConfig())
     val noExisting: util.Map[String, String] = util.Map.of()
-    val mutualExclusionError = "It is not valid to set a value for both diskless.enable and remote.storage.enable unless it's for diskless migration or consolidation."
+    val mutualExclusionError = "It is not valid to set a value for both diskless.enable and remote.storage.enable unless it's for diskless switch or consolidation."
 
     // Allowed to set diskless.enable=true at creation
     assertValid(noExisting, topicProps(TopicConfig.DISKLESS_ENABLE_CONFIG -> "true"), kafkaConfig,
@@ -579,7 +579,7 @@ class LogConfigTest {
   @Test
   def testRemoteStorageConsolidationAtUpdate(): Unit = {
     val kafkaConfig = KafkaConfig.fromProps(TestUtils.createDummyBrokerConfig())
-    val mutualExclusionError = "It is not valid to set a value for both diskless.enable and remote.storage.enable unless it's for diskless migration or consolidation."
+    val mutualExclusionError = "It is not valid to set a value for both diskless.enable and remote.storage.enable unless it's for diskless switch or consolidation."
 
     val existingWithoutDisklessOrRemote = util.Map.of(TopicConfig.RETENTION_MS_CONFIG, "1000")
     val existingWithDisklessFalse = util.Map.of(TopicConfig.DISKLESS_ENABLE_CONFIG, "false")
@@ -667,7 +667,7 @@ class LogConfigTest {
   @Test
   def testDisklessAllowFromClassicAndRemoteStorageConsolidationAtUpdate(): Unit = {
     val kafkaConfig = KafkaConfig.fromProps(TestUtils.createDummyBrokerConfig())
-    val mutualExclusionError = "It is not valid to set a value for both diskless.enable and remote.storage.enable unless it's for diskless migration or consolidation."
+    val mutualExclusionError = "It is not valid to set a value for both diskless.enable and remote.storage.enable unless it's for diskless switch or consolidation."
     val existingWithoutDisklessOrRemote = util.Map.of(TopicConfig.RETENTION_MS_CONFIG, "1000")
     val existingWithDisklessFalse = util.Map.of(TopicConfig.DISKLESS_ENABLE_CONFIG, "false")
     val existingWithDisklessTrue = util.Map.of(TopicConfig.DISKLESS_ENABLE_CONFIG, "true")
@@ -682,7 +682,7 @@ class LogConfigTest {
     assertValid(existingWithDisklessTrue, setDisklessTrue, kafkaConfig, disklessAllowFromClassic = true, remoteStorageConsolidationEnabled = true)
     // Mutual exclusion still applies when existing remote.storage.enable=false
     assertInvalid(existingWithRemoteFalse, setDisklessTrue, mutualExclusionError, kafkaConfig, disklessAllowFromClassic = true, remoteStorageConsolidationEnabled = true)
-    // Classic-to-diskless migration: setting diskless.enable=true on a topic with remote.storage.enable=true is valid.
+    // Classic-to-diskless switch: setting diskless.enable=true on a topic with remote.storage.enable=true is valid.
     // In the real controller flow (ConfigurationControlManager.validateAlterConfig), props contains the merged
     // state of existing overrides + requested changes, so remote.storage.enable=true is included in props.
     val setDisklessTrueWithExistingRemoteTrue = topicProps(
@@ -707,7 +707,7 @@ class LogConfigTest {
   @Test
   def testDisklessAndRemoteStorageAtUpdate(): Unit = {
     val kafkaConfig = KafkaConfig.fromProps(TestUtils.createDummyBrokerConfig())
-    val mutualExclusionError = "It is not valid to set a value for both diskless.enable and remote.storage.enable unless it's for diskless migration or consolidation."
+    val mutualExclusionError = "It is not valid to set a value for both diskless.enable and remote.storage.enable unless it's for diskless switch or consolidation."
     val existingWithoutDisklessOrRemote = util.Map.of(TopicConfig.RETENTION_MS_CONFIG, "1000")
     val existingWithDisklessFalse = util.Map.of(TopicConfig.DISKLESS_ENABLE_CONFIG, "false")
     val existingWithDisklessTrue = util.Map.of(TopicConfig.DISKLESS_ENABLE_CONFIG, "true")
@@ -768,7 +768,7 @@ class LogConfigTest {
   @Test
   def testDisklessAllowFromClassicAtUpdate(): Unit = {
     val kafkaConfig = KafkaConfig.fromProps(TestUtils.createDummyBrokerConfig())
-    val mutualExclusionError = "It is not valid to set a value for both diskless.enable and remote.storage.enable unless it's for diskless migration or consolidation."
+    val mutualExclusionError = "It is not valid to set a value for both diskless.enable and remote.storage.enable unless it's for diskless switch or consolidation."
     val existingWithoutDisklessOrRemote = util.Map.of(TopicConfig.RETENTION_MS_CONFIG, "1000")
     val existingWithDisklessFalse = util.Map.of(TopicConfig.DISKLESS_ENABLE_CONFIG, "false")
     val existingWithDisklessTrue = util.Map.of(TopicConfig.DISKLESS_ENABLE_CONFIG, "true")
@@ -783,7 +783,7 @@ class LogConfigTest {
     assertValid(existingWithDisklessTrue, setDisklessTrue, kafkaConfig, disklessAllowFromClassic = true)
     // Mutual exclusion still applies when existing remote.storage.enable=false
     assertInvalid(existingWithRemoteFalse, setDisklessTrue, mutualExclusionError, kafkaConfig, disklessAllowFromClassic = true)
-    // Classic-to-diskless migration: setting diskless.enable=true on a topic with remote.storage.enable=true is valid.
+    // Classic-to-diskless switch: setting diskless.enable=true on a topic with remote.storage.enable=true is valid.
     // In the real controller flow (ConfigurationControlManager.validateAlterConfig), props contains the merged
     // state of existing overrides + requested changes, so remote.storage.enable=true is included in props.
     val setDisklessTrueWithExistingRemoteTrue = topicProps(
@@ -791,7 +791,7 @@ class LogConfigTest {
       TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG -> "true"
     )
     assertValid(existingWithRemoteTrue, setDisklessTrueWithExistingRemoteTrue, kafkaConfig, disklessAllowFromClassic = true)
-    // Migration not allowed without allowFromClassic even with merged props
+    // Switch not allowed without allowFromClassic even with merged props
     assertInvalid(existingWithRemoteTrue, setDisklessTrueWithExistingRemoteTrue,
       "It is invalid to enable diskless on an already existing topic.", kafkaConfig, disklessAllowFromClassic = false)
 
@@ -804,23 +804,23 @@ class LogConfigTest {
     assertInvalid(existingWithRemoteTrue, setDisklessTrueAndRemoteFalse,
       mutualExclusionError, kafkaConfig, disklessAllowFromClassic = true)
 
-    // Case 1c: Steady state after migration — a migrated topic has both diskless.enable=true and
+    // Case 1c: Steady state after switch — a switched topic has both diskless.enable=true and
     // remote.storage.enable=true in existing configs. Updating an unrelated config (e.g. retention.ms)
     // must not be blocked by mutual exclusion. In the controller path, props is the merged state,
     // so both configs appear in requestedConfigs.
-    val existingMigrated = util.Map.of(
+    val existingSwitched = util.Map.of(
       TopicConfig.DISKLESS_ENABLE_CONFIG, "true",
       TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG, "true"
     )
-    val setRetentionOnMigrated = topicProps(
+    val setRetentionOnSwitched = topicProps(
       TopicConfig.DISKLESS_ENABLE_CONFIG -> "true",
       TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG -> "true",
       TopicConfig.RETENTION_MS_CONFIG -> "86400000"
     )
-    assertValid(existingMigrated, setRetentionOnMigrated, kafkaConfig, disklessAllowFromClassic = true)
+    assertValid(existingSwitched, setRetentionOnSwitched, kafkaConfig, disklessAllowFromClassic = true)
 
     // Case 1d: Enabling diskless while simultaneously disabling remote storage (with delete) must still
-    // be rejected. The migration bypass only applies when remote storage remains enabled.
+    // be rejected. The switch bypass only applies when remote storage remains enabled.
     val setDisklessTrueAndRemoteFalseWithDelete = topicProps(
       TopicConfig.DISKLESS_ENABLE_CONFIG -> "true",
       TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG -> "false",

--- a/core/src/test/scala/unit/kafka/server/DisklessFetchOffsetRouterTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DisklessFetchOffsetRouterTest.scala
@@ -124,7 +124,7 @@ class DisklessFetchOffsetRouterTest {
   // ---------------------------------------------------------------------------
 
   @Test
-  def routesToDisklessWhenNotMigrated(): Unit = {
+  def routesToDisklessWhenNotSwitched(): Unit = {
     when(inklessMetadataView.getClassicToDisklessStartOffset(tp)).thenReturn(PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET)
 
     val status = route(newRouter(), timestamp = ListOffsetsRequest.LATEST_TIMESTAMP)
@@ -149,32 +149,32 @@ class DisklessFetchOffsetRouterTest {
   }
 
   // ---------------------------------------------------------------------------
-  // Case 3: partition is being migrated from classic to diskless.
+  // Case 3: partition is being switched from classic to diskless.
   // ---------------------------------------------------------------------------
 
   @Test
-  def routesToClassicWithoutFollowerAccessWhenMigrationPending(): Unit = {
+  def routesToClassicWithoutFollowerAccessWhenSwitchPending(): Unit = {
     when(inklessMetadataView.getClassicToDisklessStartOffset(tp)).thenReturn(PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING)
 
     val status = route(newRouter(), timestamp = ListOffsetsRequest.LATEST_TIMESTAMP)
 
-    assertSame(defaultClassicResult, status, "migration-pending must return the classic status as-is")
+    assertSame(defaultClassicResult, status, "switch-pending must return the classic status as-is")
     assertClassicCalledWith(allowFromFollower = false)
     verify(job, never()).add(any(), any())
   }
 
   // ---------------------------------------------------------------------------
-  // Case 4: follower request on a migrated partition.
+  // Case 4: follower request on a switched partition.
   // ---------------------------------------------------------------------------
 
   @Test
-  def routesToClassicWithFollowerAccessWhenMigratedAndFollowerRequest(): Unit = {
+  def routesToClassicWithFollowerAccessWhenSwitchedAndFollowerRequest(): Unit = {
     when(inklessMetadataView.getClassicToDisklessStartOffset(tp)).thenReturn(100L)
 
     val status = route(newRouter(), timestamp = ListOffsetsRequest.LATEST_TIMESTAMP, replicaId = followerReplicaId)
 
     assertSame(defaultClassicResult, status)
-    // followers may serve from their local log on a sealed (migrated) partition.
+    // followers may serve from their local log on a sealed (switched) partition.
     assertClassicCalledWith(allowFromFollower = true)
     verify(job, never()).add(any(), any())
   }
@@ -377,8 +377,8 @@ class DisklessFetchOffsetRouterTest {
   }
 
   @Test
-  def routesToDisklessAndForwardsControlPlaneFailureWhenMigrationPendingAndManagedReplicasDisabled(): Unit = {
-    // Migration to diskless is pending while managed replicas are disabled. Migration can only have been 
+  def routesToDisklessAndForwardsControlPlaneFailureWhenSwitchPendingAndManagedReplicasDisabled(): Unit = {
+    // Switch to diskless is pending while managed replicas are disabled. Switch can only have been 
     // initiated with managed replicas enabled, so this is a misconfiguration.
     // The control plane is not expected to have a committed diskless start offset for the partition yet, so we
     // simulate the realistic outcome by completing the diskless task future exceptionally and
@@ -400,7 +400,7 @@ class DisklessFetchOffsetRouterTest {
   }
 
   @Test
-  def routesToDisklessWhenMigrationPendingButConsolidatingTopic(): Unit = {
+  def routesToDisklessWhenSwitchPendingButConsolidatingTopic(): Unit = {
     when(inklessMetadataView.getClassicToDisklessStartOffset(tp)).thenReturn(PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING)
     when(inklessMetadataView.isConsolidatingDisklessTopic(tp.topic)).thenReturn(true)
 
@@ -409,7 +409,7 @@ class DisklessFetchOffsetRouterTest {
       timestamp = ListOffsetsRequest.LATEST_TIMESTAMP
     )
 
-    assertTrue(classicCalls.isEmpty, "consolidating topics must not use migration-pending classic-only ListOffsets")
+    assertTrue(classicCalls.isEmpty, "consolidating topics must not use switch-pending classic-only ListOffsets")
     verify(job).add(eqTo(tp), any())
     assertTrue(status.futureHolderOpt.isPresent)
     assertFalse(status.responseOpt.isPresent)

--- a/core/src/test/scala/unit/kafka/server/DisklessFetchOffsetRouterTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DisklessFetchOffsetRouterTest.scala
@@ -154,7 +154,7 @@ class DisklessFetchOffsetRouterTest {
 
   @Test
   def routesToClassicWithoutFollowerAccessWhenMigrationPending(): Unit = {
-    when(inklessMetadataView.getClassicToDisklessStartOffset(tp)).thenReturn(PartitionRegistration.CLASSIC_TO_DISKLESS_MIGRATION_PENDING)
+    when(inklessMetadataView.getClassicToDisklessStartOffset(tp)).thenReturn(PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING)
 
     val status = route(newRouter(), timestamp = ListOffsetsRequest.LATEST_TIMESTAMP)
 
@@ -384,7 +384,7 @@ class DisklessFetchOffsetRouterTest {
     // simulate the realistic outcome by completing the diskless task future exceptionally and
     // assert the router forwards that failure verbatim.
     
-    when(inklessMetadataView.getClassicToDisklessStartOffset(tp)).thenReturn(PartitionRegistration.CLASSIC_TO_DISKLESS_MIGRATION_PENDING)
+    when(inklessMetadataView.getClassicToDisklessStartOffset(tp)).thenReturn(PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING)
     val controlPlaneFailure = new RuntimeException("partition not found in the diskless control plane")
     disklessTaskFuture.completeExceptionally(controlPlaneFailure)
 
@@ -401,7 +401,7 @@ class DisklessFetchOffsetRouterTest {
 
   @Test
   def routesToDisklessWhenMigrationPendingButConsolidatingTopic(): Unit = {
-    when(inklessMetadataView.getClassicToDisklessStartOffset(tp)).thenReturn(PartitionRegistration.CLASSIC_TO_DISKLESS_MIGRATION_PENDING)
+    when(inklessMetadataView.getClassicToDisklessStartOffset(tp)).thenReturn(PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING)
     when(inklessMetadataView.isConsolidatingDisklessTopic(tp.topic)).thenReturn(true)
 
     val status = route(

--- a/core/src/test/scala/unit/kafka/server/InitDisklessLogManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/InitDisklessLogManagerTest.scala
@@ -382,8 +382,8 @@ class InitDisklessLogManagerTest {
     assertEquals(Set(tp0, tp1, tp2), manager.getTrackedPartitions)
     assertTrue(initDisklessMetricsRegistered, "metrics should be registered while manager is alive")
 
-    val failedBefore = meterCount(InitDisklessLogManager.MigrationsFailedPerSecMetricName)
-    val completedBefore = meterCount(InitDisklessLogManager.MigrationsCompletedPerSecMetricName)
+    val failedBefore = meterCount(InitDisklessLogManager.InitDisklessLogFailedPerSecMetricName)
+    val completedBefore = meterCount(InitDisklessLogManager.InitDisklessLogCompletedPerSecMetricName)
 
     // When the manager is shut down
     manager.shutdown()
@@ -395,14 +395,14 @@ class InitDisklessLogManagerTest {
     assertEquals(
       failedBefore,
       meterCount(
-        InitDisklessLogManager.MigrationsFailedPerSecMetricName,
+        InitDisklessLogManager.InitDisklessLogFailedPerSecMetricName,
         defaultIfMissing = failedBefore
       )
     )
     assertEquals(
       completedBefore,
       meterCount(
-        InitDisklessLogManager.MigrationsCompletedPerSecMetricName,
+        InitDisklessLogManager.InitDisklessLogCompletedPerSecMetricName,
         defaultIfMissing = completedBefore
       )
     )
@@ -423,7 +423,7 @@ class InitDisklessLogManagerTest {
     fireLinger()
     assertEquals(1, channelManager.requests.size())
 
-    val retriedBefore = meterCount(InitDisklessLogManager.MigrationsRetriedPerSecMetricName)
+    val retriedBefore = meterCount(InitDisklessLogManager.InitDisklessLogRetriedPerSecMetricName)
 
     // When the partition is removed (e.g., leadership loss) and the
     // controller subsequently responds with a retriable error
@@ -437,7 +437,7 @@ class InitDisklessLogManagerTest {
     assertTrue(manager.getTrackedPartitions.isEmpty)
     assertEquals(
       retriedBefore,
-      meterCount(InitDisklessLogManager.MigrationsRetriedPerSecMetricName),
+      meterCount(InitDisklessLogManager.InitDisklessLogRetriedPerSecMetricName),
       "removed partition's retriable response must not increment the retried meter"
     )
 
@@ -458,7 +458,7 @@ class InitDisklessLogManagerTest {
     fireLinger()
     assertEquals(1, channelManager.requests.size())
 
-    val retriedBefore = meterCount(InitDisklessLogManager.MigrationsRetriedPerSecMetricName)
+    val retriedBefore = meterCount(InitDisklessLogManager.InitDisklessLogRetriedPerSecMetricName)
 
     manager.removePartition(tp0)
     channelManager.requests.poll().timeout()
@@ -466,7 +466,7 @@ class InitDisklessLogManagerTest {
     assertTrue(manager.getTrackedPartitions.isEmpty)
     assertEquals(
       retriedBefore,
-      meterCount(InitDisklessLogManager.MigrationsRetriedPerSecMetricName)
+      meterCount(InitDisklessLogManager.InitDisklessLogRetriedPerSecMetricName)
     )
 
     mockTime.sleep(manager.maxRetryTimeMs + 1)
@@ -482,20 +482,20 @@ class InitDisklessLogManagerTest {
     fireLinger()
     assertEquals(1, channelManager.requests.size())
 
-    val failedBefore = meterCount(InitDisklessLogManager.MigrationsFailedPerSecMetricName)
+    val failedBefore = meterCount(InitDisklessLogManager.InitDisklessLogFailedPerSecMetricName)
 
     // When the partition is removed before the response arrives
     // (e.g. on leadership loss), `removePartition` calls `queue.remove(tp)`
     // which completes the pending promise with `false`.
     manager.removePartition(tp0)
 
-    // Then the migration is no longer tracked and is NOT counted as a failure:
+    // Then the init diskless log operation is no longer tracked and is NOT counted as a failure:
     // the parasitic callback's `accepted = false` branch must distinguish a
     // cancellation (tracked already cleared) from a permanent failure.
     assertTrue(manager.getTrackedPartitions.isEmpty)
     assertEquals(
       failedBefore,
-      meterCount(InitDisklessLogManager.MigrationsFailedPerSecMetricName),
+      meterCount(InitDisklessLogManager.InitDisklessLogFailedPerSecMetricName),
       "removePartition during in-flight send must not increment the failed meter"
     )
 
@@ -505,11 +505,11 @@ class InitDisklessLogManagerTest {
     pollAndComplete(makeSuccessResponse(topicId, 0))
     assertEquals(
       failedBefore,
-      meterCount(InitDisklessLogManager.MigrationsFailedPerSecMetricName)
+      meterCount(InitDisklessLogManager.InitDisklessLogFailedPerSecMetricName)
     )
     assertEquals(
       0L,
-      meterCount(InitDisklessLogManager.MigrationsCompletedPerSecMetricName)
+      meterCount(InitDisklessLogManager.InitDisklessLogCompletedPerSecMetricName)
     )
   }
 

--- a/core/src/test/scala/unit/kafka/server/InitDisklessLogManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/InitDisklessLogManagerTest.scala
@@ -382,8 +382,8 @@ class InitDisklessLogManagerTest {
     assertEquals(Set(tp0, tp1, tp2), manager.getTrackedPartitions)
     assertTrue(initDisklessMetricsRegistered, "metrics should be registered while manager is alive")
 
-    val failedBefore = meterCount(InitDisklessLogManager.InitDisklessLogFailedPerSecMetricName)
-    val completedBefore = meterCount(InitDisklessLogManager.InitDisklessLogCompletedPerSecMetricName)
+    val failedBefore = meterCount(InitDisklessLogManager.InitFailedPerSecMetricName)
+    val completedBefore = meterCount(InitDisklessLogManager.InitCompletedPerSecMetricName)
 
     // When the manager is shut down
     manager.shutdown()
@@ -395,14 +395,14 @@ class InitDisklessLogManagerTest {
     assertEquals(
       failedBefore,
       meterCount(
-        InitDisklessLogManager.InitDisklessLogFailedPerSecMetricName,
+        InitDisklessLogManager.InitFailedPerSecMetricName,
         defaultIfMissing = failedBefore
       )
     )
     assertEquals(
       completedBefore,
       meterCount(
-        InitDisklessLogManager.InitDisklessLogCompletedPerSecMetricName,
+        InitDisklessLogManager.InitCompletedPerSecMetricName,
         defaultIfMissing = completedBefore
       )
     )
@@ -423,7 +423,7 @@ class InitDisklessLogManagerTest {
     fireLinger()
     assertEquals(1, channelManager.requests.size())
 
-    val retriedBefore = meterCount(InitDisklessLogManager.InitDisklessLogRetriedPerSecMetricName)
+    val retriedBefore = meterCount(InitDisklessLogManager.InitRetriedPerSecMetricName)
 
     // When the partition is removed (e.g., leadership loss) and the
     // controller subsequently responds with a retriable error
@@ -437,7 +437,7 @@ class InitDisklessLogManagerTest {
     assertTrue(manager.getTrackedPartitions.isEmpty)
     assertEquals(
       retriedBefore,
-      meterCount(InitDisklessLogManager.InitDisklessLogRetriedPerSecMetricName),
+      meterCount(InitDisklessLogManager.InitRetriedPerSecMetricName),
       "removed partition's retriable response must not increment the retried meter"
     )
 
@@ -458,7 +458,7 @@ class InitDisklessLogManagerTest {
     fireLinger()
     assertEquals(1, channelManager.requests.size())
 
-    val retriedBefore = meterCount(InitDisklessLogManager.InitDisklessLogRetriedPerSecMetricName)
+    val retriedBefore = meterCount(InitDisklessLogManager.InitRetriedPerSecMetricName)
 
     manager.removePartition(tp0)
     channelManager.requests.poll().timeout()
@@ -466,7 +466,7 @@ class InitDisklessLogManagerTest {
     assertTrue(manager.getTrackedPartitions.isEmpty)
     assertEquals(
       retriedBefore,
-      meterCount(InitDisklessLogManager.InitDisklessLogRetriedPerSecMetricName)
+      meterCount(InitDisklessLogManager.InitRetriedPerSecMetricName)
     )
 
     mockTime.sleep(manager.maxRetryTimeMs + 1)
@@ -482,7 +482,7 @@ class InitDisklessLogManagerTest {
     fireLinger()
     assertEquals(1, channelManager.requests.size())
 
-    val failedBefore = meterCount(InitDisklessLogManager.InitDisklessLogFailedPerSecMetricName)
+    val failedBefore = meterCount(InitDisklessLogManager.InitFailedPerSecMetricName)
 
     // When the partition is removed before the response arrives
     // (e.g. on leadership loss), `removePartition` calls `queue.remove(tp)`
@@ -495,7 +495,7 @@ class InitDisklessLogManagerTest {
     assertTrue(manager.getTrackedPartitions.isEmpty)
     assertEquals(
       failedBefore,
-      meterCount(InitDisklessLogManager.InitDisklessLogFailedPerSecMetricName),
+      meterCount(InitDisklessLogManager.InitFailedPerSecMetricName),
       "removePartition during in-flight send must not increment the failed meter"
     )
 
@@ -505,11 +505,11 @@ class InitDisklessLogManagerTest {
     pollAndComplete(makeSuccessResponse(topicId, 0))
     assertEquals(
       failedBefore,
-      meterCount(InitDisklessLogManager.InitDisklessLogFailedPerSecMetricName)
+      meterCount(InitDisklessLogManager.InitFailedPerSecMetricName)
     )
     assertEquals(
       0L,
-      meterCount(InitDisklessLogManager.InitDisklessLogCompletedPerSecMetricName)
+      meterCount(InitDisklessLogManager.InitCompletedPerSecMetricName)
     )
   }
 

--- a/core/src/test/scala/unit/kafka/server/ReplicaFetcherThreadTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaFetcherThreadTest.scala
@@ -745,7 +745,7 @@ class ReplicaFetcherThreadTest {
 
   @Test
   def shouldEvictPartitionWhenLogEndOffsetReachesClassicToDisklessSealOffset(): Unit = {
-    verifyDisklessMigrationEviction(
+    verifyDisklessSwitchEviction(
       classicToDisklessStartOffset = 100L,
       logEndOffsetAfterAppend = 100L,
       expectEviction = true)
@@ -753,7 +753,7 @@ class ReplicaFetcherThreadTest {
 
   @Test
   def shouldEvictPartitionWhenLogEndOffsetExceedsClassicToDisklessSealOffset(): Unit = {
-    verifyDisklessMigrationEviction(
+    verifyDisklessSwitchEviction(
       classicToDisklessStartOffset = 100L,
       logEndOffsetAfterAppend = 150L,
       expectEviction = true)
@@ -761,29 +761,29 @@ class ReplicaFetcherThreadTest {
 
   @Test
   def shouldNotEvictPartitionWhenLogEndOffsetBelowClassicToDisklessSealOffset(): Unit = {
-    verifyDisklessMigrationEviction(
+    verifyDisklessSwitchEviction(
       classicToDisklessStartOffset = 100L,
       logEndOffsetAfterAppend = 50L,
       expectEviction = false)
   }
 
   @Test
-  def shouldNotEvictPartitionWhenNoClassicToDisklessMigration(): Unit = {
-    verifyDisklessMigrationEviction(
+  def shouldNotEvictPartitionWhenNoClassicToDisklessSwitch(): Unit = {
+    verifyDisklessSwitchEviction(
       classicToDisklessStartOffset = PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET,
       logEndOffsetAfterAppend = 100L,
       expectEviction = false)
   }
 
   @Test
-  def shouldNotEvictPartitionWhenClassicToDisklessMigrationPending(): Unit = {
-    verifyDisklessMigrationEviction(
-      classicToDisklessStartOffset = PartitionRegistration.CLASSIC_TO_DISKLESS_MIGRATION_PENDING,
+  def shouldNotEvictPartitionWhenClassicToDisklessSwitchPending(): Unit = {
+    verifyDisklessSwitchEviction(
+      classicToDisklessStartOffset = PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING,
       logEndOffsetAfterAppend = 100L,
       expectEviction = false)
   }
 
-  private def verifyDisklessMigrationEviction(
+  private def verifyDisklessSwitchEviction(
     classicToDisklessStartOffset: Long,
     logEndOffsetAfterAppend: Long,
     expectEviction: Boolean
@@ -846,7 +846,7 @@ class ReplicaFetcherThreadTest {
     } else {
       verify(replicaFetcherManager, times(0)).removeFetcherForPartitions(any())
     }
-    assertEquals(mutable.Buffer.empty, thread.partitionsToEvictAfterDisklessMigration)
+    assertEquals(mutable.Buffer.empty, thread.partitionsToEvictAfterDisklessSwitch)
   }
 
   private def newOffsetForLeaderPartitionResult(

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -1698,12 +1698,12 @@ class ReplicaManagerTest {
       val followerImage = imageFromTopics(followerDelta.apply())
       replicaManager.applyDelta(followerDelta, followerImage)
 
-      // Mark this partition as migrated from classic to diskless (classicToDisklessStartOffset >= 0).
-      doReturn(true).when(replicaManager).isMigratedPartitionFromClassicToDiskless(tidp0)
+      // Mark this partition as switched from classic to diskless (classicToDisklessStartOffset >= 0).
+      doReturn(true).when(replicaManager).isPartitionSwitchedFromClassicToDiskless(tidp0)
 
       // Consumer fetch with empty ClientMetadata (older FETCH versions, no rackId) targeting
       // a non-leader broker. Without the override this would fail with NOT_LEADER_OR_FOLLOWER
-      // (see testFetchFollowerNotAllowedForOlderClients); migrated partitions allow any
+      // (see testFetchFollowerNotAllowedForOlderClients); switched partitions allow any
       // in-sync replica to serve the classic portion of the log, so the read should succeed.
       val partitionData = new FetchRequest.PartitionData(Uuid.ZERO_UUID, 0L, 0L, 100,
         Optional.of(0))
@@ -1715,8 +1715,8 @@ class ReplicaManagerTest {
   }
 
   @Test
-  def testFetchFromFollowerStillRequiresLeaderOnMigratedPartition(): Unit = {
-    // Regression test: the migrated-partition override must NOT relax leader-only for
+  def testFetchFromFollowerStillRequiresLeaderOnSwitchedPartition(): Unit = {
+    // Regression test: the switched-partition override must NOT relax leader-only for
     // broker-to-broker follower replication. Replication semantics (ISR/HWM) require
     // followers to fetch from the leader.
     val replicaManager = spy(setupReplicaManagerWithMockedPurgatories(new MockTimer(time), aliveBrokerIds = Seq(0, 1)))
@@ -1732,8 +1732,8 @@ class ReplicaManagerTest {
       val followerImage = imageFromTopics(followerDelta.apply())
       replicaManager.applyDelta(followerDelta, followerImage)
 
-      // Even if the partition is marked as migrated, follower fetches must keep failing.
-      doReturn(true).when(replicaManager).isMigratedPartitionFromClassicToDiskless(tidp0)
+      // Even if the partition is marked as switched, follower fetches must keep failing.
+      doReturn(true).when(replicaManager).isPartitionSwitchedFromClassicToDiskless(tidp0)
 
       val partitionData = new FetchRequest.PartitionData(Uuid.ZERO_UUID, 0L, 0L, 100,
         Optional.of(0))
@@ -6401,7 +6401,7 @@ class ReplicaManagerTest {
     }
 
     @Test
-    def testAppendDisklessMigrationPendingReturnsReplicaNotAvailable(): Unit = {
+    def testAppendDisklessSwitchPendingReturnsReplicaNotAvailable(): Unit = {
       val appendHandlerCtorMockInitializer: MockedConstruction.MockInitializer[AppendHandler] = {
         case (mock, _) =>
           when(mock.handle(any(), any())).thenReturn(CompletableFuture.completedFuture[util.Map[TopicIdPartition, PartitionResponse]](
@@ -6416,7 +6416,7 @@ class ReplicaManagerTest {
       }
 
       when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
-        .thenReturn(PartitionRegistration.CLASSIC_TO_DISKLESS_MIGRATION_PENDING)
+        .thenReturn(PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING)
 
       val responseCallback = mock(classOf[Function[Map[TopicIdPartition, PartitionResponse], Unit]])
       replicaManager.appendRecords(
@@ -6434,13 +6434,13 @@ class ReplicaManagerTest {
     }
 
     @Test
-    def testAppendDisklessMigrationPendingWithReadyPartitions(): Unit = {
-      val migratedPartition = new TopicIdPartition(Uuid.randomUuid(), 1, "diskless")
-      val migratedPartitionResponse = Map(migratedPartition -> new PartitionResponse(Errors.NONE))
+    def testAppendDisklessSwitchPendingWithReadyPartitions(): Unit = {
+      val switchedPartition = new TopicIdPartition(Uuid.randomUuid(), 1, "diskless")
+      val switchedPartitionResponse = Map(switchedPartition -> new PartitionResponse(Errors.NONE))
       val appendHandlerCtorMockInitializer: MockedConstruction.MockInitializer[AppendHandler] = {
         case (mock, _) =>
           when(mock.handle(any(), any())).thenReturn(CompletableFuture.completedFuture[util.Map[TopicIdPartition, PartitionResponse]](
-            migratedPartitionResponse.asJava
+            switchedPartitionResponse.asJava
           ))
       }
       val appendHandlerCtor = mockConstruction(classOf[AppendHandler], appendHandlerCtorMockInitializer)
@@ -6451,8 +6451,8 @@ class ReplicaManagerTest {
       }
 
       when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
-        .thenReturn(PartitionRegistration.CLASSIC_TO_DISKLESS_MIGRATION_PENDING)
-      when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(migratedPartition.topicPartition()))
+        .thenReturn(PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING)
+      when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(switchedPartition.topicPartition()))
         .thenReturn(100L)
 
       val responseCallback = mock(classOf[Function[Map[TopicIdPartition, PartitionResponse], Unit]])
@@ -6461,21 +6461,21 @@ class ReplicaManagerTest {
         requiredAcks = -1,
         internalTopicsAllowed = true,
         origin = AppendOrigin.CLIENT,
-        entriesPerPartition = Map(disklessTopicPartition -> RECORDS, migratedPartition -> RECORDS),
+        entriesPerPartition = Map(disklessTopicPartition -> RECORDS, switchedPartition -> RECORDS),
         responseCallback = responseCallback,
       )
 
       verify(responseCallback, times(1))(
         Map(
           disklessTopicPartition -> new PartitionResponse(Errors.REPLICA_NOT_AVAILABLE),
-          migratedPartition -> new PartitionResponse(Errors.NONE),
+          switchedPartition -> new PartitionResponse(Errors.NONE),
         )
       )
     }
 
     @Test
-    def testAppendDisklessMigrationPendingWithHandlerFailure(): Unit = {
-      val migratedPartition = new TopicIdPartition(Uuid.randomUuid(), 1, "diskless")
+    def testAppendDisklessSwitchPendingWithHandlerFailure(): Unit = {
+      val switchedPartition = new TopicIdPartition(Uuid.randomUuid(), 1, "diskless")
       val appendHandlerCtorMockInitializer: MockedConstruction.MockInitializer[AppendHandler] = {
         case (mock, _) =>
           when(mock.handle(any(), any())).thenReturn(CompletableFuture.failedFuture[util.Map[TopicIdPartition, PartitionResponse]](
@@ -6490,8 +6490,8 @@ class ReplicaManagerTest {
       }
 
       when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
-        .thenReturn(PartitionRegistration.CLASSIC_TO_DISKLESS_MIGRATION_PENDING)
-      when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(migratedPartition.topicPartition()))
+        .thenReturn(PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING)
+      when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(switchedPartition.topicPartition()))
         .thenReturn(100L)
 
       val responseCallback = mock(classOf[Function[Map[TopicIdPartition, PartitionResponse], Unit]])
@@ -6500,7 +6500,7 @@ class ReplicaManagerTest {
         requiredAcks = -1,
         internalTopicsAllowed = true,
         origin = AppendOrigin.CLIENT,
-        entriesPerPartition = Map(disklessTopicPartition -> RECORDS, migratedPartition -> RECORDS),
+        entriesPerPartition = Map(disklessTopicPartition -> RECORDS, switchedPartition -> RECORDS),
         responseCallback = responseCallback,
       )
 
@@ -6508,13 +6508,13 @@ class ReplicaManagerTest {
       verify(responseCallback, times(1))(
         Map(
           disklessTopicPartition -> new PartitionResponse(Errors.REPLICA_NOT_AVAILABLE),
-          migratedPartition -> new PartitionResponse(Errors.UNKNOWN_SERVER_ERROR),
+          switchedPartition -> new PartitionResponse(Errors.UNKNOWN_SERVER_ERROR),
         )
       )
     }
 
     @Test
-    def testAppendDisklessMigrationPendingWithClassicEntries(): Unit = {
+    def testAppendDisklessSwitchPendingWithClassicEntries(): Unit = {
       val appendHandlerCtorMockInitializer: MockedConstruction.MockInitializer[AppendHandler] = {
         case (mock, _) =>
           when(mock.handle(any(), any())).thenReturn(CompletableFuture.completedFuture[util.Map[TopicIdPartition, PartitionResponse]](
@@ -6529,7 +6529,7 @@ class ReplicaManagerTest {
       }
 
       when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
-        .thenReturn(PartitionRegistration.CLASSIC_TO_DISKLESS_MIGRATION_PENDING)
+        .thenReturn(PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING)
 
       val responseCallback = mock(classOf[Function[Map[TopicIdPartition, PartitionResponse], Unit]])
       replicaManager.appendRecords(
@@ -6672,15 +6672,15 @@ class ReplicaManagerTest {
     }
 
     @Test
-    def testFetchDisklessMigrationPendingReadsFromClassicLogWhenManagedReplicasEnabled(): Unit = {
+    def testFetchDisklessSwitchPendingReadsFromClassicLogWhenManagedReplicasEnabled(): Unit = {
       val fetchHandlerCtor = mockFetchHandler(Map.empty)
       try {
         val cp = mock(classOf[ControlPlane])
         val replicaManager = spy(createReplicaManager(List(disklessTopicPartition.topic()), controlPlane = Some(cp), disklessManagedReplicasEnabled = true))
 
-        // Given a diskless topic with classicToDisklessStartOffset = -2 (migration pending)
+        // Given a diskless topic with classicToDisklessStartOffset = -2 (switch pending)
         when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
-          .thenReturn(PartitionRegistration.CLASSIC_TO_DISKLESS_MIGRATION_PENDING)
+          .thenReturn(PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING)
 
         doReturn(Seq(disklessTopicPartition ->
           new LogReadResult(
@@ -6703,7 +6703,7 @@ class ReplicaManagerTest {
         }
         replicaManager.fetchMessages(fetchParams, fetchInfos, QuotaFactory.UNBOUNDED_QUOTA, responseCallback)
 
-        // Then the request is served from the unified log (classic path) because migration is still pending
+        // Then the request is served from the unified log (classic path) because switch is still pending
         assertNotNull(responseData)
         assertEquals(1, responseData.size)
         assertEquals(RECORDS, responseData(disklessTopicPartition).records)
@@ -6716,7 +6716,7 @@ class ReplicaManagerTest {
     }
 
     @Test
-    def testFetchDisklessMigrationPendingFailsWhenManagedReplicasDisabled(): Unit = {
+    def testFetchDisklessSwitchPendingFailsWhenManagedReplicasDisabled(): Unit = {
       val fetchHandlerCtor = mockFetchHandler(Map.empty)
       try {
         val cp = mock(classOf[ControlPlane])
@@ -6726,9 +6726,9 @@ class ReplicaManagerTest {
           disklessManagedReplicasEnabled = false,
         ))
 
-        // Given a diskless topic with classicToDisklessStartOffset = -2 (migration pending)
+        // Given a diskless topic with classicToDisklessStartOffset = -2 (switch pending)
         when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
-          .thenReturn(PartitionRegistration.CLASSIC_TO_DISKLESS_MIGRATION_PENDING)
+          .thenReturn(PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING)
 
         val fetchParams = new FetchParams(
           -1, -1L,
@@ -6784,7 +6784,7 @@ class ReplicaManagerTest {
           disklessManagedReplicasEnabled = true,
         ))
 
-        // Given a full diskless topic with classicToDisklessStartOffset = -1 (never migrated)
+        // Given a full diskless topic with classicToDisklessStartOffset = -1 (never switched)
         when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
           .thenReturn(PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET)
 
@@ -6817,7 +6817,7 @@ class ReplicaManagerTest {
     def testFetchFailDisklessWhenFromReplicaAndUnmanagedReplicas(): Unit = {
       val fetchHandlerCtor = mockFetchHandler(Map.empty)
       try {
-        // Given a topic partition that is fully diskless (never migrated) and managed replicas are disabled
+        // Given a topic partition that is fully diskless (never switched) and managed replicas are disabled
         val replicaManager = spy(createReplicaManager(List(disklessTopicPartition.topic()), disklessManagedReplicasEnabled = false))
         when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
           .thenReturn(PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET)
@@ -7382,7 +7382,7 @@ class ReplicaManagerTest {
     }
 
     @Test
-    def testFetchConsolidatingDisklessMigrationPendingReadsFromUnifiedLogWhenConsolidationEnabled(): Unit = {
+    def testFetchConsolidatingDisklessSwitchPendingReadsFromUnifiedLogWhenConsolidationEnabled(): Unit = {
       val fetchHandlerCtor = mockFetchHandler(Map.empty)
       try {
         val cp = mock(classOf[ControlPlane])
@@ -7394,7 +7394,7 @@ class ReplicaManagerTest {
           consolidatingDisklessTopics = Set(disklessTopicPartition.topic()),
         ))
         when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
-          .thenReturn(PartitionRegistration.CLASSIC_TO_DISKLESS_MIGRATION_PENDING)
+          .thenReturn(PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING)
         // Ensure we don't generate an additional invalid response from the consolidating-partition check.
         stubConsolidatingPartitionWithoutLocalLog(replicaManager)
 
@@ -7976,7 +7976,7 @@ class ReplicaManagerTest {
     }
 
     @Test
-    def testFetchOffsetPureDisklessRoutesToDisklessPathWhenNoMigration(): Unit = {
+    def testFetchOffsetPureDisklessRoutesToDisklessPathWhenNoSwitch(): Unit = {
       val jobMock = Mockito.mock(classOf[FetchOffsetHandler.Job])
       when(jobMock.mustHandle(any())).thenReturn(true)
       doNothing().when(jobMock).start()
@@ -7997,7 +7997,7 @@ class ReplicaManagerTest {
         fetchOffsetHandlerCtor.close()
       }
 
-      // No migration — pure diskless: classicToDisklessStartOffset == -1. Combined with managed
+      // No switch — pure diskless: classicToDisklessStartOffset == -1. Combined with managed
       // replicas disabled, the router falls into case 1 and routes the lookup to the diskless
       // control plane.
       when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
@@ -8034,7 +8034,7 @@ class ReplicaManagerTest {
     }
 
     @Test
-    def testFetchOffsetLatestUsesClassicPathWhenMigrationPending(): Unit = {
+    def testFetchOffsetLatestUsesClassicPathWhenSwitchPending(): Unit = {
       val jobMock = Mockito.mock(classOf[FetchOffsetHandler.Job])
       when(jobMock.mustHandle(any())).thenReturn(true)
       doNothing().when(jobMock).start()
@@ -8052,7 +8052,7 @@ class ReplicaManagerTest {
       }
 
       when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
-        .thenReturn(PartitionRegistration.CLASSIC_TO_DISKLESS_MIGRATION_PENDING)
+        .thenReturn(PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING)
 
       val resultHolder = new OffsetResultHolder(
         Optional.of(new FileRecords.TimestampAndOffset(RecordBatch.NO_TIMESTAMP, 50L, Optional.of[Integer](0))))
@@ -8085,7 +8085,7 @@ class ReplicaManagerTest {
     }
 
     @Test
-    def testFetchOffsetLatestUsesDisklessPathWhenMigrationComplete(): Unit = {
+    def testFetchOffsetLatestUsesDisklessPathWhenSwitchComplete(): Unit = {
       val successResult = new OffsetResultHolder.FileRecordsOrError(
         Optional.empty(),
         Optional.of(new FileRecords.TimestampAndOffset(RecordBatch.NO_TIMESTAMP, 200L, Optional.of[Integer](0))))
@@ -8136,7 +8136,7 @@ class ReplicaManagerTest {
     }
 
     @Test
-    def testFetchOffsetEarliestUsesClassicPathWhenMigrationPending(): Unit = {
+    def testFetchOffsetEarliestUsesClassicPathWhenSwitchPending(): Unit = {
       val jobMock = Mockito.mock(classOf[FetchOffsetHandler.Job])
       when(jobMock.mustHandle(any())).thenReturn(true)
       doNothing().when(jobMock).start()
@@ -8154,7 +8154,7 @@ class ReplicaManagerTest {
       }
 
       when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
-        .thenReturn(PartitionRegistration.CLASSIC_TO_DISKLESS_MIGRATION_PENDING)
+        .thenReturn(PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING)
 
       val resultHolder = new OffsetResultHolder(
         Optional.of(new FileRecords.TimestampAndOffset(RecordBatch.NO_TIMESTAMP, 0L, Optional.of[Integer](0))))
@@ -8187,7 +8187,7 @@ class ReplicaManagerTest {
     }
 
     @Test
-    def testFetchOffsetEarliestUsesDisklessPathWhenMigrationCompleteAndManagedReplicasEnabled(): Unit = {
+    def testFetchOffsetEarliestUsesDisklessPathWhenSwitchCompleteAndManagedReplicasEnabled(): Unit = {
       val successResult = new OffsetResultHolder.FileRecordsOrError(
         Optional.empty(),
         Optional.of(new FileRecords.TimestampAndOffset(RecordBatch.NO_TIMESTAMP, 0L, Optional.of[Integer](0))))
@@ -8238,7 +8238,7 @@ class ReplicaManagerTest {
     }
 
     @Test
-    def testFetchOffsetEarliestUsesDisklessPathWhenMigrationCompleteAndManagedReplicasDisabled(): Unit = {
+    def testFetchOffsetEarliestUsesDisklessPathWhenSwitchCompleteAndManagedReplicasDisabled(): Unit = {
       val successResult = new OffsetResultHolder.FileRecordsOrError(
         Optional.empty(),
         Optional.of(new FileRecords.TimestampAndOffset(RecordBatch.NO_TIMESTAMP, 0L, Optional.of[Integer](0))))
@@ -8289,7 +8289,7 @@ class ReplicaManagerTest {
     }
 
     @Test
-    def testFetchOffsetEarliestUsesClassicPathWhenMigrationCompleteAndClassicHasData(): Unit = {
+    def testFetchOffsetEarliestUsesClassicPathWhenSwitchCompleteAndClassicHasData(): Unit = {
       val jobMock = Mockito.mock(classOf[FetchOffsetHandler.Job])
       when(jobMock.mustHandle(any())).thenReturn(true)
       doNothing().when(jobMock).start()
@@ -8348,7 +8348,7 @@ class ReplicaManagerTest {
     }
 
     @Test
-    def testFetchOffsetEarliestLocalAlwaysUsesClassicWhenMigrationComplete(): Unit = {
+    def testFetchOffsetEarliestLocalAlwaysUsesClassicWhenSwitchComplete(): Unit = {
       val jobMock = Mockito.mock(classOf[FetchOffsetHandler.Job])
       when(jobMock.mustHandle(any())).thenReturn(true)
       doNothing().when(jobMock).start()
@@ -8399,7 +8399,7 @@ class ReplicaManagerTest {
     }
 
     @Test
-    def testFetchOffsetLatestTieredAlwaysUsesClassicWhenMigrationComplete(): Unit = {
+    def testFetchOffsetLatestTieredAlwaysUsesClassicWhenSwitchComplete(): Unit = {
       val jobMock = Mockito.mock(classOf[FetchOffsetHandler.Job])
       when(jobMock.mustHandle(any())).thenReturn(true)
       doNothing().when(jobMock).start()
@@ -9302,7 +9302,7 @@ class ReplicaManagerTest {
     
     @Test
     def testApplyDeltaCreatesPartitionForDisklessTopicWithLocalLogOnLeader(): Unit = {
-      val topicName = "migrated-topic"
+      val topicName = "switched-topic"
       val topicId = Uuid.randomUuid()
       val tp = new TopicPartition(topicName, 0)
       val brokerId = 1
@@ -9449,7 +9449,7 @@ class ReplicaManagerTest {
 
     @Test
     def testApplyDeltaCreatesPartitionForDisklessTopicWithLocalLogOnFollower(): Unit = {
-      val topicName = "migrated-topic"
+      val topicName = "switched-topic"
       val topicId = Uuid.randomUuid()
       val tp = new TopicPartition(topicName, 0)
       val brokerId = 1
@@ -9530,7 +9530,7 @@ class ReplicaManagerTest {
 
     @Test
     def testApplyDeltaStartsCatchUpFetcherForDisklessFollowerWithLaggingHwm(): Unit = {
-      val topicName = "migrated-topic"
+      val topicName = "switched-topic"
       val topicId = Uuid.randomUuid()
       val tp = new TopicPartition(topicName, 0)
       val brokerId = 1
@@ -9548,7 +9548,7 @@ class ReplicaManagerTest {
         val log = replicaManager.logManager.getOrCreateLog(tp, isNew = true, topicId = Optional.of(topicId))
         populateLocalLogAtLeoAndCheckpointedHwm(replicaManager, tp, log, leo = 10L, hw = 5L)
 
-        // Mark the partition as fully migrated with classicToDisklessStartOffset = 10.
+        // Mark the partition as fully switched with classicToDisklessStartOffset = 10.
         when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(tp)).thenReturn(10L)
 
         // Apply the follower delta.
@@ -9570,7 +9570,7 @@ class ReplicaManagerTest {
 
     @Test
     def testApplyDeltaDoesNotStartCatchUpFetcherWhenDisklessFollowerHwmAtSealOffset(): Unit = {
-      val topicName = "migrated-topic"
+      val topicName = "switched-topic"
       val topicId = Uuid.randomUuid()
       val tp = new TopicPartition(topicName, 0)
       val brokerId = 1
@@ -9601,8 +9601,8 @@ class ReplicaManagerTest {
     }
 
     @Test
-    def testApplyDeltaDoesNotStartCatchUpFetcherForNeverMigratedDisklessFollower(): Unit = {
-      // Never-migrated diskless topic (seal == -1) on a broker that has no on-disk
+    def testApplyDeltaDoesNotStartCatchUpFetcherForNeverSwitchedDisklessFollower(): Unit = {
+      // Never-switched diskless topic (seal == -1) on a broker that has no on-disk
       // classic data: there is nothing here to expose to consumers below a seal, and
       // there is no upper bound to fetch up to. Nothing should be done on this path.
       val topicName = "fully-diskless-topic"
@@ -9634,13 +9634,13 @@ class ReplicaManagerTest {
     }
 
     @Test
-    def testApplyDeltaSchedulesFetcherForDisklessFollowerDuringMigrationPending(): Unit = {
+    def testApplyDeltaSchedulesFetcherForDisklessFollowerDuringSwitchPending(): Unit = {
       // PENDING window: the topic is already flagged diskless but the controller has
       // not yet committed the seal offset (-2). The leader has already sealed its log
       // and frozen its LEO; followers must keep replicating up to that frozen LEO
       // with a normal ReplicaFetcher. Verify that the first follower-side applyDelta
       // during PENDING arms a fetcher pointing at the leader from the follower's LEO.
-      val topicName = "migrated-topic"
+      val topicName = "switched-topic"
       val topicId = Uuid.randomUuid()
       val tp = new TopicPartition(topicName, 0)
       val brokerId = 1
@@ -9658,7 +9658,7 @@ class ReplicaManagerTest {
         populateLocalLogAtLeoAndCheckpointedHwm(replicaManager, tp, log, leo = 10L, hw = 5L)
 
         when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(tp))
-          .thenReturn(PartitionRegistration.CLASSIC_TO_DISKLESS_MIGRATION_PENDING)
+          .thenReturn(PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING)
 
         val delta = disklessFollowerDelta(topicName, topicId, brokerId, leaderId)
         replicaManager.applyDelta(delta, imageFromTopics(delta.apply()))
@@ -9676,13 +9676,13 @@ class ReplicaManagerTest {
     }
 
     @Test
-    def testApplyDeltaReschedulesFetcherForDisklessFollowerOnLeaderChangeDuringMigrationPending(): Unit = {
-      // PENDING + leader change: if the original leader crashes mid-migration and a
+    def testApplyDeltaReschedulesFetcherForDisklessFollowerOnLeaderChangeDuringSwitchPending(): Unit = {
+      // PENDING + leader change: if the original leader crashes mid-switch and a
       // new leader is elected, the follower's existing fetcher would still target the
       // dead broker and replication would stall (the leader can never commit the seal
       // because it sees no follower fetch traffic). This test pins down that a new
       // leader epoch during PENDING reschedules the fetcher onto the new leader.
-      val topicName = "migrated-topic"
+      val topicName = "switched-topic"
       val topicId = Uuid.randomUuid()
       val tp = new TopicPartition(topicName, 0)
       val brokerId = 1
@@ -9701,7 +9701,7 @@ class ReplicaManagerTest {
         populateLocalLogAtLeoAndCheckpointedHwm(replicaManager, tp, log, leo = 10L, hw = 5L)
 
         when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(tp))
-          .thenReturn(PartitionRegistration.CLASSIC_TO_DISKLESS_MIGRATION_PENDING)
+          .thenReturn(PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING)
 
         // First apply: leader == firstLeaderId, leaderEpoch == 0.
         val delta1 = disklessFollowerDelta(topicName, topicId, brokerId, firstLeaderId)
@@ -9742,10 +9742,10 @@ class ReplicaManagerTest {
     }
 
     @Test
-    def testApplyDeltaDoesNotRescheduleFetcherForDisklessFollowerDuringMigrationPendingOnSameEpoch(): Unit = {
+    def testApplyDeltaDoesNotRescheduleFetcherForDisklessFollowerDuringSwitchPendingOnSameEpoch(): Unit = {
       // Same leader, same leader epoch: the existing fetcher is still valid, so a
       // second applyDelta during PENDING must not redundantly reschedule it.
-      val topicName = "migrated-topic"
+      val topicName = "switched-topic"
       val topicId = Uuid.randomUuid()
       val tp = new TopicPartition(topicName, 0)
       val brokerId = 1
@@ -9763,7 +9763,7 @@ class ReplicaManagerTest {
         populateLocalLogAtLeoAndCheckpointedHwm(replicaManager, tp, log, leo = 10L, hw = 5L)
 
         when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(tp))
-          .thenReturn(PartitionRegistration.CLASSIC_TO_DISKLESS_MIGRATION_PENDING)
+          .thenReturn(PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING)
 
         val delta = disklessFollowerDelta(topicName, topicId, brokerId, leaderId)
         replicaManager.applyDelta(delta, imageFromTopics(delta.apply()))
@@ -9787,7 +9787,7 @@ class ReplicaManagerTest {
           disklessManagedReplicasEnabled = true,
         ))
 
-        // Given a fully-migrated diskless topic with classicToDisklessStartOffset = 100
+        // Given a fully-switched diskless topic with classicToDisklessStartOffset = 100
         when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
           .thenReturn(100L)
 
@@ -9915,7 +9915,7 @@ class ReplicaManagerTest {
     }
 
     @Test
-    def testIsMigratedPartitionFromClassicToDiskless(): Unit = {
+    def testIsPartitionSwitchedFromClassicToDiskless(): Unit = {
       val replicaManager = spy(createReplicaManager(List(disklessTopicPartition.topic())))
       try {
         val tp = disklessTopicPartition.topicPartition()
@@ -9923,27 +9923,27 @@ class ReplicaManagerTest {
         val classicTp = classicTopicPartition.topicPartition()
         when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(classicTp))
           .thenReturn(100L)
-        assertFalse(replicaManager.isMigratedPartitionFromClassicToDiskless(classicTopicPartition))
+        assertFalse(replicaManager.isPartitionSwitchedFromClassicToDiskless(classicTopicPartition))
 
-        // Diskless but never-migrated partition: classicToDisklessStartOffset == -1.
+        // Diskless but never-switched partition: classicToDisklessStartOffset == -1.
         when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(tp))
           .thenReturn(PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET)
-        assertFalse(replicaManager.isMigratedPartitionFromClassicToDiskless(disklessTopicPartition))
+        assertFalse(replicaManager.isPartitionSwitchedFromClassicToDiskless(disklessTopicPartition))
 
-        // Migration pending: classicToDisklessStartOffset == -2 (sealed but offset not committed).
+        // Switch pending: classicToDisklessStartOffset == -2 (sealed but offset not committed).
         when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(tp))
-          .thenReturn(PartitionRegistration.CLASSIC_TO_DISKLESS_MIGRATION_PENDING)
-        assertFalse(replicaManager.isMigratedPartitionFromClassicToDiskless(disklessTopicPartition))
+          .thenReturn(PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING)
+        assertFalse(replicaManager.isPartitionSwitchedFromClassicToDiskless(disklessTopicPartition))
 
-        // Migrated (just sealed, seal at offset 0).
+        // Switched (just sealed, seal at offset 0).
         when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(tp))
           .thenReturn(0L)
-        assertTrue(replicaManager.isMigratedPartitionFromClassicToDiskless(disklessTopicPartition))
+        assertTrue(replicaManager.isPartitionSwitchedFromClassicToDiskless(disklessTopicPartition))
 
-        // Migrated (seal at a later offset).
+        // Switched (seal at a later offset).
         when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(tp))
           .thenReturn(100L)
-        assertTrue(replicaManager.isMigratedPartitionFromClassicToDiskless(disklessTopicPartition))
+        assertTrue(replicaManager.isPartitionSwitchedFromClassicToDiskless(disklessTopicPartition))
       } finally {
         replicaManager.shutdown(checkpointHW = false)
       }
@@ -9958,9 +9958,9 @@ class ReplicaManagerTest {
 
       val replicaManager = spy(createReplicaManager(List(topicName)))
       try {
-        // Never-migrated diskless topic: no local log on this broker AND no committed
+        // Never-switched diskless topic: no local log on this broker AND no committed
         // classicToDisklessStartOffset. Without an explicit stub Mockito would return
-        // 0L which means "migrated, seal at offset 0" -- not what this test models.
+        // 0L which means "switched, seal at offset 0" -- not what this test models.
         when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(tp))
           .thenReturn(PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET)
         assertTrue(replicaManager.logManager.getLog(tp).isEmpty)
@@ -9987,7 +9987,7 @@ class ReplicaManagerTest {
 
     @Test
     def testApplyDeltaCreatesPartitionAndStartsCatchUpFetcherForNewlyAddedDisklessReplica(): Unit = {
-      val topicName = "migrated-topic"
+      val topicName = "switched-topic"
       val topicId = Uuid.randomUuid()
       val tp = new TopicPartition(topicName, 0)
       val brokerId = 1
@@ -10001,7 +10001,7 @@ class ReplicaManagerTest {
         mockReplicaFetcherManager = Some(mockFetcherManager)
       ))
       try {
-        // Newly added replica on a *migrated* diskless topic: no local log yet, but
+        // Newly added replica on a *switched* diskless topic: no local log yet, but
         // the topic has a committed classicToDisklessStartOffset (seal). The broker
         // needs to create a local log on the fly and arm a catch-up fetcher to
         // backfill the classic-era prefix from another replica, so it can later
@@ -10037,13 +10037,13 @@ class ReplicaManagerTest {
     }
 
     @Test
-    def testApplyDeltaDoesNotStartCatchUpFetcherForNewlyAddedReplicaWhenMigrationPending(): Unit = {
+    def testApplyDeltaDoesNotStartCatchUpFetcherForNewlyAddedReplicaWhenSwitchPending(): Unit = {
       // A newly added replica must NOT spin up a local log + catch-up fetcher while
-      // the migration is still pending (seal == -2). There is no upper bound to
+      // the switch is still pending (seal == -2). There is no upper bound to
       // fetch up to yet, and the controller will re-trigger applyLocalFollowersDelta
       // once it commits the seal (bumping partitionEpoch), at which point the
       // standard path will create the log and arm the fetcher.
-      val topicName = "pending-migration-topic"
+      val topicName = "pending-switch-topic"
       val topicId = Uuid.randomUuid()
       val tp = new TopicPartition(topicName, 0)
       val brokerId = 1
@@ -10059,7 +10059,7 @@ class ReplicaManagerTest {
       try {
         assertTrue(replicaManager.logManager.getLog(tp).isEmpty)
         when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(tp))
-          .thenReturn(PartitionRegistration.CLASSIC_TO_DISKLESS_MIGRATION_PENDING)
+          .thenReturn(PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING)
 
         val delta = disklessFollowerDelta(topicName, topicId, brokerId, leaderId)
         replicaManager.applyDelta(delta, imageFromTopics(delta.apply()))

--- a/core/src/test/scala/unit/kafka/server/metadata/DisklessSwitchFlowTest.scala
+++ b/core/src/test/scala/unit/kafka/server/metadata/DisklessSwitchFlowTest.scala
@@ -46,7 +46,7 @@ import org.mockito.Mockito.{mock, times, verify, when}
 import java.util
 import scala.jdk.CollectionConverters._
 
-class InitDisklessLogFlowTest {
+class DisklessSwitchFlowTest {
 
   private case class TestContext(
     config: kafka.server.KafkaConfig,
@@ -133,7 +133,7 @@ class InitDisklessLogFlowTest {
   }
 
   @Test
-  def testPerStateGaugesReflectMigrationProgress(): Unit = {
+  def testPerStateGaugesReflectSwitchProgress(): Unit = {
     // Walks a single partition through the full state machine and asserts that
     // the per-state JMX gauges and meters advance, and the oldest-age-per-state
     // gauges reset on transitions and return to 0 once the partition leaves
@@ -149,7 +149,7 @@ class InitDisklessLogFlowTest {
 
     try {
       // Initially: no partitions sealed, no entries tracked, every gauge is 0
-      // and no migrations have completed/failed/retried yet.
+      // and no init diskless log have completed/failed/retried yet.
       val createDelta = new TopicsDelta(TopicsImage.EMPTY)
       createDelta.replay(new TopicRecord().setName(topicName).setTopicId(topicId))
       createDelta.replay(new PartitionRecord()
@@ -160,8 +160,8 @@ class InitDisklessLogFlowTest {
       ctx.replicaManager.applyDelta(createDelta, createImage)
       assertCountGaugesAllZero()
       assertOldestAgesAllZero()
-      assertMeterCount(InitDisklessLogManager.MigrationsCompletedPerSecMetricName, 0L)
-      assertMeterCount(InitDisklessLogManager.MigrationsFailedPerSecMetricName, 0L)
+      assertMeterCount(InitDisklessLogManager.InitDisklessLogCompletedPerSecMetricName, 0L)
+      assertMeterCount(InitDisklessLogManager.InitDisklessLogFailedPerSecMetricName, 0L)
 
       // After alter -> diskless=true: the partition is sealed and registered.
       // With a fresh mock log (HW == LEO == 0), the state machine immediately
@@ -177,7 +177,7 @@ class InitDisklessLogFlowTest {
       val disklessImage = withClusterBrokers(disklessDelta.apply(MetadataProvenance.EMPTY))
       ctx.metadataPublisher.onMetadataUpdate(disklessDelta, disklessImage, metadataManifest())
 
-      assertGauge(InitDisklessLogManager.MigrationsInFlightMetricName, 1)
+      assertGauge(InitDisklessLogManager.InitDisklessLogInFlightMetricName, 1)
       assertGauge(InitDisklessLogManager.WaitingForReplicationCountMetricName, 0)
       assertGauge(InitDisklessLogManager.SendingToControllerCountMetricName, 1)
       assertGauge(InitDisklessLogManager.AwaitingMetadataCountMetricName, 0)
@@ -201,7 +201,7 @@ class InitDisklessLogFlowTest {
       )))
 
       assertTrackedStates(ctx, Map(tp -> classOf[AwaitingMetadata]))
-      assertGauge(InitDisklessLogManager.MigrationsInFlightMetricName, 1)
+      assertGauge(InitDisklessLogManager.InitDisklessLogInFlightMetricName, 1)
       assertGauge(InitDisklessLogManager.SendingToControllerCountMetricName, 0)
       assertGauge(InitDisklessLogManager.AwaitingMetadataCountMetricName, 1)
       // The oldest SendingToController age must reset to 0 (no partitions
@@ -227,8 +227,8 @@ class InitDisklessLogFlowTest {
 
       assertCountGaugesAllZero()
       assertOldestAgesAllZero()
-      assertMeterCount(InitDisklessLogManager.MigrationsCompletedPerSecMetricName, 1L)
-      assertMeterCount(InitDisklessLogManager.MigrationsFailedPerSecMetricName, 0L)
+      assertMeterCount(InitDisklessLogManager.InitDisklessLogCompletedPerSecMetricName, 1L)
+      assertMeterCount(InitDisklessLogManager.InitDisklessLogFailedPerSecMetricName, 0L)
     } finally {
       shutdown(ctx)
     }
@@ -484,17 +484,17 @@ class InitDisklessLogFlowTest {
       // When diskless is enabled and leadership moves to this broker in the same image.
       ctx.metadataPublisher._firstPublish = false
       when(ctx.replicaManager.inklessMetadataView().isDisklessTopic(topicName)).thenReturn(true)
-      val migrationDelta = new MetadataDelta(createImage)
-      migrationDelta.replay(new ConfigRecord()
+      val switchDelta = new MetadataDelta(createImage)
+      switchDelta.replay(new ConfigRecord()
         .setResourceType(ConfigResource.Type.TOPIC.id())
         .setResourceName(topicName)
         .setName(TopicConfig.DISKLESS_ENABLE_CONFIG)
         .setValue("true"))
-      migrationDelta.replay(new PartitionChangeRecord()
+      switchDelta.replay(new PartitionChangeRecord()
         .setPartitionId(0).setTopicId(topicId)
         .setLeader(ctx.config.brokerId).setIsr(util.Arrays.asList(0, 1)))
-      val migratedImage = withClusterBrokers(migrationDelta.apply(MetadataProvenance.EMPTY))
-      ctx.metadataPublisher.onMetadataUpdate(migrationDelta, migratedImage, metadataManifest())
+      val switchedImage = withClusterBrokers(switchDelta.apply(MetadataProvenance.EMPTY))
+      ctx.metadataPublisher.onMetadataUpdate(switchDelta, switchedImage, metadataManifest())
 
       // Then the new local leader is sealed and tracked in SendingToController.
       assertTrue(partition.isLeader)
@@ -553,15 +553,15 @@ class InitDisklessLogFlowTest {
       broker1Ctx.metadataPublisher._firstPublish = false
       when(broker0Ctx.replicaManager.inklessMetadataView().isDisklessTopic(topicName)).thenReturn(true)
       when(broker1Ctx.replicaManager.inklessMetadataView().isDisklessTopic(topicName)).thenReturn(true)
-      val migrationDelta = new MetadataDelta(createImage)
-      migrationDelta.replay(new ConfigRecord()
+      val switchDelta = new MetadataDelta(createImage)
+      switchDelta.replay(new ConfigRecord()
         .setResourceType(ConfigResource.Type.TOPIC.id())
         .setResourceName(topicName)
         .setName(TopicConfig.DISKLESS_ENABLE_CONFIG)
         .setValue("true"))
-      val migratedImage = withClusterBrokers(migrationDelta.apply(MetadataProvenance.EMPTY))
-      broker0Ctx.metadataPublisher.onMetadataUpdate(migrationDelta, migratedImage, metadataManifest())
-      broker1Ctx.metadataPublisher.onMetadataUpdate(migrationDelta, migratedImage, metadataManifest())
+      val switchedImage = withClusterBrokers(switchDelta.apply(MetadataProvenance.EMPTY))
+      broker0Ctx.metadataPublisher.onMetadataUpdate(switchDelta, switchedImage, metadataManifest())
+      broker1Ctx.metadataPublisher.onMetadataUpdate(switchDelta, switchedImage, metadataManifest())
 
       // Then each broker tracks only local-leader partitions, in SendingToController state.
       assertTrackedStates(broker0Ctx, Map(tp0 -> classOf[SendingToController]))
@@ -620,18 +620,18 @@ class InitDisklessLogFlowTest {
       broker1Ctx.metadataPublisher._firstPublish = false
       when(broker0Ctx.replicaManager.inklessMetadataView().isDisklessTopic(topicName)).thenReturn(true)
       when(broker1Ctx.replicaManager.inklessMetadataView().isDisklessTopic(topicName)).thenReturn(true)
-      val migrationDelta = new MetadataDelta(createImage)
-      migrationDelta.replay(new ConfigRecord()
+      val switchDelta = new MetadataDelta(createImage)
+      switchDelta.replay(new ConfigRecord()
         .setResourceType(ConfigResource.Type.TOPIC.id())
         .setResourceName(topicName)
         .setName(TopicConfig.DISKLESS_ENABLE_CONFIG)
         .setValue("true"))
-      migrationDelta.replay(new PartitionChangeRecord()
+      switchDelta.replay(new PartitionChangeRecord()
         .setPartitionId(0).setTopicId(topicId)
         .setLeader(1).setIsr(util.Arrays.asList(0, 1)))
-      val migratedImage = withClusterBrokers(migrationDelta.apply(MetadataProvenance.EMPTY))
-      broker0Ctx.metadataPublisher.onMetadataUpdate(migrationDelta, migratedImage, metadataManifest())
-      broker1Ctx.metadataPublisher.onMetadataUpdate(migrationDelta, migratedImage, metadataManifest())
+      val switchedImage = withClusterBrokers(switchDelta.apply(MetadataProvenance.EMPTY))
+      broker0Ctx.metadataPublisher.onMetadataUpdate(switchDelta, switchedImage, metadataManifest())
+      broker1Ctx.metadataPublisher.onMetadataUpdate(switchDelta, switchedImage, metadataManifest())
 
       // Then only the new leader broker tracks the partition in SendingToController state.
       assertTrackedStates(broker0Ctx, Map.empty)
@@ -890,7 +890,7 @@ class InitDisklessLogFlowTest {
 
   private def assertCountGaugesAllZero(): Unit = {
     Set(
-      InitDisklessLogManager.MigrationsInFlightMetricName,
+      InitDisklessLogManager.InitDisklessLogInFlightMetricName,
       InitDisklessLogManager.WaitingForReplicationCountMetricName,
       InitDisklessLogManager.SendingToControllerCountMetricName,
       InitDisklessLogManager.AwaitingMetadataCountMetricName,

--- a/core/src/test/scala/unit/kafka/server/metadata/DisklessSwitchFlowTest.scala
+++ b/core/src/test/scala/unit/kafka/server/metadata/DisklessSwitchFlowTest.scala
@@ -160,8 +160,8 @@ class DisklessSwitchFlowTest {
       ctx.replicaManager.applyDelta(createDelta, createImage)
       assertCountGaugesAllZero()
       assertOldestAgesAllZero()
-      assertMeterCount(InitDisklessLogManager.InitDisklessLogCompletedPerSecMetricName, 0L)
-      assertMeterCount(InitDisklessLogManager.InitDisklessLogFailedPerSecMetricName, 0L)
+      assertMeterCount(InitDisklessLogManager.InitCompletedPerSecMetricName, 0L)
+      assertMeterCount(InitDisklessLogManager.InitFailedPerSecMetricName, 0L)
 
       // After alter -> diskless=true: the partition is sealed and registered.
       // With a fresh mock log (HW == LEO == 0), the state machine immediately
@@ -177,10 +177,10 @@ class DisklessSwitchFlowTest {
       val disklessImage = withClusterBrokers(disklessDelta.apply(MetadataProvenance.EMPTY))
       ctx.metadataPublisher.onMetadataUpdate(disklessDelta, disklessImage, metadataManifest())
 
-      assertGauge(InitDisklessLogManager.InitDisklessLogInFlightMetricName, 1)
-      assertGauge(InitDisklessLogManager.WaitingForReplicationCountMetricName, 0)
-      assertGauge(InitDisklessLogManager.SendingToControllerCountMetricName, 1)
-      assertGauge(InitDisklessLogManager.AwaitingMetadataCountMetricName, 0)
+      assertGauge(InitDisklessLogManager.InFlightPartitionsMetricName, 1)
+      assertGauge(InitDisklessLogManager.WaitingForReplicationPartitionsMetricName, 0)
+      assertGauge(InitDisklessLogManager.SendingToControllerPartitionsMetricName, 1)
+      assertGauge(InitDisklessLogManager.AwaitingMetadataPartitionsMetricName, 0)
       assertLongGauge(InitDisklessLogManager.OldestSendingToControllerAgeMsMetricName, 0L)
 
       // Age advances when virtual clock advances while the state class is unchanged.
@@ -201,9 +201,9 @@ class DisklessSwitchFlowTest {
       )))
 
       assertTrackedStates(ctx, Map(tp -> classOf[AwaitingMetadata]))
-      assertGauge(InitDisklessLogManager.InitDisklessLogInFlightMetricName, 1)
-      assertGauge(InitDisklessLogManager.SendingToControllerCountMetricName, 0)
-      assertGauge(InitDisklessLogManager.AwaitingMetadataCountMetricName, 1)
+      assertGauge(InitDisklessLogManager.InFlightPartitionsMetricName, 1)
+      assertGauge(InitDisklessLogManager.SendingToControllerPartitionsMetricName, 0)
+      assertGauge(InitDisklessLogManager.AwaitingMetadataPartitionsMetricName, 1)
       // The oldest SendingToController age must reset to 0 (no partitions
       // remain in that state) while AwaitingMetadata's age starts at 0.
       assertLongGauge(InitDisklessLogManager.OldestSendingToControllerAgeMsMetricName, 0L)
@@ -227,8 +227,8 @@ class DisklessSwitchFlowTest {
 
       assertCountGaugesAllZero()
       assertOldestAgesAllZero()
-      assertMeterCount(InitDisklessLogManager.InitDisklessLogCompletedPerSecMetricName, 1L)
-      assertMeterCount(InitDisklessLogManager.InitDisklessLogFailedPerSecMetricName, 0L)
+      assertMeterCount(InitDisklessLogManager.InitCompletedPerSecMetricName, 1L)
+      assertMeterCount(InitDisklessLogManager.InitFailedPerSecMetricName, 0L)
     } finally {
       shutdown(ctx)
     }
@@ -890,10 +890,10 @@ class DisklessSwitchFlowTest {
 
   private def assertCountGaugesAllZero(): Unit = {
     Set(
-      InitDisklessLogManager.InitDisklessLogInFlightMetricName,
-      InitDisklessLogManager.WaitingForReplicationCountMetricName,
-      InitDisklessLogManager.SendingToControllerCountMetricName,
-      InitDisklessLogManager.AwaitingMetadataCountMetricName,
+      InitDisklessLogManager.InFlightPartitionsMetricName,
+      InitDisklessLogManager.WaitingForReplicationPartitionsMetricName,
+      InitDisklessLogManager.SendingToControllerPartitionsMetricName,
+      InitDisklessLogManager.AwaitingMetadataPartitionsMetricName,
     ).foreach(name => assertGauge(name, 0))
   }
 

--- a/docker/examples/docker-compose-files/inkless/README.md
+++ b/docker/examples/docker-compose-files/inkless/README.md
@@ -95,7 +95,7 @@ docker compose exec broker /opt/kafka/bin/kafka-console-producer.sh \
   --topic test-classic
 ```
 
-**Step 3: SWitch to diskless**
+**Step 3: Switch to diskless**
 
 ```bash
 docker compose exec broker /opt/kafka/bin/kafka-configs.sh \

--- a/docker/examples/docker-compose-files/inkless/README.md
+++ b/docker/examples/docker-compose-files/inkless/README.md
@@ -29,14 +29,14 @@ See [Releases](../../../../docs/inkless/RELEASES.md#docker-images) for all avail
 
 ## Diskless Tiered Storage Unification
 
-Test classic-to-diskless migration and tiered storage unification features. The Inkless image bundles the
+Test classic-to-diskless switch and tiered storage unification features. The Inkless image bundles the
 [Aiven Tiered Storage plugin](https://github.com/Aiven-Open/tiered-storage-for-apache-kafka) (v1.1.1) —
 no local plugin build required.
 
 ### Quick start
 
 ```bash
-# Start 2-broker cluster with classic TS + diskless + migration bridge
+# Start 2-broker cluster with classic TS + diskless + classic to diskless switch bridge
 make ts-unification
 
 # Or manually:
@@ -46,14 +46,14 @@ docker compose -f docker-compose.yml -f docker-compose.s3-local.yml \
 
 ### What's enabled
 
-| Config                                | Value  | Purpose                                         |
-|---------------------------------------|--------|--------------------------------------------------|
-| `remote.log.storage.system.enable`    | `true` | Classic tiered storage via Aiven TS plugin       |
-| `diskless.allow.from.classic.enable`  | `true` | Allow classic-to-diskless topic migration        |
+| Config                                | Value  | Purpose                                             |
+|---------------------------------------|--------|-----------------------------------------------------|
+| `remote.log.storage.system.enable`    | `true` | Classic tiered storage via Aiven TS plugin          |
+| `diskless.allow.from.classic.enable`  | `true` | Allow classic-to-diskless topic switch              |
 | `classic.remote.storage.force.enable` | `true` | All classic topics get `remote.storage.enable=true` |
-| `log.diskless.enable`                 | `false`| Topics start as classic (not diskless by default)|
-| `diskless.managed.rf.enable`          | `true` | Managed replicas with rack-aware placement       |
-| `default.replication.factor`          | `2`    | One replica per AZ                               |
+| `log.diskless.enable`                 | `false`| Topics start as classic (not diskless by default)   |
+| `diskless.managed.rf.enable`          | `true` | Managed replicas with rack-aware placement          |
+| `default.replication.factor`          | `2`    | One replica per AZ                                  |
 
 ### Cluster topology
 
@@ -95,7 +95,7 @@ docker compose exec broker /opt/kafka/bin/kafka-console-producer.sh \
   --topic test-classic
 ```
 
-**Step 3: Migrate to diskless**
+**Step 3: SWitch to diskless**
 
 ```bash
 docker compose exec broker /opt/kafka/bin/kafka-configs.sh \
@@ -104,7 +104,7 @@ docker compose exec broker /opt/kafka/bin/kafka-configs.sh \
   --add-config diskless.enable=true
 ```
 
-**Step 4: Verify migration**
+**Step 4: Verify switch**
 
 ```bash
 docker compose exec broker /opt/kafka/bin/kafka-topics.sh \

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -1931,7 +1931,7 @@ public final class QuorumController implements Controller {
                 return result.withoutRecords();
             } else {
                 List<ApiMessageAndVersion> migrationRecords =
-                    replicationControl.markClassicToDisklessMigrationStarted(configChanges, result.response());
+                    replicationControl.markClassicToDisklessSwitchStarted(configChanges, result.response());
                 if (!migrationRecords.isEmpty()) {
                     List<ApiMessageAndVersion> allRecords = BoundedList.newArrayBacked(MAX_RECORDS_PER_USER_OP);
                     allRecords.addAll(result.records());

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -2890,7 +2890,7 @@ public class ReplicationControlManager {
         }
     }
 
-    List<ApiMessageAndVersion> markClassicToDisklessMigrationStarted(
+    List<ApiMessageAndVersion> markClassicToDisklessSwitchStarted(
         Map<ConfigResource, Map<String, Entry<OpType, String>>> configChanges,
         Map<ConfigResource, ApiError> configResults
     ) {
@@ -2921,11 +2921,11 @@ public class ReplicationControlManager {
                         .setPartitionId(partEntry.getKey());
                     record.unknownTaggedFields().add(
                         InitDisklessLogFields.encodeClassicToDisklessStartOffset(
-                            PartitionRegistration.CLASSIC_TO_DISKLESS_MIGRATION_PENDING));
+                            PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING));
                     records.add(new ApiMessageAndVersion(record, (short) 0));
                 }
             }
-            log.info("Marked {} partition(s) for topic {} as classic-to-diskless migration pending",
+            log.info("Marked {} partition(s) for topic {} as classic-to-diskless switch pending",
                 records.size() - sizeBefore, topicName);
         }
         return records;

--- a/metadata/src/main/java/org/apache/kafka/metadata/PartitionRegistration.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/PartitionRegistration.java
@@ -165,7 +165,7 @@ public class PartitionRegistration {
     }
 
     public static final long NO_CLASSIC_TO_DISKLESS_START_OFFSET = -1L;
-    public static final long CLASSIC_TO_DISKLESS_MIGRATION_PENDING = -2L;
+    public static final long CLASSIC_TO_DISKLESS_SWITCH_PENDING = -2L;
 
     public final int[] replicas;
     public final Uuid[] directories;

--- a/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
@@ -6240,7 +6240,7 @@ public class ReplicationControlManagerTest {
         }
 
         @Test
-        public void testInitDisklessLogAcceptsMigrationPendingPartition() {
+        public void testInitDisklessLogAcceptsSwitchPendingPartition() {
             ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder().build();
             ReplicationControlManager replicationControl = ctx.replicationControl;
             ctx.registerBrokers(0, 1, 2);
@@ -6250,17 +6250,17 @@ public class ReplicationControlManagerTest {
 
             Uuid topicId = createTopicResult.topicId();
 
-            // Simulate migration pending by replaying a PartitionChangeRecord with -2
-            PartitionChangeRecord migrationPendingRecord = new PartitionChangeRecord()
+            // Simulate switch pending by replaying a PartitionChangeRecord with -2
+            PartitionChangeRecord switchPendingRecord = new PartitionChangeRecord()
                 .setTopicId(topicId)
                 .setPartitionId(0);
-            migrationPendingRecord.unknownTaggedFields().add(
+            switchPendingRecord.unknownTaggedFields().add(
                 InitDisklessLogFields.encodeClassicToDisklessStartOffset(
-                    PartitionRegistration.CLASSIC_TO_DISKLESS_MIGRATION_PENDING));
-            ctx.replay(List.of(new ApiMessageAndVersion(migrationPendingRecord, (short) 0)));
+                    PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING));
+            ctx.replay(List.of(new ApiMessageAndVersion(switchPendingRecord, (short) 0)));
 
             PartitionRegistration pendingPartition = replicationControl.getPartition(topicId, 0);
-            assertEquals(PartitionRegistration.CLASSIC_TO_DISKLESS_MIGRATION_PENDING, pendingPartition.classicToDisklessStartOffset);
+            assertEquals(PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING, pendingPartition.classicToDisklessStartOffset);
 
             // InitDisklessLog should succeed even though classicToDisklessStartOffset is -2
             ControllerRequestContext requestContext = anonymousContextFor(ApiKeys.ALTER_PARTITION);
@@ -6280,7 +6280,7 @@ public class ReplicationControlManagerTest {
         }
 
         @Test
-        public void testMarkClassicToDisklessMigrationStartedSuccess() {
+        public void testMarkClassicToDisklessSwitchStartedSuccess() {
             ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder().build();
             ReplicationControlManager replicationControl = ctx.replicationControl;
             ctx.registerBrokers(0, 1, 2);
@@ -6297,27 +6297,27 @@ public class ReplicationControlManagerTest {
             Map<ConfigResource, ApiError> configResults = Map.of(resource, ApiError.NONE);
 
             List<ApiMessageAndVersion> records =
-                replicationControl.markClassicToDisklessMigrationStarted(configChanges, configResults);
+                replicationControl.markClassicToDisklessSwitchStarted(configChanges, configResults);
 
             assertEquals(2, records.size());
             for (int i = 0; i < 2; i++) {
                 assertInstanceOf(PartitionChangeRecord.class, records.get(i).message());
                 PartitionChangeRecord record = (PartitionChangeRecord) records.get(i).message();
                 assertEquals(topicId, record.topicId());
-                assertEquals(PartitionRegistration.CLASSIC_TO_DISKLESS_MIGRATION_PENDING,
+                assertEquals(PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING,
                     InitDisklessLogFields.decodeClassicToDisklessStartOffset(record.unknownTaggedFields()));
             }
 
             ctx.replay(records);
             for (int i = 0; i < 2; i++) {
                 PartitionRegistration partition = replicationControl.getPartition(topicId, i);
-                assertEquals(PartitionRegistration.CLASSIC_TO_DISKLESS_MIGRATION_PENDING,
+                assertEquals(PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING,
                     partition.classicToDisklessStartOffset);
             }
         }
 
         @Test
-        public void testMarkClassicToDisklessMigrationStartedSkipsIneligibleChanges() {
+        public void testMarkClassicToDisklessSwitchStartedSkipsIneligibleChanges() {
             ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder()
                 .setDisklessStorageSystemEnabled(true)
                 .build();
@@ -6354,7 +6354,7 @@ public class ReplicationControlManagerTest {
             configResults.put(unknownTopic, ApiError.NONE);
 
             List<ApiMessageAndVersion> records =
-                replicationControl.markClassicToDisklessMigrationStarted(configChanges, configResults);
+                replicationControl.markClassicToDisklessSwitchStarted(configChanges, configResults);
             assertEquals(0, records.size());
 
             // Also verify DELETE op and SET to "false" are skipped
@@ -6364,18 +6364,18 @@ public class ReplicationControlManagerTest {
                 new AbstractMap.SimpleImmutableEntry<>(AlterConfigOp.OpType.DELETE, "true")));
             configResults.put(classicTopic, ApiError.NONE);
 
-            records = replicationControl.markClassicToDisklessMigrationStarted(configChanges, configResults);
+            records = replicationControl.markClassicToDisklessSwitchStarted(configChanges, configResults);
             assertEquals(0, records.size());
 
             configChanges.put(classicTopic, Map.of(DISKLESS_ENABLE_CONFIG,
                 new AbstractMap.SimpleImmutableEntry<>(AlterConfigOp.OpType.SET, "false")));
 
-            records = replicationControl.markClassicToDisklessMigrationStarted(configChanges, configResults);
+            records = replicationControl.markClassicToDisklessSwitchStarted(configChanges, configResults);
             assertEquals(0, records.size());
         }
 
         @Test
-        public void testMarkClassicToDisklessMigrationStartedSkipsAlreadyInitializedPartitions() {
+        public void testMarkClassicToDisklessSwitchStartedSkipsAlreadyInitializedPartitions() {
             ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder().build();
             ReplicationControlManager replicationControl = ctx.replicationControl;
             ctx.registerBrokers(0, 1, 2);
@@ -6400,14 +6400,14 @@ public class ReplicationControlManagerTest {
             Map<ConfigResource, ApiError> configResults = Map.of(resource, ApiError.NONE);
 
             List<ApiMessageAndVersion> records =
-                replicationControl.markClassicToDisklessMigrationStarted(configChanges, configResults);
+                replicationControl.markClassicToDisklessSwitchStarted(configChanges, configResults);
 
             // Only partition 1 should be marked — partition 0 was already initialized
             assertEquals(1, records.size());
             PartitionChangeRecord record = (PartitionChangeRecord) records.get(0).message();
             assertEquals(topicId, record.topicId());
             assertEquals(1, record.partitionId());
-            assertEquals(PartitionRegistration.CLASSIC_TO_DISKLESS_MIGRATION_PENDING,
+            assertEquals(PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING,
                 InitDisklessLogFields.decodeClassicToDisklessStartOffset(record.unknownTaggedFields()));
         }
 

--- a/metadata/src/test/java/org/apache/kafka/metadata/PartitionRegistrationTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/PartitionRegistrationTest.java
@@ -504,16 +504,16 @@ public class PartitionRegistrationTest {
             setReplicas(new int[]{1, 2, 3}).setDirectories(DirectoryId.unassignedArray(3)).
             setIsr(new int[]{1, 2, 3}).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
             setLeaderEpoch(0).setPartitionEpoch(0).
-            setClassicToDisklessStartOffset(PartitionRegistration.CLASSIC_TO_DISKLESS_MIGRATION_PENDING).build();
+            setClassicToDisklessStartOffset(PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING).build();
 
-        assertEquals(PartitionRegistration.CLASSIC_TO_DISKLESS_MIGRATION_PENDING, original.classicToDisklessStartOffset);
+        assertEquals(PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING, original.classicToDisklessStartOffset);
 
         Uuid topicId = Uuid.randomUuid();
         ApiMessageAndVersion record = original.toRecord(topicId, 0,
             new ImageWriterOptions.Builder(MetadataVersion.latestTesting()).build());
         PartitionRecord partitionRecord = (PartitionRecord) record.message();
         PartitionRegistration restored = new PartitionRegistration(partitionRecord);
-        assertEquals(PartitionRegistration.CLASSIC_TO_DISKLESS_MIGRATION_PENDING, restored.classicToDisklessStartOffset);
+        assertEquals(PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING, restored.classicToDisklessStartOffset);
     }
 
     @Test
@@ -522,7 +522,7 @@ public class PartitionRegistrationTest {
             setReplicas(new int[]{1, 2, 3}).setDirectories(DirectoryId.unassignedArray(3)).
             setIsr(new int[]{1, 2, 3}).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
             setLeaderEpoch(0).setPartitionEpoch(0).
-            setClassicToDisklessStartOffset(PartitionRegistration.CLASSIC_TO_DISKLESS_MIGRATION_PENDING).build();
+            setClassicToDisklessStartOffset(PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING).build();
 
         PartitionChangeRecord changeRecord = new PartitionChangeRecord();
         changeRecord.unknownTaggedFields().add(
@@ -538,11 +538,11 @@ public class PartitionRegistrationTest {
             setReplicas(new int[]{1, 2, 3}).setDirectories(DirectoryId.unassignedArray(3)).
             setIsr(new int[]{1, 2, 3}).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
             setLeaderEpoch(0).setPartitionEpoch(0).
-            setClassicToDisklessStartOffset(PartitionRegistration.CLASSIC_TO_DISKLESS_MIGRATION_PENDING).build();
+            setClassicToDisklessStartOffset(PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING).build();
 
         PartitionRegistration merged = original.merge(new PartitionChangeRecord().
             setLeader(2).setIsr(List.of(2, 3)));
 
-        assertEquals(PartitionRegistration.CLASSIC_TO_DISKLESS_MIGRATION_PENDING, merged.classicToDisklessStartOffset);
+        assertEquals(PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING, merged.classicToDisklessStartOffset);
     }
 }

--- a/metadata/src/test/java/org/apache/kafka/metadata/PartitionRegistrationTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/PartitionRegistrationTest.java
@@ -499,7 +499,7 @@ public class PartitionRegistrationTest {
     }
 
     @Test
-    public void testMigrationPendingRoundTrip() {
+    public void testSwitchPendingRoundTrip() {
         PartitionRegistration original = new PartitionRegistration.Builder().
             setReplicas(new int[]{1, 2, 3}).setDirectories(DirectoryId.unassignedArray(3)).
             setIsr(new int[]{1, 2, 3}).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
@@ -517,7 +517,7 @@ public class PartitionRegistrationTest {
     }
 
     @Test
-    public void testMergeFromMigrationPendingToActualOffset() {
+    public void testMergeFromSwitchPendingToActualOffset() {
         PartitionRegistration original = new PartitionRegistration.Builder().
             setReplicas(new int[]{1, 2, 3}).setDirectories(DirectoryId.unassignedArray(3)).
             setIsr(new int[]{1, 2, 3}).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
@@ -533,7 +533,7 @@ public class PartitionRegistrationTest {
     }
 
     @Test
-    public void testMergePreservesMigrationPending() {
+    public void testMergePreservesSwitchPending() {
         PartitionRegistration original = new PartitionRegistration.Builder().
             setReplicas(new int[]{1, 2, 3}).setDirectories(DirectoryId.unassignedArray(3)).
             setIsr(new int[]{1, 2, 3}).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).

--- a/server-common/src/main/java/org/apache/kafka/server/config/ServerConfigs.java
+++ b/server-common/src/main/java/org/apache/kafka/server/config/ServerConfigs.java
@@ -138,9 +138,10 @@ public class ServerConfigs {
 
     public static final String DISKLESS_ALLOW_FROM_CLASSIC_ENABLE_CONFIG = "diskless.allow.from.classic.enable";
     public static final boolean DISKLESS_ALLOW_FROM_CLASSIC_ENABLE_DEFAULT = false;
-    public static final String DISKLESS_ALLOW_FROM_CLASSIC_ENABLE_DOC = "Allow migrating existing topics with remote.storage.enable=true from classic (diskless.enable=false) to diskless (diskless.enable=true). " +
-        "This should only be enabled in non-production environments for testing or migration purposes. " +
-        "When enabled, topics can have their diskless.enable config changed from false to true.";
+    public static final String DISKLESS_ALLOW_FROM_CLASSIC_ENABLE_DOC = "Allow switching existing topics from classic (diskless.enable=false) to diskless (diskless.enable=true). " +
+        "This should only be enabled in non-production environments for testing or switching purposes. " +
+        "When enabled, topics can have their diskless.enable config changed from false to true. " +
+        "Requires remote.log.storage.system.enable=true at the broker level.";
 
     // When enabled, diskless topics are created with user-defined replication factor.
     // RF=-1 resolves to default.replication.factor. Explicit RF values (1, 2, 3, ...) are accepted.

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/ControlPlane.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/ControlPlane.java
@@ -56,7 +56,7 @@ public interface ControlPlane extends Closeable, Configurable {
     void createTopicAndPartitions(Set<CreateTopicAndPartitionsRequest> requests);
 
     /**
-     * Initialize diskless logs for classic-to-diskless migration.
+     * Initialize diskless logs for classic-to-diskless switch.
      * <p>
      * An error is returned if the diskless log is already initialized.
      * This method should only be called by the leader of the partition after the disklessStartOffset

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LogConfig.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LogConfig.java
@@ -578,7 +578,7 @@ public class LogConfig extends AbstractConfig {
             return Boolean.parseBoolean(existingConfigs.getOrDefault(TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG, "false"));
         }
 
-        public boolean isMigratedFromClassicWithRemoteStorage() {
+        public boolean isSwitchedFromClassicWithRemoteStorage() {
             return isDisklessAllowFromClassicEnabled
                 && isDisklessEnabled()
                 && wasRemoteStorageExplicitlySet() && wasRemoteStorageEnabled()
@@ -631,13 +631,13 @@ public class LogConfig extends AbstractConfig {
         validateDisklessTransition(logConfigHelper, isDisklessAllowFromClassicEnabled);
 
         // Only one between diskless.enable and remote.storage.enable can be set, no matter the value.
-        // Exception 1: when classic-to-diskless migration is allowed, we permit diskless.enable=true
-        // on a topic that already had remote.storage.enable=true — both during the migration itself
-        // and in steady state afterward (migrated topics retain both configs).
+        // Exception 1: when classic-to-diskless switch is allowed, we permit diskless.enable=true
+        // on a topic that already had remote.storage.enable=true — both during the switch itself
+        // and in steady state afterward (switched topics retain both configs).
         // Note: in the controller path, requestedConfigs is the merged state (existing + changes),
         // so we cannot distinguish "client set this" from "already existed". We detect the exception
         // by checking that diskless is (or will be) enabled and remote storage was and remains enabled.
-        final boolean isMigratedFromClassicWithRemoteStorage = logConfigHelper.isMigratedFromClassicWithRemoteStorage();
+        final boolean isSwitchedFromClassicWithRemoteStorage = logConfigHelper.isSwitchedFromClassicWithRemoteStorage();
         // Exception 2: when we're at creation we allow both properties to be set to true if remote storage
         // consolidation is also enabled.
         final boolean isDisklessConsolidationOnCreation = logConfigHelper.isDisklessConsolidationModeOnCreation();
@@ -649,7 +649,7 @@ public class LogConfig extends AbstractConfig {
         // Exception 4: both keys were already present and remain explicitly false (no-op alter); allowed even
         // when cluster consolidation is off, so routine config updates do not trip mutual exclusion.
         final boolean isBothExplicitlyDisabledSteadyState = logConfigHelper.isBothExplicitlyDisabledSteadyStateUpdate();
-        if (!isMigratedFromClassicWithRemoteStorage && !isDisklessConsolidationOnCreation && !isValidConsolidationModeTransitionOnUpdate
+        if (!isSwitchedFromClassicWithRemoteStorage && !isDisklessConsolidationOnCreation && !isValidConsolidationModeTransitionOnUpdate
             && !isBothExplicitlyDisabledSteadyState) {
             validateDisklessAndRemoteStorageMutualExclusion(logConfigHelper);
         }
@@ -675,7 +675,7 @@ public class LogConfig extends AbstractConfig {
         // Only one between diskless.enable and remote.storage.enable can be set if consolidation isn't enabled, no matter the value.
         if ((logConfigHelper.isDisklessExplicitlySet() && hasExplicitRemoteStorage) ||
             (logConfigHelper.isRemoteStorageExplicitlySet() && hasExplicitDiskless)) {
-            throw new InvalidConfigurationException("It is not valid to set a value for both diskless.enable and remote.storage.enable unless it's for diskless migration or consolidation.");
+            throw new InvalidConfigurationException("It is not valid to set a value for both diskless.enable and remote.storage.enable unless it's for diskless switch or consolidation.");
         }
     }
 


### PR DESCRIPTION
The term migration might be misleading as there's no data transfer involved in converting a classic topic to a diskless one. Use the term switch to be more evocative of what it really happens to all the partitions of the topic: each of them starts to append to the diskless log, and maintains what it was already present in the classic UnifiedLog.
