### PR TITLE
refactor(inkless:switch): drop sealing and registering from BrokerMetadataPublisher

### DIFF
--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -33,7 +33,6 @@ import kafka.server.metadata.{InklessMetadataView, KRaftMetadataCache}
 import kafka.server.share.DelayedShareFetch
 import kafka.utils._
 import org.apache.kafka.common.{IsolationLevel, Node, TopicIdPartition, TopicPartition, Uuid}
-import org.apache.kafka.common.config.{ConfigResource, TopicConfig}
 import org.apache.kafka.common.errors._
 import org.apache.kafka.common.internals.{Plugin, Topic}
 import org.apache.kafka.common.message.DeleteRecordsResponseData.DeleteRecordsPartitionResult
@@ -56,7 +55,7 @@ import org.apache.kafka.common.requests.ProduceResponse.PartitionResponse
 import org.apache.kafka.common.requests._
 import org.apache.kafka.common.utils.{Exit, Time, Utils}
 import org.apache.kafka.coordinator.transaction.{AddPartitionsToTxnConfig, TransactionLogConfig}
-import org.apache.kafka.image.{LocalReplicaChanges, MetadataDelta, MetadataImage, TopicsDelta}
+import org.apache.kafka.image.{LocalReplicaChanges, MetadataImage, TopicsDelta}
 import org.apache.kafka.logger.StateChangeLogger
 import org.apache.kafka.metadata.{LeaderAndIsr, MetadataCache, PartitionRegistration}
 import org.apache.kafka.metadata.LeaderConstants.NO_LEADER
@@ -587,54 +586,6 @@ class ReplicaManager(val config: KafkaConfig,
     allPartitions.values.asScala.iterator.flatMap {
       case HostedPartition.Online(partition) => Some(partition)
       case _ => None
-    }
-  }
-
-  private def sealTopicPartitions(topic: String): Unit = {
-    if (initDisklessLogManager.isEmpty) {
-      error(s"Cannot seal partitions for topic $topic: InitDisklessLogManager is not enabled.")
-      return
-    }
-    allPartitions.forEach { (tp, hostedPartition) =>
-      if (tp.topic() == topic) {
-        hostedPartition match {
-          case HostedPartition.Online(partition) if partition.isLeader =>
-            partition.topicId match {
-              case Some(id) =>
-                try {
-                  partition.seal()
-                  initDisklessLogManager.foreach(_.registerPartition(partition, id))
-                } catch {
-                  case e: KafkaStorageException =>
-                    stateChangeLogger.error(s"Failed to seal partition ${partition.topicPartition} " +
-                      s"for diskless switch due to a storage error ${e.getMessage}")
-                    markPartitionOffline(tp)
-                }
-              case None =>
-                error(s"Partition ${partition.topicPartition} has no topic ID, skipping seal and switch registration")
-            }
-          case _ =>
-        }
-      }
-    }
-  }
-
-  def sealExistingLeadersOfTopicsSwitchedToDiskless(delta: MetadataDelta, newImage: MetadataImage): Unit = {
-    Option(delta.configsDelta()).foreach { configsDelta =>
-      configsDelta.changes().forEach { (resource, _) =>
-        if (resource.`type`() == ConfigResource.Type.TOPIC) {
-          val topicName = resource.name()
-          val oldProps = delta.image().configs().configProperties(resource)
-          val wasDiskless = oldProps.getProperty(TopicConfig.DISKLESS_ENABLE_CONFIG, "false").toBoolean
-          val newProps = newImage.configs().configProperties(resource)
-          val isDiskless = newProps.getProperty(TopicConfig.DISKLESS_ENABLE_CONFIG, "false").toBoolean
-          val topicExistedBefore = delta.image().topics().getTopic(topicName) != null
-          if (topicExistedBefore && !wasDiskless && isDiskless) {
-            info(s"Topic $topicName transitioning from classic to diskless, sealing leader partitions")
-            sealTopicPartitions(topicName)
-          }
-        }
-      }
     }
   }
 
@@ -3052,15 +3003,25 @@ class ReplicaManager(val config: KafkaConfig,
           }
         }
       } else if (existingPartition.isDefined && !isConsolidatingDisklessTopic) {
-        // Classic-to-diskless transition: seal the partition before making it leader
-        // so that no produce request can ever be processed by the new leader.
+        // Classic-to-diskless switch. The controller writes the diskless.enable=true
+        // ConfigRecord and the per-partition PartitionChangeRecord (with
+        // classicToDisklessStartOffset = CLASSIC_TO_DISKLESS_SWITCH_PENDING) in the
+        // same atomic op so the partition shows up here in localChanges.leaders whenever
+        // this broker is (or just became) the leader.
         val partition = existingPartition.get
         try {
           val partitionAssignedDirectoryId = directoryIds.find(_._1.topicPartition() == tp).map(_._2)
+          // Seal BEFORE makeLeader so:
+          // - if this broker was already the leader, no further classic append can succeed after this point
+          // - if this broker is being newly elected leader, the partition is sealed before
+          //   it is ever placed in the leader role, guaranteeing that no produce request
+          //   can be processed against the classic log by the new leader.
           partition.seal()
           partition.makeLeader(info.partition, false, offsetCheckpoints, Some(info.topicId), partitionAssignedDirectoryId)
 
-          initDisklessLogManager.foreach(_.registerPartition(partition, info.topicId()))
+          if (info.partition.classicToDisklessStartOffset == PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING) {
+            initDisklessLogManager.foreach(_.registerPartition(partition, info.topicId()))
+          }
           changedPartitions.add(partition)
         } catch {
           case e: KafkaStorageException =>

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -3008,6 +3008,11 @@ class ReplicaManager(val config: KafkaConfig,
         // classicToDisklessStartOffset = CLASSIC_TO_DISKLESS_SWITCH_PENDING) in the
         // same atomic op so the partition shows up here in localChanges.leaders whenever
         // this broker is (or just became) the leader.
+        if (initDisklessLogManager.isEmpty) {
+          error(s"Cannot proceed with classic to diskless switch for partition $tp: InitDisklessLogManager is not enabled.")
+          return
+        }
+
         val partition = existingPartition.get
         try {
           val partitionAssignedDirectoryId = directoryIds.find(_._1.topicPartition() == tp).map(_._2)

--- a/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
+++ b/core/src/main/scala/kafka/server/metadata/BrokerMetadataPublisher.scala
@@ -143,10 +143,6 @@ class BrokerMetadataPublisher(
         debug(s"Publishing metadata at offset $highestOffsetAndEpoch with $metadataVersionLogMsg.")
       }
 
-      // Seal existing leader partitions for topics transitioning from classic to diskless.
-      // New leaders elected are instead sealed inside ReplicaManager.applyLocalLeadersDelta.
-      replicaManager.sealExistingLeadersOfTopicsSwitchedToDiskless(delta, newImage)
-      // Apply topic deltas.
       Option(delta.topicsDelta()).foreach { topicsDelta =>
         try {
           // Notify the replica manager about changes to topics.

--- a/core/src/test/scala/unit/kafka/server/metadata/DisklessSwitchFlowTest.scala
+++ b/core/src/test/scala/unit/kafka/server/metadata/DisklessSwitchFlowTest.scala
@@ -30,6 +30,7 @@ import org.apache.kafka.common.config.{ConfigResource, TopicConfig}
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.message.InitDisklessLogResponseData
 import org.apache.kafka.metadata.LeaderConstants.NO_LEADER_CHANGE
+import org.apache.kafka.metadata.PartitionRegistration
 import org.apache.kafka.common.metadata.{ConfigRecord, PartitionChangeRecord, PartitionRecord, TopicRecord}
 import org.apache.kafka.image.{AclsImage, ClientQuotasImage, ClusterImageTest, ConfigurationsImage, DelegationTokenImage, FeaturesImage, MetadataDelta, MetadataImage, MetadataProvenance, ProducerIdsImage, ScramImage, TopicsDelta, TopicsImage}
 import org.apache.kafka.image.loader.LogDeltaManifest
@@ -87,14 +88,13 @@ class DisklessSwitchFlowTest {
       assertFalse(partition.isSealed)
 
       // Step 1: enable diskless and trigger sealing + controller init request path.
+      // The controller writes the config flip and the per-partition switch-pending marker
+      // in the same atomic op (see markClassicToDisklessSwitchStarted).
       ctx.metadataPublisher._firstPublish = false
       when(ctx.replicaManager.inklessMetadataView().isDisklessTopic(topicName)).thenReturn(true)
       val enableDisklessDelta = new MetadataDelta(createImage)
-      enableDisklessDelta.replay(new ConfigRecord()
-        .setResourceType(ConfigResource.Type.TOPIC.id())
-        .setResourceName(topicName)
-        .setName(TopicConfig.DISKLESS_ENABLE_CONFIG)
-        .setValue("true"))
+      replayClassicToDisklessSwitchStarted(enableDisklessDelta, topicName, topicId,
+        partitions = Seq((0, util.Arrays.asList(0, 1))))
       val disklessImage = withClusterBrokers(enableDisklessDelta.apply(MetadataProvenance.EMPTY))
       ctx.metadataPublisher.onMetadataUpdate(enableDisklessDelta, disklessImage, metadataManifest())
 
@@ -104,13 +104,13 @@ class DisklessSwitchFlowTest {
       assertEquals(1, ctx.channelManager.requests.size())
 
       // Simulate successful controller response.
-      ctx.channelManager.requests.poll().complete(new org.apache.kafka.common.message.InitDisklessLogResponseData().setTopics(util.List.of(
-        new org.apache.kafka.common.message.InitDisklessLogResponseData.TopicResponse()
+      ctx.channelManager.requests.poll().complete(new InitDisklessLogResponseData().setTopics(util.List.of(
+        new InitDisklessLogResponseData.TopicResponse()
           .setTopicId(topicId)
           .setPartitions(util.List.of(
-            new org.apache.kafka.common.message.InitDisklessLogResponseData.PartitionResponse()
+            new InitDisklessLogResponseData.PartitionResponse()
               .setPartitionId(0)
-              .setErrorCode(org.apache.kafka.common.protocol.Errors.NONE.code())
+              .setErrorCode(Errors.NONE.code())
           ))
       )))
 
@@ -172,11 +172,8 @@ class DisklessSwitchFlowTest {
       ctx.metadataPublisher._firstPublish = false
       when(ctx.replicaManager.inklessMetadataView().isDisklessTopic(topicName)).thenReturn(true)
       val disklessDelta = new MetadataDelta(createImage)
-      disklessDelta.replay(new ConfigRecord()
-        .setResourceType(ConfigResource.Type.TOPIC.id())
-        .setResourceName(topicName)
-        .setName(TopicConfig.DISKLESS_ENABLE_CONFIG)
-        .setValue("true"))
+      replayClassicToDisklessSwitchStarted(disklessDelta, topicName, topicId,
+        partitions = Seq((0, util.Arrays.asList(0, 1))))
       val disklessImage = withClusterBrokers(disklessDelta.apply(MetadataProvenance.EMPTY))
       ctx.metadataPublisher.onMetadataUpdate(disklessDelta, disklessImage, metadataManifest())
 
@@ -193,13 +190,13 @@ class DisklessSwitchFlowTest {
       // After linger elapses + RPC completes: state advances to AwaitingMetadata.
       ctx.time.sleep(ctx.initDisklessLogManager.lingerMs)
       ctx.scheduler.tick()
-      ctx.channelManager.requests.poll().complete(new org.apache.kafka.common.message.InitDisklessLogResponseData().setTopics(util.List.of(
-        new org.apache.kafka.common.message.InitDisklessLogResponseData.TopicResponse()
+      ctx.channelManager.requests.poll().complete(new InitDisklessLogResponseData().setTopics(util.List.of(
+        new InitDisklessLogResponseData.TopicResponse()
           .setTopicId(topicId)
           .setPartitions(util.List.of(
-            new org.apache.kafka.common.message.InitDisklessLogResponseData.PartitionResponse()
+            new InitDisklessLogResponseData.PartitionResponse()
               .setPartitionId(0)
-              .setErrorCode(org.apache.kafka.common.protocol.Errors.NONE.code())
+              .setErrorCode(Errors.NONE.code())
           ))
       )))
 
@@ -268,11 +265,8 @@ class DisklessSwitchFlowTest {
       ctx.metadataPublisher._firstPublish = false
       when(ctx.replicaManager.inklessMetadataView().isDisklessTopic(topicName)).thenReturn(true)
       val disklessDelta = new MetadataDelta(createImage)
-      disklessDelta.replay(new ConfigRecord()
-        .setResourceType(ConfigResource.Type.TOPIC.id())
-        .setResourceName(topicName)
-        .setName(TopicConfig.DISKLESS_ENABLE_CONFIG)
-        .setValue("true"))
+      replayClassicToDisklessSwitchStarted(disklessDelta, topicName, topicId,
+        partitions = Seq((0, util.Arrays.asList(0, 1))))
       val updatedImage = withClusterBrokers(disklessDelta.apply(MetadataProvenance.EMPTY))
       ctx.metadataPublisher.onMetadataUpdate(disklessDelta, updatedImage, metadataManifest())
 
@@ -422,14 +416,9 @@ class DisklessSwitchFlowTest {
       ctx.metadataPublisher._firstPublish = false
       when(ctx.replicaManager.inklessMetadataView().isDisklessTopic(topicName)).thenReturn(true)
       val toLeaderDelta = new MetadataDelta(createImage)
-      toLeaderDelta.replay(new ConfigRecord()
-        .setResourceType(ConfigResource.Type.TOPIC.id())
-        .setResourceName(topicName)
-        .setName(TopicConfig.DISKLESS_ENABLE_CONFIG)
-        .setValue("true"))
-      toLeaderDelta.replay(new PartitionChangeRecord()
-        .setPartitionId(0).setTopicId(topicId)
-        .setLeader(ctx.config.brokerId).setIsr(util.Arrays.asList(0, 1)))
+      replayClassicToDisklessSwitchStarted(toLeaderDelta, topicName, topicId,
+        partitions = Seq((0, util.Arrays.asList(0, 1))),
+        newLeaders = Map(0 -> ctx.config.brokerId))
       val leaderImage = withClusterBrokers(toLeaderDelta.apply(MetadataProvenance.EMPTY))
       ctx.metadataPublisher.onMetadataUpdate(toLeaderDelta, leaderImage, metadataManifest())
 
@@ -488,14 +477,9 @@ class DisklessSwitchFlowTest {
       ctx.metadataPublisher._firstPublish = false
       when(ctx.replicaManager.inklessMetadataView().isDisklessTopic(topicName)).thenReturn(true)
       val switchDelta = new MetadataDelta(createImage)
-      switchDelta.replay(new ConfigRecord()
-        .setResourceType(ConfigResource.Type.TOPIC.id())
-        .setResourceName(topicName)
-        .setName(TopicConfig.DISKLESS_ENABLE_CONFIG)
-        .setValue("true"))
-      switchDelta.replay(new PartitionChangeRecord()
-        .setPartitionId(0).setTopicId(topicId)
-        .setLeader(ctx.config.brokerId).setIsr(util.Arrays.asList(0, 1)))
+      replayClassicToDisklessSwitchStarted(switchDelta, topicName, topicId,
+        partitions = Seq((0, util.Arrays.asList(0, 1))),
+        newLeaders = Map(0 -> ctx.config.brokerId))
       val switchedImage = withClusterBrokers(switchDelta.apply(MetadataProvenance.EMPTY))
       ctx.metadataPublisher.onMetadataUpdate(switchDelta, switchedImage, metadataManifest())
 
@@ -557,11 +541,11 @@ class DisklessSwitchFlowTest {
       when(broker0Ctx.replicaManager.inklessMetadataView().isDisklessTopic(topicName)).thenReturn(true)
       when(broker1Ctx.replicaManager.inklessMetadataView().isDisklessTopic(topicName)).thenReturn(true)
       val switchDelta = new MetadataDelta(createImage)
-      switchDelta.replay(new ConfigRecord()
-        .setResourceType(ConfigResource.Type.TOPIC.id())
-        .setResourceName(topicName)
-        .setName(TopicConfig.DISKLESS_ENABLE_CONFIG)
-        .setValue("true"))
+      replayClassicToDisklessSwitchStarted(switchDelta, topicName, topicId,
+        partitions = Seq(
+          (0, util.Arrays.asList(0, 1)),
+          (1, util.Arrays.asList(0, 1)),
+          (2, util.Arrays.asList(0, 1))))
       val switchedImage = withClusterBrokers(switchDelta.apply(MetadataProvenance.EMPTY))
       broker0Ctx.metadataPublisher.onMetadataUpdate(switchDelta, switchedImage, metadataManifest())
       broker1Ctx.metadataPublisher.onMetadataUpdate(switchDelta, switchedImage, metadataManifest())
@@ -624,14 +608,9 @@ class DisklessSwitchFlowTest {
       when(broker0Ctx.replicaManager.inklessMetadataView().isDisklessTopic(topicName)).thenReturn(true)
       when(broker1Ctx.replicaManager.inklessMetadataView().isDisklessTopic(topicName)).thenReturn(true)
       val switchDelta = new MetadataDelta(createImage)
-      switchDelta.replay(new ConfigRecord()
-        .setResourceType(ConfigResource.Type.TOPIC.id())
-        .setResourceName(topicName)
-        .setName(TopicConfig.DISKLESS_ENABLE_CONFIG)
-        .setValue("true"))
-      switchDelta.replay(new PartitionChangeRecord()
-        .setPartitionId(0).setTopicId(topicId)
-        .setLeader(1).setIsr(util.Arrays.asList(0, 1)))
+      replayClassicToDisklessSwitchStarted(switchDelta, topicName, topicId,
+        partitions = Seq((0, util.Arrays.asList(0, 1))),
+        newLeaders = Map(0 -> 1))
       val switchedImage = withClusterBrokers(switchDelta.apply(MetadataProvenance.EMPTY))
       broker0Ctx.metadataPublisher.onMetadataUpdate(switchDelta, switchedImage, metadataManifest())
       broker1Ctx.metadataPublisher.onMetadataUpdate(switchDelta, switchedImage, metadataManifest())
@@ -680,22 +659,19 @@ class DisklessSwitchFlowTest {
       ctx.metadataPublisher._firstPublish = false
       when(ctx.replicaManager.inklessMetadataView().isDisklessTopic(topicName)).thenReturn(true)
       val disklessDelta = new MetadataDelta(createImage)
-      disklessDelta.replay(new ConfigRecord()
-        .setResourceType(ConfigResource.Type.TOPIC.id())
-        .setResourceName(topicName)
-        .setName(TopicConfig.DISKLESS_ENABLE_CONFIG)
-        .setValue("true"))
+      replayClassicToDisklessSwitchStarted(disklessDelta, topicName, topicId,
+        partitions = Seq((0, util.Arrays.asList(0, 1))))
       val disklessImage = withClusterBrokers(disklessDelta.apply(MetadataProvenance.EMPTY))
       ctx.metadataPublisher.onMetadataUpdate(disklessDelta, disklessImage, metadataManifest())
 
       ctx.time.sleep(ctx.initDisklessLogManager.lingerMs)
       ctx.scheduler.tick()
       assertEquals(1, ctx.channelManager.requests.size())
-      ctx.channelManager.requests.poll().complete(new org.apache.kafka.common.message.InitDisklessLogResponseData().setTopics(util.List.of(
-        new org.apache.kafka.common.message.InitDisklessLogResponseData.TopicResponse()
+      ctx.channelManager.requests.poll().complete(new InitDisklessLogResponseData().setTopics(util.List.of(
+        new InitDisklessLogResponseData.TopicResponse()
           .setTopicId(topicId)
           .setPartitions(util.List.of(
-            new org.apache.kafka.common.message.InitDisklessLogResponseData.PartitionResponse()
+            new InitDisklessLogResponseData.PartitionResponse()
               .setPartitionId(0)
               .setErrorCode(Errors.NONE.code())
           ))
@@ -749,11 +725,8 @@ class DisklessSwitchFlowTest {
       when(broker0Ctx.replicaManager.inklessMetadataView().isDisklessTopic(topicName)).thenReturn(true)
       when(broker1Ctx.replicaManager.inklessMetadataView().isDisklessTopic(topicName)).thenReturn(true)
       val disklessDelta = new MetadataDelta(createImage)
-      disklessDelta.replay(new ConfigRecord()
-        .setResourceType(ConfigResource.Type.TOPIC.id())
-        .setResourceName(topicName)
-        .setName(TopicConfig.DISKLESS_ENABLE_CONFIG)
-        .setValue("true"))
+      replayClassicToDisklessSwitchStarted(disklessDelta, topicName, topicId,
+        partitions = Seq((0, util.Arrays.asList(0, 1))))
       val disklessImage = withClusterBrokers(disklessDelta.apply(MetadataProvenance.EMPTY))
       broker0Ctx.metadataPublisher.onMetadataUpdate(disklessDelta, disklessImage, metadataManifest())
       broker1Ctx.metadataPublisher.onMetadataUpdate(disklessDelta, disklessImage, metadataManifest())
@@ -761,11 +734,11 @@ class DisklessSwitchFlowTest {
       broker0Ctx.time.sleep(broker0Ctx.initDisklessLogManager.lingerMs)
       broker0Ctx.scheduler.tick()
       assertEquals(1, broker0Ctx.channelManager.requests.size())
-      broker0Ctx.channelManager.requests.poll().complete(new org.apache.kafka.common.message.InitDisklessLogResponseData().setTopics(util.List.of(
+      broker0Ctx.channelManager.requests.poll().complete(new InitDisklessLogResponseData().setTopics(util.List.of(
         new InitDisklessLogResponseData.TopicResponse()
           .setTopicId(topicId)
           .setPartitions(util.List.of(
-            new org.apache.kafka.common.message.InitDisklessLogResponseData.PartitionResponse()
+            new InitDisklessLogResponseData.PartitionResponse()
               .setPartitionId(0)
               .setErrorCode(Errors.NONE.code())
           ))
@@ -821,11 +794,8 @@ class DisklessSwitchFlowTest {
       when(broker0Ctx.replicaManager.inklessMetadataView().isDisklessTopic(topicName)).thenReturn(true)
       when(broker1Ctx.replicaManager.inklessMetadataView().isDisklessTopic(topicName)).thenReturn(true)
       val disklessDelta = new MetadataDelta(createImage)
-      disklessDelta.replay(new ConfigRecord()
-        .setResourceType(ConfigResource.Type.TOPIC.id())
-        .setResourceName(topicName)
-        .setName(TopicConfig.DISKLESS_ENABLE_CONFIG)
-        .setValue("true"))
+      replayClassicToDisklessSwitchStarted(disklessDelta, topicName, topicId,
+        partitions = Seq((0, util.Arrays.asList(0, 1))))
       val disklessImage = withClusterBrokers(disklessDelta.apply(MetadataProvenance.EMPTY))
       broker0Ctx.metadataPublisher.onMetadataUpdate(disklessDelta, disklessImage, metadataManifest())
       broker1Ctx.metadataPublisher.onMetadataUpdate(disklessDelta, disklessImage, metadataManifest())
@@ -873,7 +843,7 @@ class DisklessSwitchFlowTest {
       broker1Ctx.time.sleep(broker1Ctx.initDisklessLogManager.lingerMs)
       broker1Ctx.scheduler.tick()
 
-      assertEquals(1, broker1Ctx.channelManager.requests.size())
+      assertEquals(0, broker1Ctx.channelManager.requests.size())
       verify(broker1Ctx.controlPlane, times(1)).initDisklessLog(any())
     } finally {
       shutdown(broker0Ctx)
@@ -902,24 +872,21 @@ class DisklessSwitchFlowTest {
       ctx.metadataPublisher._firstPublish = false
       when(ctx.replicaManager.inklessMetadataView().isDisklessTopic(topicName)).thenReturn(true)
       val disklessDelta = new MetadataDelta(createImage)
-      disklessDelta.replay(new ConfigRecord()
-        .setResourceType(ConfigResource.Type.TOPIC.id())
-        .setResourceName(topicName)
-        .setName(TopicConfig.DISKLESS_ENABLE_CONFIG)
-        .setValue("true"))
+      replayClassicToDisklessSwitchStarted(disklessDelta, topicName, topicId,
+        partitions = Seq((0, util.Arrays.asList(0, 1))))
       val disklessImage = withClusterBrokers(disklessDelta.apply(MetadataProvenance.EMPTY))
       ctx.metadataPublisher.onMetadataUpdate(disklessDelta, disklessImage, metadataManifest())
 
       ctx.time.sleep(ctx.initDisklessLogManager.lingerMs)
       ctx.scheduler.tick()
       assertEquals(1, ctx.channelManager.requests.size())
-      ctx.channelManager.requests.poll().complete(new org.apache.kafka.common.message.InitDisklessLogResponseData().setTopics(util.List.of(
-        new org.apache.kafka.common.message.InitDisklessLogResponseData.TopicResponse()
+      ctx.channelManager.requests.poll().complete(new InitDisklessLogResponseData().setTopics(util.List.of(
+        new InitDisklessLogResponseData.TopicResponse()
           .setTopicId(topicId)
           .setPartitions(util.List.of(
-            new org.apache.kafka.common.message.InitDisklessLogResponseData.PartitionResponse()
+            new InitDisklessLogResponseData.PartitionResponse()
               .setPartitionId(0)
-              .setErrorCode(org.apache.kafka.common.protocol.Errors.NONE.code())
+              .setErrorCode(Errors.NONE.code())
           ))
       )))
 
@@ -950,7 +917,7 @@ class DisklessSwitchFlowTest {
       ctx.time.sleep(ctx.initDisklessLogManager.lingerMs)
       ctx.scheduler.tick()
 
-      assertEquals(1, ctx.channelManager.requests.size())
+      assertEquals(0, ctx.channelManager.requests.size())
       verify(ctx.controlPlane, times(1)).initDisklessLog(any())
     } finally {
       shutdown(ctx)
@@ -1095,6 +1062,38 @@ class DisklessSwitchFlowTest {
     assertEquals(expectedTopicId, topicData.topicId())
     val partitionIds = topicData.partitions().asScala.map(_.partitionId()).toSet
     assertEquals(expectedPartitions, partitionIds)
+  }
+
+  /**
+   * Replays the records the controller's `markClassicToDisklessSwitchStarted` would emit
+   * atomically in a single op: a `ConfigRecord` flipping `diskless.enable=true` and one
+   * `PartitionChangeRecord` per partition with `classicToDisklessStartOffset` set to
+   * `CLASSIC_TO_DISKLESS_SWITCH_PENDING` (-2). Optional `newLeaders` lets a test simulate
+   * a leader election happening in the same delta (`newLeaders(partitionId)` overrides
+   * the leader for that partition).
+   */
+  private def replayClassicToDisklessSwitchStarted(
+    delta: MetadataDelta,
+    topicName: String,
+    topicId: Uuid,
+    partitions: Seq[(Int, java.util.List[Integer])],
+    newLeaders: Map[Int, Int] = Map.empty
+  ): Unit = {
+    delta.replay(new ConfigRecord()
+      .setResourceType(ConfigResource.Type.TOPIC.id())
+      .setResourceName(topicName)
+      .setName(TopicConfig.DISKLESS_ENABLE_CONFIG)
+      .setValue("true"))
+    partitions.foreach { case (partitionId, isr) =>
+      val record = new PartitionChangeRecord()
+        .setTopicId(topicId)
+        .setPartitionId(partitionId)
+        .setIsr(isr)
+      newLeaders.get(partitionId).foreach(leader => record.setLeader(leader))
+      record.unknownTaggedFields().add(InitDisklessLogFields.encodeClassicToDisklessStartOffset(
+        PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING))
+      delta.replay(record)
+    }
   }
 
   private def metadataManifest(): LogDeltaManifest = {

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -2895,7 +2895,7 @@ public class ReplicationControlManager {
      * emit a {@link PartitionChangeRecord} per partition marking
      * {@code classicToDisklessStartOffset = CLASSIC_TO_DISKLESS_SWITCH_PENDING} (-2).
      * These records MUST be committed atomically with the {@code diskless.enable=true} {@link ConfigRecord}.
-     * Brokers rely on seeing both in the same {@code MetadataDelta} to seal the local leader before 
+     * Brokers rely on seeing both in the same {@code MetadataDelta} to seal the local leader before
      * any produce hits the classic log and to register the partition for diskless log initialization.
      */
     List<ApiMessageAndVersion> markClassicToDisklessSwitchStarted(

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -2890,6 +2890,14 @@ public class ReplicationControlManager {
         }
     }
 
+    /**
+     * For every topic whose {@code diskless.enable} flips from {@code false} to {@code true},
+     * emit a {@link PartitionChangeRecord} per partition marking
+     * {@code classicToDisklessStartOffset = CLASSIC_TO_DISKLESS_SWITCH_PENDING} (-2).
+     * These records MUST be committed atomically with the {@code diskless.enable=true} {@link ConfigRecord}.
+     * Brokers rely on seeing both in the same {@code MetadataDelta} to seal the local leader before 
+     * any produce hits the classic log and to register the partition for diskless log initialization.
+     */
     List<ApiMessageAndVersion> markClassicToDisklessSwitchStarted(
         Map<ConfigResource, Map<String, Entry<OpType, String>>> configChanges,
         Map<ConfigResource, ApiError> configResults


### PR DESCRIPTION
The controller already emits the `diskless.enable=true` ConfigRecord and the per-partition `CLASSIC_TO_DISKLESS_SWITCH_PENDING` marker in a single atomic op, so the broker no longer needs a separate config-delta scan to seal existing leaders.
Sealing and InitDisklessLogManager registration are now driven entirely from `applyLocalLeadersDelta`, gated on the switch-pending marker so plain leader changes on already-diskless topics don't re-trigger init.