### PR TITLE
fix(inkless:switch): bump leader epoch on classic-to-diskless switch

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -2990,9 +2990,14 @@ public class ReplicationControlManager {
             for (Entry<Integer, PartitionRegistration> partEntry : topicInfo.parts.entrySet()) {
                 PartitionRegistration partition = partEntry.getValue();
                 if (partition.classicToDisklessStartOffset == PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET) {
+                    if (partition.leader == NO_LEADER) {
+                        log.warn("Partition {}-{} has no leader; classic-to-diskless switch will " +
+                            "remain pending until a leader is elected", topicName, partEntry.getKey());
+                    }
                     PartitionChangeRecord record = new PartitionChangeRecord()
                         .setTopicId(topicId)
-                        .setPartitionId(partEntry.getKey());
+                        .setPartitionId(partEntry.getKey())
+                        .setLeader(partition.leader); // Force leader epoch bump to trigger makeLeader on broker
                     record.unknownTaggedFields().add(
                         InitDisklessLogFields.encodeClassicToDisklessStartOffset(
                             PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING));

--- a/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
@@ -6524,6 +6524,15 @@ public class ReplicationControlManagerTest {
                 assertEquals(topicId, record.topicId());
                 assertEquals(PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING,
                     InitDisklessLogFields.decodeClassicToDisklessStartOffset(record.unknownTaggedFields()));
+                // Leader must be set to force epoch bump on broker
+                int partitionId = record.partitionId();
+                int expectedLeader = replicationControl.getPartition(topicId, partitionId).leader;
+                assertEquals(expectedLeader, record.leader());
+            }
+
+            int[] epochsBefore = new int[2];
+            for (int i = 0; i < 2; i++) {
+                epochsBefore[i] = replicationControl.getPartition(topicId, i).leaderEpoch;
             }
 
             ctx.replay(records);
@@ -6531,6 +6540,8 @@ public class ReplicationControlManagerTest {
                 PartitionRegistration partition = replicationControl.getPartition(topicId, i);
                 assertEquals(PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING,
                     partition.classicToDisklessStartOffset);
+                // Leader epoch must be bumped to trigger makeLeader on broker
+                assertEquals(epochsBefore[i] + 1, partition.leaderEpoch);
             }
         }
 


### PR DESCRIPTION
markClassicToDisklessSwitchStarted emits a PartitionChangeRecord without setting the leader field, so PartitionRegistration.merge() sees NO_LEADER_CHANGE and skips the leaderEpoch bump. Brokers only call makeLeader on epoch changes, leaving the partition stuck in PENDING.

This was latent since the method was introduced, but was masked by BrokerMetadataPublisher.sealExistingLeadersOfTopicsSwitchedToDiskless() which triggered the switch via config-delta scan — independent of epoch. PR #604 (ad647a42) removed that path and moved all switch logic into applyLocalLeadersDelta, which requires isNewLeaderEpoch == true. The controller was never updated to provide it.

Fix: set .setLeader(partition.leader) to force an epoch bump. The broker sees the new epoch, enters makeLeader, seals the log, and registers with InitDisklessLogManager. Also warn when the partition has no leader at switch time — the PENDING state persists and completes once a leader is elected.
