### PR TITLE
fix(inkless:build): pass commitId to Gradle for worktree builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ build:
 
 core/build/distributions/kafka_2.13-$(VERSION).tgz:
 	echo "Building Kafka distribution with version $(VERSION)"
-	./gradlew releaseTarGz
+	./gradlew releaseTarGz -PcommitId=$$(git rev-parse HEAD)
 
 .PHONY: build_release
 build_release: core/build/distributions/kafka_2.13-$(VERSION).tgz


### PR DESCRIPTION
Gradle's Grgit check uses .isDirectory() on .git, which fails in worktrees where .git is a file. Pass the SHA explicitly via -PcommitId.
