### PR TITLE
feat(inkless:switch): support DELETE_RECORDS for hybrid partitions

### DIFF
--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1488,9 +1488,11 @@ class ReplicaManager(val config: KafkaConfig,
                       hybridDisklessPartitions += topicPartition
                     }
                   case None =>
+                    // consolidating partition has no local log, so only diskless data can be deleted
                     disklessOffsetPerPartition += topicPartition -> requestedOffset
                 }
               case Left(_) =>
+                // cannot inspect the local log, no local component to delete, treat as pure-diskless
                 disklessOffsetPerPartition += topicPartition -> requestedOffset
             }
           case Some(_) =>

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1491,9 +1491,11 @@ class ReplicaManager(val config: KafkaConfig,
                     // consolidating partition has no local log, so only diskless data can be deleted
                     disklessOffsetPerPartition += topicPartition -> requestedOffset
                 }
-              case Left(_) =>
+              case Left(error) =>
                 // cannot inspect the local log, no local component to delete, treat as pure-diskless
                 disklessOffsetPerPartition += topicPartition -> requestedOffset
+                warn(s"Cannot find local partition for consolidating diskless topic " +
+                  s"${topicPartition}, routing delete exclusively to diskless. Error: $error")
             }
           case Some(_) =>
             // pure-diskless partition

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1466,6 +1466,33 @@ class ReplicaManager(val config: KafkaConfig,
           case Some(PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING) =>
             // partition not switched yet to diskless: data is only available in local log
             localOffsetPerPartition += topicPartition -> requestedOffset
+          case Some(PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET)
+            if config.disklessRemoteStorageConsolidationEnabled &&
+              _inklessMetadataView.isConsolidatingDisklessTopic(topicPartition.topic) =>
+            getPartitionOrError(topicPartition) match {
+              case Right(partition) =>
+                partition.log match {
+                  case Some(log) =>
+                    // consolidating diskless partition with local data
+                    val localLogEndOffset = log.logEndOffset
+                    val needsDisklessDelete = requestedOffset == DeleteRecordsRequest.HIGH_WATERMARK ||
+                      requestedOffset > localLogEndOffset
+                    val localOffset = if (needsDisklessDelete && requestedOffset != DeleteRecordsRequest.HIGH_WATERMARK) {
+                      localLogEndOffset
+                    } else {
+                      requestedOffset
+                    }
+                    localOffsetPerPartition += topicPartition -> localOffset
+                    if (needsDisklessDelete) {
+                      disklessOffsetPerPartition += topicPartition -> requestedOffset
+                      hybridDisklessPartitions += topicPartition
+                    }
+                  case None =>
+                    disklessOffsetPerPartition += topicPartition -> requestedOffset
+                }
+              case Left(_) =>
+                disklessOffsetPerPartition += topicPartition -> requestedOffset
+            }
           case Some(_) =>
             // pure-diskless partition
             disklessOffsetPerPartition += topicPartition -> requestedOffset

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1419,14 +1419,88 @@ class ReplicaManager(val config: KafkaConfig,
                     responseCallback: Map[TopicPartition, DeleteRecordsPartitionResult] => Unit,
                     allowInternalTopicDeletion: Boolean = false): Unit = {
 
-    if (inklessDeleteRecordsInterceptor.exists(_.intercept(
-      offsetPerPartition.view.mapValues(java.lang.Long.valueOf).toMap.asJava,
-      r => responseCallback(r.asScala)))) {
+    val disklessStartOffsetPerPartition = offsetPerPartition.keys.flatMap { topicPartition =>
+      if (_inklessMetadataView.isDisklessTopic(topicPartition.topic)) {
+        Some(topicPartition -> _inklessMetadataView.getClassicToDisklessStartOffset(topicPartition))
+      } else {
+        None
+      }
+    }.toMap
+    val disklessDeleteRecordsRequested = disklessStartOffsetPerPartition.nonEmpty
+
+    val failedDisklessDeleteRecords = if (disklessDeleteRecordsRequested && inklessDeleteRecordsInterceptor.isEmpty) {
+      error(s"Cannot delete records from diskless partitions ${disklessStartOffsetPerPartition.keys.mkString(", ")}: DeleteRecordsInterceptor is not enabled")
+      disklessStartOffsetPerPartition.keys.map { topicPartition =>
+        topicPartition -> new DeleteRecordsPartitionResult()
+          .setPartitionIndex(topicPartition.partition)
+          .setLowWatermark(DeleteRecordsResponse.INVALID_LOW_WATERMARK)
+          .setErrorCode(Errors.UNKNOWN_SERVER_ERROR.code)
+      }.toMap
+    } else {
+      Map.empty[TopicPartition, DeleteRecordsPartitionResult]
+    }
+
+    val localOffsetPerPartition = mutable.Map.empty[TopicPartition, Long]
+    val disklessOffsetPerPartition = mutable.Map.empty[TopicPartition, Long]
+    val hybridDisklessPartitions = mutable.Set.empty[TopicPartition]
+
+    if (disklessDeleteRecordsRequested) {
+      offsetPerPartition.filterNot { case (topicPartition, _) =>
+        failedDisklessDeleteRecords.contains(topicPartition)
+      }.foreach { case (topicPartition, requestedOffset) =>
+        disklessStartOffsetPerPartition.get(topicPartition) match {
+          case Some(classicToDisklessStartOffset) if classicToDisklessStartOffset >= 0 =>
+            // partition switched from classic to diskless
+            val needsDisklessDelete = requestedOffset == DeleteRecordsRequest.HIGH_WATERMARK ||
+              requestedOffset > classicToDisklessStartOffset
+            val localOffset = if (needsDisklessDelete && requestedOffset != DeleteRecordsRequest.HIGH_WATERMARK) {
+              classicToDisklessStartOffset
+            } else {
+              requestedOffset
+            }
+            localOffsetPerPartition += topicPartition -> localOffset
+            if (needsDisklessDelete) {
+              disklessOffsetPerPartition += topicPartition -> requestedOffset
+              hybridDisklessPartitions += topicPartition
+            }
+          case Some(PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING) =>
+            // partition not switched yet to diskless: data is only available in local log
+            localOffsetPerPartition += topicPartition -> requestedOffset
+          case Some(_) =>
+            // pure-diskless partition
+            disklessOffsetPerPartition += topicPartition -> requestedOffset
+          case None =>
+            // classic partition
+            localOffsetPerPartition += topicPartition -> requestedOffset
+        }
+      }
+    } else {
+      // No diskless partitions are present, so keep the existing local delete path.
+      localOffsetPerPartition ++= offsetPerPartition
+    }
+
+    def maybeDeleteFromDiskless(localResponse: Map[TopicPartition, DeleteRecordsPartitionResult]): Unit = {
+      // Keep pure diskless partitions and only the hybrid partitions whose local phase succeeded.
+      val disklessOffsetsAfterLocalDelete = disklessOffsetPerPartition.filterNot { case (topicPartition, _) =>
+        hybridDisklessPartitions.contains(topicPartition) &&
+          localResponse.get(topicPartition).exists(_.errorCode != Errors.NONE.code)
+      }
+      if (disklessOffsetsAfterLocalDelete.isEmpty) {
+        responseCallback(localResponse ++ failedDisklessDeleteRecords)
+      } else {
+        inklessDeleteRecordsInterceptor.get.intercept(
+          disklessOffsetsAfterLocalDelete.view.mapValues(java.lang.Long.valueOf).toMap.asJava,
+          r => responseCallback(localResponse ++ failedDisklessDeleteRecords ++ r.asScala))
+      }
+    }
+
+    if (localOffsetPerPartition.isEmpty) {
+      maybeDeleteFromDiskless(Map.empty)
       return
     }
 
     val timeBeforeLocalDeleteRecords = time.milliseconds
-    val localDeleteRecordsResults = deleteRecordsOnLocalLog(offsetPerPartition, allowInternalTopicDeletion)
+    val localDeleteRecordsResults = deleteRecordsOnLocalLog(localOffsetPerPartition, allowInternalTopicDeletion)
     debug("Delete records on local log in %d ms".format(time.milliseconds - timeBeforeLocalDeleteRecords))
 
     val deleteRecordsStatus = localDeleteRecordsResults.map { case (topicPartition, result) =>
@@ -1464,10 +1538,10 @@ class ReplicaManager(val config: KafkaConfig,
         }
       }
       // create delayed delete records operation
-      val delayedDeleteRecords = new DelayedDeleteRecords(timeout, deleteRecordsStatus.asJava, onAcks,  response => responseCallback(response.asScala))
+      val delayedDeleteRecords = new DelayedDeleteRecords(timeout, deleteRecordsStatus.asJava, onAcks, response => maybeDeleteFromDiskless(response.asScala))
 
       // create a list of (topic, partition) pairs to use as keys for this delayed delete records operation
-      val deleteRecordsRequestKeys = offsetPerPartition.keys.map(new TopicPartitionOperationKey(_)).toList
+      val deleteRecordsRequestKeys = localOffsetPerPartition.keys.map(new TopicPartitionOperationKey(_)).toList
 
       // try to complete the request immediately, otherwise put it into the purgatory
       // this is because while the delayed delete records operation is being created, new
@@ -1476,7 +1550,7 @@ class ReplicaManager(val config: KafkaConfig,
     } else {
       // we can respond immediately
       val deleteRecordsResponseStatus = deleteRecordsStatus.map { case (k, status) => k -> status.responseStatus }
-      responseCallback(deleteRecordsResponseStatus)
+      maybeDeleteFromDiskless(deleteRecordsResponseStatus)
     }
   }
 

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1508,10 +1508,14 @@ class ReplicaManager(val config: KafkaConfig,
       localOffsetPerPartition ++= offsetPerPartition
     }
 
+    // Convert to immutable before passing to the async closure to prevent accidental mutation.
+    val immutableDisklessOffsets = disklessOffsetPerPartition.toMap
+    val immutableHybridPartitions = hybridDisklessPartitions.toSet
+
     def maybeDeleteFromDiskless(localResponse: Map[TopicPartition, DeleteRecordsPartitionResult]): Unit = {
       // Keep pure diskless partitions and only the hybrid partitions whose local phase succeeded.
-      val disklessOffsetsAfterLocalDelete = disklessOffsetPerPartition.filterNot { case (topicPartition, _) =>
-        hybridDisklessPartitions.contains(topicPartition) &&
+      val disklessOffsetsAfterLocalDelete = immutableDisklessOffsets.filterNot { case (topicPartition, _) =>
+        immutableHybridPartitions.contains(topicPartition) &&
           localResponse.get(topicPartition).exists(_.errorCode != Errors.NONE.code)
       }
       if (disklessOffsetsAfterLocalDelete.isEmpty) {

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -22,7 +22,7 @@ import io.aiven.inkless.common.SharedState
 import io.aiven.inkless.config.InklessConfig
 import io.aiven.inkless.consolidation.ConsolidationFetcherManager
 import io.aiven.inkless.consume.{FetchHandler, FetchOffsetHandler}
-import io.aiven.inkless.control_plane.{BatchInfo, BatchMetadata, ControlPlane, ControlPlaneException, FindBatchResponse}
+import io.aiven.inkless.control_plane.{BatchInfo, BatchMetadata, ControlPlane, ControlPlaneException, DeleteRecordsResponse => CpDeleteRecordsResponse, FindBatchResponse}
 import kafka.server.metadata.InklessMetadataView
 import io.aiven.inkless.produce.AppendHandler
 import kafka.cluster.PartitionTest.MockPartitionListener
@@ -6583,6 +6583,194 @@ class ReplicaManagerTest {
     }
 
     @Test
+    def testDeleteRecordsHybridBelowStartOffsetDeletesOnlyLocalLog(): Unit = {
+      val controlPlane = mock(classOf[ControlPlane])
+      val replicaManager = createReplicaManager(
+        List(disklessTopicPartition.topic()),
+        controlPlane = Some(controlPlane),
+        disklessManagedReplicasEnabled = true,
+      )
+      try {
+        val partition = setupHybridLeaderPartition(replicaManager, disklessTopicPartition, localEndOffset = 101L)
+        when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
+          .thenReturn(101L)
+
+        @volatile var responseData: Map[TopicPartition, DeleteRecordsResponseData.DeleteRecordsPartitionResult] = Map.empty
+        replicaManager.deleteRecords(
+          timeout = 0L,
+          offsetPerPartition = Map(disklessTopicPartition.topicPartition() -> 50L),
+          responseCallback = response => responseData = response,
+        )
+
+        assertEquals(Errors.NONE.code, responseData(disklessTopicPartition.topicPartition()).errorCode)
+        assertEquals(50L, responseData(disklessTopicPartition.topicPartition()).lowWatermark)
+        assertEquals(50L, partition.localLogOrException.logStartOffset)
+        verify(controlPlane, never()).deleteRecords(anyList())
+      } finally {
+        replicaManager.shutdown(checkpointHW = false)
+      }
+    }
+
+    @Test
+    def testDeleteRecordsHybridPastStartOffsetDeletesLocalThenDiskless(): Unit = {
+      val controlPlane = mock(classOf[ControlPlane])
+      when(controlPlane.deleteRecords(anyList())).thenReturn(util.List.of(CpDeleteRecordsResponse.success(150L)))
+      val replicaManager = createReplicaManager(
+        List(disklessTopicPartition.topic()),
+        controlPlane = Some(controlPlane),
+        topicIdMapping = Map(disklessTopicPartition.topic() -> disklessTopicPartition.topicId()),
+        disklessManagedReplicasEnabled = true,
+      )
+      try {
+        val partition = setupHybridLeaderPartition(replicaManager, disklessTopicPartition, localEndOffset = 101L)
+        when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
+          .thenReturn(101L)
+
+        @volatile var responseData: Map[TopicPartition, DeleteRecordsResponseData.DeleteRecordsPartitionResult] = Map.empty
+        replicaManager.deleteRecords(
+          timeout = 0L,
+          offsetPerPartition = Map(disklessTopicPartition.topicPartition() -> 150L),
+          responseCallback = response => responseData = response,
+        )
+
+        waitUntilTrue(() => responseData.nonEmpty, "Hybrid delete records response was not completed")
+        assertEquals(Errors.NONE.code, responseData(disklessTopicPartition.topicPartition()).errorCode)
+        assertEquals(150L, responseData(disklessTopicPartition.topicPartition()).lowWatermark)
+        assertEquals(101L, partition.localLogOrException.logStartOffset)
+        verify(controlPlane, timeout(5000)).deleteRecords(anyList())
+      } finally {
+        replicaManager.shutdown(checkpointHW = false)
+      }
+    }
+
+    @Test
+    def testDeleteRecordsHybridPastStartOffsetDeletesBothWhenManagedReplicasDisabled(): Unit = {
+      val controlPlane = mock(classOf[ControlPlane])
+      when(controlPlane.deleteRecords(anyList())).thenReturn(util.List.of(CpDeleteRecordsResponse.success(150L)))
+      val replicaManager = createReplicaManager(
+        List(disklessTopicPartition.topic()),
+        controlPlane = Some(controlPlane),
+        topicIdMapping = Map(disklessTopicPartition.topic() -> disklessTopicPartition.topicId()),
+        disklessManagedReplicasEnabled = false,
+      )
+      try {
+        val partition = setupHybridLeaderPartition(replicaManager, disklessTopicPartition, localEndOffset = 101L)
+        when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
+          .thenReturn(101L)
+
+        @volatile var responseData: Map[TopicPartition, DeleteRecordsResponseData.DeleteRecordsPartitionResult] = Map.empty
+        replicaManager.deleteRecords(
+          timeout = 0L,
+          offsetPerPartition = Map(disklessTopicPartition.topicPartition() -> 150L),
+          responseCallback = response => responseData = response,
+        )
+
+        waitUntilTrue(() => responseData.nonEmpty, "Hybrid delete records response was not completed")
+        assertEquals(Errors.NONE.code, responseData(disklessTopicPartition.topicPartition()).errorCode)
+        assertEquals(150L, responseData(disklessTopicPartition.topicPartition()).lowWatermark)
+        assertEquals(101L, partition.localLogOrException.logStartOffset)
+        verify(controlPlane, timeout(5000)).deleteRecords(anyList())
+      } finally {
+        replicaManager.shutdown(checkpointHW = false)
+      }
+    }
+
+    @Test
+    def testDeleteRecordsMixedClassicAndPureDisklessSplitsRequest(): Unit = {
+      val controlPlane = mock(classOf[ControlPlane])
+      when(controlPlane.deleteRecords(anyList())).thenReturn(util.List.of(CpDeleteRecordsResponse.success(80L)))
+      val replicaManager = createReplicaManager(
+        List(disklessTopicPartition.topic()),
+        controlPlane = Some(controlPlane),
+        topicIdMapping = Map(disklessTopicPartition.topic() -> disklessTopicPartition.topicId()),
+      )
+      try {
+        val classicPartition = setupHybridLeaderPartition(replicaManager, classicTopicPartition, localEndOffset = 50L)
+        when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
+          .thenReturn(PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET)
+
+        @volatile var responseData: Map[TopicPartition, DeleteRecordsResponseData.DeleteRecordsPartitionResult] = Map.empty
+        replicaManager.deleteRecords(
+          timeout = 0L,
+          offsetPerPartition = Map(
+            classicTopicPartition.topicPartition() -> 20L,
+            disklessTopicPartition.topicPartition() -> 80L,
+          ),
+          responseCallback = response => responseData = response,
+        )
+
+        waitUntilTrue(() => responseData.size == 2, "Mixed delete records response was not completed")
+        assertEquals(Errors.NONE.code, responseData(classicTopicPartition.topicPartition()).errorCode)
+        assertEquals(20L, responseData(classicTopicPartition.topicPartition()).lowWatermark)
+        assertEquals(20L, classicPartition.localLogOrException.logStartOffset)
+        assertEquals(Errors.NONE.code, responseData(disklessTopicPartition.topicPartition()).errorCode)
+        assertEquals(80L, responseData(disklessTopicPartition.topicPartition()).lowWatermark)
+        verify(controlPlane, timeout(5000)).deleteRecords(anyList())
+      } finally {
+        replicaManager.shutdown(checkpointHW = false)
+      }
+    }
+
+    @Test
+    def testDeleteRecordsMixedClassicAndDisklessWithoutInterceptorOnlyFailsDiskless(): Unit = {
+      val replicaManager = createReplicaManager(
+        List(disklessTopicPartition.topic()),
+        inklessSharedStateEnabled = false,
+      )
+      try {
+        val classicPartition = setupHybridLeaderPartition(replicaManager, classicTopicPartition, localEndOffset = 50L)
+        when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
+          .thenReturn(PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET)
+
+        @volatile var responseData: Map[TopicPartition, DeleteRecordsResponseData.DeleteRecordsPartitionResult] = Map.empty
+        replicaManager.deleteRecords(
+          timeout = 0L,
+          offsetPerPartition = Map(
+            classicTopicPartition.topicPartition() -> 20L,
+            disklessTopicPartition.topicPartition() -> 80L,
+          ),
+          responseCallback = response => responseData = response,
+        )
+
+        assertEquals(Errors.NONE.code, responseData(classicTopicPartition.topicPartition()).errorCode)
+        assertEquals(20L, responseData(classicTopicPartition.topicPartition()).lowWatermark)
+        assertEquals(20L, classicPartition.localLogOrException.logStartOffset)
+        assertEquals(Errors.UNKNOWN_SERVER_ERROR.code, responseData(disklessTopicPartition.topicPartition()).errorCode)
+        assertEquals(DeleteRecordsResponse.INVALID_LOW_WATERMARK, responseData(disklessTopicPartition.topicPartition()).lowWatermark)
+      } finally {
+        replicaManager.shutdown(checkpointHW = false)
+      }
+    }
+
+    @Test
+    def testDeleteRecordsHybridDoesNotDeleteDisklessWhenLocalDeleteFails(): Unit = {
+      val controlPlane = mock(classOf[ControlPlane])
+      val replicaManager = createReplicaManager(
+        List(disklessTopicPartition.topic()),
+        controlPlane = Some(controlPlane),
+        topicIdMapping = Map(disklessTopicPartition.topic() -> disklessTopicPartition.topicId()),
+        disklessManagedReplicasEnabled = true,
+      )
+      try {
+        when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
+          .thenReturn(101L)
+
+        @volatile var responseData: Map[TopicPartition, DeleteRecordsResponseData.DeleteRecordsPartitionResult] = Map.empty
+        replicaManager.deleteRecords(
+          timeout = 0L,
+          offsetPerPartition = Map(disklessTopicPartition.topicPartition() -> 150L),
+          responseCallback = response => responseData = response,
+        )
+
+        assertEquals(Errors.UNKNOWN_TOPIC_OR_PARTITION.code, responseData(disklessTopicPartition.topicPartition()).errorCode)
+        assertEquals(DeleteRecordsResponse.INVALID_LOW_WATERMARK, responseData(disklessTopicPartition.topicPartition()).lowWatermark)
+        verify(controlPlane, never()).deleteRecords(anyList())
+      } finally {
+        replicaManager.shutdown(checkpointHW = false)
+      }
+    }
+
+    @Test
     def testFetchDisklessBelowStartOffsetReadsFromClassicLogWhenManagedReplicasEnabled(): Unit = {
       val fetchHandlerCtor = mockFetchHandler(Map.empty)
       try {
@@ -10158,6 +10346,48 @@ class ReplicaManagerTest {
       }
     }
 
+    private def setupHybridLeaderPartition(replicaManager: ReplicaManager,
+                                           topicIdPartition: TopicIdPartition,
+                                           localEndOffset: Long): Partition = {
+      val topicDelta = new TopicsDelta(TopicsImage.EMPTY)
+      topicDelta.replay(new TopicRecord()
+        .setName(topicIdPartition.topic())
+        .setTopicId(topicIdPartition.topicId()))
+      topicDelta.replay(new PartitionRecord()
+        .setTopicId(topicIdPartition.topicId())
+        .setPartitionId(topicIdPartition.partition())
+        .setLeader(replicaManager.config.brokerId)
+        .setLeaderEpoch(0)
+        .setPartitionEpoch(0)
+        .setReplicas(List[Integer](replicaManager.config.brokerId).asJava)
+        .setIsr(List[Integer](replicaManager.config.brokerId).asJava))
+
+      val (partition, _) = replicaManager.getOrCreatePartition(
+        topicIdPartition.topicPartition(),
+        topicDelta,
+        topicIdPartition.topicId()).get
+      partition.makeLeader(
+        partitionRegistration(
+          replicaManager.config.brokerId,
+          leaderEpoch = 0,
+          isr = Array(replicaManager.config.brokerId),
+          partitionEpoch = 0,
+          replicas = Array(replicaManager.config.brokerId)),
+        isNew = false,
+        new LazyOffsetCheckpoints(replicaManager.highWatermarkCheckpoints.asJava),
+        None)
+
+      if (localEndOffset > 0) {
+        val records = (0L until localEndOffset).map { i =>
+          new SimpleRecord(s"key-$i".getBytes, s"value-$i".getBytes)
+        }.toArray
+        val log = partition.localLogOrException
+        log.appendAsLeader(MemoryRecords.withRecords(0L, Compression.NONE, 0, records: _*), 0)
+        log.updateHighWatermark(localEndOffset)
+      }
+      partition
+    }
+
     private def mockFetchHandler(disklessResponse: Map[TopicIdPartition, FetchPartitionData]) = {
       // We use constructor mocking here to inject a FetchHandler mock into ReplicaManager,
       // because ReplicaManager internally constructs its own FetchHandler instance and does not
@@ -10180,7 +10410,8 @@ class ReplicaManagerTest {
       disklessManagedReplicasEnabled: Boolean = false,
       disklessRemoteStorageConsolidationEnabled: Boolean = false,
       consolidatingDisklessTopics: Set[String] = Set.empty,
-      mockReplicaFetcherManager: Option[ReplicaFetcherManager] = None
+      mockReplicaFetcherManager: Option[ReplicaFetcherManager] = None,
+      inklessSharedStateEnabled: Boolean = true
     ): ReplicaManager = {
       val props = TestUtils.createBrokerConfig(1, logDirCount = 2)
       if (disklessManagedReplicasEnabled || disklessRemoteStorageConsolidationEnabled) {
@@ -10222,7 +10453,7 @@ class ReplicaManagerTest {
         metadataCache = new KRaftMetadataCache(config.brokerId, () => KRaftVersion.KRAFT_VERSION_0),
         logDirFailureChannel = logDirFailureChannel,
         alterPartitionManager = alterPartitionManager,
-        inklessSharedState = Some(sharedState),
+        inklessSharedState = if (inklessSharedStateEnabled) Some(sharedState) else None,
         inklessMetadataView = Some(inklessMetadata),
       ) {
         override protected def createReplicaFetcherManager(

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -6644,38 +6644,6 @@ class ReplicaManagerTest {
     }
 
     @Test
-    def testDeleteRecordsHybridPastStartOffsetDeletesBothWhenManagedReplicasDisabled(): Unit = {
-      val controlPlane = mock(classOf[ControlPlane])
-      when(controlPlane.deleteRecords(anyList())).thenReturn(util.List.of(CpDeleteRecordsResponse.success(150L)))
-      val replicaManager = createReplicaManager(
-        List(disklessTopicPartition.topic()),
-        controlPlane = Some(controlPlane),
-        topicIdMapping = Map(disklessTopicPartition.topic() -> disklessTopicPartition.topicId()),
-        disklessManagedReplicasEnabled = false,
-      )
-      try {
-        val partition = setupHybridLeaderPartition(replicaManager, disklessTopicPartition, localEndOffset = 101L)
-        when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
-          .thenReturn(101L)
-
-        @volatile var responseData: Map[TopicPartition, DeleteRecordsResponseData.DeleteRecordsPartitionResult] = Map.empty
-        replicaManager.deleteRecords(
-          timeout = 0L,
-          offsetPerPartition = Map(disklessTopicPartition.topicPartition() -> 150L),
-          responseCallback = response => responseData = response,
-        )
-
-        waitUntilTrue(() => responseData.nonEmpty, "Hybrid delete records response was not completed")
-        assertEquals(Errors.NONE.code, responseData(disklessTopicPartition.topicPartition()).errorCode)
-        assertEquals(150L, responseData(disklessTopicPartition.topicPartition()).lowWatermark)
-        assertEquals(101L, partition.localLogOrException.logStartOffset)
-        verify(controlPlane, timeout(5000)).deleteRecords(anyList())
-      } finally {
-        replicaManager.shutdown(checkpointHW = false)
-      }
-    }
-
-    @Test
     def testDeleteRecordsMixedClassicAndPureDisklessSplitsRequest(): Unit = {
       val controlPlane = mock(classOf[ControlPlane])
       when(controlPlane.deleteRecords(anyList())).thenReturn(util.List.of(CpDeleteRecordsResponse.success(80L)))
@@ -6737,6 +6705,40 @@ class ReplicaManagerTest {
         assertEquals(20L, classicPartition.localLogOrException.logStartOffset)
         assertEquals(Errors.UNKNOWN_SERVER_ERROR.code, responseData(disklessTopicPartition.topicPartition()).errorCode)
         assertEquals(DeleteRecordsResponse.INVALID_LOW_WATERMARK, responseData(disklessTopicPartition.topicPartition()).lowWatermark)
+      } finally {
+        replicaManager.shutdown(checkpointHW = false)
+      }
+    }
+
+    @Test
+    def testDeleteRecordsConsolidatingDisklessWithLocalLogDeletesLocalThenDiskless(): Unit = {
+      val controlPlane = mock(classOf[ControlPlane])
+      when(controlPlane.deleteRecords(anyList())).thenReturn(util.List.of(CpDeleteRecordsResponse.success(150L)))
+      val replicaManager = createReplicaManager(
+        List(disklessTopicPartition.topic()),
+        controlPlane = Some(controlPlane),
+        topicIdMapping = Map(disklessTopicPartition.topic() -> disklessTopicPartition.topicId()),
+        disklessManagedReplicasEnabled = true,
+        disklessRemoteStorageConsolidationEnabled = true,
+        consolidatingDisklessTopics = Set(disklessTopicPartition.topic()),
+      )
+      try {
+        val partition = setupHybridLeaderPartition(replicaManager, disklessTopicPartition, localEndOffset = 101L)
+        when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
+          .thenReturn(PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET)
+
+        @volatile var responseData: Map[TopicPartition, DeleteRecordsResponseData.DeleteRecordsPartitionResult] = Map.empty
+        replicaManager.deleteRecords(
+          timeout = 0L,
+          offsetPerPartition = Map(disklessTopicPartition.topicPartition() -> 150L),
+          responseCallback = response => responseData = response,
+        )
+
+        waitUntilTrue(() => responseData.nonEmpty, "Consolidating delete records response was not completed")
+        assertEquals(Errors.NONE.code, responseData(disklessTopicPartition.topicPartition()).errorCode)
+        assertEquals(150L, responseData(disklessTopicPartition.topicPartition()).lowWatermark)
+        assertEquals(101L, partition.localLogOrException.logStartOffset)
+        verify(controlPlane, timeout(5000)).deleteRecords(anyList())
       } finally {
         replicaManager.shutdown(checkpointHW = false)
       }

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -6773,6 +6773,37 @@ class ReplicaManagerTest {
     }
 
     @Test
+    def testDeleteRecordsHybridHighWatermarkDeletesLocalThenDiskless(): Unit = {
+      val controlPlane = mock(classOf[ControlPlane])
+      when(controlPlane.deleteRecords(anyList())).thenReturn(util.List.of(CpDeleteRecordsResponse.success(200L)))
+      val replicaManager = createReplicaManager(
+        List(disklessTopicPartition.topic()),
+        controlPlane = Some(controlPlane),
+        topicIdMapping = Map(disklessTopicPartition.topic() -> disklessTopicPartition.topicId()),
+        disklessManagedReplicasEnabled = true,
+      )
+      try {
+        val partition = setupHybridLeaderPartition(replicaManager, disklessTopicPartition, localEndOffset = 101L)
+        when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
+          .thenReturn(101L)
+        @volatile var responseData: Map[TopicPartition, DeleteRecordsResponseData.DeleteRecordsPartitionResult] = Map.empty
+        replicaManager.deleteRecords(
+          timeout = 0L,
+          offsetPerPartition = Map(disklessTopicPartition.topicPartition() -> DeleteRecordsRequest.HIGH_WATERMARK),
+          responseCallback = response => responseData = response,
+        )
+        waitUntilTrue(() => responseData.nonEmpty, "HIGH_WATERMARK hybrid delete records response was not completed")
+        assertEquals(Errors.NONE.code, responseData(disklessTopicPartition.topicPartition()).errorCode)
+        assertEquals(200L, responseData(disklessTopicPartition.topicPartition()).lowWatermark)
+        // Local log should be deleted up to classicToDisklessStartOffset (not HIGH_WATERMARK)
+        assertEquals(101L, partition.localLogOrException.logStartOffset)
+        verify(controlPlane, timeout(5000)).deleteRecords(anyList())
+      } finally {
+        replicaManager.shutdown(checkpointHW = false)
+      }
+    }
+
+    @Test
     def testFetchDisklessBelowStartOffsetReadsFromClassicLogWhenManagedReplicasEnabled(): Unit = {
       val fetchHandlerCtor = mockFetchHandler(Map.empty)
       try {


### PR DESCRIPTION
Handle DELETE_RECORDS in case of topics being switched from classic to diskless and/or consolidating to Tiered Storage.