### PR TITLE
feat(inkless:switch): expose DisklessWithoutRemoteStorageCount metric for legacy topics

### DIFF
--- a/docs/inkless/FEATURES.md
+++ b/docs/inkless/FEATURES.md
@@ -188,6 +188,7 @@ New JMX metrics are available on the active controller (`kafka.controller:type=K
 | `DisklessTopicCount` | Total number of diskless topics |
 | `DisklessPartitionCount` | Total number of partitions in diskless topics |
 | `DisklessOfflinePartitionCount` | Diskless partitions without a leader (leader=-1), typically because no eligible assigned replica is available to lead |
+| `DisklessWithoutRemoteStorageCount` | Diskless topics with `remote.storage.enable` explicitly set to `false` — a misconfiguration. Useful during the transition to remote storage consolidation to detect legacy topics that need remediation. Only counts explicit `false`, not absent config. Refreshed on metadata snapshot (default: every hour or 20 MB of metadata records) |
 
 These metrics are tracked separately from classic partition metrics to avoid false alerts — diskless topics may show offline replicas in KRaft metadata while remaining fully available via the metadata transformer.
 

--- a/metadata/src/main/java/org/apache/kafka/controller/metrics/ControllerMetadataMetrics.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/metrics/ControllerMetadataMetrics.java
@@ -76,6 +76,8 @@ public final class ControllerMetadataMetrics implements AutoCloseable {
         "KafkaController", "DisklessPartitionCount");
     private static final MetricName DISKLESS_OFFLINE_PARTITION_COUNT = getMetricName(
         "KafkaController", "DisklessOfflinePartitionCount");
+    private static final MetricName DISKLESS_WITHOUT_REMOTE_STORAGE_COUNT = getMetricName(
+        "KafkaController", "DisklessWithoutRemoteStorageCount");
 
     private final Optional<MetricsRegistry> registry;
     private final AtomicInteger fencedBrokerCount = new AtomicInteger(0);
@@ -93,6 +95,7 @@ public final class ControllerMetadataMetrics implements AutoCloseable {
     private final AtomicInteger disklessTopicCount = new AtomicInteger(0);
     private final AtomicInteger disklessPartitionCount = new AtomicInteger(0);
     private final AtomicInteger disklessOfflinePartitionCount = new AtomicInteger(0);
+    private final AtomicInteger disklessWithoutRemoteStorageCount = new AtomicInteger(0);
 
     /**
      * Create a new ControllerMetadataMetrics object.
@@ -176,6 +179,12 @@ public final class ControllerMetadataMetrics implements AutoCloseable {
             @Override
             public Integer value() {
                 return disklessOfflinePartitionCount();
+            }
+        }));
+        registry.ifPresent(r -> r.newGauge(DISKLESS_WITHOUT_REMOTE_STORAGE_COUNT, new Gauge<Integer>() {
+            @Override
+            public Integer value() {
+                return disklessWithoutRemoteStorageCount();
             }
         }));
     }
@@ -372,6 +381,14 @@ public final class ControllerMetadataMetrics implements AutoCloseable {
         return this.disklessOfflinePartitionCount.get();
     }
 
+    public void setDisklessWithoutRemoteStorageCount(int count) {
+        this.disklessWithoutRemoteStorageCount.set(count);
+    }
+
+    public int disklessWithoutRemoteStorageCount() {
+        return this.disklessWithoutRemoteStorageCount.get();
+    }
+
     @Override
     public void close() {
         registry.ifPresent(r -> List.of(
@@ -388,7 +405,8 @@ public final class ControllerMetadataMetrics implements AutoCloseable {
             IGNORED_STATIC_VOTERS,
             DISKLESS_TOPIC_COUNT,
             DISKLESS_PARTITION_COUNT,
-            DISKLESS_OFFLINE_PARTITION_COUNT
+            DISKLESS_OFFLINE_PARTITION_COUNT,
+            DISKLESS_WITHOUT_REMOTE_STORAGE_COUNT
         ).forEach(r::removeMetric));
         for (int brokerId : brokerRegistrationStates.keySet()) {
             removeBrokerRegistrationStateMetric(brokerId);

--- a/metadata/src/main/java/org/apache/kafka/controller/metrics/ControllerMetadataMetricsPublisher.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/metrics/ControllerMetadataMetricsPublisher.java
@@ -31,6 +31,11 @@ import org.apache.kafka.metadata.BrokerRegistration;
 import org.apache.kafka.metadata.PartitionRegistration;
 import org.apache.kafka.server.fault.FaultHandler;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
@@ -45,6 +50,8 @@ import java.util.Optional;
  *
  */
 public class ControllerMetadataMetricsPublisher implements MetadataPublisher {
+    private static final Logger log = LoggerFactory.getLogger(ControllerMetadataMetricsPublisher.class);
+
     private final ControllerMetadataMetrics metrics;
     private final FaultHandler faultHandler;
     private MetadataImage prevImage = MetadataImage.EMPTY;
@@ -166,11 +173,19 @@ public class ControllerMetadataMetricsPublisher implements MetadataPublisher {
         int disklessTopics = 0;
         int disklessPartitions = 0;
         int disklessOfflinePartitions = 0;
+        int disklessWithoutRemoteStorage = 0;
+        List<String> disklessTopicsWithoutRemoteStorage = new ArrayList<>();
         for (TopicImage topicImage : newImage.topics().topicsById().values()) {
             // Check diskless from newImage configs directly for consistency with delta path
             final boolean isDiskless = isDisklessTopic(newImage.configs(), topicImage.name());
             if (isDiskless) {
                 disklessTopics++;
+                if (hasRemoteStorageExplicitlyDisabled(newImage.configs(), topicImage.name())) {
+                    disklessWithoutRemoteStorage++;
+                    if (disklessTopicsWithoutRemoteStorage.size() < 20) {
+                        disklessTopicsWithoutRemoteStorage.add(topicImage.name());
+                    }
+                }
             }
             for (PartitionRegistration partition : topicImage.partitions().values()) {
                 totalPartitions++;
@@ -195,12 +210,36 @@ public class ControllerMetadataMetricsPublisher implements MetadataPublisher {
         metrics.setDisklessTopicCount(disklessTopics);
         metrics.setDisklessPartitionCount(disklessPartitions);
         metrics.setDisklessOfflinePartitionCount(disklessOfflinePartitions);
+        // Only refreshed on snapshot (not delta) — advisory metric for legacy topic detection,
+        // not a real-time alert. Snapshots occur on controller failover or periodically
+        // (default: every hour or 20MB of metadata records, whichever comes first).
+        metrics.setDisklessWithoutRemoteStorageCount(disklessWithoutRemoteStorage);
+        warnDisklessWithoutRemoteStorage(disklessWithoutRemoteStorage, disklessTopicsWithoutRemoteStorage);
     }
 
     private static boolean isDisklessTopic(ConfigurationsImage configsImage, String topicName) {
         ConfigResource resource = new ConfigResource(ConfigResource.Type.TOPIC, topicName);
         Map<String, String> configMap = configsImage.configMapForResource(resource);
         return Boolean.parseBoolean(configMap.getOrDefault(TopicConfig.DISKLESS_ENABLE_CONFIG, "false"));
+    }
+
+    private static boolean hasRemoteStorageExplicitlyDisabled(ConfigurationsImage configsImage, String topicName) {
+        ConfigResource resource = new ConfigResource(ConfigResource.Type.TOPIC, topicName);
+        Map<String, String> configMap = configsImage.configMapForResource(resource);
+        // Only flag topics where remote.storage.enable is explicitly stored as false.
+        // Absent means "never configured" — the controller will auto-enable on next interaction.
+        String value = configMap.get(TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG);
+        return value != null && !Boolean.parseBoolean(value);
+    }
+
+    private void warnDisklessWithoutRemoteStorage(int count, List<String> topicNames) {
+        if (count > 0 && count <= 20) {
+            log.warn("Found {} diskless topic(s) with remote.storage.enable explicitly set to false: {}. "
+                + "Set remote.storage.enable=true on these topics.", count, topicNames);
+        } else if (count > 20) {
+            log.warn("Found {} diskless topic(s) with remote.storage.enable explicitly set to false (truncated, first 20): {}. "
+                + "Set remote.storage.enable=true on these topics.", count, topicNames.stream().limit(20).toList());
+        }
     }
 
     @Override

--- a/metadata/src/test/java/org/apache/kafka/controller/metrics/ControllerMetadataMetricsPublisherTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/metrics/ControllerMetadataMetricsPublisherTest.java
@@ -212,6 +212,38 @@ public class ControllerMetadataMetricsPublisherTest {
             assertEquals(7, env.metrics.disklessPartitionCount());
             // 3 partitions from "quux" topic are offline (leader=-1)
             assertEquals(3, env.metrics.disklessOfflinePartitionCount());
+            // remote.storage.enable absent (never configured) — not counted; only explicit false triggers the metric
+            assertEquals(0, env.metrics.disklessWithoutRemoteStorageCount());
+        }
+    }
+
+    @Test
+    public void testDisklessWithoutRemoteStorageCountsOnlyExplicitFalse() {
+        // Only diskless topics with remote.storage.enable explicitly stored as "false" are counted.
+        try (TestEnv env = new TestEnv()) {
+            // Build image with 3 diskless topics: remote.storage.enable=true, =false, and absent
+            Map<ConfigResource, ConfigurationImage> configs = new HashMap<>();
+            for (TopicImage topicImage : TOPICS_IMAGE1.topicsById().values()) {
+                ConfigResource resource = new ConfigResource(ConfigResource.Type.TOPIC, topicImage.name());
+                Map<String, String> configMap = new HashMap<>();
+                configMap.put(TopicConfig.DISKLESS_ENABLE_CONFIG, "true");
+                if (topicImage.name().equals("foo")) {
+                    configMap.put(TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG, "true");
+                } else if (topicImage.name().equals("bar")) {
+                    configMap.put(TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG, "false");
+                }
+                // "quux" has no remote.storage.enable config (absent)
+                configs.put(resource, new ConfigurationImage(resource, configMap));
+            }
+            MetadataImage image = fakeImageFromTopicsImage(TOPICS_IMAGE1, new ConfigurationsImage(configs));
+            MetadataDelta delta = new MetadataDelta(MetadataImage.EMPTY);
+            ImageReWriter writer = new ImageReWriter(delta);
+            image.write(writer, new ImageWriterOptions.Builder(MetadataVersion.MINIMUM_VERSION).build());
+            env.publisher.onMetadataUpdate(delta, image, fakeManifest(true));
+
+            assertEquals(3, env.metrics.disklessTopicCount());
+            // Only "bar" (remote.storage.enable explicitly false) is counted
+            assertEquals(1, env.metrics.disklessWithoutRemoteStorageCount());
         }
     }
 

--- a/metadata/src/test/java/org/apache/kafka/controller/metrics/ControllerMetadataMetricsTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/metrics/ControllerMetadataMetricsTest.java
@@ -66,6 +66,7 @@ public class ControllerMetadataMetricsTest {
                         "kafka.controller:type=KafkaController,name=DisklessTopicCount",
                         "kafka.controller:type=KafkaController,name=DisklessPartitionCount",
                         "kafka.controller:type=KafkaController,name=DisklessOfflinePartitionCount",
+                        "kafka.controller:type=KafkaController,name=DisklessWithoutRemoteStorageCount",
                         "kafka.controller:type=ControllerStats,name=UncleanLeaderElectionsPerSec",
                         "kafka.controller:type=ControllerStats,name=ElectionFromEligibleLeaderReplicasPerSec"
                     ));
@@ -330,5 +331,22 @@ public class ControllerMetadataMetricsTest {
             (m, v) -> m.setDisklessOfflinePartitionCount(v),
             (m, v) -> m.addToDisklessOfflinePartitionCount(v)
         );
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testDisklessWithoutRemoteStorageCountMetric() {
+        MetricsRegistry registry = new MetricsRegistry();
+        try (ControllerMetadataMetrics metrics = new ControllerMetadataMetrics(Optional.of(registry))) {
+            assertEquals(0, metrics.disklessWithoutRemoteStorageCount());
+            assertEquals(0, ((Gauge<Integer>) registry.allMetrics().
+                    get(metricName("KafkaController", "DisklessWithoutRemoteStorageCount"))).value());
+            metrics.setDisklessWithoutRemoteStorageCount(5);
+            assertEquals(5, metrics.disklessWithoutRemoteStorageCount());
+            assertEquals(5, ((Gauge<Integer>) registry.allMetrics().
+                    get(metricName("KafkaController", "DisklessWithoutRemoteStorageCount"))).value());
+        } finally {
+            registry.shutdown();
+        }
     }
 }


### PR DESCRIPTION
Adds a gauge metric counting diskless topics that have `remote.storage.enable` explicitly set to `false`. Topics where RS is absent (never configured) are not counted — the controller will auto-enable RS on next interaction.

Logs a warning with topic names on snapshot load, letting operators fix at their pace.

## Changes

- `ControllerMetadataMetrics`: new `DisklessWithoutRemoteStorageCount` gauge
- `ControllerMetadataMetricsPublisher`: counts topics in `publishSnapshot()` where RS is explicitly `false`; advisory-only, refreshed on snapshot (default: every hour or 20MB of metadata)
- Tests: metric gauge test + publisher snapshot test with mixed RS states

🤖 Generated with [Claude Code](https://claude.com/claude-code)