### PR TITLE
feat(inkless:switch): auto-enable remote.storage.enable on diskless topic creation

### DIFF
--- a/core/src/main/scala/kafka/server/ControllerServer.scala
+++ b/core/src/main/scala/kafka/server/ControllerServer.scala
@@ -241,6 +241,7 @@ class ControllerServer(
           setDefaultDisklessEnable(config.logDisklessEnable).
           setDisklessStorageSystemEnabled(config.disklessStorageSystemEnabled).
           setDisklessManagedReplicasEnabled(config.disklessManagedReplicasEnabled).
+          setDisklessRemoteStorageConsolidationEnabled(config.disklessRemoteStorageConsolidationEnabled).
           setClassicRemoteStorageForceEnabled(config.classicRemoteStorageForceEnabled).
           setClassicRemoteStorageForceExcludeTopicRegexes(config.classicRemoteStorageForceExcludeTopicRegexes).
           setSessionTimeoutNs(TimeUnit.NANOSECONDS.convert(config.brokerSessionTimeoutMs.longValue(),

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -227,6 +227,7 @@ public final class QuorumController implements Controller {
         private boolean defaultDisklessEnable = false;
         private boolean disklessStorageSystemEnabled = false;
         private boolean disklessManagedReplicasEnabled = false;
+        private boolean disklessRemoteStorageConsolidationEnabled = false;
         private boolean classicRemoteStorageForceEnabled = false;
         private List<String> classicRemoteStorageForceExcludeTopicRegexes = List.of();
 
@@ -301,6 +302,11 @@ public final class QuorumController implements Controller {
 
         public Builder setDisklessManagedReplicasEnabled(boolean disklessManagedReplicasEnabled) {
             this.disklessManagedReplicasEnabled = disklessManagedReplicasEnabled;
+            return this;
+        }
+
+        public Builder setDisklessRemoteStorageConsolidationEnabled(boolean disklessRemoteStorageConsolidationEnabled) {
+            this.disklessRemoteStorageConsolidationEnabled = disklessRemoteStorageConsolidationEnabled;
             return this;
         }
 
@@ -464,6 +470,7 @@ public final class QuorumController implements Controller {
                     defaultDisklessEnable,
                     disklessStorageSystemEnabled,
                     disklessManagedReplicasEnabled,
+                    disklessRemoteStorageConsolidationEnabled,
                     classicRemoteStorageForceEnabled,
                     classicRemoteStorageForceExcludeTopicRegexes,
                     replicaPlacer,
@@ -1508,6 +1515,7 @@ public final class QuorumController implements Controller {
         boolean defaultDisklessEnable,
         boolean disklessStorageSystemEnabled,
         boolean disklessManagedReplicasEnabled,
+        boolean disklessRemoteStorageConsolidationEnabled,
         boolean classicRemoteStorageForceEnabled,
         List<String> classicRemoteStorageForceExcludeTopicRegexes,
         ReplicaPlacer replicaPlacer,
@@ -1595,6 +1603,7 @@ public final class QuorumController implements Controller {
             setDefaultDisklessEnable(defaultDisklessEnable).
             setDisklessStorageSystemEnabled(disklessStorageSystemEnabled).
             setDisklessManagedReplicasEnabled(disklessManagedReplicasEnabled).
+            setDisklessRemoteStorageConsolidationEnabled(disklessRemoteStorageConsolidationEnabled).
             setClassicRemoteStorageForceEnabled(classicRemoteStorageForceEnabled).
             setClassicRemoteStorageForceExcludeTopicRegexes(classicRemoteStorageForceExcludeTopicRegexes).
             setMaxElectionsPerImbalance(ReplicationControlManager.MAX_ELECTIONS_PER_IMBALANCE).

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -132,6 +132,7 @@ import static org.apache.kafka.clients.admin.AlterConfigOp.OpType.SET;
 import static org.apache.kafka.common.config.ConfigResource.Type.TOPIC;
 import static org.apache.kafka.common.config.TopicConfig.DISKLESS_ENABLE_CONFIG;
 import static org.apache.kafka.common.config.TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG;
+import static org.apache.kafka.common.config.TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG;
 import static org.apache.kafka.common.internals.Topic.CLUSTER_METADATA_TOPIC_NAME;
 import static org.apache.kafka.common.protocol.Errors.FENCED_LEADER_EPOCH;
 import static org.apache.kafka.common.protocol.Errors.INELIGIBLE_REPLICA;
@@ -176,6 +177,7 @@ public class ReplicationControlManager {
         private boolean defaultDisklessEnable = false;
         private boolean isDisklessStorageSystemEnabled = false;
         private boolean isDisklessManagedReplicasEnabled = false;
+        private boolean isDisklessRemoteStorageConsolidationEnabled = false;
         private boolean classicRemoteStorageForceEnabled = false;
         private List<String> classicRemoteStorageForceExcludeTopicRegexes = List.of();
 
@@ -217,6 +219,11 @@ public class ReplicationControlManager {
 
         public Builder setDisklessManagedReplicasEnabled(boolean isDisklessManagedReplicasEnabled) {
             this.isDisklessManagedReplicasEnabled = isDisklessManagedReplicasEnabled;
+            return this;
+        }
+
+        public Builder setDisklessRemoteStorageConsolidationEnabled(boolean isDisklessRemoteStorageConsolidationEnabled) {
+            this.isDisklessRemoteStorageConsolidationEnabled = isDisklessRemoteStorageConsolidationEnabled;
             return this;
         }
 
@@ -273,6 +280,7 @@ public class ReplicationControlManager {
                 defaultDisklessEnable,
                 isDisklessStorageSystemEnabled,
                 isDisklessManagedReplicasEnabled,
+                isDisklessRemoteStorageConsolidationEnabled,
                 classicRemoteStorageForceEnabled,
                 classicRemoteStorageForceExcludeTopicRegexes,
                 maxElectionsPerImbalance,
@@ -356,6 +364,12 @@ public class ReplicationControlManager {
      * When true, the diskless storage system is enabled, allowing diskless topics to be created.
      */
     private final boolean isDisklessStorageSystemEnabled;
+
+    /**
+     * When true, diskless topics use remote storage consolidation; this is separate from
+     * classic tiered storage behavior, which is controlled by {@code classicTopicRemoteStorageForcePolicy}.
+     */
+    private final boolean isDisklessRemoteStorageConsolidationEnabled;
     private final ClassicTopicRemoteStorageForcePolicy classicTopicRemoteStorageForcePolicy;
 
     /**
@@ -456,6 +470,7 @@ public class ReplicationControlManager {
         boolean defaultDisklessEnable,
         boolean isDisklessStorageSystemEnabled,
         boolean isDisklessManagedReplicasEnabled,
+        boolean isDisklessRemoteStorageConsolidationEnabled,
         boolean classicRemoteStorageForceEnabled,
         List<String> classicRemoteStorageForceExcludeTopicRegexes,
         int maxElectionsPerImbalance,
@@ -471,6 +486,7 @@ public class ReplicationControlManager {
         this.defaultDisklessEnable = defaultDisklessEnable;
         this.isDisklessStorageSystemEnabled = isDisklessStorageSystemEnabled;
         this.isDisklessManagedReplicasEnabled = isDisklessManagedReplicasEnabled;
+        this.isDisklessRemoteStorageConsolidationEnabled = isDisklessRemoteStorageConsolidationEnabled;
         this.classicTopicRemoteStorageForcePolicy = new ClassicTopicRemoteStorageForcePolicy(
             classicRemoteStorageForceEnabled,
             classicRemoteStorageForceExcludeTopicRegexes
@@ -819,6 +835,14 @@ public class ReplicationControlManager {
         // Re-apply ClassicTopicRemoteStorageForcePolicy on this creation configs view for validations and to include forced configs in the response payload.
         final boolean disklessEnabledForRemotePolicy = disklessEnabledOnTopicCreation(creationConfigs);
         classicTopicRemoteStorageForcePolicy.maybeForceRemoteStorageEnable(topic.name(), disklessEnabledForRemotePolicy, creationConfigs);
+        // Include remote.storage.enable=true in creationConfigs for diskless topics.
+        // This affects the CreateTopicsResponse effective-config view and topic policy checks.
+        // The actual persistence happens in validConfigRecords() via ConfigRecord.
+        // Exclude system topics — they are never diskless regardless of defaultDisklessEnable.
+        if (disklessEnabledForRemotePolicy && isDisklessRemoteStorageConsolidationEnabled
+                && !isSystemTopic(topic.name())) {
+            creationConfigs.putIfAbsent(REMOTE_LOG_STORAGE_ENABLE_CONFIG, "true");
+        }
         Map<Integer, PartitionRegistration> newParts = new HashMap<>();
 
         String disklessEnableConfigValue = creationConfigs.get(DISKLESS_ENABLE_CONFIG);
@@ -847,6 +871,16 @@ public class ReplicationControlManager {
             if (!isDisklessManagedReplicasEnabled && Math.abs(topic.replicationFactor()) != 1) {
                 return new ApiError(Errors.INVALID_REPLICATION_FACTOR,
                     "Replication factor for diskless topics must be 1 or -1 when managed replicas are disabled.");
+            }
+            // Reject diskless topic creation with remote.storage.enable explicitly set to false.
+            // Undefined (absent) is fine — validConfigRecords() will auto-enable it.
+            // Invalid boolean formats (e.g. "foo") are handled by ConfigurationControlManager's
+            // config validation pipeline, not here.
+            if (isDisklessRemoteStorageConsolidationEnabled
+                    && "false".equalsIgnoreCase(creationConfigs.get(REMOTE_LOG_STORAGE_ENABLE_CONFIG))) {
+                return new ApiError(Errors.INVALID_CONFIG,
+                    "Diskless topics must have remote storage enabled. "
+                        + "Cannot set remote.storage.enable=false when diskless is enabled.");
             }
         }
 
@@ -1038,6 +1072,20 @@ public class ReplicationControlManager {
                 .setValue(String.valueOf(disklessEnabled))
                 .setResourceName(topic.name())
                 .setResourceType(ResourceType.TOPIC.code()), (short) 0));
+        }
+        // Persist remote.storage.enable=true to the metadata log for diskless topics.
+        // This is the source of truth; the creationConfigs update in createTopic() only
+        // affects the CreateTopicsResponse payload.
+        if (disklessEnabled && isDisklessRemoteStorageConsolidationEnabled) {
+            boolean isRemoteStorageEnableDefined = validConfigRecord.stream()
+                .anyMatch(r -> ((ConfigRecord) r.message()).name().equals(REMOTE_LOG_STORAGE_ENABLE_CONFIG));
+            if (!isRemoteStorageEnableDefined) {
+                validConfigRecord.add(new ApiMessageAndVersion(new ConfigRecord()
+                    .setName(REMOTE_LOG_STORAGE_ENABLE_CONFIG)
+                    .setValue("true")
+                    .setResourceName(topic.name())
+                    .setResourceType(ResourceType.TOPIC.code()), (short) 0));
+            }
         }
         return validConfigRecord;
     }

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -833,14 +833,15 @@ public class ReplicationControlManager {
         final Map<String, String> creationConfigs = new HashMap<>(translateCreationConfigs(topic.configs()));
         // Configs here are rebuilt from the request (creationConfigs).
         // Re-apply ClassicTopicRemoteStorageForcePolicy on this creation configs view for validations and to include forced configs in the response payload.
-        final boolean disklessEnabledForRemotePolicy = disklessEnabledOnTopicCreation(creationConfigs);
-        classicTopicRemoteStorageForcePolicy.maybeForceRemoteStorageEnable(topic.name(), disklessEnabledForRemotePolicy, creationConfigs);
+        final boolean disklessEnabledOnCreation = disklessEnabledOnTopicCreation(creationConfigs);
+        classicTopicRemoteStorageForcePolicy.maybeForceRemoteStorageEnable(topic.name(), disklessEnabledOnCreation, creationConfigs);
         // Include remote.storage.enable=true in creationConfigs for diskless topics.
         // This affects the CreateTopicsResponse effective-config view and topic policy checks.
         // The actual persistence happens in validConfigRecords() via ConfigRecord.
         // Exclude system topics — they are never diskless regardless of defaultDisklessEnable.
-        if (disklessEnabledForRemotePolicy && isDisklessRemoteStorageConsolidationEnabled
-                && !isSystemTopic(topic.name())) {
+        if (disklessEnabledOnCreation &&
+                isDisklessRemoteStorageConsolidationEnabled &&
+                !isSystemTopic(topic.name())) {
             creationConfigs.putIfAbsent(REMOTE_LOG_STORAGE_ENABLE_CONFIG, "true");
         }
         Map<Integer, PartitionRegistration> newParts = new HashMap<>();
@@ -876,8 +877,8 @@ public class ReplicationControlManager {
             // Undefined (absent) is fine — validConfigRecords() will auto-enable it.
             // Invalid boolean formats (e.g. "foo") are handled by ConfigurationControlManager's
             // config validation pipeline, not here.
-            if (isDisklessRemoteStorageConsolidationEnabled
-                    && "false".equalsIgnoreCase(creationConfigs.get(REMOTE_LOG_STORAGE_ENABLE_CONFIG))) {
+            if (isDisklessRemoteStorageConsolidationEnabled &&
+                    "false".equalsIgnoreCase(creationConfigs.get(REMOTE_LOG_STORAGE_ENABLE_CONFIG))) {
                 return new ApiError(Errors.INVALID_CONFIG,
                     "Diskless topics must have remote storage enabled. "
                         + "Cannot set remote.storage.enable=false when diskless is enabled.");

--- a/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
@@ -191,6 +191,7 @@ public class ReplicationControlManagerTest {
             private boolean defaultDisklessEnable = false;
             private boolean disklessStorageSystemEnable = false;
             private boolean disklessManagedReplicasEnable = false;
+            private boolean disklessRemoteStorageConsolidationEnabled = false;
             private boolean classicRemoteStorageForceEnabled = false;
             private List<String> classicRemoteStorageForceExcludeTopicRegexes = List.of();
 
@@ -234,6 +235,11 @@ public class ReplicationControlManagerTest {
                 return this;
             }
 
+            Builder setDisklessRemoteStorageConsolidationEnabled(boolean enabled) {
+                this.disklessRemoteStorageConsolidationEnabled = enabled;
+                return this;
+            }
+
             Builder setClassicRemoteStorageForceEnabled(final boolean classicRemoteStorageForceEnabled) {
                 this.classicRemoteStorageForceEnabled = classicRemoteStorageForceEnabled;
                 return this;
@@ -253,6 +259,7 @@ public class ReplicationControlManagerTest {
                     defaultDisklessEnable,
                     disklessStorageSystemEnable,
                     disklessManagedReplicasEnable,
+                    disklessRemoteStorageConsolidationEnabled,
                     classicRemoteStorageForceEnabled,
                     classicRemoteStorageForceExcludeTopicRegexes);
             }
@@ -283,6 +290,7 @@ public class ReplicationControlManagerTest {
             boolean defaultDisklessEnable,
             boolean disklessStorageSystemEnable,
             boolean disklessManagedReplicasEnable,
+            boolean disklessRemoteStorageConsolidationEnabled,
             final boolean classicRemoteStorageForceEnabled,
             final List<String> classicRemoteStorageForceExcludeTopicRegexes
         ) {
@@ -331,6 +339,7 @@ public class ReplicationControlManagerTest {
                 setDefaultDisklessEnable(defaultDisklessEnable).
                 setDisklessStorageSystemEnabled(disklessStorageSystemEnable).
                 setDisklessManagedReplicasEnabled(disklessManagedReplicasEnable).
+                setDisklessRemoteStorageConsolidationEnabled(disklessRemoteStorageConsolidationEnabled).
                 setClassicRemoteStorageForceEnabled(classicRemoteStorageForceEnabled).
                 setClassicRemoteStorageForceExcludeTopicRegexes(classicRemoteStorageForceExcludeTopicRegexes).
                 build();
@@ -5794,6 +5803,210 @@ public class ReplicationControlManagerTest {
                 replication.createTopics(requestContext, request, Set.of("foo"));
             assertEquals(Errors.INVALID_REPLICATION_FACTOR.code(),
                 result.response().topics().find("foo").errorCode());
+        }
+    }
+
+    @Nested
+    class DisklessRemoteStorageConsolidationTests {
+
+        @Test
+        void testAutoEnableRemoteStorageOnDisklessTopicCreation() {
+            // When consolidation is enabled and a diskless topic is created with explicit
+            // diskless.enable=true but no remote.storage.enable, auto-persist it.
+            final ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder()
+                .setDisklessStorageSystemEnabled(true)
+                .setDisklessManagedReplicasEnabled(true)
+                .setDisklessRemoteStorageConsolidationEnabled(true)
+                .build();
+            ctx.registerBrokers(0, 1, 2);
+            ctx.unfenceBrokers(0, 1, 2);
+
+            final CreateTopicsRequestData request = new CreateTopicsRequestData();
+            final CreateTopicsRequestData.CreatableTopicConfigCollection configs =
+                new CreateTopicsRequestData.CreatableTopicConfigCollection();
+            configs.add(new CreateTopicsRequestData.CreatableTopicConfig()
+                .setName(DISKLESS_ENABLE_CONFIG)
+                .setValue("true"));
+            request.topics().add(new CreatableTopic()
+                .setName("foo")
+                .setNumPartitions(-1)
+                .setReplicationFactor((short) -1)
+                .setConfigs(configs));
+
+            final ControllerResult<CreateTopicsResponseData> result = ctx.replicationControl.createTopics(
+                anonymousContextFor(ApiKeys.CREATE_TOPICS), request, Set.of("foo"));
+            assertEquals(NONE.code(), result.response().topics().find("foo").errorCode());
+            assertTrue(result.records().stream()
+                .filter(m -> m.message() instanceof ConfigRecord)
+                .map(m -> (ConfigRecord) m.message())
+                .anyMatch(r -> r.name().equals(REMOTE_LOG_STORAGE_ENABLE_CONFIG) && r.value().equals("true")),
+                "ConfigRecord for remote.storage.enable=true should be persisted");
+        }
+
+        @Test
+        void testAutoEnableRemoteStorageViaDefaultDisklessEnable() {
+            // When defaultDisklessEnable=true and topic is created with no explicit configs,
+            // remote.storage.enable=true is still auto-persisted.
+            final ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder()
+                .setDefaultDisklessEnable(true)
+                .setDisklessStorageSystemEnabled(true)
+                .setDisklessManagedReplicasEnabled(true)
+                .setDisklessRemoteStorageConsolidationEnabled(true)
+                .build();
+            ctx.registerBrokers(0, 1, 2);
+            ctx.unfenceBrokers(0, 1, 2);
+
+            final CreateTopicsRequestData request = new CreateTopicsRequestData();
+            request.topics().add(new CreatableTopic()
+                .setName("foo")
+                .setNumPartitions(-1)
+                .setReplicationFactor((short) -1)
+                .setConfigs(new CreateTopicsRequestData.CreatableTopicConfigCollection()));
+
+            final ControllerResult<CreateTopicsResponseData> result = ctx.replicationControl.createTopics(
+                anonymousContextFor(ApiKeys.CREATE_TOPICS), request, Set.of("foo"));
+            assertEquals(NONE.code(), result.response().topics().find("foo").errorCode());
+            assertTrue(result.records().stream()
+                .filter(m -> m.message() instanceof ConfigRecord)
+                .map(m -> (ConfigRecord) m.message())
+                .anyMatch(r -> r.name().equals(REMOTE_LOG_STORAGE_ENABLE_CONFIG) && r.value().equals("true")),
+                "ConfigRecord for remote.storage.enable=true should be persisted via defaultDisklessEnable");
+        }
+
+        @Test
+        void testExplicitRemoteStorageEnableDoesNotDuplicate() {
+            // When the request already includes remote.storage.enable=true,
+            // no duplicate ConfigRecord is produced.
+            final ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder()
+                .setDisklessStorageSystemEnabled(true)
+                .setDisklessManagedReplicasEnabled(true)
+                .setDisklessRemoteStorageConsolidationEnabled(true)
+                .build();
+            ctx.registerBrokers(0, 1, 2);
+            ctx.unfenceBrokers(0, 1, 2);
+
+            final CreateTopicsRequestData request = new CreateTopicsRequestData();
+            final CreateTopicsRequestData.CreatableTopicConfigCollection configs =
+                new CreateTopicsRequestData.CreatableTopicConfigCollection();
+            configs.add(new CreateTopicsRequestData.CreatableTopicConfig()
+                .setName(DISKLESS_ENABLE_CONFIG)
+                .setValue("true"));
+            configs.add(new CreateTopicsRequestData.CreatableTopicConfig()
+                .setName(REMOTE_LOG_STORAGE_ENABLE_CONFIG)
+                .setValue("true"));
+            request.topics().add(new CreatableTopic()
+                .setName("foo")
+                .setNumPartitions(-1)
+                .setReplicationFactor((short) -1)
+                .setConfigs(configs));
+
+            final ControllerResult<CreateTopicsResponseData> result = ctx.replicationControl.createTopics(
+                anonymousContextFor(ApiKeys.CREATE_TOPICS), request, Set.of("foo"));
+            assertEquals(NONE.code(), result.response().topics().find("foo").errorCode());
+            long remoteStorageConfigCount = result.records().stream()
+                .filter(m -> m.message() instanceof ConfigRecord)
+                .map(m -> (ConfigRecord) m.message())
+                .filter(r -> r.name().equals(REMOTE_LOG_STORAGE_ENABLE_CONFIG))
+                .count();
+            assertEquals(1, remoteStorageConfigCount,
+                "Only one ConfigRecord for remote.storage.enable should exist (no duplicate)");
+        }
+
+        @Test
+        void testSystemTopicExcludedFromAutoEnable() {
+            // System topics are never diskless, so remote.storage.enable should not be auto-added
+            // even when defaultDisklessEnable=true and consolidation is enabled.
+            final ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder()
+                .setDefaultDisklessEnable(true)
+                .setDisklessStorageSystemEnabled(true)
+                .setDisklessManagedReplicasEnabled(true)
+                .setDisklessRemoteStorageConsolidationEnabled(true)
+                .build();
+            ctx.registerBrokers(0, 1, 2);
+            ctx.unfenceBrokers(0, 1, 2);
+
+            final CreateTopicsRequestData request = new CreateTopicsRequestData();
+            request.topics().add(new CreatableTopic()
+                .setName(Topic.GROUP_METADATA_TOPIC_NAME)
+                .setNumPartitions(1)
+                .setReplicationFactor((short) 1)
+                .setConfigs(new CreateTopicsRequestData.CreatableTopicConfigCollection()));
+
+            final ControllerResult<CreateTopicsResponseData> result = ctx.replicationControl.createTopics(
+                anonymousContextFor(ApiKeys.CREATE_TOPICS), request, Set.of(Topic.GROUP_METADATA_TOPIC_NAME));
+            assertEquals(NONE.code(), result.response().topics().find(Topic.GROUP_METADATA_TOPIC_NAME).errorCode());
+            assertTrue(result.records().stream()
+                .filter(m -> m.message() instanceof ConfigRecord)
+                .map(m -> (ConfigRecord) m.message())
+                .noneMatch(r -> r.name().equals(REMOTE_LOG_STORAGE_ENABLE_CONFIG)),
+                "System topics should not get remote.storage.enable ConfigRecord");
+        }
+
+        @Test
+        void testConsolidationDisabledDoesNotAutoEnable() {
+            // When consolidation is disabled, remote.storage.enable is not auto-added
+            // even for diskless topics.
+            final ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder()
+                .setDisklessStorageSystemEnabled(true)
+                .setDisklessManagedReplicasEnabled(true)
+                .setDisklessRemoteStorageConsolidationEnabled(false)
+                .build();
+            ctx.registerBrokers(0, 1, 2);
+            ctx.unfenceBrokers(0, 1, 2);
+
+            final CreateTopicsRequestData request = new CreateTopicsRequestData();
+            final CreateTopicsRequestData.CreatableTopicConfigCollection configs =
+                new CreateTopicsRequestData.CreatableTopicConfigCollection();
+            configs.add(new CreateTopicsRequestData.CreatableTopicConfig()
+                .setName(DISKLESS_ENABLE_CONFIG)
+                .setValue("true"));
+            request.topics().add(new CreatableTopic()
+                .setName("foo")
+                .setNumPartitions(-1)
+                .setReplicationFactor((short) -1)
+                .setConfigs(configs));
+
+            final ControllerResult<CreateTopicsResponseData> result = ctx.replicationControl.createTopics(
+                anonymousContextFor(ApiKeys.CREATE_TOPICS), request, Set.of("foo"));
+            assertEquals(NONE.code(), result.response().topics().find("foo").errorCode());
+            assertTrue(result.records().stream()
+                .filter(m -> m.message() instanceof ConfigRecord)
+                .map(m -> (ConfigRecord) m.message())
+                .noneMatch(r -> r.name().equals(REMOTE_LOG_STORAGE_ENABLE_CONFIG)),
+                "remote.storage.enable should not be auto-added when consolidation is disabled");
+        }
+
+        @Test
+        void testExplicitRemoteStorageFalseRejected() {
+            // Creating a diskless topic with remote.storage.enable=false when consolidation
+            // is enabled must fail — the controller rejects the invalid combination.
+            final ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder()
+                .setDisklessStorageSystemEnabled(true)
+                .setDisklessManagedReplicasEnabled(true)
+                .setDisklessRemoteStorageConsolidationEnabled(true)
+                .build();
+            ctx.registerBrokers(0, 1, 2);
+            ctx.unfenceBrokers(0, 1, 2);
+
+            final CreateTopicsRequestData request = new CreateTopicsRequestData();
+            final CreateTopicsRequestData.CreatableTopicConfigCollection configs =
+                new CreateTopicsRequestData.CreatableTopicConfigCollection();
+            configs.add(new CreateTopicsRequestData.CreatableTopicConfig()
+                .setName(DISKLESS_ENABLE_CONFIG)
+                .setValue("true"));
+            configs.add(new CreateTopicsRequestData.CreatableTopicConfig()
+                .setName(REMOTE_LOG_STORAGE_ENABLE_CONFIG)
+                .setValue("false"));
+            request.topics().add(new CreatableTopic()
+                .setName("foo")
+                .setNumPartitions(-1)
+                .setReplicationFactor((short) -1)
+                .setConfigs(configs));
+
+            final ControllerResult<CreateTopicsResponseData> result = ctx.replicationControl.createTopics(
+                anonymousContextFor(ApiKeys.CREATE_TOPICS), request, Set.of("foo"));
+            assertEquals(Errors.INVALID_CONFIG.code(), result.response().topics().find("foo").errorCode(),
+                "Diskless topic with remote.storage.enable=false should be rejected");
         }
     }
 

--- a/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
@@ -5866,9 +5866,14 @@ public class ReplicationControlManagerTest {
             final ControllerResult<CreateTopicsResponseData> result = ctx.replicationControl.createTopics(
                 anonymousContextFor(ApiKeys.CREATE_TOPICS), request, Set.of("foo"));
             assertEquals(NONE.code(), result.response().topics().find("foo").errorCode());
-            assertTrue(result.records().stream()
+            List<ConfigRecord> configRecords = result.records().stream()
                 .filter(m -> m.message() instanceof ConfigRecord)
                 .map(m -> (ConfigRecord) m.message())
+                .toList();
+            assertTrue(configRecords.stream()
+                .anyMatch(r -> r.name().equals(DISKLESS_ENABLE_CONFIG) && r.value().equals("true")),
+                "ConfigRecord for diskless.enable=true should be persisted via defaultDisklessEnable");
+            assertTrue(configRecords.stream()
                 .anyMatch(r -> r.name().equals(REMOTE_LOG_STORAGE_ENABLE_CONFIG) && r.value().equals("true")),
                 "ConfigRecord for remote.storage.enable=true should be persisted via defaultDisklessEnable");
         }


### PR DESCRIPTION
When consolidation is enabled and a diskless topic is created, automatically persist remote.storage.enable=true in the topic config records. This ensures diskless topics always have remote storage in the consolidated model without requiring the operator to explicitly include it in the create request.

Also rejects creation with remote.storage.enable explicitly set to a non-true value, and excludes system topics from the auto-enable logic (they are never diskless).

Follows the same pattern as the existing diskless.enable auto-persist logic in validConfigRecords().