### PR TITLE
fix(inkless:consolidation): prevent ConsolidationFetcherThread crash on topic deletion

### DIFF
--- a/.github/workflows/inkless.yml
+++ b/.github/workflows/inkless.yml
@@ -169,11 +169,13 @@ jobs:
             --tests "org.apache.kafka.image.TopicsImageTest" && \
           ./gradlew ${GRADLE_ARGS} :core:test \
             --tests "*Inkless*" --tests "*Diskless*" \
+            --tests "io.aiven.inkless.*" \
             --tests "kafka.log.LogConfigTest" \
             --tests "kafka.server.KafkaConfigTest" \
             --tests "kafka.server.ReplicaManagerTest" \
             --tests "kafka.server.KafkaApisTest" \
             --tests "kafka.cluster.PartitionTest" \
+            --tests "kafka.server.AbstractFetcherThreadTest" \
             --tests "kafka.server.DynamicBrokerConfigTest" \
             --tests "kafka.server.DynamicConfigChangeTest" \
             --tests "kafka.server.ReplicaFetcherThreadTest" \

--- a/core/src/main/scala/io/aiven/inkless/consolidation/DisklessLeaderEndPoint.scala
+++ b/core/src/main/scala/io/aiven/inkless/consolidation/DisklessLeaderEndPoint.scala
@@ -22,7 +22,7 @@ import io.aiven.inkless.consume.{FetchHandler, FetchOffsetHandler}
 import kafka.server.{KafkaConfig, ReplicaManager, ReplicaQuota}
 import kafka.utils.Logging
 import org.apache.kafka.common.Uuid
-import org.apache.kafka.common.errors.KafkaStorageException
+import org.apache.kafka.common.errors.{KafkaStorageException, UnknownTopicOrPartitionException}
 import org.apache.kafka.common.message.{FetchResponseData, OffsetForLeaderEpochRequestData}
 import org.apache.kafka.common.message.ListOffsetsRequestData.ListOffsetsPartition
 import org.apache.kafka.common.message.OffsetForLeaderEpochResponseData.EpochEndOffset
@@ -252,7 +252,10 @@ class DisklessLeaderEndPoint(
               )
             )
           } catch {
-            case _: KafkaStorageException =>
+            // UnknownTopicOrPartitionException from localLogOrException when partition is
+            // deleted from allPartitions before the fetcher's partitionStates is cleaned up.
+            case e @ (_: KafkaStorageException | _: UnknownTopicOrPartitionException) =>
+              logger.info("Partition {} unavailable during buildFetch: {}", topicPartition, e.getMessage)
               partitionsWithError += topicPartition
           }
         }

--- a/core/src/test/scala/io/aiven/inkless/consolidation/DisklessLeaderEndPointTest.scala
+++ b/core/src/test/scala/io/aiven/inkless/consolidation/DisklessLeaderEndPointTest.scala
@@ -463,6 +463,29 @@ class DisklessLeaderEndPointTest {
   }
 
   @Test
+  def testBuildFetchMarksPartitionWithUnknownTopicOrPartitionException(): Unit = {
+    val fetchHandler = mock(classOf[FetchHandler])
+    val fetchOffsetHandler = mock(classOf[FetchOffsetHandler])
+    val replicaManager = mock(classOf[ReplicaManager])
+    when(replicaManager.localLogOrException(topicPartition)).thenThrow(new UnknownTopicOrPartitionException("deleted"))
+
+    val endPoint = newEndPoint(fetchHandler, fetchOffsetHandler, replicaManager)
+    val fetchState = new PartitionFetchState(
+      Optional.of(topicId),
+      0L,
+      Optional.empty(),
+      1,
+      Optional.empty(),
+      ReplicaState.FETCHING,
+      Optional.empty()
+    )
+    val result = endPoint.buildFetch(util.Map.of(topicPartition, fetchState))
+
+    assertTrue(result.result.isEmpty)
+    assertEquals(Set(topicPartition), result.partitionsWithError.asScala.toSet)
+  }
+
+  @Test
   def testBuildFetchSkipsPartitionWhenFollowerShouldThrottle(): Unit = {
     val fetchHandler = mock(classOf[FetchHandler])
     val fetchOffsetHandler = mock(classOf[FetchOffsetHandler])


### PR DESCRIPTION
When a diskless topic is deleted, `ConsolidationFetcherThread` dies permanently — blocking
consolidation for **all** topics on that broker until restart.

```
ERROR [ConsolidationFetcherThread-0-1]: Error due to
      org.apache.kafka.common.errors.UnknownTopicOrPartitionException
INFO  [ConsolidationFetcherThread-0-1]: Stopped
```

### Root cause

`DisklessLeaderEndPoint.buildFetch()` calls `replicaManager.localLogOrException(tp)` which
throws `UnknownTopicOrPartitionException` for deleted partitions. Only `KafkaStorageException`
is caught — the exception escapes `doWork()`, and `ShutdownableThread` exits permanently.

The race: `BrokerMetadataPublisher` sets `metadataCache.setImage(newImage)` (line 132)
before `applyDelta` (line 149) calls `stopPartitions` → `removeFetcherForPartitions`. In
that window the fetcher still has the partition in `partitionStates` but it's gone from
`allPartitions`/`metadataCache`.

The regular `ReplicaFetcher` never hits this because `stopPartitions` removes from the
fetcher BEFORE `allPartitions.remove` — proper ordering prevents the fetcher from ever
seeing a deleted partition.

### The fix

Catch `UnknownTopicOrPartitionException` alongside `KafkaStorageException` in
`DisklessLeaderEndPoint.buildFetch()`:

```scala
} catch {
  case e @ (_: KafkaStorageException | _: UnknownTopicOrPartitionException) =>
    logger.info("Partition {} unavailable during buildFetch: {}", topicPartition, e.getMessage)
    partitionsWithError += topicPartition
}
```

Partition goes to `partitionsWithError` → delayed → evicted on next cycle once
`removePartitions` completes.

### Test plan

- [x] `DisklessLeaderEndPointTest.testBuildFetchMarksPartitionWithUnknownTopicOrPartitionException`
- [x] `DisklessLeaderEndPointTest` — full suite passes
- [x] `ConsolidationFetcherThreadTest` — full suite passes
