### PR TITLE
fix(inkless:switch): Advance HW past stale checkpoint for sealed leader after restart

### DIFF
--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -3076,6 +3076,16 @@ class ReplicaManager(val config: KafkaConfig,
             val partitionAssignedDirectoryId = directoryIds.find(_._1.topicPartition() == tp).map(_._2)
             partition.makeLeader(info.partition, isNew, offsetCheckpoints, Some(info.topicId), partitionAssignedDirectoryId)
             partition.seal()
+            // makeLeader reloads HW from the on-disk checkpoint, which may be stale
+            // (unclean shutdown, or checkpoint interval hadn't fired). Since the
+            // partition is sealed, no produces or follower fetches can ever advance
+            // HW naturally — restore it to the seal offset so consumers can read.
+            val sealOffset = _inklessMetadataView.getClassicToDisklessStartOffset(tp)
+            if (sealOffset >= 0 && partition.localLogOrException.highWatermark < sealOffset) {
+              partition.localLogOrException.maybeUpdateHighWatermark(sealOffset)
+              stateChangeLogger.info(s"Advanced high watermark to seal offset $sealOffset for " +
+                s"switched leader partition $tp after restart")
+            }
             changedPartitions.add(partition)
           } catch {
             case e: KafkaStorageException =>

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -9343,6 +9343,92 @@ class ReplicaManagerTest {
     }
 
     @Test
+    def testApplyDeltaAdvancesHwmToSealOffsetForSealedLeaderWithStaleCheckpoint(): Unit = {
+      // After restart, makeLeader reloads HW from the on-disk checkpoint file.
+      // If the checkpoint is stale (e.g. unclean shutdown, or checkpoint interval
+      // hadn't fired since HW advanced), HW will be below the seal offset.
+      // Since the partition is sealed, no produces or follower fetches can ever
+      // advance HW naturally — consumers cannot read classic data below the seal.
+      // applyDelta must detect this and restore HW to the seal offset.
+      val topicName = "switched-topic"
+      val topicId = Uuid.randomUuid()
+      val tp = new TopicPartition(topicName, 0)
+      val brokerId = 1
+
+      val replicaManager = spy(createReplicaManager(List(topicName)))
+      try {
+        val log = replicaManager.logManager.getOrCreateLog(tp, isNew = true, topicId = Optional.of(topicId))
+        populateLocalLogAtLeoAndCheckpointedHwm(replicaManager, tp, log, leo = 10L, hw = 5L)
+
+        // Mark the partition as fully switched with classicToDisklessStartOffset = 10.
+        when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(tp)).thenReturn(10L)
+
+        // Apply a delta that makes this broker the leader (post-restart path).
+        val delta = new TopicsDelta(TopicsImage.EMPTY)
+        delta.replay(new TopicRecord().setName(topicName).setTopicId(topicId))
+        delta.replay(new PartitionRecord()
+          .setPartitionId(0)
+          .setTopicId(topicId)
+          .setReplicas(util.Arrays.asList(brokerId, brokerId + 1))
+          .setIsr(util.Arrays.asList(brokerId, brokerId + 1))
+          .setLeader(brokerId)
+          .setLeaderEpoch(0)
+          .setPartitionEpoch(0)
+        )
+        replicaManager.applyDelta(delta, imageFromTopics(delta.apply()))
+
+        val partition = replicaManager.getPartition(tp)
+        assertTrue(partition.isInstanceOf[HostedPartition.Online], "Partition should be online")
+        val onlinePartition = partition.asInstanceOf[HostedPartition.Online].partition
+        assertTrue(onlinePartition.isLeader, "Partition should be leader")
+        assertTrue(onlinePartition.isSealed, "Partition should be sealed")
+        // HW must have been advanced to the seal offset.
+        assertEquals(10L, onlinePartition.localLogOrException.highWatermark,
+          "High watermark should be advanced to the seal offset")
+      } finally {
+        replicaManager.shutdown(checkpointHW = false)
+      }
+    }
+
+    @Test
+    def testApplyDeltaDoesNotAdvanceHwmForSealedLeaderWithCurrentCheckpoint(): Unit = {
+      // Post-restart with a fresh checkpoint (HW == seal): no advancement needed.
+      val topicName = "switched-topic"
+      val topicId = Uuid.randomUuid()
+      val tp = new TopicPartition(topicName, 0)
+      val brokerId = 1
+
+      val replicaManager = spy(createReplicaManager(List(topicName)))
+      try {
+        val log = replicaManager.logManager.getOrCreateLog(tp, isNew = true, topicId = Optional.of(topicId))
+        populateLocalLogAtLeoAndCheckpointedHwm(replicaManager, tp, log, leo = 10L, hw = 10L)
+
+        when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(tp)).thenReturn(10L)
+
+        val delta = new TopicsDelta(TopicsImage.EMPTY)
+        delta.replay(new TopicRecord().setName(topicName).setTopicId(topicId))
+        delta.replay(new PartitionRecord()
+          .setPartitionId(0)
+          .setTopicId(topicId)
+          .setReplicas(util.Arrays.asList(brokerId, brokerId + 1))
+          .setIsr(util.Arrays.asList(brokerId, brokerId + 1))
+          .setLeader(brokerId)
+          .setLeaderEpoch(0)
+          .setPartitionEpoch(0)
+        )
+        replicaManager.applyDelta(delta, imageFromTopics(delta.apply()))
+
+        val partition = replicaManager.getPartition(tp)
+        val onlinePartition = partition.asInstanceOf[HostedPartition.Online].partition
+        // HW should remain at 10 (unchanged, since it's already at the seal).
+        assertEquals(10L, onlinePartition.localLogOrException.highWatermark,
+          "High watermark should remain at seal offset when already caught up")
+      } finally {
+        replicaManager.shutdown(checkpointHW = false)
+      }
+    }
+
+    @Test
     def testApplyDeltaSkipsPartitionForConsolidatingDisklessTopicWithLocalLogOnLeader(): Unit = {
       val topicName = "consolidating-topic"
       val topicId = Uuid.randomUuid()


### PR DESCRIPTION
After a broker restart, sealed leader partitions can have their high watermark stuck at a stale value loaded from the on-disk checkpoint. Since `seal()` prevents any natural HW advancement (no produces, no follower fetches), consumers cannot read classic data below the seal offset.

This PR advances HW to `classicToDisklessStartOffset` in the post-restart leader path when the checkpointed value is below it.

## Root cause

`makeLeader` reloads HW from the checkpoint file. The checkpoint can be stale when:

- Unclean shutdown (no final flush)
- Checkpoint interval hadn't fired since HW advanced to the seal offset
- First restart after seal commit

Once `seal()` is called immediately after, HW is permanently stuck — no mechanism exists to advance it.

## Reproduction (3-broker cluster)

1. Create topic with RF=2 (leader=broker1, follower=broker2)
2. Produce messages (e.g. 100 records, LEO=100)
3. Switch topic to diskless (`diskless.enable=true`)
4. Wait for seal to commit (`classicToDisklessStartOffset=100`)
5. Restart the leader broker (broker1)
6. Broker1 reclaims leadership via `applyDelta` -> `makeLeader` + `seal`
7. Consumer reading from offset 0 times out: HW stuck at the stale checkpointed value
