### PR TITLE
fix(inkless): Remove consolidating fetchers unconditionally

### DIFF
--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -496,12 +496,9 @@ class ReplicaManager(val config: KafkaConfig,
     val partitions = partitionsToStop.map(_.topicPartition)
     replicaFetcherManager.removeFetcherForPartitions(partitions)
     replicaAlterLogDirsManager.removeFetcherForPartitions(partitions)
-    val consolidatingPartitionsToStop = if (config.disklessRemoteStorageConsolidationEnabled)
-      partitions.filter(p => _inklessMetadataView.isConsolidatingDisklessTopic(p.topic))
-      else Set[TopicPartition]()
-    consolidationFetcherManager.foreach(_.removeFetcherForPartitions(consolidatingPartitionsToStop))
+    consolidationFetcherManager.foreach(_.removeFetcherForPartitions(partitions))
     consolidationMetrics.foreach { metrics =>
-      consolidatingPartitionsToStop.foreach(tp => metrics.unregisterPartition(tp))
+      partitions.foreach(tp => metrics.unregisterPartition(tp))
     }
 
     // Second remove deleted partitions from the partition map. Fetchers rely on the


### PR DESCRIPTION
Metadata is updated sooner than the applyDelta is being called, so checking whether the partition is consolidating there is incorrect. Since `removeFetcherForPartitions` ignore partitions it can't find, it's simpler and safer not to filter there.
