### PR TITLE
test(inkless:switch): Add invariant tests for sealed partition recovery

### DIFF
--- a/core/src/test/scala/unit/kafka/server/DisklessSwitchInvariantsTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DisklessSwitchInvariantsTest.scala
@@ -1,0 +1,266 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.server
+
+import io.aiven.inkless.common.SharedState
+import io.aiven.inkless.config.InklessConfig
+import io.aiven.inkless.control_plane.ControlPlane
+import kafka.server.metadata.InklessMetadataView
+import kafka.utils.TestUtils
+import org.apache.kafka.common.{TopicPartition, Uuid}
+import org.apache.kafka.common.compress.Compression
+import org.apache.kafka.common.metadata.{PartitionRecord, TopicRecord}
+import org.apache.kafka.common.metrics.Metrics
+import org.apache.kafka.common.record.{MemoryRecords, SimpleRecord}
+import org.apache.kafka.common.utils.Time
+import org.apache.kafka.image._
+import org.apache.kafka.server.common.{KRaftVersion, MetadataVersion}
+import org.apache.kafka.server.config.ServerConfigs
+import org.apache.kafka.server.PartitionFetchState
+import org.apache.kafka.server.util.MockTime
+import org.apache.kafka.storage.internals.log.{LogConfig, LogDirFailureChannel, UnifiedLog}
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.{Arguments, MethodSource}
+import org.mockito.ArgumentMatchers._
+import org.mockito.Mockito._
+import org.mockito.Answers
+import kafka.server.metadata.KRaftMetadataCache
+
+import java.io.File
+import java.util
+import java.util.{Collections, Optional, Properties}
+import scala.jdk.CollectionConverters._
+
+/**
+ * Invariant tests for the diskless switch recovery paths.
+ *
+ * After applyDelta completes for a sealed partition, certain invariants must
+ * hold regardless of the checkpoint state at restart time. These tests verify
+ * those invariants across a matrix of scenarios:
+ *
+ *   - Role after restart: leader vs follower
+ *   - Checkpoint HW: stale (0, partial) vs fresh (== seal)
+ *   - Seal state: committed (>= 0) vs pending (-2) vs none (-1)
+ */
+class DisklessSwitchInvariantsTest {
+
+  private val time = new MockTime()
+  private val metrics = new Metrics()
+  private val brokerId = 1
+  private var replicaManager: ReplicaManager = _
+
+  @AfterEach
+  def tearDown(): Unit = {
+    if (replicaManager != null) {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+    metrics.close()
+  }
+
+  // --- Invariant: Sealed leader HW >= seal offset ---
+
+  @ParameterizedTest(name = "leader checkpoint hw={0}, seal={1}")
+  @MethodSource(Array("sealedLeaderScenarios"))
+  def testSealedLeaderHwInvariant(checkpointHw: Long, sealOffset: Long, expectedHw: Long): Unit = {
+    val topicName = "switched-topic"
+    val topicId = Uuid.randomUuid()
+    val tp = new TopicPartition(topicName, 0)
+    val leo = sealOffset // LEO == seal for a fully-replicated partition
+
+    replicaManager = createReplicaManager(List(topicName))
+    val log = replicaManager.logManager.getOrCreateLog(tp, isNew = true, topicId = Optional.of(topicId))
+    populateLocalLogAtLeoAndCheckpointedHwm(replicaManager, tp, log, leo, checkpointHw)
+
+    when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(tp))
+      .thenReturn(sealOffset)
+
+    val delta = leaderDelta(topicName, topicId)
+    replicaManager.applyDelta(delta, imageFromTopics(delta.apply()))
+
+    // --- Assert invariant ---
+    val partition = replicaManager.getPartition(tp).asInstanceOf[HostedPartition.Online].partition
+    assertTrue(partition.isSealed, "Partition must be sealed")
+    assertTrue(partition.isLeader, "Partition must be leader")
+    assertEquals(expectedHw, partition.localLogOrException.highWatermark,
+      s"Sealed leader invariant: HW must be >= sealOffset ($sealOffset) " +
+      s"regardless of checkpoint state ($checkpointHw)")
+  }
+
+  // --- Invariant: Sealed follower with HW < seal triggers catch-up fetcher ---
+
+  @ParameterizedTest(name = "follower checkpoint hw={0}, seal={1}, expectFetcher={2}")
+  @MethodSource(Array("sealedFollowerScenarios"))
+  def testSealedFollowerFetcherInvariant(checkpointHw: Long, sealOffset: Long, expectFetcher: Boolean): Unit = {
+    val topicName = "switched-topic"
+    val topicId = Uuid.randomUuid()
+    val tp = new TopicPartition(topicName, 0)
+    val leaderId = 2
+    val leo = sealOffset
+
+    val mockFetcherManager = mock(classOf[ReplicaFetcherManager])
+    when(mockFetcherManager.removeFetcherForPartitions(any())).thenReturn(Map.empty[TopicPartition, PartitionFetchState])
+
+    replicaManager = spy(createReplicaManager(
+      List(topicName),
+      mockReplicaFetcherManager = Some(mockFetcherManager)
+    ))
+    val log = replicaManager.logManager.getOrCreateLog(tp, isNew = true, topicId = Optional.of(topicId))
+    populateLocalLogAtLeoAndCheckpointedHwm(replicaManager, tp, log, leo, checkpointHw)
+
+    when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(tp))
+      .thenReturn(sealOffset)
+
+    val delta = followerDelta(topicName, topicId, leaderId)
+    replicaManager.applyDelta(delta, imageFromTopics(delta.apply()))
+
+    // --- Assert invariant ---
+    val partition = replicaManager.getPartition(tp).asInstanceOf[HostedPartition.Online].partition
+    assertTrue(partition.isSealed, "Partition must be sealed")
+
+    if (expectFetcher) {
+      verify(mockFetcherManager).addFetcherForPartitions(any())
+    } else {
+      verify(mockFetcherManager, never()).addFetcherForPartitions(any())
+    }
+  }
+
+  // --- Test data ---
+
+  private def leaderDelta(topicName: String, topicId: Uuid): TopicsDelta = {
+    val delta = new TopicsDelta(TopicsImage.EMPTY)
+    delta.replay(new TopicRecord().setName(topicName).setTopicId(topicId))
+    delta.replay(new PartitionRecord()
+      .setPartitionId(0)
+      .setTopicId(topicId)
+      .setReplicas(util.Arrays.asList(brokerId, brokerId + 1))
+      .setIsr(util.Arrays.asList(brokerId, brokerId + 1))
+      .setLeader(brokerId)
+      .setLeaderEpoch(0)
+      .setPartitionEpoch(0)
+    )
+    delta
+  }
+
+  private def followerDelta(topicName: String, topicId: Uuid, leaderId: Int): TopicsDelta = {
+    val delta = new TopicsDelta(TopicsImage.EMPTY)
+    delta.replay(new TopicRecord().setName(topicName).setTopicId(topicId))
+    delta.replay(new PartitionRecord()
+      .setPartitionId(0)
+      .setTopicId(topicId)
+      .setReplicas(util.Arrays.asList(brokerId, leaderId))
+      .setIsr(util.Arrays.asList(brokerId, leaderId))
+      .setLeader(leaderId)
+      .setLeaderEpoch(0)
+      .setPartitionEpoch(0)
+    )
+    delta
+  }
+
+  private def populateLocalLogAtLeoAndCheckpointedHwm(
+      replicaManager: ReplicaManager, tp: TopicPartition,
+      log: UnifiedLog, leo: Long, hw: Long): Unit = {
+    if (leo > 0) {
+      val simpleRecords = (0L until leo).map(i => new SimpleRecord(s"msg-$i".getBytes)).toArray
+      val records = MemoryRecords.withRecords(Compression.NONE, 0, simpleRecords: _*)
+      log.appendAsFollower(records, 0)
+    }
+    val checkpoint = replicaManager.highWatermarkCheckpoints(log.parentDir)
+    checkpoint.write(Collections.singletonMap(tp, java.lang.Long.valueOf(hw)))
+    log.maybeUpdateHighWatermark(hw)
+  }
+
+  private def createReplicaManager(
+    disklessTopics: Seq[String],
+    mockReplicaFetcherManager: Option[ReplicaFetcherManager] = None
+  ): ReplicaManager = {
+    val props = TestUtils.createBrokerConfig(brokerId, logDirCount = 2)
+    props.put(ServerConfigs.DISKLESS_STORAGE_SYSTEM_ENABLE_CONFIG, "true")
+    val config = KafkaConfig.fromProps(props)
+    val mockLogMgr = TestUtils.createLogManager(config.logDirs.asScala.map(new File(_)), new LogConfig(new Properties()))
+    val sharedState = mock(classOf[SharedState], Answers.RETURNS_DEEP_STUBS)
+    when(sharedState.time()).thenReturn(Time.SYSTEM)
+    when(sharedState.config()).thenReturn(new InklessConfig(new util.HashMap[String, Object]()))
+    when(sharedState.controlPlane()).thenReturn(mock(classOf[ControlPlane]))
+    val inklessMetadata = mock(classOf[InklessMetadataView])
+    when(inklessMetadata.isDisklessTopic(any())).thenReturn(false)
+    disklessTopics.foreach(t => when(inklessMetadata.isDisklessTopic(t)).thenReturn(true))
+    when(sharedState.metadata()).thenReturn(inklessMetadata)
+
+    val logDirFailureChannel = new LogDirFailureChannel(config.logDirs.size)
+
+    new ReplicaManager(
+      metrics = metrics,
+      config = config,
+      time = time,
+      scheduler = time.scheduler,
+      logManager = mockLogMgr,
+      quotaManagers = mock(classOf[QuotaFactory.QuotaManagers]),
+      metadataCache = new KRaftMetadataCache(config.brokerId, () => KRaftVersion.KRAFT_VERSION_0),
+      logDirFailureChannel = logDirFailureChannel,
+      alterPartitionManager = mock(classOf[AlterPartitionManager]),
+      inklessSharedState = Some(sharedState),
+      inklessMetadataView = Some(inklessMetadata),
+    ) {
+      override protected def createReplicaFetcherManager(
+        metrics: Metrics,
+        time: Time,
+        quotaManager: ReplicationQuotaManager
+      ): ReplicaFetcherManager = {
+        mockReplicaFetcherManager.getOrElse(super.createReplicaFetcherManager(metrics, time, quotaManager))
+      }
+    }
+  }
+
+  private def imageFromTopics(topicsImage: TopicsImage): MetadataImage = {
+    new MetadataImage(
+      new MetadataProvenance(100L, 10, 1000L, true),
+      new FeaturesImage(Collections.emptyMap(), MetadataVersion.latestProduction()),
+      ClusterImageTest.IMAGE1,
+      topicsImage,
+      ConfigurationsImage.EMPTY,
+      ClientQuotasImage.EMPTY,
+      ProducerIdsImage.EMPTY,
+      AclsImage.EMPTY,
+      ScramImage.EMPTY,
+      DelegationTokenImage.EMPTY
+    )
+  }
+}
+
+object DisklessSwitchInvariantsTest {
+
+  def sealedLeaderScenarios(): java.util.stream.Stream[Arguments] = {
+    // (checkpointHw, sealOffset, expectedHwAfterApplyDelta)
+    java.util.stream.Stream.of(
+      Arguments.of(0L: java.lang.Long,  10L: java.lang.Long, 10L: java.lang.Long),  // unclean shutdown
+      Arguments.of(5L: java.lang.Long,  10L: java.lang.Long, 10L: java.lang.Long),  // partial flush
+      Arguments.of(10L: java.lang.Long, 10L: java.lang.Long, 10L: java.lang.Long),  // clean shutdown
+    )
+  }
+
+  def sealedFollowerScenarios(): java.util.stream.Stream[Arguments] = {
+    // (checkpointHw, sealOffset, expectFetcher)
+    java.util.stream.Stream.of(
+      Arguments.of(0L: java.lang.Long,  10L: java.lang.Long, true: java.lang.Boolean),   // stale
+      Arguments.of(5L: java.lang.Long,  10L: java.lang.Long, true: java.lang.Boolean),   // partial
+      Arguments.of(10L: java.lang.Long, 10L: java.lang.Long, false: java.lang.Boolean),  // fresh
+    )
+  }
+}

--- a/core/src/test/scala/unit/kafka/server/DisklessSwitchInvariantsTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DisklessSwitchInvariantsTest.scala
@@ -57,7 +57,15 @@ import scala.jdk.CollectionConverters._
  *
  *   - Role after restart: leader vs follower
  *   - Checkpoint HW: stale (0, partial) vs fresh (== seal)
- *   - Seal state: committed (>= 0) vs pending (-2) vs none (-1)
+ *   - Seal state: committed (>= 0) vs pending (CLASSIC_TO_DISKLESS_SWITCH_PENDING = -2)
+ *                 vs none (NO_CLASSIC_TO_DISKLESS_START_OFFSET = -1)
+ *
+ * Key invariants:
+ *   - Committed seal → leader HW is advanced to seal offset regardless of checkpoint
+ *   - Committed seal → follower fetcher starts only when HW < seal
+ *   - Pending seal → partition is sealed, HW not advanced (seal offset unknown);
+ *                     follower starts fetcher on new leader epoch
+ *   - No switch → partition is sealed, HW not advanced, no fetcher
  */
 class DisklessSwitchInvariantsTest {
 
@@ -82,7 +90,8 @@ class DisklessSwitchInvariantsTest {
     val topicName = "switched-topic"
     val topicId = Uuid.randomUuid()
     val tp = new TopicPartition(topicName, 0)
-    val leo = sealOffset // LEO == seal for a fully-replicated partition
+    // For committed seals, LEO == seal (fully replicated). For pending/none, use a fixed LEO.
+    val leo = if (sealOffset >= 0) sealOffset else 10L
 
     replicaManager = createReplicaManager(List(topicName))
     val log = replicaManager.logManager.getOrCreateLog(tp, isNew = true, topicId = Optional.of(topicId))
@@ -112,7 +121,7 @@ class DisklessSwitchInvariantsTest {
     val topicId = Uuid.randomUuid()
     val tp = new TopicPartition(topicName, 0)
     val leaderId = 2
-    val leo = sealOffset
+    val leo = if (sealOffset >= 0) sealOffset else 10L
 
     val mockFetcherManager = mock(classOf[ReplicaFetcherManager])
     when(mockFetcherManager.removeFetcherForPartitions(any())).thenReturn(Map.empty[TopicPartition, PartitionFetchState])
@@ -190,7 +199,7 @@ class DisklessSwitchInvariantsTest {
     disklessTopics: Seq[String],
     mockReplicaFetcherManager: Option[ReplicaFetcherManager] = None
   ): ReplicaManager = {
-    val props = TestUtils.createBrokerConfig(brokerId, logDirCount = 2)
+    val props = TestUtils.createBrokerConfig(brokerId, logDirCount = 1)
     props.put(ServerConfigs.DISKLESS_STORAGE_SYSTEM_ENABLE_CONFIG, "true")
     val config = KafkaConfig.fromProps(props)
     val mockLogMgr = TestUtils.createLogManager(config.logDirs.asScala.map(new File(_)), new LogConfig(new Properties()))
@@ -246,21 +255,44 @@ class DisklessSwitchInvariantsTest {
 
 object DisklessSwitchInvariantsTest {
 
+  import org.apache.kafka.metadata.PartitionRegistration._
+
   def sealedLeaderScenarios(): java.util.stream.Stream[Arguments] = {
     // (checkpointHw, sealOffset, expectedHwAfterApplyDelta)
+    // Committed seal (>= 0): HW is always advanced to sealOffset regardless of checkpoint.
+    // The post-restart path (getOrCreatePartition + makeLeader) creates a new Partition object
+    // that re-initializes HW from the checkpoint via LazyOffsetCheckpoints. However, since the
+    // log already exists, LogManager returns it without re-reading the checkpoint. The seal
+    // offset advancement at line 3050 compensates by forcing HW = sealOffset.
     java.util.stream.Stream.of(
       Arguments.of(0L: java.lang.Long,  10L: java.lang.Long, 10L: java.lang.Long),  // unclean shutdown
       Arguments.of(5L: java.lang.Long,  10L: java.lang.Long, 10L: java.lang.Long),  // partial flush
       Arguments.of(10L: java.lang.Long, 10L: java.lang.Long, 10L: java.lang.Long),  // clean shutdown
+      // Pending seal (-2): partition is sealed. The HW is NOT advanced because the seal
+      // offset is not yet committed. The post-restart path does not restore HW from
+      // checkpoint for pending seals — the pending fetcher (follower side) will eventually
+      // propagate the correct HW when the seal commits.
+      Arguments.of(0L: java.lang.Long,  CLASSIC_TO_DISKLESS_SWITCH_PENDING: java.lang.Long, 0L: java.lang.Long),
+      Arguments.of(5L: java.lang.Long,  CLASSIC_TO_DISKLESS_SWITCH_PENDING: java.lang.Long, 0L: java.lang.Long),
+      // No switch (-1): partition is sealed but HW is not advanced (no seal offset to target).
+      Arguments.of(0L: java.lang.Long,  NO_CLASSIC_TO_DISKLESS_START_OFFSET: java.lang.Long, 0L: java.lang.Long),
+      Arguments.of(5L: java.lang.Long,  NO_CLASSIC_TO_DISKLESS_START_OFFSET: java.lang.Long, 0L: java.lang.Long),
     )
   }
 
   def sealedFollowerScenarios(): java.util.stream.Stream[Arguments] = {
     // (checkpointHw, sealOffset, expectFetcher)
+    // Committed seal (>= 0): fetcher starts when HW < seal
     java.util.stream.Stream.of(
       Arguments.of(0L: java.lang.Long,  10L: java.lang.Long, true: java.lang.Boolean),   // stale
       Arguments.of(5L: java.lang.Long,  10L: java.lang.Long, true: java.lang.Boolean),   // partial
       Arguments.of(10L: java.lang.Long, 10L: java.lang.Long, false: java.lang.Boolean),  // fresh
+      // Pending seal (-2): fetcher starts (new leader epoch triggers catch-up)
+      Arguments.of(0L: java.lang.Long,  CLASSIC_TO_DISKLESS_SWITCH_PENDING: java.lang.Long, true: java.lang.Boolean),
+      Arguments.of(5L: java.lang.Long,  CLASSIC_TO_DISKLESS_SWITCH_PENDING: java.lang.Long, true: java.lang.Boolean),
+      // No switch (-1): sealed but no fetcher needed
+      Arguments.of(0L: java.lang.Long,  NO_CLASSIC_TO_DISKLESS_START_OFFSET: java.lang.Long, false: java.lang.Boolean),
+      Arguments.of(5L: java.lang.Long,  NO_CLASSIC_TO_DISKLESS_START_OFFSET: java.lang.Long, false: java.lang.Boolean),
     )
   }
 }

--- a/core/src/test/scala/unit/kafka/server/DisklessSwitchInvariantsTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DisklessSwitchInvariantsTest.scala
@@ -142,6 +142,7 @@ class DisklessSwitchInvariantsTest {
     // --- Assert invariant ---
     val partition = replicaManager.getPartition(tp).asInstanceOf[HostedPartition.Online].partition
     assertTrue(partition.isSealed, "Partition must be sealed")
+    assertFalse(partition.isLeader, "Partition must be follower")
 
     if (expectFetcher) {
       verify(mockFetcherManager).addFetcherForPartitions(any())
@@ -263,7 +264,8 @@ object DisklessSwitchInvariantsTest {
     // The post-restart path (getOrCreatePartition + makeLeader) creates a new Partition object
     // that re-initializes HW from the checkpoint via LazyOffsetCheckpoints. However, since the
     // log already exists, LogManager returns it without re-reading the checkpoint. The seal
-    // offset advancement at line 3050 compensates by forcing HW = sealOffset.
+    // offset advancement in applyLocalLeadersDelta (sealOffset >= 0 && HW < sealOffset guard)
+    // compensates by forcing HW = sealOffset.
     java.util.stream.Stream.of(
       Arguments.of(0L: java.lang.Long,  10L: java.lang.Long, 10L: java.lang.Long),  // unclean shutdown
       Arguments.of(5L: java.lang.Long,  10L: java.lang.Long, 10L: java.lang.Long),  // partial flush

--- a/core/src/test/scala/unit/kafka/server/DisklessSwitchInvariantsTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DisklessSwitchInvariantsTest.scala
@@ -276,7 +276,9 @@ object DisklessSwitchInvariantsTest {
       // propagate the correct HW when the seal commits.
       Arguments.of(0L: java.lang.Long,  CLASSIC_TO_DISKLESS_SWITCH_PENDING: java.lang.Long, 0L: java.lang.Long),
       Arguments.of(5L: java.lang.Long,  CLASSIC_TO_DISKLESS_SWITCH_PENDING: java.lang.Long, 0L: java.lang.Long),
-      // No switch (-1): partition is sealed but HW is not advanced (no seal offset to target).
+      // No switch (-1): not realistic today but documents defensive behavior of the
+      // post-restart path which seals unconditionally. Relevant if diskless topics
+      // eventually use local logs as a read cache.
       Arguments.of(0L: java.lang.Long,  NO_CLASSIC_TO_DISKLESS_START_OFFSET: java.lang.Long, 0L: java.lang.Long),
       Arguments.of(5L: java.lang.Long,  NO_CLASSIC_TO_DISKLESS_START_OFFSET: java.lang.Long, 0L: java.lang.Long),
     )
@@ -292,7 +294,7 @@ object DisklessSwitchInvariantsTest {
       // Pending seal (-2): fetcher starts (new leader epoch triggers catch-up)
       Arguments.of(0L: java.lang.Long,  CLASSIC_TO_DISKLESS_SWITCH_PENDING: java.lang.Long, true: java.lang.Boolean),
       Arguments.of(5L: java.lang.Long,  CLASSIC_TO_DISKLESS_SWITCH_PENDING: java.lang.Long, true: java.lang.Boolean),
-      // No switch (-1): sealed but no fetcher needed
+      // No switch (-1): defensive — documents post-restart seal behavior (see leader scenarios)
       Arguments.of(0L: java.lang.Long,  NO_CLASSIC_TO_DISKLESS_START_OFFSET: java.lang.Long, false: java.lang.Boolean),
       Arguments.of(5L: java.lang.Long,  NO_CLASSIC_TO_DISKLESS_START_OFFSET: java.lang.Long, false: java.lang.Boolean),
     )


### PR DESCRIPTION
Parameterized tests that verify invariants across a matrix of checkpoint states (stale/partial/fresh) for both leader and follower roles after restart:

- Sealed leader: HW must be >= seal offset regardless of checkpoint
- Sealed follower: catch-up fetcher must be scheduled when HW < seal

These invariants catch bugs where makeLeader reloads a stale HW from the on-disk checkpoint and seal() permanently prevents natural advancement.