### PR TITLE
refactor(inkless:consolidation): rename and improve ConsolidationMetrics

### DIFF
--- a/core/src/main/scala/io/aiven/inkless/consolidation/ConsolidationFetcherThread.scala
+++ b/core/src/main/scala/io/aiven/inkless/consolidation/ConsolidationFetcherThread.scala
@@ -60,7 +60,7 @@ class ConsolidationFetcherThread(name: String,
 
         metrics.updateLocalLag(topicPartition, Math.max(0L, disklessLogEndOffset - localLogEndOffset))
         if (remoteLogEndOffset >= 0) {
-          metrics.updateLag(topicPartition, Math.max(0L, disklessLogEndOffset - remoteLogEndOffset))
+          metrics.updateTotalLag(topicPartition, Math.max(0L, disklessLogEndOffset - remoteLogEndOffset))
           metrics.updateDeletableMessages(topicPartition, Math.max(0L, remoteLogEndOffset - log.localLogStartOffset()))
         }
       }

--- a/core/src/main/scala/io/aiven/inkless/consolidation/ConsolidationMetrics.scala
+++ b/core/src/main/scala/io/aiven/inkless/consolidation/ConsolidationMetrics.scala
@@ -26,23 +26,39 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicLong
 import scala.jdk.CollectionConverters._
 
+/**
+ * Tracks consolidation pipeline lag per partition and aggregated at broker level.
+ * All lag values are in offsets (messages).
+ *
+ * Pipeline: Diskless WAL → Local Log → Remote/Tiered Storage
+ *
+ * - ConsolidationLocalLag: disklessLEO - localLogEndOffset (first hop: diskless → local)
+ * - ConsolidationTotalLag: disklessLEO - remoteLogEndOffset (full pipeline: diskless → remote).
+ *   Only updated when remote storage is active (highestOffsetInRemoteStorage ≥ 0); stays at 0 otherwise.
+ * - ConsolidationDeletableMessages: messages already in remote storage eligible for WAL pruning
+ */
 class ConsolidationMetrics extends Closeable {
-  private val Lag = "inkless.remote.consolidation.lag"
-  private val LocalLag = "inkless.remote.consolidation.local.lag"
-  private val DeletableMessages = "inkless.remote.consolidation.deletable.messages"
+  private val TotalLag = "ConsolidationTotalLag"
+  private val LocalLag = "ConsolidationLocalLag"
+  private val DeletableMessages = "ConsolidationDeletableMessages"
 
   private val metricsGroup = new KafkaMetricsGroup("io.aiven.inkless.consolidation", "ConsolidationMetrics")
 
-  private val lagByPartition = new ConcurrentHashMap[TopicPartition, AtomicLong]()
+  private val totalLagByPartition = new ConcurrentHashMap[TopicPartition, AtomicLong]()
   private val localLagByPartition = new ConcurrentHashMap[TopicPartition, AtomicLong]()
   private val deletableByPartition = new ConcurrentHashMap[TopicPartition, AtomicLong]()
+
+  // Broker-level aggregate gauges (sum across all partitions)
+  metricsGroup.newGauge(TotalLag, () => sumValues(totalLagByPartition))
+  metricsGroup.newGauge(LocalLag, () => sumValues(localLagByPartition))
+  metricsGroup.newGauge(DeletableMessages, () => sumValues(deletableByPartition))
 
   def registerPartition(tp: TopicPartition): Unit = {
     val tags = Map("topic" -> tp.topic, "partition" -> tp.partition.toString).asJava
 
-    lagByPartition.computeIfAbsent(tp, _ => {
+    totalLagByPartition.computeIfAbsent(tp, _ => {
       val value = new AtomicLong(0)
-      metricsGroup.newGauge(Lag, () => value.get, tags)
+      metricsGroup.newGauge(TotalLag, () => value.get, tags)
       value
     }).set(0)
     localLagByPartition.computeIfAbsent(tp, _ => {
@@ -57,8 +73,8 @@ class ConsolidationMetrics extends Closeable {
     }).set(0)
   }
 
-  def updateLag(tp: TopicPartition, lag: Long): Unit =
-    Option(lagByPartition.get(tp)).foreach(_.set(lag))
+  def updateTotalLag(tp: TopicPartition, lag: Long): Unit =
+    Option(totalLagByPartition.get(tp)).foreach(_.set(lag))
 
   def updateLocalLag(tp: TopicPartition, lag: Long): Unit =
     Option(localLagByPartition.get(tp)).foreach(_.set(lag))
@@ -68,15 +84,23 @@ class ConsolidationMetrics extends Closeable {
 
   def unregisterPartition(tp: TopicPartition): Unit = {
     val tags = Map("topic" -> tp.topic, "partition" -> tp.partition.toString).asJava
-    lagByPartition.remove(tp)
+    totalLagByPartition.remove(tp)
     localLagByPartition.remove(tp)
     deletableByPartition.remove(tp)
-    metricsGroup.removeMetric(Lag, tags)
+    metricsGroup.removeMetric(TotalLag, tags)
     metricsGroup.removeMetric(LocalLag, tags)
     metricsGroup.removeMetric(DeletableMessages, tags)
   }
 
   override def close(): Unit = {
-    lagByPartition.keys.asScala.toList.foreach(unregisterPartition)
+    // Using same keys to unregister all partition-level metrics
+    totalLagByPartition.keys.asScala.toList.foreach(unregisterPartition)
+    // Unregistering aggregated metrics
+    metricsGroup.removeMetric(TotalLag)
+    metricsGroup.removeMetric(LocalLag)
+    metricsGroup.removeMetric(DeletableMessages)
   }
+
+  private def sumValues(map: ConcurrentHashMap[TopicPartition, AtomicLong]): Long =
+    map.values.asScala.foldLeft(0L)(_ + _.get)
 }

--- a/core/src/test/scala/io/aiven/inkless/consolidation/ConsolidationFetcherThreadTest.scala
+++ b/core/src/test/scala/io/aiven/inkless/consolidation/ConsolidationFetcherThreadTest.scala
@@ -139,9 +139,9 @@ class ConsolidationFetcherThreadTest {
 
     thread.processPartitionData(topicPartition, localLEO, Int.MaxValue, buildPartitionData(disklessLEO))
 
-    assertEquals(40L, findGaugeValue("inkless.remote.consolidation.lag", topicPartition))
-    assertEquals(20L, findGaugeValue("inkless.remote.consolidation.local.lag", topicPartition))
-    assertEquals(50L, findGaugeValue("inkless.remote.consolidation.deletable.messages", topicPartition))
+    assertEquals(40L, findGaugeValue("ConsolidationTotalLag", topicPartition))
+    assertEquals(20L, findGaugeValue("ConsolidationLocalLag", topicPartition))
+    assertEquals(50L, findGaugeValue("ConsolidationDeletableMessages", topicPartition))
   }
 
   @Test
@@ -158,9 +158,9 @@ class ConsolidationFetcherThreadTest {
 
     thread.processPartitionData(topicPartition, localLEO, Int.MaxValue, buildPartitionData(disklessLEO))
 
-    assertEquals(20L, findGaugeValue("inkless.remote.consolidation.local.lag", topicPartition))
-    assertEquals(0L, findGaugeValue("inkless.remote.consolidation.lag", topicPartition))
-    assertEquals(0L, findGaugeValue("inkless.remote.consolidation.deletable.messages", topicPartition))
+    assertEquals(20L, findGaugeValue("ConsolidationLocalLag", topicPartition))
+    assertEquals(0L, findGaugeValue("ConsolidationTotalLag", topicPartition))
+    assertEquals(0L, findGaugeValue("ConsolidationDeletableMessages", topicPartition))
   }
 
   @Test
@@ -178,9 +178,9 @@ class ConsolidationFetcherThreadTest {
 
     thread.processPartitionData(topicPartition, localLEO, Int.MaxValue, buildPartitionData(disklessLEO))
 
-    assertEquals(0L, findGaugeValue("inkless.remote.consolidation.lag", topicPartition))
-    assertEquals(0L, findGaugeValue("inkless.remote.consolidation.local.lag", topicPartition))
-    assertEquals(70L, findGaugeValue("inkless.remote.consolidation.deletable.messages", topicPartition))
+    assertEquals(0L, findGaugeValue("ConsolidationTotalLag", topicPartition))
+    assertEquals(0L, findGaugeValue("ConsolidationLocalLag", topicPartition))
+    assertEquals(70L, findGaugeValue("ConsolidationDeletableMessages", topicPartition))
   }
 
   @Test
@@ -191,9 +191,35 @@ class ConsolidationFetcherThreadTest {
 
     thread.processPartitionData(topicPartition, 80L, Int.MaxValue, buildPartitionData(100L))
 
-    assertNull(findGaugeOrNull("inkless.remote.consolidation.lag", topicPartition))
-    assertNull(findGaugeOrNull("inkless.remote.consolidation.local.lag", topicPartition))
-    assertNull(findGaugeOrNull("inkless.remote.consolidation.deletable.messages", topicPartition))
+    assertNull(findGaugeOrNull("ConsolidationTotalLag", topicPartition))
+    assertNull(findGaugeOrNull("ConsolidationLocalLag", topicPartition))
+    assertNull(findGaugeOrNull("ConsolidationDeletableMessages", topicPartition))
+  }
+
+  @Test
+  def testBrokerLevelAggregateGauges(): Unit = {
+    val tp0 = new TopicPartition("topic-a", 0)
+    val tp1 = new TopicPartition("topic-a", 1)
+
+    metrics.registerPartition(tp0)
+    metrics.registerPartition(tp1)
+
+    metrics.updateTotalLag(tp0, 30L)
+    metrics.updateTotalLag(tp1, 50L)
+    metrics.updateLocalLag(tp0, 10L)
+    metrics.updateLocalLag(tp1, 20L)
+    metrics.updateDeletableMessages(tp0, 5L)
+    metrics.updateDeletableMessages(tp1, 15L)
+
+    assertEquals(80L, findBrokerGaugeValue("ConsolidationTotalLag"))
+    assertEquals(30L, findBrokerGaugeValue("ConsolidationLocalLag"))
+    assertEquals(20L, findBrokerGaugeValue("ConsolidationDeletableMessages"))
+
+    metrics.unregisterPartition(tp0)
+
+    assertEquals(50L, findBrokerGaugeValue("ConsolidationTotalLag"))
+    assertEquals(20L, findBrokerGaugeValue("ConsolidationLocalLag"))
+    assertEquals(15L, findBrokerGaugeValue("ConsolidationDeletableMessages"))
   }
 
   private def findGaugeOrNull(name: String, tp: TopicPartition): com.yammer.metrics.core.Gauge[_] = {
@@ -210,5 +236,16 @@ class ConsolidationFetcherThreadTest {
     val gauge = findGaugeOrNull(name, tp)
     assertNotNull(gauge, s"Gauge $name not found for $tp")
     gauge.asInstanceOf[com.yammer.metrics.core.Gauge[Long]].value()
+  }
+
+  private def findBrokerGaugeValue(name: String): Long = {
+    val gauge = KafkaYammerMetrics.defaultRegistry.allMetrics.asScala
+      .find { case (metricName, _) =>
+        metricName.getName == name && metricName.getScope == null
+      }
+      .map(_._2.asInstanceOf[com.yammer.metrics.core.Gauge[Long]])
+      .orNull
+    assertNotNull(gauge, s"Broker-level gauge $name not found")
+    gauge.value()
   }
 }


### PR DESCRIPTION
Rename metric names from dot-separated `inkless.remote.consolidation.*` to CamelCase `Consolidation*` aligned with other Kafka metrics. Add broker-level aggregate gauges (sum across partitions) for alerting.
