### PR TITLE
feat(inkless): add controller guards for classic-to-diskless switch [POD-2464]

### DIFF
--- a/core/src/test/java/kafka/server/InklessTopicTypeSwitcherClusterTest.java
+++ b/core/src/test/java/kafka/server/InklessTopicTypeSwitcherClusterTest.java
@@ -77,6 +77,7 @@ import io.aiven.inkless.test_utils.PostgreSQLTestContainer;
 import io.aiven.inkless.test_utils.S3TestContainer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Testcontainers
@@ -364,6 +365,103 @@ public class InklessTopicTypeSwitcherClusterTest {
             .map(entry -> new AlterConfigOp(new ConfigEntry(entry.getKey(), entry.getValue()), AlterConfigOp.OpType.SET))
             .toList();
         admin.incrementalAlterConfigs(Map.of(topicResource, operations)).all().get(20, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void testSwitchRejectedWhenPartitionIsOfflineOrUnderReplicated() throws Exception {
+        final String topic = "switch-unhealthy-" + UUID.randomUUID().toString().substring(0, 8);
+
+        try (Admin admin = AdminClient.create(baseClientConfigs())) {
+            // Create a classic topic with RF=3
+            admin.createTopics(List.of(
+                new NewTopic(topic, 1, (short) 3)
+                    .configs(Map.of(TopicConfig.DISKLESS_ENABLE_CONFIG, "false"))
+            )).all().get(30, TimeUnit.SECONDS);
+
+            // Shut down a broker to make the partition under-replicated
+            final int brokerToShutdown = 2;
+            cluster.brokers().get(brokerToShutdown).shutdown();
+            waitForIsrShrink(admin, topic, 0, 3);
+
+            // Attempt to switch to diskless (should fail with INVALID_CONFIG)
+            final ExecutionException ex = assertThrows(ExecutionException.class, () ->
+                alterTopicConfig(admin, topic, Map.of(TopicConfig.DISKLESS_ENABLE_CONFIG, "true")));
+            assertTrue(ex.getCause().getMessage().contains("INVALID_CONFIG") ||
+                       ex.getCause().getMessage().contains("under-replicated") ||
+                       ex.getCause().getMessage().contains("offline"),
+                "Expected INVALID_CONFIG for unhealthy topic, got: " + ex.getCause().getMessage());
+
+            // Restart the broker
+            cluster.brokers().get(brokerToShutdown).startup();
+        }
+    }
+
+    @Test
+    public void testUncleanLeaderElectionRejectedWhileSwitchPending() throws Exception {
+        final String topic = "switch-unclean-" + UUID.randomUUID().toString().substring(0, 8);
+
+        try (Admin admin = AdminClient.create(baseClientConfigs())) {
+            // Create a classic topic and switch it to diskless
+            admin.createTopics(List.of(
+                new NewTopic(topic, 1, (short) 3)
+                    .configs(Map.of(TopicConfig.DISKLESS_ENABLE_CONFIG, "false"))
+            )).all().get(30, TimeUnit.SECONDS);
+
+            // Enable diskless to mark partition as switch pending
+            alterTopicConfig(admin, topic, Map.of(TopicConfig.DISKLESS_ENABLE_CONFIG, "true"));
+
+            // Should fail trying to enable unclean leader election
+            final ExecutionException ex = assertThrows(ExecutionException.class, () ->
+                alterTopicConfig(admin, topic, Map.of(
+                    TopicConfig.UNCLEAN_LEADER_ELECTION_ENABLE_CONFIG, "true")));
+            assertTrue(ex.getCause().getMessage().contains("INVALID_CONFIG") ||
+                       ex.getCause().getMessage().contains("pending classic-to-diskless switch"),
+                "Expected INVALID_CONFIG for pending switch, got: " + ex.getCause().getMessage());
+        }
+    }
+
+    @Test
+    public void testSwitchRejectedWhenUncleanLeaderElectionEnabledAtClusterLevel() throws Exception {
+        final String topic = "switch-cluster-unclean-" + UUID.randomUUID().toString().substring(0, 8);
+
+        try (Admin admin = AdminClient.create(baseClientConfigs())) {
+            // Enable unclean leader election at cluster level first
+            final ConfigResource clusterResource = new ConfigResource(ConfigResource.Type.BROKER, "");
+            admin.incrementalAlterConfigs(Map.of(clusterResource, List.of(
+                new AlterConfigOp(new ConfigEntry(
+                    TopicConfig.UNCLEAN_LEADER_ELECTION_ENABLE_CONFIG, "true"),
+                    AlterConfigOp.OpType.SET)
+            ))).all().get(20, TimeUnit.SECONDS);
+
+            // Create a classic topic
+            admin.createTopics(List.of(
+                new NewTopic(topic, 1, (short) 3)
+                    .configs(Map.of(TopicConfig.DISKLESS_ENABLE_CONFIG, "false"))
+            )).all().get(30, TimeUnit.SECONDS);
+
+            // Attempt to switch to diskless — should fail because unclean leader election
+            // is enabled (via cluster-level config)
+            final ExecutionException ex = assertThrows(ExecutionException.class, () ->
+                alterTopicConfig(admin, topic, Map.of(TopicConfig.DISKLESS_ENABLE_CONFIG, "true")));
+            assertTrue(ex.getCause().getMessage().contains("unclean leader election"),
+                "Expected 'unclean leader election' in error, got: " + ex.getCause().getMessage());
+        }
+    }
+
+    private void waitForIsrShrink(final Admin admin, final String topic,
+                                   final int partition, final int maxIsrSize) throws Exception {
+        final long deadline = System.currentTimeMillis() + Duration.ofSeconds(30).toMillis();
+        while (System.currentTimeMillis() < deadline) {
+            final var description = admin.describeTopics(List.of(topic)).allTopicNames()
+                .get(10, TimeUnit.SECONDS).get(topic);
+            final int isrSize = description.partitions().get(partition).isr().size();
+            if (isrSize < maxIsrSize) {
+                return;
+            }
+            Thread.sleep(200);
+        }
+        throw new AssertionError("ISR for " + topic + "-" + partition +
+            " did not shrink below " + maxIsrSize + " within timeout");
     }
 
     private Map<String, String> getTopicConfig(final Admin admin, final String topic) throws Exception {

--- a/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
@@ -727,6 +727,17 @@ public class ConfigurationControlManager {
         return false;
     }
 
+    /**
+     * Check if unclean leader election would be enabled for a topic after its topic-level
+     * override is removed (i.e., resolving from node/cluster/static config only).
+     */
+    boolean uncleanLeaderElectionEnabledExcludingTopicOverride(String topicName) {
+        String value = configSchema.resolveEffectiveTopicConfig(
+            UNCLEAN_LEADER_ELECTION_ENABLE_CONFIG,
+            staticConfig, clusterConfig(), currentControllerConfig(), Map.of()).value();
+        return !value.isEmpty() && Boolean.parseBoolean(value);
+    }
+
     Map<String, ConfigEntry> computeEffectiveTopicConfigs(Map<String, String> creationConfigs) {
         return configSchema.resolveEffectiveTopicConfigs(staticConfig, clusterConfig(),
             currentControllerConfig(), creationConfigs);

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -1952,20 +1952,55 @@ public final class QuorumController implements Controller {
             return CompletableFuture.completedFuture(Map.of());
         }
         return appendWriteEvent("incrementalAlterConfigs", context.deadlineNs(), () -> {
-            ControllerResult<Map<ConfigResource, ApiError>> result =
-                configurationControl.incrementalAlterConfigs(configChanges, false);
-            if (validateOnly) {
-                return result.withoutRecords();
+            // Pre-validate switch preconditions and unclean leader election changes
+            Map<ConfigResource, ApiError> preconditionErrors =
+                replicationControl.validateClassicToDisklessSwitchPreconditions(configChanges);
+            Map<ConfigResource, ApiError> uncleanErrors =
+                replicationControl.validateUncleanLeaderElectionChange(configChanges);
+
+            // Merge pre-validation errors and remove failing resources from configChanges
+            Map<ConfigResource, ApiError> preErrors = new HashMap<>(preconditionErrors);
+            preErrors.putAll(uncleanErrors);
+
+            Map<ConfigResource, Map<String, Entry<OpType, String>>> filteredChanges;
+            if (preErrors.isEmpty()) {
+                filteredChanges = configChanges;
             } else {
-                List<ApiMessageAndVersion> migrationRecords =
-                    replicationControl.markClassicToDisklessSwitchStarted(configChanges, result.response());
-                if (!migrationRecords.isEmpty()) {
+                filteredChanges = new HashMap<>(configChanges);
+                preErrors.keySet().forEach(filteredChanges::remove);
+            }
+
+            ControllerResult<Map<ConfigResource, ApiError>> result;
+            if (filteredChanges.isEmpty()) {
+                result = ControllerResult.atomicOf(List.of(), Map.of());
+            } else {
+                result = configurationControl.incrementalAlterConfigs(filteredChanges, false);
+            }
+
+            // Merge pre-validation errors into the result
+            Map<ConfigResource, ApiError> mergedResponse;
+            if (preErrors.isEmpty()) {
+                mergedResponse = result.response();
+            } else {
+                mergedResponse = new HashMap<>(result.response());
+                mergedResponse.putAll(preErrors);
+            }
+
+            if (validateOnly) {
+                return ControllerResult.atomicOf(List.of(), mergedResponse);
+            } else {
+                List<ApiMessageAndVersion> switchRecords =
+                    replicationControl.markClassicToDisklessSwitchStarted(filteredChanges, mergedResponse);
+                if (!switchRecords.isEmpty()) {
                     List<ApiMessageAndVersion> allRecords = BoundedList.newArrayBacked(MAX_RECORDS_PER_USER_OP);
                     allRecords.addAll(result.records());
-                    allRecords.addAll(migrationRecords);
-                    return ControllerResult.atomicOf(allRecords, result.response());
+                    allRecords.addAll(switchRecords);
+                    return ControllerResult.atomicOf(allRecords, mergedResponse);
                 }
-                return result;
+                if (preErrors.isEmpty()) {
+                    return result;
+                }
+                return ControllerResult.atomicOf(result.records(), mergedResponse);
             }
         });
     }

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -128,14 +128,17 @@ import java.util.function.IntPredicate;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
+import static org.apache.kafka.clients.admin.AlterConfigOp.OpType.DELETE;
 import static org.apache.kafka.clients.admin.AlterConfigOp.OpType.SET;
 import static org.apache.kafka.common.config.ConfigResource.Type.TOPIC;
 import static org.apache.kafka.common.config.TopicConfig.DISKLESS_ENABLE_CONFIG;
 import static org.apache.kafka.common.config.TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG;
 import static org.apache.kafka.common.config.TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG;
+import static org.apache.kafka.common.config.TopicConfig.UNCLEAN_LEADER_ELECTION_ENABLE_CONFIG;
 import static org.apache.kafka.common.internals.Topic.CLUSTER_METADATA_TOPIC_NAME;
 import static org.apache.kafka.common.protocol.Errors.FENCED_LEADER_EPOCH;
 import static org.apache.kafka.common.protocol.Errors.INELIGIBLE_REPLICA;
+import static org.apache.kafka.common.protocol.Errors.INVALID_CONFIG;
 import static org.apache.kafka.common.protocol.Errors.INVALID_REQUEST;
 import static org.apache.kafka.common.protocol.Errors.INVALID_UPDATE_VERSION;
 import static org.apache.kafka.common.protocol.Errors.NEW_LEADER_ELECTED;
@@ -1151,7 +1154,7 @@ public class ReplicationControlManager {
 
     /**
      * Create a topic assignment for a diskless topic.
-     * @return the assignment or {@code null} if there are no brokers avaiable.
+     * @return the assignment or {@code null} if there are no brokers available.
      */
     private TopicAssignment createDisklessAssignment(int numPartitions) {
         final Iterator<UsableBroker> usableBrokers = clusterControl.usableBrokers();
@@ -1447,7 +1450,7 @@ public class ReplicationControlManager {
                     getTopicEffectiveMinIsr(topic.name)
                 )
                     .setEligibleLeaderReplicasEnabled(featureControl.isElrFeatureEnabled());
-                if (configurationControl.uncleanLeaderElectionEnabledForTopic(topic.name())) {
+                if (isUncleanElectionEligible(topic.name(), partition)) {
                     builder.setElection(PartitionChangeBuilder.Election.UNCLEAN);
                 }
                 Optional<ApiMessageAndVersion> record = builder
@@ -2251,7 +2254,8 @@ public class ReplicationControlManager {
         while (iterator.hasNext() && records.size() < maxElections) {
             TopicIdPartition topicIdPartition = iterator.next();
             TopicControlInfo topic = topics.get(topicIdPartition.topicId());
-            if (configurationControl.uncleanLeaderElectionEnabledForTopic(topic.name)) {
+            PartitionRegistration partition = topic.parts.get(topicIdPartition.partitionId());
+            if (isUncleanElectionEligible(topic.name, partition)) {
                 ApiError result = electLeader(topic.name, topicIdPartition.partitionId(),
                         ElectionType.UNCLEAN, records);
                 if (result.error().equals(Errors.NONE)) {
@@ -2263,7 +2267,7 @@ public class ReplicationControlManager {
                 }
             } else if (log.isDebugEnabled()) {
                 log.debug("Cannot trigger unclean leader election for offline partition {}-{} " +
-                                "because unclean leader election is disabled for this topic.",
+                                "because unclean leader election is not eligible for this partition.",
                         topic.name, topicIdPartition.partitionId());
             }
         }
@@ -2499,7 +2503,7 @@ public class ReplicationControlManager {
                 getTopicEffectiveMinIsr(topic.name)
             );
             builder.setEligibleLeaderReplicasEnabled(featureControl.isElrFeatureEnabled());
-            if (configurationControl.uncleanLeaderElectionEnabledForTopic(topic.name)) {
+            if (isUncleanElectionEligible(topic.name, partition)) {
                 builder.setElection(PartitionChangeBuilder.Election.UNCLEAN);
             }
             if (brokerWithUncleanShutdown != NO_LEADER) {
@@ -2605,10 +2609,14 @@ public class ReplicationControlManager {
         }
         PartitionReassignmentRevert revert = new PartitionReassignmentRevert(part);
         if (revert.unclean()) {
-            if (!configurationControl.uncleanLeaderElectionEnabledForTopic(topicName)) {
+            if (!isUncleanElectionEligible(topicName, part)) {
+                String reason = part.classicToDisklessStartOffset ==
+                    PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING
+                    ? "it has a pending classic-to-diskless switch"
+                    : "unclean leader election is not enabled";
                 throw new InvalidReplicaAssignmentException("Unable to revert partition " +
                     "assignment for " + topicName + ":" + tp.partitionId() + " because " +
-                    "it would require an unclean leader election.");
+                    reason + ".");
             }
         }
         PartitionChangeBuilder builder = new PartitionChangeBuilder(
@@ -2620,7 +2628,7 @@ public class ReplicationControlManager {
             getTopicEffectiveMinIsr(topicName)
         );
         builder.setEligibleLeaderReplicasEnabled(featureControl.isElrFeatureEnabled());
-        if (configurationControl.uncleanLeaderElectionEnabledForTopic(topicName)) {
+        if (isUncleanElectionEligible(topicName, part)) {
             builder.setElection(PartitionChangeBuilder.Election.UNCLEAN);
         }
         return builder
@@ -2957,6 +2965,148 @@ public class ReplicationControlManager {
     }
 
     /**
+     * Validate that a classic-to-diskless switch can proceed for each topic in the config changes.
+     * Returns a map of ConfigResource to ApiError for topics that fail validation.
+     * Only checks topics where diskless.enable is being set to true.
+     */
+    Map<ConfigResource, ApiError> validateClassicToDisklessSwitchPreconditions(
+        Map<ConfigResource, Map<String, Entry<OpType, String>>> configChanges
+    ) {
+        Map<ConfigResource, ApiError> errors = new HashMap<>();
+        for (Entry<ConfigResource, Map<String, Entry<OpType, String>>> entry : configChanges.entrySet()) {
+            ConfigResource resource = entry.getKey();
+            if (resource.type() != TOPIC) continue;
+            Map<String, Entry<OpType, String>> changes = entry.getValue();
+            if (isNotSettingConfigToTrue(changes, DISKLESS_ENABLE_CONFIG)) continue;
+            if (isDisklessTopic(resource.name())) continue;
+
+            String topicName = resource.name();
+            Optional<TopicControlInfo> maybeTopicInfo = getTopicInfo(topicName);
+            if (maybeTopicInfo.isEmpty()) continue;
+            TopicControlInfo topicInfo = maybeTopicInfo.get();
+
+            // Check unclean leader election enabled (considering both existing config and the requested changes)
+            if (isUncleanLeaderElectionEnabledConsideringChanges(topicName, changes)) {
+                errors.put(resource, new ApiError(INVALID_CONFIG,
+                    "Cannot switch topic " + topicName + " to diskless: " +
+                    "unclean leader election is enabled."));
+                continue;
+            }
+
+            // Check each partition for unhealthy state
+            validatePartitionsForSwitch(topicName, topicInfo)
+                .ifPresent(error -> errors.put(resource, error));
+        }
+        return errors;
+    }
+
+    /**
+     * Check if unclean leader election is eligible for a partition, considering both
+     * the topic configuration and whether a classic-to-diskless switch is pending.
+     */
+    boolean isUncleanElectionEligible(String topicName, PartitionRegistration partition) {
+        if (!configurationControl.uncleanLeaderElectionEnabledForTopic(topicName)) {
+            return false;
+        }
+        return partition.classicToDisklessStartOffset !=
+            PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING;
+    }
+
+    private boolean isUncleanLeaderElectionEnabledConsideringChanges(
+        String topicName,
+        Map<String, Entry<OpType, String>> changes
+    ) {
+        Entry<OpType, String> uncleanChange = changes.get(UNCLEAN_LEADER_ELECTION_ENABLE_CONFIG);
+        if (uncleanChange != null) {
+            if (uncleanChange.getKey() == SET) {
+                return Boolean.parseBoolean(uncleanChange.getValue());
+            }
+            if (uncleanChange.getKey() == DELETE) {
+                // Topic-level override is being removed; resolve without it
+                return configurationControl.uncleanLeaderElectionEnabledExcludingTopicOverride(topicName);
+            }
+        }
+        // Fall back to existing effective config
+        return configurationControl.uncleanLeaderElectionEnabledForTopic(topicName);
+    }
+
+    private Optional<ApiError> validatePartitionsForSwitch(String topicName, TopicControlInfo topicInfo) {
+        for (Entry<Integer, PartitionRegistration> partEntry : topicInfo.parts.entrySet()) {
+            int partitionId = partEntry.getKey();
+            PartitionRegistration partition = partEntry.getValue();
+
+            if (!partition.hasLeader()) {
+                return Optional.of(new ApiError(INVALID_CONFIG,
+                    "Cannot switch topic " + topicName + " to diskless: " +
+                    "partition " + partitionId + " is offline (has no leader)."));
+            }
+
+            if (partition.leaderRecoveryState == LeaderRecoveryState.RECOVERING) {
+                return Optional.of(new ApiError(INVALID_CONFIG,
+                    "Cannot switch topic " + topicName + " to diskless: " +
+                    "partition " + partitionId + " is recovering from an unclean leader election."));
+            }
+
+            if (isReassignmentInProgress(partition)) {
+                return Optional.of(new ApiError(INVALID_CONFIG,
+                    "Cannot switch topic " + topicName + " to diskless: " +
+                    "partition " + partitionId + " has a reassignment in progress."));
+            }
+
+            if (partition.elr.length > 0) {
+                return Optional.of(new ApiError(INVALID_CONFIG,
+                    "Cannot switch topic " + topicName + " to diskless: " +
+                    "partition " + partitionId + " has a non-empty ELR."));
+            }
+
+            if (partition.lastKnownElr.length > 0) {
+                return Optional.of(new ApiError(INVALID_CONFIG,
+                    "Cannot switch topic " + topicName + " to diskless: " +
+                    "partition " + partitionId + " has a non-empty last-known ELR."));
+            }
+
+            if (partition.isr.length < partition.replicas.length) {
+                return Optional.of(new ApiError(INVALID_CONFIG,
+                    "Cannot switch topic " + topicName + " to diskless: " +
+                    "partition " + partitionId + " is under-replicated " +
+                    "(ISR size " + partition.isr.length + " < replicas " + partition.replicas.length + ")."));
+            }
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Validate that unclean.leader.election.enable=true is not being set on a topic
+     * that has any partition with a pending classic-to-diskless switch.
+     */
+    Map<ConfigResource, ApiError> validateUncleanLeaderElectionChange(
+        Map<ConfigResource, Map<String, Entry<OpType, String>>> configChanges
+    ) {
+        Map<ConfigResource, ApiError> errors = new HashMap<>();
+        for (Entry<ConfigResource, Map<String, Entry<OpType, String>>> entry : configChanges.entrySet()) {
+            ConfigResource resource = entry.getKey();
+            if (resource.type() != TOPIC) continue;
+            Map<String, Entry<OpType, String>> changes = entry.getValue();
+            if (isNotSettingConfigToTrue(changes, UNCLEAN_LEADER_ELECTION_ENABLE_CONFIG)) continue;
+
+            String topicName = resource.name();
+            Optional<TopicControlInfo> maybeTopicInfo = getTopicInfo(topicName);
+            if (maybeTopicInfo.isEmpty()) continue;
+
+            for (Entry<Integer, PartitionRegistration> partEntry : maybeTopicInfo.get().parts.entrySet()) {
+                if (partEntry.getValue().classicToDisklessStartOffset ==
+                        PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING) {
+                    errors.put(resource, new ApiError(INVALID_CONFIG,
+                        "Cannot enable unclean leader election on topic " + topicName + ": " +
+                        "partition " + partEntry.getKey() + " has a pending classic-to-diskless switch."));
+                    break;
+                }
+            }
+        }
+        return errors;
+    }
+
+    /**
      * For every topic whose {@code diskless.enable} flips from {@code false} to {@code true},
      * emit a {@link PartitionChangeRecord} per partition marking
      * {@code classicToDisklessStartOffset = CLASSIC_TO_DISKLESS_SWITCH_PENDING} (-2).
@@ -2975,16 +3125,13 @@ public class ReplicationControlManager {
             ApiError error = configResults.get(resource);
             if (error != null && error != ApiError.NONE) continue;
             Map<String, Entry<OpType, String>> changes = entry.getValue();
-            Entry<OpType, String> disklessChange = changes.get(DISKLESS_ENABLE_CONFIG);
-            if (disklessChange == null) continue;
-            if (disklessChange.getKey() != SET || !Boolean.parseBoolean(disklessChange.getValue())) continue;
+            if (isNotSettingConfigToTrue(changes, DISKLESS_ENABLE_CONFIG)) continue;
             if (isDisklessTopic(resource.name())) continue;
 
             String topicName = resource.name();
-            Uuid topicId = topicsByName.get(topicName);
-            if (topicId == null) continue;
-            TopicControlInfo topicInfo = topics.get(topicId);
-            if (topicInfo == null) continue;
+            Optional<TopicControlInfo> maybeTopicInfo = getTopicInfo(topicName);
+            if (maybeTopicInfo.isEmpty()) continue;
+            TopicControlInfo topicInfo = maybeTopicInfo.get();
 
             int sizeBefore = records.size();
             for (Entry<Integer, PartitionRegistration> partEntry : topicInfo.parts.entrySet()) {
@@ -2995,7 +3142,7 @@ public class ReplicationControlManager {
                             "remain pending until a leader is elected", topicName, partEntry.getKey());
                     }
                     PartitionChangeRecord record = new PartitionChangeRecord()
-                        .setTopicId(topicId)
+                        .setTopicId(topicInfo.id)
                         .setPartitionId(partEntry.getKey())
                         .setLeader(partition.leader); // Force leader epoch bump to trigger makeLeader on broker
                     record.unknownTaggedFields().add(
@@ -3008,6 +3155,18 @@ public class ReplicationControlManager {
                 records.size() - sizeBefore, topicName);
         }
         return records;
+    }
+
+    private static boolean isNotSettingConfigToTrue(Map<String, Entry<OpType, String>> changes, String configKey) {
+        Entry<OpType, String> change = changes.get(configKey);
+        return change == null || change.getKey() != SET || !Boolean.parseBoolean(change.getValue());
+    }
+
+    private Optional<TopicControlInfo> getTopicInfo(String topicName) {
+        Uuid topicId = topicsByName.get(topicName);
+        if (topicId == null) return Optional.empty();
+        TopicControlInfo info = topics.get(topicId);
+        return Optional.ofNullable(info);
     }
 
     private boolean isDisklessTopic(String topicName) {

--- a/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
@@ -6640,6 +6640,448 @@ public class ReplicationControlManagerTest {
                 InitDisklessLogFields.decodeClassicToDisklessStartOffset(record.unknownTaggedFields()));
         }
 
+        @Test
+        public void testSwitchRejectedWhenPartitionIsOffline() {
+            ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder()
+                .setStaticConfig(ServerConfigs.DISKLESS_ALLOW_FROM_CLASSIC_ENABLE_CONFIG, true)
+                .build();
+            ctx.registerBrokers(0, 1, 2);
+            ctx.unfenceBrokers(0, 1, 2);
+            ctx.createTestTopic("foo", new int[][] {new int[] {0, 1, 2}});
+
+            // Fence all brokers to make the partition offline
+            ctx.fenceBrokers(0, 1, 2);
+
+            ConfigResource resource = new ConfigResource(ConfigResource.Type.TOPIC, "foo");
+            Map<ConfigResource, Map<String, Map.Entry<AlterConfigOp.OpType, String>>> configChanges = Map.of(
+                resource, Map.of(DISKLESS_ENABLE_CONFIG,
+                    new AbstractMap.SimpleImmutableEntry<>(AlterConfigOp.OpType.SET, "true")));
+
+            Map<ConfigResource, ApiError> errors =
+                ctx.replicationControl.validateClassicToDisklessSwitchPreconditions(configChanges);
+
+            assertEquals(1, errors.size());
+            ApiError error = errors.get(resource);
+            assertEquals(Errors.INVALID_CONFIG, error.error());
+            assertTrue(error.message().contains("offline"), "Expected 'offline' in: " + error.message());
+        }
+
+        @Test
+        public void testSwitchRejectedWhenReassignmentInProgress() {
+            ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder()
+                .setStaticConfig(ServerConfigs.DISKLESS_ALLOW_FROM_CLASSIC_ENABLE_CONFIG, true)
+                .build();
+            ctx.registerBrokers(0, 1, 2, 3);
+            ctx.unfenceBrokers(0, 1, 2, 3);
+            ctx.createTestTopic("foo", new int[][] {new int[] {0, 1, 2}});
+
+            // Start a reassignment
+            ControllerResult<AlterPartitionReassignmentsResponseData> alterResult =
+                ctx.replicationControl.alterPartitionReassignments(
+                    new AlterPartitionReassignmentsRequestData().setTopics(List.of(
+                        new ReassignableTopic().setName("foo").setPartitions(List.of(
+                            new ReassignablePartition().setPartitionIndex(0).
+                                setReplicas(List.of(1, 2, 3)))))));
+            ctx.replay(alterResult.records());
+
+            ConfigResource resource = new ConfigResource(ConfigResource.Type.TOPIC, "foo");
+            Map<ConfigResource, Map<String, Map.Entry<AlterConfigOp.OpType, String>>> configChanges = Map.of(
+                resource, Map.of(DISKLESS_ENABLE_CONFIG,
+                    new AbstractMap.SimpleImmutableEntry<>(AlterConfigOp.OpType.SET, "true")));
+
+            Map<ConfigResource, ApiError> errors =
+                ctx.replicationControl.validateClassicToDisklessSwitchPreconditions(configChanges);
+
+            assertEquals(1, errors.size());
+            ApiError error = errors.get(resource);
+            assertEquals(Errors.INVALID_CONFIG, error.error());
+            assertTrue(error.message().contains("reassignment"), "Expected 'reassignment' in: " + error.message());
+        }
+
+        @Test
+        public void testSwitchRejectedWhenUnderReplicated() {
+            ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder()
+                .setStaticConfig(ServerConfigs.DISKLESS_ALLOW_FROM_CLASSIC_ENABLE_CONFIG, true)
+                .build();
+            ctx.registerBrokers(0, 1, 2);
+            ctx.unfenceBrokers(0, 1, 2);
+            Uuid fooId = ctx.createTestTopic("foo", new int[][] {new int[] {0, 1, 2}}).topicId();
+
+            // Shrink ISR to make it under-replicated (fence one broker then unfence it without rejoining ISR)
+            ctx.fenceBrokers(2);
+            // Now partition has ISR < replicas but still has a leader
+            PartitionRegistration partition = ctx.replicationControl.getPartition(fooId, 0);
+            assertTrue(partition.hasLeader());
+            assertTrue(partition.isr.length < partition.replicas.length);
+
+            ConfigResource resource = new ConfigResource(ConfigResource.Type.TOPIC, "foo");
+            Map<ConfigResource, Map<String, Map.Entry<AlterConfigOp.OpType, String>>> configChanges = Map.of(
+                resource, Map.of(DISKLESS_ENABLE_CONFIG,
+                    new AbstractMap.SimpleImmutableEntry<>(AlterConfigOp.OpType.SET, "true")));
+
+            Map<ConfigResource, ApiError> errors =
+                ctx.replicationControl.validateClassicToDisklessSwitchPreconditions(configChanges);
+
+            assertEquals(1, errors.size());
+            ApiError error = errors.get(resource);
+            assertEquals(Errors.INVALID_CONFIG, error.error());
+            assertTrue(error.message().contains("under-replicated"), "Expected 'under-replicated' in: " + error.message());
+        }
+
+        @Test
+        public void testSwitchRejectedWhenElrIsNonEmpty() {
+            ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder()
+                .setStaticConfig(ServerConfigs.DISKLESS_ALLOW_FROM_CLASSIC_ENABLE_CONFIG, true)
+                .setStaticConfig(TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG, "3")
+                .setIsElrEnabled(true)
+                .build();
+            ctx.registerBrokers(0, 1, 2);
+            ctx.unfenceBrokers(0, 1, 2);
+            Uuid fooId = ctx.createTestTopic("foo", new int[][] {new int[] {0, 1, 2}}).topicId();
+
+            // Fence broker 2 — ISR drops below minISR (3), so broker 2 goes to ELR
+            ctx.fenceBrokers(2);
+            PartitionRegistration partition = ctx.replicationControl.getPartition(fooId, 0);
+            assertTrue(partition.elr.length > 0,
+                "Expected ELR to be non-empty after fencing with minISR=3, got elr=" +
+                Arrays.toString(partition.elr));
+
+            ConfigResource resource = new ConfigResource(ConfigResource.Type.TOPIC, "foo");
+            Map<ConfigResource, Map<String, Map.Entry<AlterConfigOp.OpType, String>>> configChanges = Map.of(
+                resource, Map.of(DISKLESS_ENABLE_CONFIG,
+                    new AbstractMap.SimpleImmutableEntry<>(AlterConfigOp.OpType.SET, "true")));
+
+            Map<ConfigResource, ApiError> errors =
+                ctx.replicationControl.validateClassicToDisklessSwitchPreconditions(configChanges);
+
+            assertEquals(1, errors.size());
+            ApiError error = errors.get(resource);
+            assertEquals(Errors.INVALID_CONFIG, error.error());
+            assertTrue(error.message().contains("non-empty ELR"),
+                "Expected 'non-empty ELR' in: " + error.message());
+        }
+
+        @Test
+        public void testSwitchRejectedWhenLastKnownElrIsNonEmpty() {
+            ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder()
+                .setStaticConfig(ServerConfigs.DISKLESS_ALLOW_FROM_CLASSIC_ENABLE_CONFIG, true)
+                .setStaticConfig(TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG, "3")
+                .setIsElrEnabled(true)
+                .build();
+            ctx.registerBrokers(0, 1, 2);
+            ctx.unfenceBrokers(0, 1, 2);
+            Uuid fooId = ctx.createTestTopic("foo", new int[][] {new int[] {0, 1, 2}}).topicId();
+
+            // Fence broker 2 — ISR drops below minISR (3), so broker 2 goes to ELR
+            ctx.fenceBrokers(2);
+            PartitionRegistration partition = ctx.replicationControl.getPartition(fooId, 0);
+            assertTrue(partition.elr.length > 0 || partition.lastKnownElr.length > 0,
+                "Expected ELR or lastKnownElr to be non-empty after fencing, got elr=" +
+                Arrays.toString(partition.elr) + " lastKnownElr=" + Arrays.toString(partition.lastKnownElr));
+
+            ConfigResource resource = new ConfigResource(ConfigResource.Type.TOPIC, "foo");
+            Map<ConfigResource, Map<String, Map.Entry<AlterConfigOp.OpType, String>>> configChanges = Map.of(
+                resource, Map.of(DISKLESS_ENABLE_CONFIG,
+                    new AbstractMap.SimpleImmutableEntry<>(AlterConfigOp.OpType.SET, "true")));
+
+            Map<ConfigResource, ApiError> errors =
+                ctx.replicationControl.validateClassicToDisklessSwitchPreconditions(configChanges);
+
+            assertEquals(1, errors.size());
+            ApiError error = errors.get(resource);
+            assertEquals(Errors.INVALID_CONFIG, error.error());
+            assertTrue(error.message().contains("ELR") || error.message().contains("last-known ELR"),
+                "Expected 'ELR' or 'last-known ELR' in: " + error.message());
+        }
+
+        @Test
+        public void testReassignmentRevertBlockedForPendingSwitchPartition() {
+            // Enable unclean so the revert would normally be allowed (without pending switch)
+            ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder()
+                .setStaticConfig(TopicConfig.UNCLEAN_LEADER_ELECTION_ENABLE_CONFIG, "true")
+                .build();
+            ctx.registerBrokers(0, 1, 2, 3);
+            ctx.unfenceBrokers(0, 1, 2, 3);
+            // Create topic with replicas [0 (leader), 1]
+            Uuid fooId = ctx.createTestTopic("foo", new int[][] {new int[] {0, 1}}).topicId();
+
+            // Reassign from [0, 1] to [2, 3]. Adding=[2,3], Removing=[0,1]
+            ControllerResult<AlterPartitionReassignmentsResponseData> alterResult =
+                ctx.replicationControl.alterPartitionReassignments(
+                    new AlterPartitionReassignmentsRequestData().setTopics(List.of(
+                        new ReassignableTopic().setName("foo").setPartitions(List.of(
+                            new ReassignablePartition().setPartitionIndex(0).
+                                setReplicas(List.of(2, 3)))))));
+            ctx.replay(alterResult.records());
+
+            // Expand ISR to include only ONE adding replica (broker 2).
+            // If we added both [2,3], the reassignment would auto-complete.
+            TopicIdPartition tp = new TopicIdPartition(fooId, 0);
+            ctx.alterPartition(tp, 0, isrWithDefaultEpoch(0, 1, 2), LeaderRecoveryState.RECOVERED);
+
+            // Fence original replicas. ISR becomes [2] (only an adding replica).
+            // Reassignment stays in progress because not all targets [2,3] are in ISR.
+            ctx.fenceBrokers(0, 1);
+            PartitionRegistration partition = ctx.replicationControl.getPartition(fooId, 0);
+            assertEquals(2, partition.leader);
+
+            // Mark the partition as switch pending
+            ConfigResource resource = new ConfigResource(ConfigResource.Type.TOPIC, "foo");
+            Map<ConfigResource, Map<String, Map.Entry<AlterConfigOp.OpType, String>>> disklessChanges = Map.of(
+                resource, Map.of(DISKLESS_ENABLE_CONFIG,
+                    new AbstractMap.SimpleImmutableEntry<>(AlterConfigOp.OpType.SET, "true")));
+            List<ApiMessageAndVersion> switchRecords =
+                ctx.replicationControl.markClassicToDisklessSwitchStarted(
+                    disklessChanges, Map.of(resource, ApiError.NONE));
+            ctx.replay(switchRecords);
+
+            // Cancel the reassignment — reverting would require unclean election because
+            // ISR=[2] and adding=[2,3], so ISR-adding=empty → revert.unclean()=true.
+            // Normally allowed (unclean enabled), but pending switch blocks it.
+            ControllerResult<AlterPartitionReassignmentsResponseData> cancelResult =
+                ctx.replicationControl.alterPartitionReassignments(
+                    new AlterPartitionReassignmentsRequestData().setTopics(List.of(
+                        new ReassignableTopic().setName("foo").setPartitions(List.of(
+                            new ReassignablePartition().setPartitionIndex(0).
+                                setReplicas(null))))));
+            ReassignablePartitionResponse partitionResponse =
+                cancelResult.response().responses().get(0).partitions().get(0);
+            assertEquals(INVALID_REPLICA_ASSIGNMENT.code(), partitionResponse.errorCode());
+            assertTrue(partitionResponse.errorMessage().contains("pending classic-to-diskless switch"),
+                "Expected 'pending classic-to-diskless switch' in: " + partitionResponse.errorMessage());
+        }
+
+        @Test
+        public void testSwitchRejectedWhenRecovering() {
+            ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder()
+                .setStaticConfig(ServerConfigs.DISKLESS_ALLOW_FROM_CLASSIC_ENABLE_CONFIG, true)
+                .setStaticConfig(TopicConfig.UNCLEAN_LEADER_ELECTION_ENABLE_CONFIG, "true")
+                .build();
+            ctx.registerBrokers(0, 1, 2);
+            ctx.unfenceBrokers(0, 1, 2);
+            Uuid fooId = ctx.createTestTopic("foo", new int[][] {new int[] {0, 1, 2}}).topicId();
+
+            // Fence brokers 1, 2 to shrink ISR to [0]
+            ctx.fenceBrokers(1, 2);
+            // Fence broker 0 to make partition leaderless
+            ctx.fenceBrokers(0, 1, 2);
+            // Unfence broker 1 to trigger unclean election (RECOVERING state)
+            ctx.unfenceBrokers(1);
+
+            PartitionRegistration partition = ctx.replicationControl.getPartition(fooId, 0);
+            assertEquals(LeaderRecoveryState.RECOVERING, partition.leaderRecoveryState);
+
+            // Disable unclean leader election so the unclean check doesn't fire first
+            ctx.replay(ctx.configurationControl.incrementalAlterConfigs(
+                Map.of(new ConfigResource(ConfigResource.Type.TOPIC, "foo"),
+                    Map.of(TopicConfig.UNCLEAN_LEADER_ELECTION_ENABLE_CONFIG,
+                        new AbstractMap.SimpleImmutableEntry<>(AlterConfigOp.OpType.SET, "false"))),
+                false).records());
+
+            ConfigResource resource = new ConfigResource(ConfigResource.Type.TOPIC, "foo");
+            Map<ConfigResource, Map<String, Map.Entry<AlterConfigOp.OpType, String>>> configChanges = Map.of(
+                resource, Map.of(DISKLESS_ENABLE_CONFIG,
+                    new AbstractMap.SimpleImmutableEntry<>(AlterConfigOp.OpType.SET, "true")));
+
+            Map<ConfigResource, ApiError> errors =
+                ctx.replicationControl.validateClassicToDisklessSwitchPreconditions(configChanges);
+
+            assertEquals(1, errors.size());
+            ApiError error = errors.get(resource);
+            assertEquals(Errors.INVALID_CONFIG, error.error());
+            assertTrue(error.message().contains("recovering"),
+                "Expected 'recovering' in: " + error.message());
+        }
+
+        @Test
+        public void testSwitchRejectedWhenUncleanLeaderElectionAlreadyEnabled() {
+            ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder()
+                .setStaticConfig(ServerConfigs.DISKLESS_ALLOW_FROM_CLASSIC_ENABLE_CONFIG, true)
+                .build();
+            ctx.registerBrokers(0, 1, 2);
+            ctx.unfenceBrokers(0, 1, 2);
+            ctx.createTestTopic("foo", new int[][] {new int[] {0, 1, 2}});
+
+            // Enable unclean leader election on the topic
+            ctx.replay(ctx.configurationControl.incrementalAlterConfigs(
+                Map.of(new ConfigResource(ConfigResource.Type.TOPIC, "foo"),
+                    Map.of(TopicConfig.UNCLEAN_LEADER_ELECTION_ENABLE_CONFIG,
+                        new AbstractMap.SimpleImmutableEntry<>(AlterConfigOp.OpType.SET, "true"))),
+                false).records());
+
+            ConfigResource resource = new ConfigResource(ConfigResource.Type.TOPIC, "foo");
+            Map<ConfigResource, Map<String, Map.Entry<AlterConfigOp.OpType, String>>> configChanges = Map.of(
+                resource, Map.of(DISKLESS_ENABLE_CONFIG,
+                    new AbstractMap.SimpleImmutableEntry<>(AlterConfigOp.OpType.SET, "true")));
+
+            Map<ConfigResource, ApiError> errors =
+                ctx.replicationControl.validateClassicToDisklessSwitchPreconditions(configChanges);
+
+            assertEquals(1, errors.size());
+            ApiError error = errors.get(resource);
+            assertEquals(Errors.INVALID_CONFIG, error.error());
+            assertTrue(error.message().contains("unclean leader election"),
+                "Expected 'unclean leader election' in: " + error.message());
+        }
+
+        @Test
+        public void testSwitchRejectedWhenUncleanLeaderElectionSetInSameRequest() {
+            ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder()
+                .setStaticConfig(ServerConfigs.DISKLESS_ALLOW_FROM_CLASSIC_ENABLE_CONFIG, true)
+                .build();
+            ctx.registerBrokers(0, 1, 2);
+            ctx.unfenceBrokers(0, 1, 2);
+            ctx.createTestTopic("foo", new int[][] {new int[] {0, 1, 2}});
+
+            ConfigResource resource = new ConfigResource(ConfigResource.Type.TOPIC, "foo");
+            // Set both diskless.enable=true and unclean.leader.election.enable=true in the same request
+            Map<ConfigResource, Map<String, Map.Entry<AlterConfigOp.OpType, String>>> configChanges = Map.of(
+                resource, Map.of(
+                    DISKLESS_ENABLE_CONFIG,
+                        new AbstractMap.SimpleImmutableEntry<>(AlterConfigOp.OpType.SET, "true"),
+                    TopicConfig.UNCLEAN_LEADER_ELECTION_ENABLE_CONFIG,
+                        new AbstractMap.SimpleImmutableEntry<>(AlterConfigOp.OpType.SET, "true")));
+
+            Map<ConfigResource, ApiError> errors =
+                ctx.replicationControl.validateClassicToDisklessSwitchPreconditions(configChanges);
+
+            assertEquals(1, errors.size());
+            ApiError error = errors.get(resource);
+            assertEquals(Errors.INVALID_CONFIG, error.error());
+            assertTrue(error.message().contains("unclean leader election"),
+                "Expected 'unclean leader election' in: " + error.message());
+        }
+
+        @Test
+        public void testUncleanLeaderElectionRejectedWhileSwitchPending() {
+            ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder().build();
+            ctx.registerBrokers(0, 1, 2);
+            ctx.unfenceBrokers(0, 1, 2);
+            ctx.createTestTopic("foo", new int[][] {new int[] {0, 1, 2}});
+
+            // Mark the partition as switch pending
+            ConfigResource resource = new ConfigResource(ConfigResource.Type.TOPIC, "foo");
+            Map<ConfigResource, Map<String, Map.Entry<AlterConfigOp.OpType, String>>> disklessChanges = Map.of(
+                resource, Map.of(DISKLESS_ENABLE_CONFIG,
+                    new AbstractMap.SimpleImmutableEntry<>(AlterConfigOp.OpType.SET, "true")));
+            List<ApiMessageAndVersion> switchRecords =
+                ctx.replicationControl.markClassicToDisklessSwitchStarted(
+                    disklessChanges, Map.of(resource, ApiError.NONE));
+            ctx.replay(switchRecords);
+
+            // Now try to enable unclean leader election
+            Map<ConfigResource, Map<String, Map.Entry<AlterConfigOp.OpType, String>>> uncleanChanges = Map.of(
+                resource, Map.of(TopicConfig.UNCLEAN_LEADER_ELECTION_ENABLE_CONFIG,
+                    new AbstractMap.SimpleImmutableEntry<>(AlterConfigOp.OpType.SET, "true")));
+
+            Map<ConfigResource, ApiError> errors =
+                ctx.replicationControl.validateUncleanLeaderElectionChange(uncleanChanges);
+
+            assertEquals(1, errors.size());
+            ApiError error = errors.get(resource);
+            assertEquals(Errors.INVALID_CONFIG, error.error());
+            assertTrue(error.message().contains("pending classic-to-diskless switch"),
+                "Expected 'pending classic-to-diskless switch' in: " + error.message());
+        }
+
+        @Test
+        public void testUncleanLeaderElectionAllowedAfterSwitchCompletes() {
+            ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder().build();
+            ctx.registerBrokers(0, 1, 2);
+            ctx.unfenceBrokers(0, 1, 2);
+            Uuid fooId = ctx.createTestTopic("foo", new int[][] {new int[] {0, 1, 2}}).topicId();
+
+            // Mark the partition as switch pending
+            ConfigResource resource = new ConfigResource(ConfigResource.Type.TOPIC, "foo");
+            Map<ConfigResource, Map<String, Map.Entry<AlterConfigOp.OpType, String>>> disklessChanges = Map.of(
+                resource, Map.of(DISKLESS_ENABLE_CONFIG,
+                    new AbstractMap.SimpleImmutableEntry<>(AlterConfigOp.OpType.SET, "true")));
+            List<ApiMessageAndVersion> switchRecords =
+                ctx.replicationControl.markClassicToDisklessSwitchStarted(
+                    disklessChanges, Map.of(resource, ApiError.NONE));
+            ctx.replay(switchRecords);
+
+            // Complete the switch by setting a real start offset via initDisklessLog
+            PartitionRegistration partition = ctx.replicationControl.getPartition(fooId, 0);
+            ControllerRequestContext requestContext = anonymousContextFor(ApiKeys.ALTER_PARTITION);
+            InitDisklessLogRequestData initRequest = singlePartitionRequest(
+                0, defaultBrokerEpoch(0), fooId, 0, 100L, partition.leaderEpoch, List.of());
+            ControllerResult<InitDisklessLogResponseData> initResult =
+                ctx.replicationControl.initDisklessLog(requestContext, initRequest);
+            ctx.replay(initResult.records());
+
+            // Now unclean leader election should be allowed
+            Map<ConfigResource, Map<String, Map.Entry<AlterConfigOp.OpType, String>>> uncleanChanges = Map.of(
+                resource, Map.of(TopicConfig.UNCLEAN_LEADER_ELECTION_ENABLE_CONFIG,
+                    new AbstractMap.SimpleImmutableEntry<>(AlterConfigOp.OpType.SET, "true")));
+
+            Map<ConfigResource, ApiError> errors =
+                ctx.replicationControl.validateUncleanLeaderElectionChange(uncleanChanges);
+
+            assertTrue(errors.isEmpty(), "Expected no errors but got: " + errors);
+        }
+
+        @Test
+        public void testMaybeTriggerUncleanElectionSkipsPendingSwitchPartition() {
+            ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder()
+                .setStaticConfig(TopicConfig.UNCLEAN_LEADER_ELECTION_ENABLE_CONFIG, "true")
+                .build();
+            ctx.registerBrokers(0, 1, 2);
+            ctx.unfenceBrokers(0, 1, 2);
+            ctx.createTestTopic("foo", new int[][] {new int[] {0, 1, 2}});
+
+            // Mark the partition as switch pending
+            ConfigResource resource = new ConfigResource(ConfigResource.Type.TOPIC, "foo");
+            Map<ConfigResource, Map<String, Map.Entry<AlterConfigOp.OpType, String>>> disklessChanges = Map.of(
+                resource, Map.of(DISKLESS_ENABLE_CONFIG,
+                    new AbstractMap.SimpleImmutableEntry<>(AlterConfigOp.OpType.SET, "true")));
+            List<ApiMessageAndVersion> switchRecords =
+                ctx.replicationControl.markClassicToDisklessSwitchStarted(
+                    disklessChanges, Map.of(resource, ApiError.NONE));
+            ctx.replay(switchRecords);
+
+            // Fence all brokers to make partition leaderless
+            ctx.fenceBrokers(0, 1, 2);
+
+            // Unfence one broker
+            ctx.unfenceBrokers(1);
+
+            // Try unclean election — should NOT happen because of pending switch
+            List<ApiMessageAndVersion> electionRecords = new ArrayList<>();
+            ctx.replicationControl.maybeTriggerUncleanLeaderElectionForLeaderlessPartitions(
+                electionRecords, Integer.MAX_VALUE);
+
+            assertEquals(0, electionRecords.size(),
+                "Expected no unclean election for partition with pending switch");
+        }
+
+        @Test
+        public void testBrokerFencingDoesNotTriggerUncleanElectionForPendingSwitchPartition() {
+            ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder()
+                .setStaticConfig(TopicConfig.UNCLEAN_LEADER_ELECTION_ENABLE_CONFIG, "true")
+                .build();
+            ctx.registerBrokers(0, 1, 2);
+            ctx.unfenceBrokers(0, 1, 2);
+            Uuid fooId = ctx.createTestTopic("foo", new int[][] {new int[] {0, 1, 2}}).topicId();
+
+            // Mark the partition as switch pending
+            ConfigResource resource = new ConfigResource(ConfigResource.Type.TOPIC, "foo");
+            Map<ConfigResource, Map<String, Map.Entry<AlterConfigOp.OpType, String>>> disklessChanges = Map.of(
+                resource, Map.of(DISKLESS_ENABLE_CONFIG,
+                    new AbstractMap.SimpleImmutableEntry<>(AlterConfigOp.OpType.SET, "true")));
+            List<ApiMessageAndVersion> switchRecords =
+                ctx.replicationControl.markClassicToDisklessSwitchStarted(
+                    disklessChanges, Map.of(resource, ApiError.NONE));
+            ctx.replay(switchRecords);
+
+            // Fence the leader — with unclean enabled but pending switch, should NOT do unclean election
+            ctx.fenceBrokers(0, 1, 2);
+            PartitionRegistration partition = ctx.replicationControl.getPartition(fooId, 0);
+
+            // Partition should be leaderless, not unclean-elected
+            assertFalse(partition.hasLeader());
+        }
+
     }
 
 }


### PR DESCRIPTION
Enforce the following guards when altering the topic config to use diskless.enable=true:
  - Partitions are online
  - No reassignment in progress
  - Enough ISRs
  - No unclean leader election (active recovery nor enablement)