### PR TITLE
feat(inkless): Introduce CREATE_TOPICS config interceptor framework and DisklessForceCreateTopicInterceptor

### DIFF
--- a/core/src/main/scala/kafka/server/ControllerServer.scala
+++ b/core/src/main/scala/kafka/server/ControllerServer.scala
@@ -244,6 +244,8 @@ class ControllerServer(
           setDisklessRemoteStorageConsolidationEnabled(config.disklessRemoteStorageConsolidationEnabled).
           setClassicRemoteStorageForceEnabled(config.classicRemoteStorageForceEnabled).
           setClassicRemoteStorageForceExcludeTopicRegexes(config.classicRemoteStorageForceExcludeTopicRegexes).
+          setDisklessForceEnabled(config.disklessForceEnabled).
+          setDisklessForceIncludeTopicRegexes(config.disklessForceIncludeTopicRegexes).
           setSessionTimeoutNs(TimeUnit.NANOSECONDS.convert(config.brokerSessionTimeoutMs.longValue(),
             TimeUnit.MILLISECONDS)).
           setLeaderImbalanceCheckIntervalNs(leaderImbalanceCheckIntervalNs).

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -431,6 +431,10 @@ class KafkaConfig private(doLog: Boolean, val props: util.Map[_, _])
   val classicRemoteStorageForceExcludeTopicRegexes: java.util.List[String] =
     getList(ServerConfigs.CLASSIC_REMOTE_STORAGE_FORCE_EXCLUDE_TOPIC_REGEXES_CONFIG)
 
+  val disklessForceEnabled: Boolean = getBoolean(ServerConfigs.DISKLESS_FORCE_ENABLE_CONFIG)
+  val disklessForceIncludeTopicRegexes: java.util.List[String] =
+    getList(ServerConfigs.DISKLESS_FORCE_INCLUDE_TOPIC_REGEXES_CONFIG)
+
   def addReconfigurable(reconfigurable: Reconfigurable): Unit = {
     dynamicConfig.addReconfigurable(reconfigurable)
   }

--- a/metadata/src/main/java/org/apache/kafka/controller/ClassicTopicRemoteStorageForceCreateTopicInterceptor.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ClassicTopicRemoteStorageForceCreateTopicInterceptor.java
@@ -28,52 +28,63 @@ import java.util.regex.Pattern;
 
 import static org.apache.kafka.clients.admin.AlterConfigOp.OpType.SET;
 
-final class ClassicTopicRemoteStorageForcePolicy {
-    private final boolean enabled;
+/**
+ * A {@link CreateTopicConfigInterceptor} that forces {@code remote.storage.enable=true} on
+ * classic (non-diskless) topics, unless the topic is excluded by cleanup policy, regex, or
+ * system topic rules.
+ *
+ * <p>Controlled by the {@code classic.remote.storage.force.enable} config.
+ */
+final class ClassicTopicRemoteStorageForceCreateTopicInterceptor implements CreateTopicConfigInterceptor {
     private final List<Pattern> excludeTopicPatterns;
+    private final boolean defaultDisklessEnable;
 
-
-    ClassicTopicRemoteStorageForcePolicy(final boolean enabled, final List<String> excludeTopicRegexes) {
-        this.enabled = enabled;
+    ClassicTopicRemoteStorageForceCreateTopicInterceptor(final List<String> excludeTopicRegexes, final boolean defaultDisklessEnable) {
         this.excludeTopicPatterns = excludeTopicRegexes.stream().map(Pattern::compile).toList();
+        this.defaultDisklessEnable = defaultDisklessEnable;
     }
 
-    void maybeForceRemoteStorageEnable(
+    @Override
+    public boolean intercept(
         final String topicName,
-        final boolean disklessEnabled,
         final Map<String, String> requestConfigs,
         final Map<String, Entry<OpType, String>> targetConfigOps
     ) {
-        if (!enabled) {
-            return;
-        }
-        if (shouldForceRemoteStorageEnable(topicName, disklessEnabled, requestConfigs)) {
+        if (shouldForceRemoteStorageEnable(topicName, requestConfigs)) {
             targetConfigOps.put(TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG, new SimpleImmutableEntry<>(SET, "true"));
+            return true;
         }
+        return false;
     }
 
-    void maybeForceRemoteStorageEnable(
+    @Override
+    public boolean intercept(
         final String topicName,
-        final boolean disklessEnabled,
         final Map<String, String> targetConfigs
     ) {
-        if (!enabled) {
-            return;
-        }
-        if (shouldForceRemoteStorageEnable(topicName, disklessEnabled, targetConfigs)) {
+        if (shouldForceRemoteStorageEnable(topicName, targetConfigs)) {
             targetConfigs.put(TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG, "true");
+            return true;
         }
+        return false;
     }
 
     private boolean shouldForceRemoteStorageEnable(
         final String topicName,
-        final boolean disklessEnabled,
         final Map<String, String> topicConfigs
     ) {
-        return !(disklessEnabled
+        return !(disklessEnabled(topicConfigs)
             || ReplicationControlManager.isSystemTopic(topicName)
             || topicExcludedByRegex(topicName)
             || cleanupPolicyContainsCompact(topicConfigs));
+    }
+
+    private boolean disklessEnabled(final Map<String, String> topicConfigs) {
+        final String disklessEnableConfigValue = topicConfigs.get(TopicConfig.DISKLESS_ENABLE_CONFIG);
+        if (disklessEnableConfigValue != null) {
+            return Boolean.parseBoolean(disklessEnableConfigValue);
+        }
+        return defaultDisklessEnable;
     }
 
     private boolean cleanupPolicyContainsCompact(final Map<String, String> topicConfigs) {

--- a/metadata/src/main/java/org/apache/kafka/controller/CreateTopicConfigInterceptor.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/CreateTopicConfigInterceptor.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.controller;
+
+import org.apache.kafka.clients.admin.AlterConfigOp.OpType;
+
+import java.util.Map;
+import java.util.Map.Entry;
+
+/**
+ * Interface for intercepting CREATE_TOPICS API requests and mutating the topic configs.
+ *
+ * <p>Interceptors are chained and executed in order. Only the first interceptor that matches
+ * (returns {@code true}) is applied; subsequent interceptors in the chain are skipped.
+ *
+ * <p>Each interceptor is controlled by a Controller config that enables or disables it.
+ */
+public interface CreateTopicConfigInterceptor {
+
+    /**
+     * Intercept topic creation and potentially mutate the target config operations.
+     * This variant is used when building config records for persistence.
+     *
+     * @param topicName the name of the topic being created
+     * @param requestConfigs the configs from the create topic request
+     * @param targetConfigOps the mutable map of config operations to apply; interceptors may add entries
+     * @return {@code true} if this interceptor matched and applied mutations, {@code false} otherwise
+     */
+    boolean intercept(
+        String topicName,
+        Map<String, String> requestConfigs,
+        Map<String, Entry<OpType, String>> targetConfigOps
+    );
+
+    /**
+     * Intercept topic creation and potentially mutate the target configs map directly.
+     * This variant is used for validation and response payload generation.
+     *
+     * @param topicName the name of the topic being created
+     * @param targetConfigs the mutable map of topic configs; interceptors may add or modify entries
+     * @return {@code true} if this interceptor matched and applied mutations, {@code false} otherwise
+     */
+    boolean intercept(
+        String topicName,
+        Map<String, String> targetConfigs
+    );
+}

--- a/metadata/src/main/java/org/apache/kafka/controller/CreateTopicConfigInterceptors.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/CreateTopicConfigInterceptors.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.controller;
+
+import org.apache.kafka.clients.admin.AlterConfigOp.OpType;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+/**
+ * Container for CREATE_TOPICS config interceptors. Interceptors are chained and executed in order;
+ * only the first interceptor that matches a topic is applied (first-match-wins).
+ */
+final class CreateTopicConfigInterceptors {
+    static final CreateTopicConfigInterceptors EMPTY = new CreateTopicConfigInterceptors(List.of());
+
+    private final List<CreateTopicConfigInterceptor> interceptors;
+
+    private CreateTopicConfigInterceptors(final List<CreateTopicConfigInterceptor> interceptors) {
+        this.interceptors = interceptors;
+    }
+
+    /**
+     * Creates the interceptors chain based on the provided configuration.
+     *
+     * @param classicRemoteStorageForceEnabled whether the remote storage force interceptor is enabled
+     * @param classicRemoteStorageForceExcludeTopicRegexes topic regexes to exclude from remote storage forcing
+     * @param defaultDisklessEnable whether diskless is enabled by default
+     * @return the configured interceptors chain
+     */
+    static CreateTopicConfigInterceptors create(
+        final boolean classicRemoteStorageForceEnabled,
+        final List<String> classicRemoteStorageForceExcludeTopicRegexes,
+        final boolean defaultDisklessEnable
+    ) {
+        final List<CreateTopicConfigInterceptor> chain = new ArrayList<>();
+        if (classicRemoteStorageForceEnabled) {
+            chain.add(new ClassicTopicRemoteStorageForceCreateTopicInterceptor(classicRemoteStorageForceExcludeTopicRegexes, defaultDisklessEnable));
+        }
+        if (chain.isEmpty()) {
+            return EMPTY;
+        }
+        return new CreateTopicConfigInterceptors(List.copyOf(chain));
+    }
+
+    /**
+     * Apply the interceptor chain. The first interceptor that matches the topic is applied;
+     * subsequent interceptors are skipped.
+     *
+     * @param topicName the name of the topic being created
+     * @param requestConfigs the configs from the create topic request
+     * @param targetConfigOps the mutable map of config operations to apply
+     */
+    void intercept(
+        final String topicName,
+        final Map<String, String> requestConfigs,
+        final Map<String, Entry<OpType, String>> targetConfigOps
+    ) {
+        for (CreateTopicConfigInterceptor interceptor : interceptors) {
+            if (interceptor.intercept(topicName, requestConfigs, targetConfigOps)) {
+                return;
+            }
+        }
+    }
+
+    /**
+     * Apply the interceptor chain. The first interceptor that matches the topic is applied;
+     * subsequent interceptors are skipped.
+     *
+     * @param topicName the name of the topic being created
+     * @param targetConfigs the mutable map of topic configs
+     */
+    void intercept(
+        final String topicName,
+        final Map<String, String> targetConfigs
+    ) {
+        for (CreateTopicConfigInterceptor interceptor : interceptors) {
+            if (interceptor.intercept(topicName, targetConfigs)) {
+                return;
+            }
+        }
+    }
+}

--- a/metadata/src/main/java/org/apache/kafka/controller/CreateTopicConfigInterceptors.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/CreateTopicConfigInterceptors.java
@@ -19,6 +19,9 @@ package org.apache.kafka.controller;
 
 import org.apache.kafka.clients.admin.AlterConfigOp.OpType;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -32,6 +35,8 @@ import java.util.Map.Entry;
  * This ensures that topics matching the diskless allow list are not also forced to remote storage.
  */
 final class CreateTopicConfigInterceptors {
+    private static final Logger LOG = LoggerFactory.getLogger(CreateTopicConfigInterceptors.class);
+
     static final CreateTopicConfigInterceptors EMPTY = new CreateTopicConfigInterceptors(List.of());
 
     private final List<CreateTopicConfigInterceptor> interceptors;
@@ -48,6 +53,7 @@ final class CreateTopicConfigInterceptors {
      * @param classicRemoteStorageForceEnabled whether the remote storage force interceptor is enabled
      * @param classicRemoteStorageForceExcludeTopicRegexes topic regexes to exclude from remote storage forcing
      * @param defaultDisklessEnable whether diskless is enabled by default
+     * @param disklessStorageSystemEnabled whether the system-level diskless storage is enabled
      * @param disklessForceEnabled whether the diskless force interceptor is enabled
      * @param disklessForceIncludeTopicRegexes topic regexes that define the allow list for diskless forcing
      * @return the configured interceptors chain
@@ -56,13 +62,19 @@ final class CreateTopicConfigInterceptors {
         final boolean classicRemoteStorageForceEnabled,
         final List<String> classicRemoteStorageForceExcludeTopicRegexes,
         final boolean defaultDisklessEnable,
+        final boolean disklessStorageSystemEnabled,
         final boolean disklessForceEnabled,
         final List<String> disklessForceIncludeTopicRegexes
     ) {
         final List<CreateTopicConfigInterceptor> chain = new ArrayList<>();
         // Diskless interceptor is first in the chain (higher priority)
         if (disklessForceEnabled) {
-            chain.add(new DisklessForceCreateTopicInterceptor(disklessForceIncludeTopicRegexes));
+            if (disklessStorageSystemEnabled) {
+                chain.add(new DisklessForceCreateTopicInterceptor(disklessForceIncludeTopicRegexes));
+            } else {
+                LOG.warn("diskless.force.enable is set to true but system-level diskless storage is not enabled. " +
+                    "The diskless force interceptor will not be activated.");
+            }
         }
         if (classicRemoteStorageForceEnabled) {
             chain.add(new ClassicTopicRemoteStorageForceCreateTopicInterceptor(classicRemoteStorageForceExcludeTopicRegexes, defaultDisklessEnable));

--- a/metadata/src/main/java/org/apache/kafka/controller/CreateTopicConfigInterceptors.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/CreateTopicConfigInterceptors.java
@@ -27,6 +27,9 @@ import java.util.Map.Entry;
 /**
  * Container for CREATE_TOPICS config interceptors. Interceptors are chained and executed in order;
  * only the first interceptor that matches a topic is applied (first-match-wins).
+ *
+ * <p>The chain order is: diskless force interceptor first, then remote storage force interceptor.
+ * This ensures that topics matching the diskless allow list are not also forced to remote storage.
  */
 final class CreateTopicConfigInterceptors {
     static final CreateTopicConfigInterceptors EMPTY = new CreateTopicConfigInterceptors(List.of());
@@ -39,18 +42,28 @@ final class CreateTopicConfigInterceptors {
 
     /**
      * Creates the interceptors chain based on the provided configuration.
+     * The diskless force interceptor is placed first in the chain so that matching topics
+     * are handled by it before the remote storage force interceptor is considered.
      *
      * @param classicRemoteStorageForceEnabled whether the remote storage force interceptor is enabled
      * @param classicRemoteStorageForceExcludeTopicRegexes topic regexes to exclude from remote storage forcing
      * @param defaultDisklessEnable whether diskless is enabled by default
+     * @param disklessForceEnabled whether the diskless force interceptor is enabled
+     * @param disklessForceIncludeTopicRegexes topic regexes that define the allow list for diskless forcing
      * @return the configured interceptors chain
      */
     static CreateTopicConfigInterceptors create(
         final boolean classicRemoteStorageForceEnabled,
         final List<String> classicRemoteStorageForceExcludeTopicRegexes,
-        final boolean defaultDisklessEnable
+        final boolean defaultDisklessEnable,
+        final boolean disklessForceEnabled,
+        final List<String> disklessForceIncludeTopicRegexes
     ) {
         final List<CreateTopicConfigInterceptor> chain = new ArrayList<>();
+        // Diskless interceptor is first in the chain (higher priority)
+        if (disklessForceEnabled) {
+            chain.add(new DisklessForceCreateTopicInterceptor(disklessForceIncludeTopicRegexes));
+        }
         if (classicRemoteStorageForceEnabled) {
             chain.add(new ClassicTopicRemoteStorageForceCreateTopicInterceptor(classicRemoteStorageForceExcludeTopicRegexes, defaultDisklessEnable));
         }

--- a/metadata/src/main/java/org/apache/kafka/controller/DisklessForceCreateTopicInterceptor.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/DisklessForceCreateTopicInterceptor.java
@@ -34,6 +34,7 @@ import static org.apache.kafka.clients.admin.AlterConfigOp.OpType.SET;
  *
  * <p>Excluded from forcing:
  * <ul>
+ *   <li>Topics starting with "__"</li>
  *   <li>System topics (as determined by {@link ReplicationControlManager#isSystemTopic})</li>
  *   <li>Topics with a cleanup policy containing "compact"</li>
  * </ul>

--- a/metadata/src/main/java/org/apache/kafka/controller/DisklessForceCreateTopicInterceptor.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/DisklessForceCreateTopicInterceptor.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.controller;
+
+import org.apache.kafka.clients.admin.AlterConfigOp.OpType;
+import org.apache.kafka.common.config.TopicConfig;
+
+import java.util.AbstractMap.SimpleImmutableEntry;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.regex.Pattern;
+
+import static org.apache.kafka.clients.admin.AlterConfigOp.OpType.SET;
+
+/**
+ * A {@link CreateTopicConfigInterceptor} that forces {@code diskless.enable=true} on topics
+ * whose names match at least one regex in the configured allow list.
+ *
+ * <p>Excluded from forcing:
+ * <ul>
+ *   <li>System topics (as determined by {@link ReplicationControlManager#isSystemTopic})</li>
+ *   <li>Topics with a cleanup policy containing "compact"</li>
+ * </ul>
+ *
+ * <p>Controlled by the {@code diskless.force.enable} config, with the allow list
+ * specified via {@code diskless.force.include.topic.regexes}.
+ */
+final class DisklessForceCreateTopicInterceptor implements CreateTopicConfigInterceptor {
+    private final List<Pattern> includeTopicPatterns;
+
+    /**
+     * @param includeTopicRegexes list of regexes; topics matching at least one are forced to diskless.
+     */
+    DisklessForceCreateTopicInterceptor(final List<String> includeTopicRegexes) {
+        this.includeTopicPatterns = includeTopicRegexes.stream().map(Pattern::compile).toList();
+    }
+
+    @Override
+    public boolean intercept(
+        final String topicName,
+        final Map<String, String> requestConfigs,
+        final Map<String, Entry<OpType, String>> targetConfigOps
+    ) {
+        if (shouldForceDisklessEnable(topicName, requestConfigs)) {
+            targetConfigOps.put(TopicConfig.DISKLESS_ENABLE_CONFIG, new SimpleImmutableEntry<>(SET, "true"));
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public boolean intercept(
+        final String topicName,
+        final Map<String, String> targetConfigs
+    ) {
+        if (shouldForceDisklessEnable(topicName, targetConfigs)) {
+            targetConfigs.put(TopicConfig.DISKLESS_ENABLE_CONFIG, "true");
+            return true;
+        }
+        return false;
+    }
+
+    private boolean shouldForceDisklessEnable(
+        final String topicName,
+        final Map<String, String> topicConfigs
+    ) {
+        if (topicName.startsWith("__")) {
+            return false;
+        }
+        if (ReplicationControlManager.isSystemTopic(topicName)) {
+            return false;
+        }
+        if (cleanupPolicyContainsCompact(topicConfigs)) {
+            return false;
+        }
+        return topicMatchesIncludeRegex(topicName);
+    }
+
+    private boolean topicMatchesIncludeRegex(final String topicName) {
+        for (Pattern pattern : includeTopicPatterns) {
+            if (pattern.matcher(topicName).matches()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean cleanupPolicyContainsCompact(final Map<String, String> topicConfigs) {
+        final String cleanupPolicy = topicConfigs.get(TopicConfig.CLEANUP_POLICY_CONFIG);
+        if (cleanupPolicy == null || cleanupPolicy.isEmpty()) {
+            return false;
+        }
+        for (String policy : cleanupPolicy.split(",")) {
+            if (TopicConfig.CLEANUP_POLICY_COMPACT.equals(policy.trim())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+}

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -230,6 +230,8 @@ public final class QuorumController implements Controller {
         private boolean disklessRemoteStorageConsolidationEnabled = false;
         private boolean classicRemoteStorageForceEnabled = false;
         private List<String> classicRemoteStorageForceExcludeTopicRegexes = List.of();
+        private boolean disklessForceEnabled = false;
+        private List<String> disklessForceIncludeTopicRegexes = List.of();
 
         public Builder(int nodeId, String clusterId) {
             this.nodeId = nodeId;
@@ -317,6 +319,16 @@ public final class QuorumController implements Controller {
 
         public Builder setClassicRemoteStorageForceExcludeTopicRegexes(List<String> classicRemoteStorageForceExcludeTopicRegexes) {
             this.classicRemoteStorageForceExcludeTopicRegexes = classicRemoteStorageForceExcludeTopicRegexes;
+            return this;
+        }
+
+        public Builder setDisklessForceEnabled(boolean disklessForceEnabled) {
+            this.disklessForceEnabled = disklessForceEnabled;
+            return this;
+        }
+
+        public Builder setDisklessForceIncludeTopicRegexes(List<String> disklessForceIncludeTopicRegexes) {
+            this.disklessForceIncludeTopicRegexes = disklessForceIncludeTopicRegexes;
             return this;
         }
 
@@ -473,6 +485,8 @@ public final class QuorumController implements Controller {
                     disklessRemoteStorageConsolidationEnabled,
                     classicRemoteStorageForceEnabled,
                     classicRemoteStorageForceExcludeTopicRegexes,
+                    disklessForceEnabled,
+                    disklessForceIncludeTopicRegexes,
                     replicaPlacer,
                     leaderImbalanceCheckIntervalNs,
                     maxIdleIntervalNs,
@@ -1518,6 +1532,8 @@ public final class QuorumController implements Controller {
         boolean disklessRemoteStorageConsolidationEnabled,
         boolean classicRemoteStorageForceEnabled,
         List<String> classicRemoteStorageForceExcludeTopicRegexes,
+        boolean disklessForceEnabled,
+        List<String> disklessForceIncludeTopicRegexes,
         ReplicaPlacer replicaPlacer,
         OptionalLong leaderImbalanceCheckIntervalNs,
         OptionalLong maxIdleIntervalNs,
@@ -1606,6 +1622,8 @@ public final class QuorumController implements Controller {
             setDisklessRemoteStorageConsolidationEnabled(disklessRemoteStorageConsolidationEnabled).
             setClassicRemoteStorageForceEnabled(classicRemoteStorageForceEnabled).
             setClassicRemoteStorageForceExcludeTopicRegexes(classicRemoteStorageForceExcludeTopicRegexes).
+            setDisklessForceEnabled(disklessForceEnabled).
+            setDisklessForceIncludeTopicRegexes(disklessForceIncludeTopicRegexes).
             setMaxElectionsPerImbalance(ReplicationControlManager.MAX_ELECTIONS_PER_IMBALANCE).
             setConfigurationControl(configurationControl).
             setClusterControl(clusterControl).

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -180,6 +180,8 @@ public class ReplicationControlManager {
         private boolean isDisklessRemoteStorageConsolidationEnabled = false;
         private boolean classicRemoteStorageForceEnabled = false;
         private List<String> classicRemoteStorageForceExcludeTopicRegexes = List.of();
+        private boolean disklessForceEnabled = false;
+        private List<String> disklessForceIncludeTopicRegexes = List.of();
 
         private int maxElectionsPerImbalance = MAX_ELECTIONS_PER_IMBALANCE;
         private ConfigurationControlManager configurationControl = null;
@@ -237,6 +239,16 @@ public class ReplicationControlManager {
             return this;
         }
 
+        public Builder setDisklessForceEnabled(boolean disklessForceEnabled) {
+            this.disklessForceEnabled = disklessForceEnabled;
+            return this;
+        }
+
+        public Builder setDisklessForceIncludeTopicRegexes(List<String> disklessForceIncludeTopicRegexes) {
+            this.disklessForceIncludeTopicRegexes = disklessForceIncludeTopicRegexes;
+            return this;
+        }
+
         Builder setMaxElectionsPerImbalance(int maxElectionsPerImbalance) {
             this.maxElectionsPerImbalance = maxElectionsPerImbalance;
             return this;
@@ -283,6 +295,8 @@ public class ReplicationControlManager {
                 isDisklessRemoteStorageConsolidationEnabled,
                 classicRemoteStorageForceEnabled,
                 classicRemoteStorageForceExcludeTopicRegexes,
+                disklessForceEnabled,
+                disklessForceIncludeTopicRegexes,
                 maxElectionsPerImbalance,
                 configurationControl,
                 clusterControl,
@@ -473,6 +487,8 @@ public class ReplicationControlManager {
         boolean isDisklessRemoteStorageConsolidationEnabled,
         boolean classicRemoteStorageForceEnabled,
         List<String> classicRemoteStorageForceExcludeTopicRegexes,
+        boolean disklessForceEnabled,
+        List<String> disklessForceIncludeTopicRegexes,
         int maxElectionsPerImbalance,
         ConfigurationControlManager configurationControl,
         ClusterControlManager clusterControl,
@@ -490,7 +506,9 @@ public class ReplicationControlManager {
         this.createTopicConfigInterceptors = CreateTopicConfigInterceptors.create(
             classicRemoteStorageForceEnabled,
             classicRemoteStorageForceExcludeTopicRegexes,
-            defaultDisklessEnable
+            defaultDisklessEnable,
+            disklessForceEnabled,
+            disklessForceIncludeTopicRegexes
         );
         this.maxElectionsPerImbalance = maxElectionsPerImbalance;
         this.configurationControl = configurationControl;

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -370,7 +370,7 @@ public class ReplicationControlManager {
      * classic tiered storage behavior, which is controlled by {@code classicTopicRemoteStorageForcePolicy}.
      */
     private final boolean isDisklessRemoteStorageConsolidationEnabled;
-    private final ClassicTopicRemoteStorageForcePolicy classicTopicRemoteStorageForcePolicy;
+    private final CreateTopicConfigInterceptors createTopicConfigInterceptors;
 
     /**
      * When true, diskless topics use managed replicas with user-defined RF
@@ -487,9 +487,10 @@ public class ReplicationControlManager {
         this.isDisklessStorageSystemEnabled = isDisklessStorageSystemEnabled;
         this.isDisklessManagedReplicasEnabled = isDisklessManagedReplicasEnabled;
         this.isDisklessRemoteStorageConsolidationEnabled = isDisklessRemoteStorageConsolidationEnabled;
-        this.classicTopicRemoteStorageForcePolicy = new ClassicTopicRemoteStorageForcePolicy(
+        this.createTopicConfigInterceptors = CreateTopicConfigInterceptors.create(
             classicRemoteStorageForceEnabled,
-            classicRemoteStorageForceExcludeTopicRegexes
+            classicRemoteStorageForceExcludeTopicRegexes,
+            defaultDisklessEnable
         );
         this.maxElectionsPerImbalance = maxElectionsPerImbalance;
         this.configurationControl = configurationControl;
@@ -752,17 +753,15 @@ public class ReplicationControlManager {
             // Figure out what ConfigRecords should be created, if any.
             ConfigResource configResource = new ConfigResource(TOPIC, topic.name());
             Map<String, Entry<OpType, String>> keyToOps = configChanges.get(configResource);
-            // Add remote.storage.enable=true to config records if ClassicTopicRemoteStorageForcePolicy is enabled
+            // Apply CREATE_TOPICS config interceptors (e.g. remote storage force)
             final Map<String, String> requestConfigs = new HashMap<>(translateCreationConfigs(topic.configs()));
-            final boolean disklessEnabled = disklessEnabledOnTopicCreation(requestConfigs);
             if (keyToOps == null) {
                 keyToOps = new HashMap<>();
             } else {
                 keyToOps = new HashMap<>(keyToOps);
             }
-            classicTopicRemoteStorageForcePolicy.maybeForceRemoteStorageEnable(
+            createTopicConfigInterceptors.intercept(
                 topic.name(),
-                disklessEnabled,
                 requestConfigs,
                 keyToOps
             );
@@ -831,14 +830,13 @@ public class ReplicationControlManager {
                                  List<ApiMessageAndVersion> configRecords,
                                  boolean authorizedToReturnConfigs) {
         final Map<String, String> creationConfigs = new HashMap<>(translateCreationConfigs(topic.configs()));
-        // Configs here are rebuilt from the request (creationConfigs).
-        // Re-apply ClassicTopicRemoteStorageForcePolicy on this creation configs view for validations and to include forced configs in the response payload.
-        final boolean disklessEnabledOnCreation = disklessEnabledOnTopicCreation(creationConfigs);
-        classicTopicRemoteStorageForcePolicy.maybeForceRemoteStorageEnable(topic.name(), disklessEnabledOnCreation, creationConfigs);
+        // Re-apply CREATE_TOPICS config interceptors on this creation configs view for validations and to include forced configs in the response payload.
+        createTopicConfigInterceptors.intercept(topic.name(), creationConfigs);
         // Include remote.storage.enable=true in creationConfigs for diskless topics.
         // This affects the CreateTopicsResponse effective-config view and topic policy checks.
         // The actual persistence happens in validConfigRecords() via ConfigRecord.
         // Exclude system topics — they are never diskless regardless of defaultDisklessEnable.
+        final boolean disklessEnabledOnCreation = disklessEnabledOnTopicCreation(creationConfigs);
         if (disklessEnabledOnCreation &&
                 isDisklessRemoteStorageConsolidationEnabled &&
                 !isSystemTopic(topic.name())) {

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -507,6 +507,7 @@ public class ReplicationControlManager {
             classicRemoteStorageForceEnabled,
             classicRemoteStorageForceExcludeTopicRegexes,
             defaultDisklessEnable,
+            isDisklessStorageSystemEnabled,
             disklessForceEnabled,
             disklessForceIncludeTopicRegexes
         );

--- a/metadata/src/test/java/org/apache/kafka/controller/ClassicTopicRemoteStorageForceCreateTopicInterceptorTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ClassicTopicRemoteStorageForceCreateTopicInterceptorTest.java
@@ -33,38 +33,24 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-public class ClassicTopicRemoteStorageForcePolicyTest {
+public class ClassicTopicRemoteStorageForceCreateTopicInterceptorTest {
     @Test
     public void forcesRemoteStorageForClassicTopic() {
-        final var policy = new ClassicTopicRemoteStorageForcePolicy(true, List.of());
+        final var interceptor = new ClassicTopicRemoteStorageForceCreateTopicInterceptor(List.of(), false);
         final String topicName = "classic-topic-force-enabled";
         final Map<String, String> requestConfigs = new HashMap<>();
         final Map<String, Entry<OpType, String>> targetConfigOps = new HashMap<>();
         final Map<String, String> targetConfigs = new HashMap<>();
 
-        policy.maybeForceRemoteStorageEnable(topicName, false, requestConfigs, targetConfigOps);
-        policy.maybeForceRemoteStorageEnable(topicName, false, targetConfigs);
+        interceptor.intercept(topicName, requestConfigs, targetConfigOps);
+        interceptor.intercept(topicName, targetConfigs);
 
         assertRemoteStorageEnabled(targetConfigOps, targetConfigs);
     }
 
     @Test
-    public void doesNotForceWhenPolicyDisabled() {
-        final var policy = new ClassicTopicRemoteStorageForcePolicy(false, List.of());
-        final String topicName = "classic-topic-policy-disabled";
-        final Map<String, String> requestConfigs = new HashMap<>();
-        final Map<String, Entry<OpType, String>> targetConfigOps = new HashMap<>();
-        final Map<String, String> targetConfigs = new HashMap<>();
-
-        policy.maybeForceRemoteStorageEnable(topicName, false, requestConfigs, targetConfigOps);
-        policy.maybeForceRemoteStorageEnable(topicName, false, targetConfigs);
-
-        assertRemoteStorageDisabled(targetConfigOps, targetConfigs);
-    }
-
-    @Test
     public void doesNotForceForCompactedTopicCleanupPolicyCompact() {
-        final var policy = new ClassicTopicRemoteStorageForcePolicy(true, List.of());
+        final var interceptor = new ClassicTopicRemoteStorageForceCreateTopicInterceptor(List.of(), false);
         final String topicName = "compacted-topic-only-compact";
         final Map<String, String> requestConfigs = Map.of(
             TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_COMPACT
@@ -72,15 +58,15 @@ public class ClassicTopicRemoteStorageForcePolicyTest {
         final Map<String, Entry<OpType, String>> targetConfigOps = new HashMap<>();
         final Map<String, String> targetConfigs = new HashMap<>(requestConfigs);
 
-        policy.maybeForceRemoteStorageEnable(topicName, false, requestConfigs, targetConfigOps);
-        policy.maybeForceRemoteStorageEnable(topicName, false, targetConfigs);
+        interceptor.intercept(topicName, requestConfigs, targetConfigOps);
+        interceptor.intercept(topicName, targetConfigs);
 
         assertRemoteStorageDisabled(targetConfigOps, targetConfigs);
     }
 
     @Test
     public void doesNotForceForCompactedTopicCleanupPolicyDeleteCompact() {
-        final var policy = new ClassicTopicRemoteStorageForcePolicy(true, List.of());
+        final var interceptor = new ClassicTopicRemoteStorageForceCreateTopicInterceptor(List.of(), false);
         final String topicName = "compacted-topic-delete-compact";
         final Map<String, String> requestConfigs = Map.of(
             TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_DELETE + ", " + TopicConfig.CLEANUP_POLICY_COMPACT
@@ -88,15 +74,15 @@ public class ClassicTopicRemoteStorageForcePolicyTest {
         final Map<String, Entry<OpType, String>> targetConfigOps = new HashMap<>();
         final Map<String, String> targetConfigs = new HashMap<>(requestConfigs);
 
-        policy.maybeForceRemoteStorageEnable(topicName, false, requestConfigs, targetConfigOps);
-        policy.maybeForceRemoteStorageEnable(topicName, false, targetConfigs);
+        interceptor.intercept(topicName, requestConfigs, targetConfigOps);
+        interceptor.intercept(topicName, targetConfigs);
 
         assertRemoteStorageDisabled(targetConfigOps, targetConfigs);
     }
 
     @Test
     public void doesNotForceForCompactedTopicCleanupPolicyCompactDelete() {
-        final var policy = new ClassicTopicRemoteStorageForcePolicy(true, List.of());
+        final var interceptor = new ClassicTopicRemoteStorageForceCreateTopicInterceptor(List.of(), false);
         final String topicName = "compacted-topic-compact-delete";
         final Map<String, String> requestConfigs = Map.of(
             TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_COMPACT + "," + TopicConfig.CLEANUP_POLICY_DELETE
@@ -104,27 +90,27 @@ public class ClassicTopicRemoteStorageForcePolicyTest {
         final Map<String, Entry<OpType, String>> targetConfigOps = new HashMap<>();
         final Map<String, String> targetConfigs = new HashMap<>(requestConfigs);
 
-        policy.maybeForceRemoteStorageEnable(topicName, false, requestConfigs, targetConfigOps);
-        policy.maybeForceRemoteStorageEnable(topicName, false, targetConfigs);
+        interceptor.intercept(topicName, requestConfigs, targetConfigOps);
+        interceptor.intercept(topicName, targetConfigs);
 
         assertRemoteStorageDisabled(targetConfigOps, targetConfigs);
     }
 
     @Test
     public void doesNotForceForExcludedTopicRegex() {
-        final var policy = new ClassicTopicRemoteStorageForcePolicy(true, List.of("_schemas", "mm2-(.*)"));
+        final var interceptor = new ClassicTopicRemoteStorageForceCreateTopicInterceptor(List.of("_schemas", "mm2-(.*)"), false);
         final Map<String, Entry<OpType, String>> targetConfigOps = new HashMap<>();
         final Map<String, String> targetConfigs = new HashMap<>();
 
-        policy.maybeForceRemoteStorageEnable("_schemas", false, Map.of(), targetConfigOps);
-        policy.maybeForceRemoteStorageEnable("mm2-heartbeats", false, targetConfigs);
+        interceptor.intercept("_schemas", Map.of(), targetConfigOps);
+        interceptor.intercept("mm2-heartbeats", targetConfigs);
 
         assertRemoteStorageDisabled(targetConfigOps, targetConfigs);
     }
 
     @Test
     public void doesNotForceForCompactedExcludedTopicRegex() {
-        final var policy = new ClassicTopicRemoteStorageForcePolicy(true, List.of("_schemas", "mm2-(.*)"));
+        final var interceptor = new ClassicTopicRemoteStorageForceCreateTopicInterceptor(List.of("_schemas", "mm2-(.*)"), false);
         final String topicName = "_schemas";
         final Map<String, String> compactedConfigs = Map.of(
             TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_COMPACT
@@ -132,29 +118,43 @@ public class ClassicTopicRemoteStorageForcePolicyTest {
         final Map<String, Entry<OpType, String>> targetConfigOps = new HashMap<>();
         final Map<String, String> targetConfigs = new HashMap<>(compactedConfigs);
 
-        policy.maybeForceRemoteStorageEnable(topicName, false, compactedConfigs, targetConfigOps);
-        policy.maybeForceRemoteStorageEnable(topicName, false, targetConfigs);
+        interceptor.intercept(topicName, compactedConfigs, targetConfigOps);
+        interceptor.intercept(topicName, targetConfigs);
 
         assertRemoteStorageDisabled(targetConfigOps, targetConfigs);
     }
 
     @Test
-    public void doesNotForceForDisklessTopic() {
-        final var policy = new ClassicTopicRemoteStorageForcePolicy(true, List.of());
+    public void doesNotForceForDisklessTopicExplicit() {
+        final var interceptor = new ClassicTopicRemoteStorageForceCreateTopicInterceptor(List.of(), false);
         final String topicName = "diskless-topic";
+        final Map<String, String> requestConfigs = new HashMap<>(Map.of(TopicConfig.DISKLESS_ENABLE_CONFIG, "true"));
+        final Map<String, Entry<OpType, String>> targetConfigOps = new HashMap<>();
+        final Map<String, String> targetConfigs = new HashMap<>(Map.of(TopicConfig.DISKLESS_ENABLE_CONFIG, "true"));
+
+        interceptor.intercept(topicName, requestConfigs, targetConfigOps);
+        interceptor.intercept(topicName, targetConfigs);
+
+        assertRemoteStorageDisabled(targetConfigOps, targetConfigs);
+    }
+
+    @Test
+    public void doesNotForceForDisklessTopicByDefault() {
+        final var interceptor = new ClassicTopicRemoteStorageForceCreateTopicInterceptor(List.of(), true);
+        final String topicName = "diskless-topic-by-default";
         final Map<String, String> requestConfigs = new HashMap<>();
         final Map<String, Entry<OpType, String>> targetConfigOps = new HashMap<>();
         final Map<String, String> targetConfigs = new HashMap<>();
 
-        policy.maybeForceRemoteStorageEnable(topicName, true, requestConfigs, targetConfigOps);
-        policy.maybeForceRemoteStorageEnable(topicName, true, targetConfigs);
+        interceptor.intercept(topicName, requestConfigs, targetConfigOps);
+        interceptor.intercept(topicName, targetConfigs);
 
         assertRemoteStorageDisabled(targetConfigOps, targetConfigs);
     }
 
     @Test
     public void doesNotForceForAllExcludedInternalTopics() {
-        final var policy = new ClassicTopicRemoteStorageForcePolicy(true, List.of());
+        final var interceptor = new ClassicTopicRemoteStorageForceCreateTopicInterceptor(List.of(), false);
         for (String topicName : List.of(
             Topic.GROUP_METADATA_TOPIC_NAME,
             Topic.TRANSACTION_STATE_TOPIC_NAME,
@@ -166,8 +166,8 @@ public class ClassicTopicRemoteStorageForcePolicyTest {
             final Map<String, Entry<OpType, String>> targetConfigOps = new HashMap<>();
             final Map<String, String> targetConfigs = new HashMap<>();
 
-            policy.maybeForceRemoteStorageEnable(topicName, false, requestConfigs, targetConfigOps);
-            policy.maybeForceRemoteStorageEnable(topicName, false, targetConfigs);
+            interceptor.intercept(topicName, requestConfigs, targetConfigOps);
+            interceptor.intercept(topicName, targetConfigs);
 
             assertRemoteStorageDisabled(targetConfigOps, targetConfigs);
         }

--- a/metadata/src/test/java/org/apache/kafka/controller/CreateTopicConfigInterceptorsTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/CreateTopicConfigInterceptorsTest.java
@@ -50,7 +50,7 @@ public class CreateTopicConfigInterceptorsTest {
 
     @Test
     public void noInterceptorWhenDisabled() {
-        final var interceptors = CreateTopicConfigInterceptors.create(false, List.of(), false, false, List.of());
+        final var interceptors = CreateTopicConfigInterceptors.create(false, List.of(), false, false, false, List.of());
         final Map<String, String> targetConfigs = new HashMap<>();
 
         interceptors.intercept("test-topic", targetConfigs);
@@ -60,7 +60,7 @@ public class CreateTopicConfigInterceptorsTest {
 
     @Test
     public void remoteStorageInterceptorAppliesWhenEnabled() {
-        final var interceptors = CreateTopicConfigInterceptors.create(true, List.of(), false, false, List.of());
+        final var interceptors = CreateTopicConfigInterceptors.create(true, List.of(), false, false, false, List.of());
         final Map<String, String> requestConfigs = new HashMap<>();
         final Map<String, Entry<OpType, String>> targetConfigOps = new HashMap<>();
         final Map<String, String> targetConfigs = new HashMap<>();
@@ -74,7 +74,7 @@ public class CreateTopicConfigInterceptorsTest {
 
     @Test
     public void remoteStorageInterceptorDoesNotApplyForExcludedTopic() {
-        final var interceptors = CreateTopicConfigInterceptors.create(true, List.of("excluded-.*"), false, false, List.of());
+        final var interceptors = CreateTopicConfigInterceptors.create(true, List.of("excluded-.*"), false, false, false, List.of());
         final Map<String, String> requestConfigs = new HashMap<>();
         final Map<String, Entry<OpType, String>> targetConfigOps = new HashMap<>();
         final Map<String, String> targetConfigs = new HashMap<>();
@@ -88,7 +88,7 @@ public class CreateTopicConfigInterceptorsTest {
 
     @Test
     public void disklessInterceptorAppliesWhenEnabledAndTopicMatches() {
-        final var interceptors = CreateTopicConfigInterceptors.create(false, List.of(), false, true, List.of("my-topic-.*"));
+        final var interceptors = CreateTopicConfigInterceptors.create(false, List.of(), false, true, true, List.of("my-topic-.*"));
         final Map<String, String> requestConfigs = new HashMap<>();
         final Map<String, Entry<OpType, String>> targetConfigOps = new HashMap<>();
         final Map<String, String> targetConfigs = new HashMap<>();
@@ -102,7 +102,7 @@ public class CreateTopicConfigInterceptorsTest {
 
     @Test
     public void disklessInterceptorDoesNotApplyWhenTopicDoesNotMatch() {
-        final var interceptors = CreateTopicConfigInterceptors.create(false, List.of(), false, true, List.of("my-topic-.*"));
+        final var interceptors = CreateTopicConfigInterceptors.create(false, List.of(), false, true, true, List.of("my-topic-.*"));
         final Map<String, String> targetConfigs = new HashMap<>();
 
         interceptors.intercept("other-topic", targetConfigs);
@@ -115,7 +115,7 @@ public class CreateTopicConfigInterceptorsTest {
         // Both enabled, no explicit exclude regex needed — diskless wins by chain order
         final var interceptors = CreateTopicConfigInterceptors.create(
             true, List.of(), false,
-            true, List.of("diskless-.*")
+            true, true, List.of("diskless-.*")
         );
 
         // A classic topic (not matching diskless regex) gets remote storage forced
@@ -134,10 +134,21 @@ public class CreateTopicConfigInterceptorsTest {
     @Test
     public void disklessInterceptorSkipsTopicsWithDoubleUnderscorePrefix() {
         final CreateTopicConfigInterceptors interceptors =
-            CreateTopicConfigInterceptors.create(false, List.of(), false, true, List.of(".*"));
+            CreateTopicConfigInterceptors.create(false, List.of(), false, true, true, List.of(".*"));
 
         final Map<String, String> targetConfigs = new HashMap<>();
         interceptors.intercept("__consumer_offsets", targetConfigs);
+
+        assertNull(targetConfigs.get(TopicConfig.DISKLESS_ENABLE_CONFIG));
+    }
+
+    @Test
+    public void disklessInterceptorNotActivatedWhenSystemDisklessDisabled() {
+        // disklessForceEnabled=true but disklessStorageSystemEnabled=false
+        final var interceptors = CreateTopicConfigInterceptors.create(false, List.of(), false, false, true, List.of("my-topic-.*"));
+        final Map<String, String> targetConfigs = new HashMap<>();
+
+        interceptors.intercept("my-topic-1", targetConfigs);
 
         assertNull(targetConfigs.get(TopicConfig.DISKLESS_ENABLE_CONFIG));
     }

--- a/metadata/src/test/java/org/apache/kafka/controller/CreateTopicConfigInterceptorsTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/CreateTopicConfigInterceptorsTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.controller;
+
+import org.apache.kafka.clients.admin.AlterConfigOp.OpType;
+import org.apache.kafka.common.config.TopicConfig;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import static org.apache.kafka.clients.admin.AlterConfigOp.OpType.SET;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class CreateTopicConfigInterceptorsTest {
+
+    @Test
+    public void emptyInterceptorsDoNotModifyConfigs() {
+        final Map<String, String> requestConfigs = new HashMap<>();
+        final Map<String, Entry<OpType, String>> targetConfigOps = new HashMap<>();
+        final Map<String, String> targetConfigs = new HashMap<>();
+
+        CreateTopicConfigInterceptors.EMPTY.intercept("test-topic", requestConfigs, targetConfigOps);
+        CreateTopicConfigInterceptors.EMPTY.intercept("test-topic", targetConfigs);
+
+        assertTrue(targetConfigOps.isEmpty());
+        assertTrue(targetConfigs.isEmpty());
+    }
+
+    @Test
+    public void noInterceptorWhenDisabled() {
+        final var interceptors = CreateTopicConfigInterceptors.create(false, List.of(), false);
+        final Map<String, String> targetConfigs = new HashMap<>();
+
+        interceptors.intercept("test-topic", targetConfigs);
+
+        assertNull(targetConfigs.get(TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG));
+    }
+
+    @Test
+    public void remoteStorageInterceptorAppliesWhenEnabled() {
+        final var interceptors = CreateTopicConfigInterceptors.create(true, List.of(), false);
+        final Map<String, String> requestConfigs = new HashMap<>();
+        final Map<String, Entry<OpType, String>> targetConfigOps = new HashMap<>();
+        final Map<String, String> targetConfigs = new HashMap<>();
+
+        interceptors.intercept("test-topic", requestConfigs, targetConfigOps);
+        interceptors.intercept("test-topic", targetConfigs);
+
+        assertEquals(Map.entry(SET, "true"), targetConfigOps.get(TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG));
+        assertEquals("true", targetConfigs.get(TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG));
+    }
+
+    @Test
+    public void remoteStorageInterceptorDoesNotApplyForExcludedTopic() {
+        final var interceptors = CreateTopicConfigInterceptors.create(true, List.of("excluded-.*"), false);
+        final Map<String, String> requestConfigs = new HashMap<>();
+        final Map<String, Entry<OpType, String>> targetConfigOps = new HashMap<>();
+        final Map<String, String> targetConfigs = new HashMap<>();
+
+        interceptors.intercept("excluded-topic", requestConfigs, targetConfigOps);
+        interceptors.intercept("excluded-topic", targetConfigs);
+
+        assertFalse(targetConfigOps.containsKey(TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG));
+        assertNull(targetConfigs.get(TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG));
+    }
+}

--- a/metadata/src/test/java/org/apache/kafka/controller/CreateTopicConfigInterceptorsTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/CreateTopicConfigInterceptorsTest.java
@@ -50,7 +50,7 @@ public class CreateTopicConfigInterceptorsTest {
 
     @Test
     public void noInterceptorWhenDisabled() {
-        final var interceptors = CreateTopicConfigInterceptors.create(false, List.of(), false);
+        final var interceptors = CreateTopicConfigInterceptors.create(false, List.of(), false, false, List.of());
         final Map<String, String> targetConfigs = new HashMap<>();
 
         interceptors.intercept("test-topic", targetConfigs);
@@ -60,7 +60,7 @@ public class CreateTopicConfigInterceptorsTest {
 
     @Test
     public void remoteStorageInterceptorAppliesWhenEnabled() {
-        final var interceptors = CreateTopicConfigInterceptors.create(true, List.of(), false);
+        final var interceptors = CreateTopicConfigInterceptors.create(true, List.of(), false, false, List.of());
         final Map<String, String> requestConfigs = new HashMap<>();
         final Map<String, Entry<OpType, String>> targetConfigOps = new HashMap<>();
         final Map<String, String> targetConfigs = new HashMap<>();
@@ -74,7 +74,7 @@ public class CreateTopicConfigInterceptorsTest {
 
     @Test
     public void remoteStorageInterceptorDoesNotApplyForExcludedTopic() {
-        final var interceptors = CreateTopicConfigInterceptors.create(true, List.of("excluded-.*"), false);
+        final var interceptors = CreateTopicConfigInterceptors.create(true, List.of("excluded-.*"), false, false, List.of());
         final Map<String, String> requestConfigs = new HashMap<>();
         final Map<String, Entry<OpType, String>> targetConfigOps = new HashMap<>();
         final Map<String, String> targetConfigs = new HashMap<>();
@@ -84,5 +84,61 @@ public class CreateTopicConfigInterceptorsTest {
 
         assertFalse(targetConfigOps.containsKey(TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG));
         assertNull(targetConfigs.get(TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG));
+    }
+
+    @Test
+    public void disklessInterceptorAppliesWhenEnabledAndTopicMatches() {
+        final var interceptors = CreateTopicConfigInterceptors.create(false, List.of(), false, true, List.of("my-topic-.*"));
+        final Map<String, String> requestConfigs = new HashMap<>();
+        final Map<String, Entry<OpType, String>> targetConfigOps = new HashMap<>();
+        final Map<String, String> targetConfigs = new HashMap<>();
+
+        interceptors.intercept("my-topic-1", requestConfigs, targetConfigOps);
+        interceptors.intercept("my-topic-1", targetConfigs);
+
+        assertEquals(Map.entry(SET, "true"), targetConfigOps.get(TopicConfig.DISKLESS_ENABLE_CONFIG));
+        assertEquals("true", targetConfigs.get(TopicConfig.DISKLESS_ENABLE_CONFIG));
+    }
+
+    @Test
+    public void disklessInterceptorDoesNotApplyWhenTopicDoesNotMatch() {
+        final var interceptors = CreateTopicConfigInterceptors.create(false, List.of(), false, true, List.of("my-topic-.*"));
+        final Map<String, String> targetConfigs = new HashMap<>();
+
+        interceptors.intercept("other-topic", targetConfigs);
+
+        assertNull(targetConfigs.get(TopicConfig.DISKLESS_ENABLE_CONFIG));
+    }
+
+    @Test
+    public void disklessInterceptorTakesPriorityOverRemoteStorage() {
+        // Both enabled, no explicit exclude regex needed — diskless wins by chain order
+        final var interceptors = CreateTopicConfigInterceptors.create(
+            true, List.of(), false,
+            true, List.of("diskless-.*")
+        );
+
+        // A classic topic (not matching diskless regex) gets remote storage forced
+        final Map<String, String> classicConfigs = new HashMap<>();
+        interceptors.intercept("classic-topic", classicConfigs);
+        assertEquals("true", classicConfigs.get(TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG));
+        assertNull(classicConfigs.get(TopicConfig.DISKLESS_ENABLE_CONFIG));
+
+        // A diskless topic (matching diskless regex) gets diskless forced, NOT remote storage
+        final Map<String, String> disklessConfigs = new HashMap<>();
+        interceptors.intercept("diskless-topic", disklessConfigs);
+        assertNull(disklessConfigs.get(TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG));
+        assertEquals("true", disklessConfigs.get(TopicConfig.DISKLESS_ENABLE_CONFIG));
+    }
+
+    @Test
+    public void disklessInterceptorSkipsTopicsWithDoubleUnderscorePrefix() {
+        final CreateTopicConfigInterceptors interceptors =
+            CreateTopicConfigInterceptors.create(false, List.of(), false, true, List.of(".*"));
+
+        final Map<String, String> targetConfigs = new HashMap<>();
+        interceptors.intercept("__consumer_offsets", targetConfigs);
+
+        assertNull(targetConfigs.get(TopicConfig.DISKLESS_ENABLE_CONFIG));
     }
 }

--- a/metadata/src/test/java/org/apache/kafka/controller/DisklessForceCreateTopicInterceptorTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/DisklessForceCreateTopicInterceptorTest.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.controller;
+
+import org.apache.kafka.clients.admin.AlterConfigOp.OpType;
+import org.apache.kafka.common.config.TopicConfig;
+import org.apache.kafka.common.internals.Topic;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import static org.apache.kafka.clients.admin.AlterConfigOp.OpType.SET;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class DisklessForceCreateTopicInterceptorTest {
+
+    @Test
+    public void forcesDisklessWhenTopicMatchesRegex() {
+        final var interceptor = new DisklessForceCreateTopicInterceptor(List.of("my-topic-.*", "other-.*"));
+        final Map<String, String> requestConfigs = new HashMap<>();
+        final Map<String, Entry<OpType, String>> targetConfigOps = new HashMap<>();
+        final Map<String, String> targetConfigs = new HashMap<>();
+
+        interceptor.intercept("my-topic-1", requestConfigs, targetConfigOps);
+        interceptor.intercept("my-topic-1", targetConfigs);
+
+        assertEquals(Map.entry(SET, "true"), targetConfigOps.get(TopicConfig.DISKLESS_ENABLE_CONFIG));
+        assertEquals("true", targetConfigs.get(TopicConfig.DISKLESS_ENABLE_CONFIG));
+    }
+
+    @Test
+    public void forcesDisklessEvenWhenRequestHadDisklessFalse() {
+        final var interceptor = new DisklessForceCreateTopicInterceptor(List.of("my-topic-.*"));
+        final Map<String, String> requestConfigs = new HashMap<>(Map.of(TopicConfig.DISKLESS_ENABLE_CONFIG, "false"));
+        final Map<String, Entry<OpType, String>> targetConfigOps = new HashMap<>();
+        final Map<String, String> targetConfigs = new HashMap<>(Map.of(TopicConfig.DISKLESS_ENABLE_CONFIG, "false"));
+
+        interceptor.intercept("my-topic-1", requestConfigs, targetConfigOps);
+        interceptor.intercept("my-topic-1", targetConfigs);
+
+        assertEquals(Map.entry(SET, "true"), targetConfigOps.get(TopicConfig.DISKLESS_ENABLE_CONFIG));
+        assertEquals("true", targetConfigs.get(TopicConfig.DISKLESS_ENABLE_CONFIG));
+    }
+
+    @Test
+    public void doesNotForceWhenTopicDoesNotMatchRegex() {
+        final var interceptor = new DisklessForceCreateTopicInterceptor(List.of("my-topic-.*"));
+        final Map<String, String> requestConfigs = new HashMap<>();
+        final Map<String, Entry<OpType, String>> targetConfigOps = new HashMap<>();
+        final Map<String, String> targetConfigs = new HashMap<>();
+
+        interceptor.intercept("unmatched-topic", requestConfigs, targetConfigOps);
+        interceptor.intercept("unmatched-topic", targetConfigs);
+
+        assertFalse(targetConfigOps.containsKey(TopicConfig.DISKLESS_ENABLE_CONFIG));
+        assertNull(targetConfigs.get(TopicConfig.DISKLESS_ENABLE_CONFIG));
+    }
+
+    @Test
+    public void doesNotForceForSystemTopics() {
+        final var interceptor = new DisklessForceCreateTopicInterceptor(List.of(".*"));
+        for (String topicName : List.of(
+            Topic.GROUP_METADATA_TOPIC_NAME,
+            Topic.TRANSACTION_STATE_TOPIC_NAME,
+            Topic.SHARE_GROUP_STATE_TOPIC_NAME,
+            Topic.CLUSTER_METADATA_TOPIC_NAME,
+            "__remote_log_metadata"
+        )) {
+            final Map<String, String> requestConfigs = new HashMap<>();
+            final Map<String, Entry<OpType, String>> targetConfigOps = new HashMap<>();
+            final Map<String, String> targetConfigs = new HashMap<>();
+
+            interceptor.intercept(topicName, requestConfigs, targetConfigOps);
+            interceptor.intercept(topicName, targetConfigs);
+
+            assertFalse(targetConfigOps.containsKey(TopicConfig.DISKLESS_ENABLE_CONFIG),
+                "Should not force diskless for system topic: " + topicName);
+            assertNull(targetConfigs.get(TopicConfig.DISKLESS_ENABLE_CONFIG),
+                "Should not force diskless for system topic: " + topicName);
+        }
+    }
+
+    @Test
+    public void doesNotForceForCompactedTopic() {
+        final var interceptor = new DisklessForceCreateTopicInterceptor(List.of("my-topic-.*"));
+        final Map<String, String> requestConfigs = Map.of(
+            TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_COMPACT
+        );
+        final Map<String, Entry<OpType, String>> targetConfigOps = new HashMap<>();
+        final Map<String, String> targetConfigs = new HashMap<>(requestConfigs);
+
+        interceptor.intercept("my-topic-compacted", requestConfigs, targetConfigOps);
+        interceptor.intercept("my-topic-compacted", targetConfigs);
+
+        assertFalse(targetConfigOps.containsKey(TopicConfig.DISKLESS_ENABLE_CONFIG));
+        assertNull(targetConfigs.get(TopicConfig.DISKLESS_ENABLE_CONFIG));
+    }
+
+    @Test
+    public void doesNotForceForCompactDeleteTopic() {
+        final var interceptor = new DisklessForceCreateTopicInterceptor(List.of("my-topic-.*"));
+        final Map<String, String> requestConfigs = Map.of(
+            TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_DELETE + "," + TopicConfig.CLEANUP_POLICY_COMPACT
+        );
+        final Map<String, Entry<OpType, String>> targetConfigOps = new HashMap<>();
+        final Map<String, String> targetConfigs = new HashMap<>(requestConfigs);
+
+        interceptor.intercept("my-topic-compact-delete", requestConfigs, targetConfigOps);
+        interceptor.intercept("my-topic-compact-delete", targetConfigs);
+
+        assertFalse(targetConfigOps.containsKey(TopicConfig.DISKLESS_ENABLE_CONFIG));
+        assertNull(targetConfigs.get(TopicConfig.DISKLESS_ENABLE_CONFIG));
+    }
+
+    @Test
+    public void matchesSecondRegexInList() {
+        final var interceptor = new DisklessForceCreateTopicInterceptor(List.of("first-.*", "second-.*"));
+        final Map<String, String> targetConfigs = new HashMap<>();
+
+        interceptor.intercept("second-topic", targetConfigs);
+
+        assertEquals("true", targetConfigs.get(TopicConfig.DISKLESS_ENABLE_CONFIG));
+    }
+
+    @Test
+    public void doesNotForceForTopicWithDoubleUnderscorePrefix() {
+        final DisklessForceCreateTopicInterceptor interceptor =
+            new DisklessForceCreateTopicInterceptor(List.of(".*"));
+
+        final Map<String, String> targetConfigs = new HashMap<>();
+        boolean result = interceptor.intercept("__consumer_offsets", targetConfigs);
+
+        assertFalse(result);
+        assertNull(targetConfigs.get(TopicConfig.DISKLESS_ENABLE_CONFIG));
+    }
+
+    @Test
+    public void doesNotForceForTopicWithDoubleUnderscorePrefixOpType() {
+        final DisklessForceCreateTopicInterceptor interceptor =
+            new DisklessForceCreateTopicInterceptor(List.of(".*"));
+
+        final Map<String, Map.Entry<OpType, String>> targetConfigOps = new HashMap<>();
+        boolean result = interceptor.intercept("__custom_internal", Map.of(), targetConfigOps);
+
+        assertFalse(result);
+        assertNull(targetConfigOps.get(TopicConfig.DISKLESS_ENABLE_CONFIG));
+    }
+}

--- a/server-common/src/main/java/org/apache/kafka/server/config/ServerConfigs.java
+++ b/server-common/src/main/java/org/apache/kafka/server/config/ServerConfigs.java
@@ -171,6 +171,19 @@ public class ServerConfigs {
     public static final String CLASSIC_REMOTE_STORAGE_FORCE_EXCLUDE_TOPIC_REGEXES_DOC = "A list of topic name regular expressions excluded from " +
         "classic.remote.storage.force.enable.";
 
+    public static final String DISKLESS_FORCE_ENABLE_CONFIG = "diskless.force.enable";
+    public static final boolean DISKLESS_FORCE_ENABLE_DEFAULT = false;
+    public static final String DISKLESS_FORCE_ENABLE_DOC = "Force topics to be created with diskless.enable=true when their name matches " +
+        "at least one regex in diskless.force.include.topic.regexes. Excluded: system topics and compacted topics. " +
+        "Can be enabled simultaneously with classic.remote.storage.force.enable; the diskless interceptor takes priority " +
+        "for matching topics (first-match-wins).";
+
+    public static final String DISKLESS_FORCE_INCLUDE_TOPIC_REGEXES_CONFIG = "diskless.force.include.topic.regexes";
+    public static final List<String> DISKLESS_FORCE_INCLUDE_TOPIC_REGEXES_DEFAULT = List.of();
+    public static final String DISKLESS_FORCE_INCLUDE_TOPIC_REGEXES_DOC = "A list of topic name regular expressions that define " +
+        "the allow list for diskless.force.enable. Topics matching at least one regex will be forced to diskless.enable=true. " +
+        "Topics starting with \"__\" are always excluded regardless of regex matches.";
+
 
     /************* Authorizer Configuration ***********/
     public static final String AUTHORIZER_CLASS_NAME_CONFIG = "authorizer.class.name";
@@ -228,6 +241,10 @@ public class ServerConfigs {
                 CLASSIC_REMOTE_STORAGE_FORCE_ENABLE_DOC)
             .define(CLASSIC_REMOTE_STORAGE_FORCE_EXCLUDE_TOPIC_REGEXES_CONFIG, LIST, CLASSIC_REMOTE_STORAGE_FORCE_EXCLUDE_TOPIC_REGEXES_DEFAULT,
                 ConfigDef.ValidList.anyNonDuplicateValues(true, false), LOW, CLASSIC_REMOTE_STORAGE_FORCE_EXCLUDE_TOPIC_REGEXES_DOC)
+            .define(DISKLESS_FORCE_ENABLE_CONFIG, BOOLEAN, DISKLESS_FORCE_ENABLE_DEFAULT, LOW,
+                DISKLESS_FORCE_ENABLE_DOC)
+            .define(DISKLESS_FORCE_INCLUDE_TOPIC_REGEXES_CONFIG, LIST, DISKLESS_FORCE_INCLUDE_TOPIC_REGEXES_DEFAULT,
+                ConfigDef.ValidList.anyNonDuplicateValues(true, false), LOW, DISKLESS_FORCE_INCLUDE_TOPIC_REGEXES_DOC)
             /** Internal Configurations **/
             // This indicates whether unreleased APIs should be advertised by this node.
             .defineInternal(UNSTABLE_API_VERSIONS_ENABLE_CONFIG, BOOLEAN, false, HIGH)


### PR DESCRIPTION
# Introduce CREATE_TOPICS config interceptor framework and DisklessForceCreateTopicInterceptor

## Summary

Introduce a generic interceptor framework for mutating topic configs during CREATE_TOPICS API requests, then use it to add a new diskless force interceptor.

## Motivation

`ClassicTopicRemoteStorageForcePolicy` was implemented to automatically set `remote.storage.enable=true` on topic creation. For Diskless-enabled-by-default, we need a similar mechanism that forces `diskless.enable=true`. Rather than adding another one-off policy, this PR refactors the approach into a generic, chainable interceptor pattern.

## Changes

### Commit 1: Interceptor framework

- `CreateTopicConfigInterceptor` — interface with `intercept()` methods returning `boolean` (true = matched)
- `CreateTopicConfigInterceptors` — container that chains interceptors with **first-match-wins** semantics
- Refactored `ClassicTopicRemoteStorageForcePolicy` → `ClassicTopicRemoteStorageForceCreateTopicInterceptor`
- Updated `ReplicationControlManager` to use the new abstraction

### Commit 2: Diskless force interceptor

- `DisklessForceCreateTopicInterceptor` — forces `diskless.enable=true` for topics matching an allow-list of regexes
- Excludes system topics, compacted topics, and topics with `__` prefix
- Chained with higher priority than the classic remote storage interceptor
- Both interceptors can be enabled simultaneously (users configure regexes to avoid overlap)

## New configs

| Config | Type | Default | Description |
|--------|------|---------|-------------|
| `diskless.force.enable` | boolean | `false` | Enable the diskless force interceptor |
| `diskless.force.include.topic.regexes` | list | `[]` | Allow-list of regexes; matching topics get `diskless.enable=true` |

## Example configuration

```properties
# Enable both interceptors
classic.remote.storage.force.enable=true
classic.remote.storage.force.exclude.topic.regexes=diskless-.*

diskless.force.enable=true
diskless.force.include.topic.regexes=diskless-.*
```

## Testing

- Unit tests for `DisklessForceCreateTopicInterceptor` (regex matching, exclusions, `__` prefix skip)
- Unit tests for `CreateTopicConfigInterceptors` (chaining, first-match-wins, empty chain)
- Existing `ClassicTopicRemoteStorageForceCreateTopicInterceptorTest` continues to pass
