### PR TITLE
fix(inkless): add KafkaConfigTest validation for diskless force topic regexes

### DIFF
--- a/.github/workflows/inkless.yml
+++ b/.github/workflows/inkless.yml
@@ -164,7 +164,7 @@ jobs:
           timeout ${TIMEOUT_MINUTES}m \
           ./gradlew ${GRADLE_ARGS} :storage:inkless:test :storage:inkless:integrationTest && \
           ./gradlew ${GRADLE_ARGS} :metadata:test --tests "org.apache.kafka.controller.*" && \
-          ./gradlew ${GRADLE_ARGS} :core:test --tests "*Inkless*" --tests "*Diskless*" --tests "kafka.log.LogConfigTest"
+          ./gradlew ${GRADLE_ARGS} :core:test --tests "*Inkless*" --tests "*Diskless*" --tests "kafka.log.LogConfigTest" --tests "kafka.server.KafkaConfigTest"
           exitcode="$?"
           echo "exitcode=$exitcode" >> $GITHUB_OUTPUT
       - name: Archive JUnit HTML reports

--- a/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
@@ -905,6 +905,8 @@ class KafkaConfigTest {
         case ServerConfigs.DELETE_TOPIC_ENABLE_CONFIG => assertPropertyInvalid(baseProperties, name, "not_a_boolean", "0")
         case ServerConfigs.CLASSIC_REMOTE_STORAGE_FORCE_EXCLUDE_TOPIC_REGEXES_CONFIG =>
           assertPropertyInvalid(baseProperties, name, "topicA,topicA")
+        case ServerConfigs.DISKLESS_FORCE_INCLUDE_TOPIC_REGEXES_CONFIG =>
+          assertPropertyInvalid(baseProperties, name, "topicA,topicA")
 
         case MetricConfigs.METRIC_NUM_SAMPLES_CONFIG => assertPropertyInvalid(baseProperties, name, "not_a_number", "-1", "0")
         case MetricConfigs.METRIC_SAMPLE_WINDOW_MS_CONFIG => assertPropertyInvalid(baseProperties, name, "not_a_number", "-1", "0")


### PR DESCRIPTION
The diskless.force.include.topic.regexes LIST config added in #614 was missing a case in testFromPropsInvalid(), causing the nightly CI to fail when the catch-all tested "not_a_number" (valid for a list type). Also adds KafkaConfigTest to the regular Inkless PR CI workflow.
