### PR TITLE
feat(inkless): KC-156 diskless leader epoch for consolidation truncation

### DIFF
--- a/core/src/main/scala/io/aiven/inkless/consolidation/ConsolidationFetcherThread.scala
+++ b/core/src/main/scala/io/aiven/inkless/consolidation/ConsolidationFetcherThread.scala
@@ -22,6 +22,8 @@ import io.aiven.inkless.consume.ConcatenatedRecords
 import kafka.server.{FailedPartitions, KafkaConfig, ReplicaFetcherThread, ReplicaManager, ReplicaQuota}
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.record.{MemoryRecords, Records}
+import org.apache.kafka.common.requests.FetchResponse
+import org.apache.kafka.metadata.PartitionRegistration
 import org.apache.kafka.server.LeaderEndPoint
 import org.apache.kafka.storage.internals.log.LogAppendInfo
 
@@ -51,6 +53,7 @@ class ConsolidationFetcherThread(name: String,
     partitionLeaderEpoch: Int,
     partitionData: FetchData
   ): Option[LogAppendInfo] = {
+    maybeStampDisklessLeaderEpoch(topicPartition, partitionData)
     val result = super.processPartitionData(topicPartition, fetchOffset, partitionLeaderEpoch, partitionData)
 
     consolidationMetrics.foreach { metrics =>
@@ -69,5 +72,27 @@ class ConsolidationFetcherThread(name: String,
     }
 
     result
+  }
+
+  /**
+   * Stamp the frozen diskless leader epoch (E_d) onto materialized batches so the local log keeps a
+   * monotonic epoch lineage (diskless records are produced with epoch 0, which would otherwise break
+   * the LeaderEpochFileCache after a switched partition's higher classic epochs and disable divergence
+   * truncation). Born-diskless / not-yet-switched partitions (E_d == NO_DISKLESS_LEADER_EPOCH) are left
+   * at epoch 0. Done in place to reuse the append path's single flatten; partitionLeaderEpoch is outside
+   * the batch CRC, so no checksum recompute is needed.
+   */
+  private def maybeStampDisklessLeaderEpoch(topicPartition: TopicPartition, partitionData: FetchData): Unit = {
+    val disklessLeaderEpoch = replicaMgr.disklessLeaderEpoch(topicPartition)
+    if (disklessLeaderEpoch == PartitionRegistration.NO_DISKLESS_LEADER_EPOCH) {
+      return
+    }
+    FetchResponse.recordsOrFail(partitionData) match {
+      case records: ConcatenatedRecords =>
+        records.batches().forEach(batch => batch.setPartitionLeaderEpoch(disklessLeaderEpoch))
+      case records: MemoryRecords =>
+        records.batches().forEach(batch => batch.setPartitionLeaderEpoch(disklessLeaderEpoch))
+      case _ =>
+    }
   }
 }

--- a/core/src/main/scala/io/aiven/inkless/consolidation/ConsolidationFetcherThread.scala
+++ b/core/src/main/scala/io/aiven/inkless/consolidation/ConsolidationFetcherThread.scala
@@ -75,7 +75,7 @@ class ConsolidationFetcherThread(name: String,
   }
 
   /**
-   * Stamp the frozen diskless leader epoch (E_d) onto materialized batches so the local log keeps a
+   * Stamp the captured diskless leader epoch (E_d) onto materialized batches so the local log keeps a
    * monotonic epoch lineage (diskless records are produced with epoch 0, which would otherwise break
    * the LeaderEpochFileCache after a switched partition's higher classic epochs and disable divergence
    * truncation). Born-diskless / not-yet-switched partitions (E_d == NO_DISKLESS_LEADER_EPOCH) are left

--- a/core/src/main/scala/io/aiven/inkless/consolidation/DisklessLeaderEndPoint.scala
+++ b/core/src/main/scala/io/aiven/inkless/consolidation/DisklessLeaderEndPoint.scala
@@ -175,14 +175,14 @@ class DisklessLeaderEndPoint(
    *
    * A switched partition's local log is laid out as a classic prefix `[logStart, seal)` carrying the
    * original classic leader epochs, followed by the diskless region `[seal, LEO)` stamped with the
-   * frozen diskless leader epoch `E_d` (see [[ConsolidationFetcherThread]]). Two cases:
+   * diskless leader epoch `E_d` captured at the switch (see [[ConsolidationFetcherThread]]). Two cases:
    *   - queried epoch `< E_d`: the epoch belongs to the classic prefix, whose lineage on the diskless
    *     leader ends at the seal, so the end offset is the seal. A follower whose stale classic tail
    *     runs past the seal truncates back to it. Collapsing every classic epoch to the seal (rather
    *     than the start of the next epoch, as standard OffsetsForLeaderEpoch would) is correct only
    *     because the classic prefix `[logStart, seal)` is committed and identical across all replicas,
    *     so intra-prefix divergence cannot occur.
-   *   - queried epoch `>= E_d` (or a born-diskless partition with no frozen epoch): the end offset is
+   *   - queried epoch `>= E_d` (or a born-diskless partition with no captured epoch): the end offset is
    *     the current diskless LEO, fetched via a LATEST list-offsets call.
    */
   override def fetchEpochEndOffsets(

--- a/core/src/main/scala/io/aiven/inkless/consolidation/DisklessLeaderEndPoint.scala
+++ b/core/src/main/scala/io/aiven/inkless/consolidation/DisklessLeaderEndPoint.scala
@@ -30,7 +30,7 @@ import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.record.FileRecords.TimestampAndOffset
 import org.apache.kafka.common.requests.{FetchRequest, FetchResponse, ListOffsetsRequest, OffsetsForLeaderEpochResponse}
 import org.apache.kafka.common.TopicPartition
-import org.apache.kafka.metadata.LeaderAndIsr
+import org.apache.kafka.metadata.{LeaderAndIsr, PartitionRegistration}
 import org.apache.kafka.server.common.{MetadataVersion, OffsetAndEpoch}
 import org.apache.kafka.server.network.BrokerEndPoint
 import org.apache.kafka.server.storage.log.{FetchIsolation, FetchParams}
@@ -169,6 +169,22 @@ class DisklessLeaderEndPoint(
     new OffsetAndEpoch(tao.offset, tao.leaderEpoch.orElse(0))
   }
 
+  /**
+   * Answers OffsetsForLeaderEpoch for diskless consolidating partitions so followers can perform
+   * standard divergence truncation against the diskless leader.
+   *
+   * A switched partition's local log is laid out as a classic prefix `[logStart, seal)` carrying the
+   * original classic leader epochs, followed by the diskless region `[seal, LEO)` stamped with the
+   * frozen diskless leader epoch `E_d` (see [[ConsolidationFetcherThread]]). Two cases:
+   *   - queried epoch `< E_d`: the epoch belongs to the classic prefix, whose lineage on the diskless
+   *     leader ends at the seal, so the end offset is the seal. A follower whose stale classic tail
+   *     runs past the seal truncates back to it. Collapsing every classic epoch to the seal (rather
+   *     than the start of the next epoch, as standard OffsetsForLeaderEpoch would) is correct only
+   *     because the classic prefix `[logStart, seal)` is committed and identical across all replicas,
+   *     so intra-prefix divergence cannot occur.
+   *   - queried epoch `>= E_d` (or a born-diskless partition with no frozen epoch): the end offset is
+   *     the current diskless LEO, fetched via a LATEST list-offsets call.
+   */
   override def fetchEpochEndOffsets(
     partitions: util.Map[TopicPartition, OffsetForLeaderEpochRequestData.OffsetForLeaderPartition]
   ): util.Map[TopicPartition, EpochEndOffset] = {
@@ -178,14 +194,27 @@ class DisklessLeaderEndPoint(
 
     val job = fetchOffsetHandler.createJob()
     val futures = mutable.Map.empty[TopicPartition, CompletableFuture[FileRecordsOrError]]
+    // Partitions whose queried epoch resolves to the seal without needing a diskless list-offsets call.
+    val sealEndOffsets = mutable.Map.empty[TopicPartition, Long]
 
     partitions.forEach { (tp, epochData) =>
       if (epochData.leaderEpoch != OffsetsForLeaderEpochResponse.UNDEFINED_EPOCH && job.mustHandle(tp.topic)) {
-        val partitionRequest = new ListOffsetsPartition()
-          .setPartitionIndex(tp.partition)
-          .setCurrentLeaderEpoch(LeaderAndIsr.INITIAL_LEADER_EPOCH)
-          .setTimestamp(ListOffsetsRequest.LATEST_TIMESTAMP)
-        futures.put(tp, job.add(tp, partitionRequest))
+        val seal = replicaManager.classicToDisklessStartOffset(tp)
+        val disklessLeaderEpoch = replicaManager.disklessLeaderEpoch(tp)
+        // Upgrade caveat: partitions switched before this change carry a seal but no E_d (no tag 102),
+        // so they fall through to the LATEST-LEO branch and keep the old (no divergence truncation)
+        // behavior until they are re-switched. This is a safe fallback, not a correctness regression.
+        if (seal >= 0 &&
+            disklessLeaderEpoch != PartitionRegistration.NO_DISKLESS_LEADER_EPOCH &&
+            epochData.leaderEpoch < disklessLeaderEpoch) {
+          sealEndOffsets.put(tp, seal)
+        } else {
+          val partitionRequest = new ListOffsetsPartition()
+            .setPartitionIndex(tp.partition)
+            .setCurrentLeaderEpoch(LeaderAndIsr.INITIAL_LEADER_EPOCH)
+            .setTimestamp(ListOffsetsRequest.LATEST_TIMESTAMP)
+          futures.put(tp, job.add(tp, partitionRequest))
+        }
       }
     }
 
@@ -196,6 +225,12 @@ class DisklessLeaderEndPoint(
         tp -> new EpochEndOffset()
           .setPartition(tp.partition)
           .setErrorCode(Errors.NONE.code)
+      } else if (sealEndOffsets.contains(tp)) {
+        tp -> new EpochEndOffset()
+          .setPartition(tp.partition)
+          .setErrorCode(Errors.NONE.code)
+          .setLeaderEpoch(epochData.leaderEpoch)
+          .setEndOffset(sealEndOffsets(tp))
       } else if (!futures.contains(tp)) {
         tp -> new EpochEndOffset()
           .setPartition(tp.partition)

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -3195,6 +3195,12 @@ class ReplicaManager(val config: KafkaConfig,
     consolidationReconciler.foreach(_.startConsolidationFetchersForCaughtUpClassicPartitions(topicPartitions))
   }
 
+  def classicToDisklessStartOffset(topicPartition: TopicPartition): Long =
+    _inklessMetadataView.getClassicToDisklessStartOffset(topicPartition)
+
+  def disklessLeaderEpoch(topicPartition: TopicPartition): Int =
+    _inklessMetadataView.getDisklessLeaderEpoch(topicPartition)
+
   /**
    * Whether a follower of a consolidating diskless topic is ready to be handed to the consolidation
    * fetcher rather than the classic ReplicaFetcher:

--- a/core/src/main/scala/kafka/server/metadata/InklessMetadataView.scala
+++ b/core/src/main/scala/kafka/server/metadata/InklessMetadataView.scala
@@ -103,7 +103,7 @@ class InklessMetadataView(val metadataCache: KRaftMetadataCache, val defaultConf
   }
 
   /**
-   * The frozen diskless leader epoch (E_d) captured at the classic-to-diskless switch, or
+   * The diskless leader epoch (E_d) captured at the classic-to-diskless switch, or
    * [[PartitionRegistration.NO_DISKLESS_LEADER_EPOCH]] when the partition never switched (born-diskless
    * or switch still pending). It is strictly greater than every classic-prefix leader epoch.
    */

--- a/core/src/main/scala/kafka/server/metadata/InklessMetadataView.scala
+++ b/core/src/main/scala/kafka/server/metadata/InklessMetadataView.scala
@@ -102,6 +102,18 @@ class InklessMetadataView(val metadataCache: KRaftMetadataCache, val defaultConf
       .getOrElse(PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET)
   }
 
+  /**
+   * The frozen diskless leader epoch (E_d) captured at the classic-to-diskless switch, or
+   * [[PartitionRegistration.NO_DISKLESS_LEADER_EPOCH]] when the partition never switched (born-diskless
+   * or switch still pending). It is strictly greater than every classic-prefix leader epoch.
+   */
+  def getDisklessLeaderEpoch(topicPartition: TopicPartition): Int = {
+    Option(metadataCache.currentImage().topics().getTopic(topicPartition.topic()))
+      .flatMap(topicImage => Option(topicImage.partitions().get(topicPartition.partition())))
+      .map(_.disklessLeaderEpoch)
+      .getOrElse(PartitionRegistration.NO_DISKLESS_LEADER_EPOCH)
+  }
+
   override def getTopicConfig(topicName: String): LogConfig = topicConfigs.computeIfAbsent(topicName, t => {
     val props = metadataCache.topicConfig(t)
     if (props.isEmpty) new LogConfig(getDefaultConfig)

--- a/core/src/test/scala/io/aiven/inkless/consolidation/ConsolidationFetcherThreadTest.scala
+++ b/core/src/test/scala/io/aiven/inkless/consolidation/ConsolidationFetcherThreadTest.scala
@@ -191,8 +191,8 @@ class ConsolidationFetcherThreadTest {
   }
 
   /**
-   * Scenario: a partition switched classic->diskless at seal offset 100 with a frozen diskless leader
-   * epoch E_d=5. After a leader failover this follower still has a STALE classic tail past the seal:
+   * Scenario: a partition switched classic->diskless at seal offset 100 with a diskless leader epoch
+   * E_d=5 captured at the switch. After a leader failover this follower still has a STALE classic tail past the seal:
    * its local log runs to LEO 130 and its latest local epoch is a classic epoch (2 < E_d). The
    * diskless region [100, ...) on the (new) diskless leader is authoritative, so the follower must
    * truncate its divergent tail back to the seal.
@@ -219,7 +219,7 @@ class ConsolidationFetcherThreadTest {
     when(replicaManager.localLogOrException(topicPartition)).thenReturn(log)
     when(replicaManager.getPartitionOrException(topicPartition)).thenReturn(partition)
     when(replicaManager.brokerTopicStats).thenReturn(new BrokerTopicStats)
-    // Committed metadata for the switched partition: seal at 100, frozen diskless epoch E_d=5.
+    // Committed metadata for the switched partition: seal at 100, captured diskless epoch E_d=5.
     when(replicaManager.classicToDisklessStartOffset(topicPartition)).thenReturn(seal)
     when(replicaManager.disklessLeaderEpoch(topicPartition)).thenReturn(disklessLeaderEpoch)
 

--- a/core/src/test/scala/io/aiven/inkless/consolidation/ConsolidationFetcherThreadTest.scala
+++ b/core/src/test/scala/io/aiven/inkless/consolidation/ConsolidationFetcherThreadTest.scala
@@ -18,6 +18,7 @@
 
 package io.aiven.inkless.consolidation
 
+import io.aiven.inkless.consume.{ConcatenatedRecords, FetchHandler, FetchOffsetHandler}
 import kafka.cluster.Partition
 import kafka.server._
 import kafka.server.metadata.InklessMetadataView
@@ -25,17 +26,19 @@ import kafka.utils.TestUtils
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.compress.Compression
 import org.apache.kafka.common.message.FetchResponseData
-import org.apache.kafka.common.record.{MemoryRecords, SimpleRecord}
+import org.apache.kafka.common.record.{BaseRecords, MemoryRecords, SimpleRecord}
 import org.apache.kafka.metadata.PartitionRegistration
 import org.apache.kafka.server.LeaderEndPoint
+import org.apache.kafka.server.common.{MetadataVersion, OffsetAndEpoch}
 import org.apache.kafka.server.network.BrokerEndPoint
 import org.apache.kafka.server.metrics.KafkaYammerMetrics
 import org.apache.kafka.storage.internals.log.{LogAppendInfo, UnifiedLog}
 import org.apache.kafka.storage.log.metrics.BrokerTopicStats
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
+import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.{any, anyLong}
-import org.mockito.Mockito.{mock, when}
+import org.mockito.Mockito.{RETURNS_DEEP_STUBS, doNothing, mock, verify, when}
 
 import java.nio.charset.StandardCharsets
 import java.util.Optional
@@ -122,6 +125,153 @@ class ConsolidationFetcherThreadTest {
       .setRecords(records)
       .setHighWatermark(highWatermark)
       .setLogStartOffset(0)
+  }
+
+  private def recordsWithEpoch(baseOffset: Long, epoch: Int, value: String): MemoryRecords =
+    MemoryRecords.withRecords(baseOffset, Compression.NONE, epoch,
+      new SimpleRecord(1000, value.getBytes(StandardCharsets.UTF_8)))
+
+  private def partitionDataWith(records: BaseRecords): FetchResponseData.PartitionData =
+    new FetchResponseData.PartitionData()
+      .setPartitionIndex(topicPartition.partition)
+      .setRecords(records)
+      .setHighWatermark(10L)
+      .setLogStartOffset(0)
+
+  // Capture the records actually appended to the local log and return each batch's leader epoch.
+  private def appendedBatchEpochs(partition: Partition): List[Int] = {
+    val captor = ArgumentCaptor.forClass(classOf[MemoryRecords])
+    verify(partition).appendRecordsToFollowerOrFutureReplica(captor.capture(), any[Boolean], any[Int])
+    captor.getValue.batches().asScala.map(_.partitionLeaderEpoch).toList
+  }
+
+  @Test
+  def testStampsDisklessLeaderEpochOnConcatenatedRecords(): Unit = {
+    val disklessLeaderEpoch = 7
+    val partition = mockPartitionWithLog(logEndOffset = 0L, highestOffsetInRemoteStorage = -1L)
+    val replicaManager = mockReplicaManager(partition)
+    when(replicaManager.disklessLeaderEpoch(any[TopicPartition])).thenReturn(disklessLeaderEpoch)
+    val thread = createConsolidationFetcherThread(replicaManager, None)
+
+    val records = new ConcatenatedRecords(java.util.List.of(
+      recordsWithEpoch(0L, 0, "a"),
+      recordsWithEpoch(1L, 0, "b")
+    ))
+
+    thread.processPartitionData(topicPartition, 0L, Int.MaxValue, partitionDataWith(records))
+
+    assertEquals(List(disklessLeaderEpoch, disklessLeaderEpoch), appendedBatchEpochs(partition))
+  }
+
+  @Test
+  def testStampsDisklessLeaderEpochOnMemoryRecords(): Unit = {
+    val disklessLeaderEpoch = 7
+    val partition = mockPartitionWithLog(logEndOffset = 0L, highestOffsetInRemoteStorage = -1L)
+    val replicaManager = mockReplicaManager(partition)
+    when(replicaManager.disklessLeaderEpoch(any[TopicPartition])).thenReturn(disklessLeaderEpoch)
+    val thread = createConsolidationFetcherThread(replicaManager, None)
+
+    thread.processPartitionData(topicPartition, 0L, Int.MaxValue, partitionDataWith(recordsWithEpoch(0L, 0, "a")))
+
+    assertEquals(List(disklessLeaderEpoch), appendedBatchEpochs(partition))
+  }
+
+  @Test
+  def testBornDisklessLeavesEpochUntouched(): Unit = {
+    val partition = mockPartitionWithLog(logEndOffset = 0L, highestOffsetInRemoteStorage = -1L)
+    val replicaManager = mockReplicaManager(partition)
+    when(replicaManager.disklessLeaderEpoch(any[TopicPartition]))
+      .thenReturn(PartitionRegistration.NO_DISKLESS_LEADER_EPOCH)
+    val thread = createConsolidationFetcherThread(replicaManager, None)
+
+    thread.processPartitionData(topicPartition, 0L, Int.MaxValue, partitionDataWith(recordsWithEpoch(0L, 0, "a")))
+
+    // The guard short-circuits: had stamping run with E_d == -1 it would have written -1, not left 0.
+    assertEquals(List(0), appendedBatchEpochs(partition))
+  }
+
+  /**
+   * Scenario: a partition switched classic->diskless at seal offset 100 with a frozen diskless leader
+   * epoch E_d=5. After a leader failover this follower still has a STALE classic tail past the seal:
+   * its local log runs to LEO 130 and its latest local epoch is a classic epoch (2 < E_d). The
+   * diskless region [100, ...) on the (new) diskless leader is authoritative, so the follower must
+   * truncate its divergent tail back to the seal.
+   */
+  @Test
+  def testFollowerTruncatesStaleClassicTailToSealAfterFailover(): Unit = {
+    val seal = 100L
+    val disklessLeaderEpoch = 5
+    val staleClassicEpoch = 2
+    val divergentLeo = 130L
+
+    val log = mock(classOf[UnifiedLog])
+    when(log.latestEpoch).thenReturn(Optional.of(Int.box(staleClassicEpoch)))
+    when(log.logStartOffset).thenReturn(0L)
+    when(log.logEndOffset).thenReturn(divergentLeo)
+    when(log.endOffsetForEpoch(staleClassicEpoch))
+      .thenReturn(Optional.of(new OffsetAndEpoch(divergentLeo, staleClassicEpoch)))
+
+    val partition = mock(classOf[Partition])
+
+    // Deep stubs so the truncation-complete callback (replicaAlterLogDirsManager.markPartitionsForTruncation,
+    // a kafka.server-private member we cannot reference from here) is auto-stubbed to a no-op.
+    val replicaManager = mock(classOf[ReplicaManager], RETURNS_DEEP_STUBS)
+    when(replicaManager.localLogOrException(topicPartition)).thenReturn(log)
+    when(replicaManager.getPartitionOrException(topicPartition)).thenReturn(partition)
+    when(replicaManager.brokerTopicStats).thenReturn(new BrokerTopicStats)
+    // Committed metadata for the switched partition: seal at 100, frozen diskless epoch E_d=5.
+    when(replicaManager.classicToDisklessStartOffset(topicPartition)).thenReturn(seal)
+    when(replicaManager.disklessLeaderEpoch(topicPartition)).thenReturn(disklessLeaderEpoch)
+
+    // Real diskless leader endpoint backing OffsetsForLeaderEpoch for the consolidating follower.
+    val fetchHandler = mock(classOf[FetchHandler])
+    val fetchOffsetHandler = mock(classOf[FetchOffsetHandler])
+    val job = mock(classOf[FetchOffsetHandler.Job])
+    when(fetchOffsetHandler.createJob()).thenReturn(job)
+    when(job.mustHandle(topicPartition.topic())).thenReturn(true)
+    doNothing().when(job).start()
+
+    val brokerEndPoint = new BrokerEndPoint(0, "localhost", 9092)
+    // Quota "exceeded" so the post-truncation fetch round (buildFetch) is a no-op and the test stays
+    // focused on truncation.
+    val endpointQuota = mock(classOf[ReplicaQuota])
+    when(endpointQuota.isQuotaExceeded).thenReturn(true)
+
+    val props = TestUtils.createBrokerConfig(nodeId = 1)
+    props.put("replica.fetch.backoff.ms", "1")
+    val config = KafkaConfig.fromProps(props)
+
+    val endpoint = new DisklessLeaderEndPoint(
+      brokerEndPoint,
+      fetchHandler,
+      fetchOffsetHandler,
+      replicaManager,
+      config,
+      endpointQuota,
+      () => MetadataVersion.LATEST_PRODUCTION,
+      () => 1L
+    )
+
+    val thread = new ConsolidationFetcherThread(
+      "consolidation-fetcher-truncation-test",
+      endpoint,
+      config,
+      failedPartitions,
+      replicaManager,
+      QuotaFactory.UNBOUNDED_QUOTA,
+      "[ConsolidationFetcherTruncationTest] ",
+      None
+    )
+
+    // Follower joins the consolidation fetcher in the Truncating phase (isTruncationOnFetchSupported=false).
+    thread.addPartitions(Map(
+      topicPartition -> InitialFetchState(None, brokerEndPoint, currentLeaderEpoch = 8, initOffset = divergentLeo)
+    ))
+
+    thread.doWork()
+
+    // The stale tail [seal, LEO) is truncated away: the follower truncates back to the committed seal.
+    verify(partition).truncateTo(seal, isFuture = false)
   }
 
   @Test

--- a/core/src/test/scala/io/aiven/inkless/consolidation/DisklessLeaderEndPointTest.scala
+++ b/core/src/test/scala/io/aiven/inkless/consolidation/DisklessLeaderEndPointTest.scala
@@ -448,7 +448,7 @@ class DisklessLeaderEndPointTest {
     when(fetchOffsetHandler.createJob()).thenReturn(job)
     when(job.mustHandle(topicPartition.topic())).thenReturn(true)
     when(job.add(eqTo(topicPartition), any())).thenReturn(CompletableFuture.completedFuture(holder))
-    // Born-diskless / never switched: no classic seal and no frozen diskless epoch.
+    // Born-diskless / never switched: no classic seal and no captured diskless epoch.
     when(replicaManager.classicToDisklessStartOffset(topicPartition))
       .thenReturn(org.apache.kafka.metadata.PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET)
     when(replicaManager.disklessLeaderEpoch(topicPartition))

--- a/core/src/test/scala/io/aiven/inkless/consolidation/DisklessLeaderEndPointTest.scala
+++ b/core/src/test/scala/io/aiven/inkless/consolidation/DisklessLeaderEndPointTest.scala
@@ -363,6 +363,112 @@ class DisklessLeaderEndPointTest {
   }
 
   @Test
+  def testFetchEpochEndOffsetsBelowDisklessEpochReturnsSeal(): Unit = {
+    val fetchHandler = mock(classOf[FetchHandler])
+    val fetchOffsetHandler = mock(classOf[FetchOffsetHandler])
+    val replicaManager = mock(classOf[ReplicaManager])
+    val job = mock(classOf[FetchOffsetHandler.Job])
+
+    when(fetchOffsetHandler.createJob()).thenReturn(job)
+    when(job.mustHandle(topicPartition.topic())).thenReturn(true)
+    doNothing().when(job).start()
+    // Switched partition: classic prefix ends at the seal (100), diskless region carries epoch 5.
+    when(replicaManager.classicToDisklessStartOffset(topicPartition)).thenReturn(100L)
+    when(replicaManager.disklessLeaderEpoch(topicPartition)).thenReturn(5)
+
+    val endPoint = newEndPoint(fetchHandler, fetchOffsetHandler, replicaManager)
+    // A classic-prefix epoch (3 < 5) must resolve to the seal, without a diskless list-offsets call.
+    val queriedEpoch = 3
+    val result = endPoint.fetchEpochEndOffsets(
+      util.Map.of(
+        topicPartition,
+        new OffsetForLeaderPartition()
+          .setPartition(topicPartition.partition)
+          .setLeaderEpoch(queriedEpoch)
+      )
+    ).asScala
+
+    val expected = new EpochEndOffset()
+      .setPartition(topicPartition.partition)
+      .setErrorCode(Errors.NONE.code)
+      .setLeaderEpoch(queriedEpoch)
+      .setEndOffset(100L)
+    assertEquals(Map(topicPartition -> expected), result)
+    verify(job, org.mockito.Mockito.never()).add(eqTo(topicPartition), any())
+  }
+
+  @Test
+  def testFetchEpochEndOffsetsAtOrAboveDisklessEpochReturnsDisklessLeo(): Unit = {
+    val fetchHandler = mock(classOf[FetchHandler])
+    val fetchOffsetHandler = mock(classOf[FetchOffsetHandler])
+    val replicaManager = mock(classOf[ReplicaManager])
+    val job = mock(classOf[FetchOffsetHandler.Job])
+
+    val holder = new FileRecordsOrError(
+      Optional.empty(),
+      Optional.of(new TimestampAndOffset(0L, 250L, Optional.of(5)))
+    )
+    when(fetchOffsetHandler.createJob()).thenReturn(job)
+    when(job.mustHandle(topicPartition.topic())).thenReturn(true)
+    when(job.add(eqTo(topicPartition), any())).thenReturn(CompletableFuture.completedFuture(holder))
+    when(replicaManager.classicToDisklessStartOffset(topicPartition)).thenReturn(100L)
+    when(replicaManager.disklessLeaderEpoch(topicPartition)).thenReturn(5)
+
+    val endPoint = newEndPoint(fetchHandler, fetchOffsetHandler, replicaManager)
+    // The diskless epoch itself (5 >= 5) resolves to the current diskless LEO.
+    val queriedEpoch = 5
+    val result = endPoint.fetchEpochEndOffsets(
+      util.Map.of(
+        topicPartition,
+        new OffsetForLeaderPartition()
+          .setPartition(topicPartition.partition)
+          .setLeaderEpoch(queriedEpoch)
+      )
+    ).asScala
+
+    val expected = new EpochEndOffset()
+      .setPartition(topicPartition.partition)
+      .setErrorCode(Errors.NONE.code)
+      .setLeaderEpoch(queriedEpoch)
+      .setEndOffset(250L)
+    assertEquals(Map(topicPartition -> expected), result)
+  }
+
+  @Test
+  def testFetchEpochEndOffsetsBornDisklessReturnsDisklessLeo(): Unit = {
+    val fetchHandler = mock(classOf[FetchHandler])
+    val fetchOffsetHandler = mock(classOf[FetchOffsetHandler])
+    val replicaManager = mock(classOf[ReplicaManager])
+    val job = mock(classOf[FetchOffsetHandler.Job])
+
+    val holder = new FileRecordsOrError(
+      Optional.empty(),
+      Optional.of(new TimestampAndOffset(0L, 42L, Optional.of(0)))
+    )
+    when(fetchOffsetHandler.createJob()).thenReturn(job)
+    when(job.mustHandle(topicPartition.topic())).thenReturn(true)
+    when(job.add(eqTo(topicPartition), any())).thenReturn(CompletableFuture.completedFuture(holder))
+    // Born-diskless / never switched: no classic seal and no frozen diskless epoch.
+    when(replicaManager.classicToDisklessStartOffset(topicPartition))
+      .thenReturn(org.apache.kafka.metadata.PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET)
+    when(replicaManager.disklessLeaderEpoch(topicPartition))
+      .thenReturn(org.apache.kafka.metadata.PartitionRegistration.NO_DISKLESS_LEADER_EPOCH)
+
+    val endPoint = newEndPoint(fetchHandler, fetchOffsetHandler, replicaManager)
+    val result = endPoint.fetchEpochEndOffsets(
+      util.Map.of(
+        topicPartition,
+        new OffsetForLeaderPartition()
+          .setPartition(topicPartition.partition)
+          .setLeaderEpoch(0)
+      )
+    ).asScala
+
+    assertEquals(42L, result(topicPartition).endOffset)
+    assertEquals(Errors.NONE.code, result(topicPartition).errorCode)
+  }
+
+  @Test
   def testFetchEpochEndOffsetsHolderException(): Unit = {
     val fetchHandler = mock(classOf[FetchHandler])
     val fetchOffsetHandler = mock(classOf[FetchOffsetHandler])

--- a/core/src/test/scala/kafka/server/metadata/InklessMetadataViewTest.scala
+++ b/core/src/test/scala/kafka/server/metadata/InklessMetadataViewTest.scala
@@ -19,7 +19,9 @@
 package kafka.server.metadata
 
 import org.apache.kafka.common.config.TopicConfig
-import org.apache.kafka.common.{TopicIdPartition, Uuid}
+import org.apache.kafka.common.{DirectoryId, TopicIdPartition, TopicPartition, Uuid}
+import org.apache.kafka.image.{MetadataImage, TopicImage, TopicsImage}
+import org.apache.kafka.metadata.{LeaderRecoveryState, PartitionRegistration}
 import org.junit.jupiter.api.{BeforeEach, Nested, Test}
 import org.junit.jupiter.api.Assertions._
 import org.mockito.ArgumentMatchers.anyString
@@ -214,6 +216,84 @@ class InklessMetadataViewTest {
     diskless.foreach(v => props.put(TopicConfig.DISKLESS_ENABLE_CONFIG, v))
     remoteStorageEnable.foreach(v => props.put(TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG, v))
     props
+  }
+
+  private def partitionRegistration(disklessLeaderEpoch: Option[Int] = None, seal: Option[Long] = None): PartitionRegistration = {
+    val builder = new PartitionRegistration.Builder()
+      .setReplicas(Array(1))
+      .setDirectories(DirectoryId.unassignedArray(1))
+      .setIsr(Array(1))
+      .setLeader(1)
+      .setLeaderRecoveryState(LeaderRecoveryState.RECOVERED)
+      .setLeaderEpoch(3)
+      .setPartitionEpoch(0)
+    disklessLeaderEpoch.foreach(builder.setDisklessLeaderEpoch)
+    seal.foreach(builder.setClassicToDisklessStartOffset)
+    builder.build()
+  }
+
+  // Wires metadataCache.currentImage().topics().getTopic(topic) -> topicImage holding the given partitions.
+  private def stubImageTopic(topic: String, partitions: util.Map[Integer, PartitionRegistration]): Unit = {
+    val image = mock(classOf[MetadataImage])
+    val topicsImage = mock(classOf[TopicsImage])
+    val topicImage = mock(classOf[TopicImage])
+    when(metadataCache.currentImage()).thenReturn(image)
+    when(image.topics()).thenReturn(topicsImage)
+    when(topicsImage.getTopic(topic)).thenReturn(topicImage)
+    when(topicImage.partitions()).thenReturn(partitions)
+  }
+
+  // Wires metadataCache.currentImage().topics().getTopic(topic) -> null (topic absent from the image).
+  private def stubImageWithoutTopic(topic: String): Unit = {
+    val image = mock(classOf[MetadataImage])
+    val topicsImage = mock(classOf[TopicsImage])
+    when(metadataCache.currentImage()).thenReturn(image)
+    when(image.topics()).thenReturn(topicsImage)
+    when(topicsImage.getTopic(topic)).thenReturn(null.asInstanceOf[TopicImage])
+  }
+
+  @Test
+  def testGetDisklessLeaderEpochReturnsValueFromImage(): Unit = {
+    val tp = new TopicPartition("switched", 0)
+    stubImageTopic(tp.topic(), util.Map.of(Integer.valueOf(0), partitionRegistration(disklessLeaderEpoch = Some(7))))
+    assertEquals(7, metadataView.getDisklessLeaderEpoch(tp))
+  }
+
+  @Test
+  def testGetDisklessLeaderEpochReturnsSentinelWhenUnset(): Unit = {
+    // Born-diskless / never-switched partition carries no diskless epoch.
+    val tp = new TopicPartition("born-diskless", 0)
+    stubImageTopic(tp.topic(), util.Map.of(Integer.valueOf(0), partitionRegistration()))
+    assertEquals(PartitionRegistration.NO_DISKLESS_LEADER_EPOCH, metadataView.getDisklessLeaderEpoch(tp))
+  }
+
+  @Test
+  def testGetDisklessLeaderEpochReturnsSentinelWhenTopicMissing(): Unit = {
+    val tp = new TopicPartition("missing", 0)
+    stubImageWithoutTopic(tp.topic())
+    assertEquals(PartitionRegistration.NO_DISKLESS_LEADER_EPOCH, metadataView.getDisklessLeaderEpoch(tp))
+  }
+
+  @Test
+  def testGetDisklessLeaderEpochReturnsSentinelWhenPartitionMissing(): Unit = {
+    val tp = new TopicPartition("switched", 1)
+    // Topic present, but only partition 0 exists in the image.
+    stubImageTopic(tp.topic(), util.Map.of(Integer.valueOf(0), partitionRegistration(disklessLeaderEpoch = Some(7))))
+    assertEquals(PartitionRegistration.NO_DISKLESS_LEADER_EPOCH, metadataView.getDisklessLeaderEpoch(tp))
+  }
+
+  @Test
+  def testGetClassicToDisklessStartOffsetReturnsValueFromImage(): Unit = {
+    val tp = new TopicPartition("switched", 0)
+    stubImageTopic(tp.topic(), util.Map.of(Integer.valueOf(0), partitionRegistration(seal = Some(42L))))
+    assertEquals(42L, metadataView.getClassicToDisklessStartOffset(tp))
+  }
+
+  @Test
+  def testGetClassicToDisklessStartOffsetReturnsSentinelWhenTopicMissing(): Unit = {
+    val tp = new TopicPartition("missing", 0)
+    stubImageWithoutTopic(tp.topic())
+    assertEquals(PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET, metadataView.getClassicToDisklessStartOffset(tp))
   }
 
   @Nested

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerInklessTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerInklessTest.scala
@@ -139,6 +139,33 @@ class ReplicaManagerInklessTest {
   }
 
   @Test
+  def testDisklessLeaderEpochDelegatesToMetadataView(): Unit = {
+    val replicaManager = createReplicaManager(List(disklessTopicPartition.topic()))
+    try {
+      when(replicaManager.inklessMetadataView().getDisklessLeaderEpoch(disklessTopicPartition.topicPartition()))
+        .thenReturn(7)
+
+      assertEquals(7, replicaManager.disklessLeaderEpoch(disklessTopicPartition.topicPartition()))
+      verify(replicaManager.inklessMetadataView()).getDisklessLeaderEpoch(disklessTopicPartition.topicPartition())
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
+  def testClassicToDisklessStartOffsetDelegatesToMetadataView(): Unit = {
+    val replicaManager = createReplicaManager(List(disklessTopicPartition.topic()))
+    try {
+      when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
+        .thenReturn(42L)
+
+      assertEquals(42L, replicaManager.classicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
   def testAppendValidDisklessAndInvalidClassic(): Unit = {
     val entriesPerPartition = Map(
       disklessTopicPartition -> RECORDS,

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -1628,11 +1628,11 @@ public class ReplicationControlManager {
                         .toList();
 
                 // Capture the partition's current leader epoch as the diskless leader epoch (E_d). The
-                // classic-to-diskless switch already bumped the leader epoch (Phase A), so this value is
-                // strictly greater than every classic-prefix epoch. Capturing it here, at the commit,
-                // keeps it correct even if a leader change landed between Phase A and this point. E_d is
-                // stamped onto materialized diskless batches and answers OffsetsForLeaderEpoch so that a
-                // stale classic tail truncates back to the seal.
+                // classic-to-diskless switch already bumped the leader epoch, so this value is strictly
+                // greater than every classic-prefix epoch. Capturing it here, at the commit, keeps it
+                // correct even if a leader change landed in the meantime. E_d is stamped onto materialized
+                // diskless batches and answers OffsetsForLeaderEpoch so that a stale classic tail truncates
+                // back to the seal.
                 int disklessLeaderEpoch = partition.leaderEpoch;
 
                 PartitionChangeRecord record = new PartitionChangeRecord()

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -1627,6 +1627,14 @@ public class ReplicationControlManager {
                             ps.batchMaxTimestamp()))
                         .toList();
 
+                // Freeze the partition's current leader epoch as the diskless leader epoch (E_d). The
+                // classic-to-diskless switch already bumped the leader epoch (Phase A), so this value is
+                // strictly greater than every classic-prefix epoch. Capturing it here, at the commit,
+                // keeps it correct even if a leader change landed between Phase A and this point. E_d is
+                // stamped onto materialized diskless batches and answers OffsetsForLeaderEpoch so that a
+                // stale classic tail truncates back to the seal.
+                int disklessLeaderEpoch = partition.leaderEpoch;
+
                 PartitionChangeRecord record = new PartitionChangeRecord()
                     .setTopicId(topicId)
                     .setPartitionId(partitionId);
@@ -1636,11 +1644,13 @@ public class ReplicationControlManager {
                     record.unknownTaggedFields().add(
                         InitDisklessLogFields.encodeProducerStates(producerStates));
                 }
+                record.unknownTaggedFields().add(
+                    InitDisklessLogFields.encodeDisklessLeaderEpoch(disklessLeaderEpoch));
 
                 records.add(new ApiMessageAndVersion(record, (short) 0));
 
-                log.info("InitDisklessLog for {}-{}: classicToDisklessStartOffset={}, producerStates.size={}",
-                    topic.name, partitionId, partitionData.disklessStartOffset(),
+                log.info("InitDisklessLog for {}-{}: classicToDisklessStartOffset={}, disklessLeaderEpoch={}, producerStates.size={}",
+                    topic.name, partitionId, partitionData.disklessStartOffset(), disklessLeaderEpoch,
                     producerStates.size());
 
                 partitionResponses.add(new InitDisklessLogResponseData.PartitionResponse()

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -1627,7 +1627,7 @@ public class ReplicationControlManager {
                             ps.batchMaxTimestamp()))
                         .toList();
 
-                // Freeze the partition's current leader epoch as the diskless leader epoch (E_d). The
+                // Capture the partition's current leader epoch as the diskless leader epoch (E_d). The
                 // classic-to-diskless switch already bumped the leader epoch (Phase A), so this value is
                 // strictly greater than every classic-prefix epoch. Capturing it here, at the commit,
                 // keeps it correct even if a leader change landed between Phase A and this point. E_d is

--- a/metadata/src/main/java/org/apache/kafka/metadata/InitDisklessLogFields.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/InitDisklessLogFields.java
@@ -33,6 +33,7 @@ public final class InitDisklessLogFields {
 
     public static final int CLASSIC_TO_DISKLESS_START_OFFSET_TAG = 100;
     public static final int PRODUCER_STATES_TAG = 101;
+    public static final int DISKLESS_LEADER_EPOCH_TAG = 102;
 
     private InitDisklessLogFields() {}
 
@@ -51,6 +52,26 @@ public final class InitDisklessLogFields {
             }
         }
         return PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET;
+    }
+
+    // --- disklessLeaderEpoch (tag 102): a single int32 ---
+    // The frozen leader epoch assigned to the diskless region at the classic-to-diskless switch.
+    // Strictly greater than every classic-prefix epoch, it lets standard OffsetsForLeaderEpoch
+    // truncation distinguish a stale classic tail from authoritative consolidated data.
+
+    public static RawTaggedField encodeDisklessLeaderEpoch(int disklessLeaderEpoch) {
+        byte[] data = new byte[4];
+        ByteBuffer.wrap(data).putInt(disklessLeaderEpoch);
+        return new RawTaggedField(DISKLESS_LEADER_EPOCH_TAG, data);
+    }
+
+    public static int decodeDisklessLeaderEpoch(List<RawTaggedField> taggedFields) {
+        for (RawTaggedField field : taggedFields) {
+            if (field.tag() == DISKLESS_LEADER_EPOCH_TAG) {
+                return ByteBuffer.wrap(field.data()).getInt();
+            }
+        }
+        return PartitionRegistration.NO_DISKLESS_LEADER_EPOCH;
     }
 
     // --- producerStates (tag 101): count + fixed-size entries ---

--- a/metadata/src/main/java/org/apache/kafka/metadata/InitDisklessLogFields.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/InitDisklessLogFields.java
@@ -55,7 +55,7 @@ public final class InitDisklessLogFields {
     }
 
     // --- disklessLeaderEpoch (tag 102): a single int32 ---
-    // The frozen leader epoch assigned to the diskless region at the classic-to-diskless switch.
+    // The leader epoch captured for the diskless region at the classic-to-diskless switch.
     // Strictly greater than every classic-prefix epoch, it lets standard OffsetsForLeaderEpoch
     // truncation distinguish a stale classic tail from authoritative consolidated data.
 

--- a/metadata/src/main/java/org/apache/kafka/metadata/PartitionRegistration.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/PartitionRegistration.java
@@ -173,7 +173,7 @@ public class PartitionRegistration {
 
     public static final long NO_CLASSIC_TO_DISKLESS_START_OFFSET = -1L;
     public static final long CLASSIC_TO_DISKLESS_SWITCH_PENDING = -2L;
-    // Sentinel for a partition that has no frozen diskless leader epoch (never switched, born-diskless,
+    // Sentinel for a partition that has no captured diskless leader epoch (never switched, born-diskless,
     // or switch still pending). A real diskless leader epoch is always >= 0.
     public static final int NO_DISKLESS_LEADER_EPOCH = -1;
 
@@ -310,7 +310,7 @@ public class PartitionRegistration {
             newClassicToDisklessStartOffset = classicToDisklessStartOffset;
             newDisklessProducerStates = disklessProducerStates;
         }
-        // The diskless leader epoch is frozen at the classic-to-diskless switch and only carried by that
+        // The diskless leader epoch is captured at the classic-to-diskless switch and only carried by that
         // single change record; every other change record omits the tag, so keep the existing value.
         int newDisklessLeaderEpoch = InitDisklessLogFields.decodeDisklessLeaderEpoch(record.unknownTaggedFields());
         if (newDisklessLeaderEpoch == NO_DISKLESS_LEADER_EPOCH) {

--- a/metadata/src/main/java/org/apache/kafka/metadata/PartitionRegistration.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/PartitionRegistration.java
@@ -53,6 +53,7 @@ public class PartitionRegistration {
         private Integer partitionEpoch;
         private long classicToDisklessStartOffset = -1L;
         private List<InitDisklessLogFields.ProducerStateEntry> disklessProducerStates = List.of();
+        private int disklessLeaderEpoch = NO_DISKLESS_LEADER_EPOCH;
 
         public Builder setReplicas(int[] replicas) {
             this.replicas = replicas;
@@ -119,6 +120,11 @@ public class PartitionRegistration {
             return this;
         }
 
+        public Builder setDisklessLeaderEpoch(int disklessLeaderEpoch) {
+            this.disklessLeaderEpoch = disklessLeaderEpoch;
+            return this;
+        }
+
         public PartitionRegistration build() {
             if (replicas == null) {
                 throw new IllegalStateException("You must set replicas.");
@@ -159,13 +165,17 @@ public class PartitionRegistration {
                 elr,
                 lastKnownElr,
                 classicToDisklessStartOffset,
-                disklessProducerStates
+                disklessProducerStates,
+                disklessLeaderEpoch
             );
         }
     }
 
     public static final long NO_CLASSIC_TO_DISKLESS_START_OFFSET = -1L;
     public static final long CLASSIC_TO_DISKLESS_SWITCH_PENDING = -2L;
+    // Sentinel for a partition that has no frozen diskless leader epoch (never switched, born-diskless,
+    // or switch still pending). A real diskless leader epoch is always >= 0.
+    public static final int NO_DISKLESS_LEADER_EPOCH = -1;
 
     public final int[] replicas;
     public final Uuid[] directories;
@@ -180,6 +190,7 @@ public class PartitionRegistration {
     public final int partitionEpoch;
     public final long classicToDisklessStartOffset;
     public final List<InitDisklessLogFields.ProducerStateEntry> disklessProducerStates;
+    public final int disklessLeaderEpoch;
 
     public static boolean electionWasUnclean(byte leaderRecoveryState) {
         return leaderRecoveryState == LeaderRecoveryState.RECOVERING.value();
@@ -231,14 +242,17 @@ public class PartitionRegistration {
             Replicas.toArray(record.eligibleLeaderReplicas()),
             Replicas.toArray(record.lastKnownElr()),
             InitDisklessLogFields.decodeClassicToDisklessStartOffset(record.unknownTaggedFields()),
-            InitDisklessLogFields.decodeProducerStates(record.unknownTaggedFields()));
+            InitDisklessLogFields.decodeProducerStates(record.unknownTaggedFields()),
+            InitDisklessLogFields.decodeDisklessLeaderEpoch(record.unknownTaggedFields()));
     }
 
+    @SuppressWarnings("checkstyle:ParameterNumber")
     private PartitionRegistration(int[] replicas, Uuid[] directories, int[] isr, int[] removingReplicas,
                                   int[] addingReplicas, int leader, LeaderRecoveryState leaderRecoveryState,
                                   int leaderEpoch, int partitionEpoch, int[] elr, int[] lastKnownElr,
                                   long classicToDisklessStartOffset,
-                                  List<InitDisklessLogFields.ProducerStateEntry> disklessProducerStates) {
+                                  List<InitDisklessLogFields.ProducerStateEntry> disklessProducerStates,
+                                  int disklessLeaderEpoch) {
         Objects.requireNonNull(directories);
         if (directories.length > 0 && directories.length != replicas.length) {
             throw new IllegalArgumentException("The lengths for replicas and directories do not match.");
@@ -254,6 +268,7 @@ public class PartitionRegistration {
         this.partitionEpoch = partitionEpoch;
         this.classicToDisklessStartOffset = classicToDisklessStartOffset;
         this.disklessProducerStates = disklessProducerStates != null ? disklessProducerStates : List.of();
+        this.disklessLeaderEpoch = disklessLeaderEpoch;
 
         // We could parse a lower version record without elr/lastKnownElr.
         this.elr = elr == null ? new int[0] : elr;
@@ -295,6 +310,12 @@ public class PartitionRegistration {
             newClassicToDisklessStartOffset = classicToDisklessStartOffset;
             newDisklessProducerStates = disklessProducerStates;
         }
+        // The diskless leader epoch is frozen at the classic-to-diskless switch and only carried by that
+        // single change record; every other change record omits the tag, so keep the existing value.
+        int newDisklessLeaderEpoch = InitDisklessLogFields.decodeDisklessLeaderEpoch(record.unknownTaggedFields());
+        if (newDisklessLeaderEpoch == NO_DISKLESS_LEADER_EPOCH) {
+            newDisklessLeaderEpoch = disklessLeaderEpoch;
+        }
         return new PartitionRegistration(newReplicas,
             newDirectories,
             newIsr,
@@ -307,13 +328,14 @@ public class PartitionRegistration {
             newElr,
             newLastKnownElr,
             newClassicToDisklessStartOffset,
-            newDisklessProducerStates);
+            newDisklessProducerStates,
+            newDisklessLeaderEpoch);
     }
 
     public PartitionRegistration withClassicToDisklessStartOffset(long classicToDisklessStartOffset) {
         return new PartitionRegistration(replicas, directories, isr, removingReplicas,
             addingReplicas, leader, leaderRecoveryState, leaderEpoch, partitionEpoch,
-            elr, lastKnownElr, classicToDisklessStartOffset, disklessProducerStates);
+            elr, lastKnownElr, classicToDisklessStartOffset, disklessProducerStates, disklessLeaderEpoch);
     }
 
     public String diff(PartitionRegistration prev) {
@@ -390,6 +412,11 @@ public class PartitionRegistration {
             builder.append(prefix).append("disklessProducerStates: ").
                 append(prev.disklessProducerStates.size()).append(" entries -> ").
                 append(disklessProducerStates.size()).append(" entries");
+            prefix = ", ";
+        }
+        if (disklessLeaderEpoch != prev.disklessLeaderEpoch) {
+            builder.append(prefix).append("disklessLeaderEpoch: ").
+                append(prev.disklessLeaderEpoch).append(" -> ").append(disklessLeaderEpoch);
         }
         return builder.toString();
     }
@@ -449,6 +476,10 @@ public class PartitionRegistration {
                     InitDisklessLogFields.encodeProducerStates(disklessProducerStates));
             }
         }
+        if (disklessLeaderEpoch != NO_DISKLESS_LEADER_EPOCH) {
+            record.unknownTaggedFields().add(
+                InitDisklessLogFields.encodeDisklessLeaderEpoch(disklessLeaderEpoch));
+        }
 
         if (options.metadataVersion() == null) {
             options.handleLoss("the metadata version");
@@ -472,7 +503,7 @@ public class PartitionRegistration {
         return Objects.hash(Arrays.hashCode(replicas), Arrays.hashCode(isr), Arrays.hashCode(removingReplicas),
             Arrays.hashCode(directories), Arrays.hashCode(elr), Arrays.hashCode(lastKnownElr),
             Arrays.hashCode(addingReplicas), leader, leaderRecoveryState, leaderEpoch, partitionEpoch,
-            classicToDisklessStartOffset, disklessProducerStates);
+            classicToDisklessStartOffset, disklessProducerStates, disklessLeaderEpoch);
     }
 
     @Override
@@ -490,7 +521,8 @@ public class PartitionRegistration {
             leaderEpoch == other.leaderEpoch &&
             partitionEpoch == other.partitionEpoch &&
             classicToDisklessStartOffset == other.classicToDisklessStartOffset &&
-            Objects.equals(disklessProducerStates, other.disklessProducerStates);
+            Objects.equals(disklessProducerStates, other.disklessProducerStates) &&
+            disklessLeaderEpoch == other.disklessLeaderEpoch;
     }
 
     @Override
@@ -508,6 +540,7 @@ public class PartitionRegistration {
                 ", partitionEpoch=" + partitionEpoch +
                 ", classicToDisklessStartOffset=" + classicToDisklessStartOffset +
                 ", disklessProducerStates=" + disklessProducerStates +
+                ", disklessLeaderEpoch=" + disklessLeaderEpoch +
                 ")";
     }
 }

--- a/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
@@ -6190,6 +6190,9 @@ public class ReplicationControlManagerTest {
             assertEquals(topicId, record.topicId());
             assertEquals(0, record.partitionId());
             assertEquals(100L, InitDisklessLogFields.decodeClassicToDisklessStartOffset(record.unknownTaggedFields()));
+            // The change record freezes the partition's current leader epoch as the diskless leader epoch.
+            assertEquals(partition.leaderEpoch,
+                InitDisklessLogFields.decodeDisklessLeaderEpoch(record.unknownTaggedFields()));
 
             List<InitDisklessLogFields.ProducerStateEntry> producerStates =
                 InitDisklessLogFields.decodeProducerStates(record.unknownTaggedFields());
@@ -6232,6 +6235,7 @@ public class ReplicationControlManagerTest {
             PartitionRegistration updatedPartition = replicationControl.getPartition(topicId, 0);
             assertEquals(42L, updatedPartition.classicToDisklessStartOffset);
             assertTrue(updatedPartition.disklessProducerStates.isEmpty());
+            assertEquals(partition.leaderEpoch, updatedPartition.disklessLeaderEpoch);
         }
 
         @Test

--- a/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
@@ -6190,7 +6190,7 @@ public class ReplicationControlManagerTest {
             assertEquals(topicId, record.topicId());
             assertEquals(0, record.partitionId());
             assertEquals(100L, InitDisklessLogFields.decodeClassicToDisklessStartOffset(record.unknownTaggedFields()));
-            // The change record freezes the partition's current leader epoch as the diskless leader epoch.
+            // The change record captures the partition's current leader epoch as the diskless leader epoch.
             assertEquals(partition.leaderEpoch,
                 InitDisklessLogFields.decodeDisklessLeaderEpoch(record.unknownTaggedFields()));
 

--- a/metadata/src/test/java/org/apache/kafka/metadata/PartitionRegistrationTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/PartitionRegistrationTest.java
@@ -582,7 +582,7 @@ public class PartitionRegistrationTest {
             setLeaderEpoch(5).setPartitionEpoch(0).
             setClassicToDisklessStartOffset(PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING).build();
 
-        // Simulates the initDisklessLog commit: it carries both the seal and the frozen leader epoch.
+        // Simulates the initDisklessLog commit: it carries both the seal and the captured leader epoch.
         PartitionChangeRecord changeRecord = new PartitionChangeRecord();
         changeRecord.unknownTaggedFields().add(
             InitDisklessLogFields.encodeClassicToDisklessStartOffset(100L));

--- a/metadata/src/test/java/org/apache/kafka/metadata/PartitionRegistrationTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/PartitionRegistrationTest.java
@@ -545,4 +545,68 @@ public class PartitionRegistrationTest {
 
         assertEquals(PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING, merged.classicToDisklessStartOffset);
     }
+
+    @Test
+    public void testDefaultDisklessLeaderEpoch() {
+        PartitionRegistration registration = new PartitionRegistration.Builder().
+            setReplicas(new int[]{1, 2, 3}).setDirectories(DirectoryId.unassignedArray(3)).
+            setIsr(new int[]{1, 2, 3}).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
+            setLeaderEpoch(0).setPartitionEpoch(0).build();
+        assertEquals(PartitionRegistration.NO_DISKLESS_LEADER_EPOCH, registration.disklessLeaderEpoch);
+    }
+
+    @Test
+    public void testDisklessLeaderEpochRoundTrip() {
+        PartitionRegistration original = new PartitionRegistration.Builder().
+            setReplicas(new int[]{1, 2, 3}).setDirectories(DirectoryId.unassignedArray(3)).
+            setIsr(new int[]{1, 2, 3}).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
+            setLeaderEpoch(7).setPartitionEpoch(0).setClassicToDisklessStartOffset(42L).
+            setDisklessLeaderEpoch(7).build();
+
+        Uuid topicId = Uuid.randomUuid();
+        ApiMessageAndVersion record = original.toRecord(topicId, 0,
+            new ImageWriterOptions.Builder(MetadataVersion.latestTesting()).build());
+        PartitionRecord partitionRecord = (PartitionRecord) record.message();
+        PartitionRegistration restored = new PartitionRegistration(partitionRecord);
+
+        assertEquals(7, restored.disklessLeaderEpoch);
+        assertEquals(42L, restored.classicToDisklessStartOffset);
+        assertEquals(original, restored);
+    }
+
+    @Test
+    public void testMergeCapturesDisklessLeaderEpoch() {
+        PartitionRegistration original = new PartitionRegistration.Builder().
+            setReplicas(new int[]{1, 2, 3}).setDirectories(DirectoryId.unassignedArray(3)).
+            setIsr(new int[]{1, 2, 3}).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
+            setLeaderEpoch(5).setPartitionEpoch(0).
+            setClassicToDisklessStartOffset(PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING).build();
+
+        // Simulates the initDisklessLog commit: it carries both the seal and the frozen leader epoch.
+        PartitionChangeRecord changeRecord = new PartitionChangeRecord();
+        changeRecord.unknownTaggedFields().add(
+            InitDisklessLogFields.encodeClassicToDisklessStartOffset(100L));
+        changeRecord.unknownTaggedFields().add(
+            InitDisklessLogFields.encodeDisklessLeaderEpoch(5));
+
+        PartitionRegistration merged = original.merge(changeRecord);
+        assertEquals(100L, merged.classicToDisklessStartOffset);
+        assertEquals(5, merged.disklessLeaderEpoch);
+    }
+
+    @Test
+    public void testMergePreservesDisklessLeaderEpoch() {
+        PartitionRegistration original = new PartitionRegistration.Builder().
+            setReplicas(new int[]{1, 2, 3}).setDirectories(DirectoryId.unassignedArray(3)).
+            setIsr(new int[]{1, 2, 3}).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
+            setLeaderEpoch(5).setPartitionEpoch(0).setClassicToDisklessStartOffset(100L).
+            setDisklessLeaderEpoch(5).build();
+
+        // A subsequent change record (e.g. a leader change) does not carry the diskless epoch tag.
+        PartitionRegistration merged = original.merge(new PartitionChangeRecord().
+            setLeader(2).setIsr(List.of(2, 3)));
+
+        assertEquals(5, merged.disklessLeaderEpoch);
+        assertEquals(100L, merged.classicToDisklessStartOffset);
+    }
 }


### PR DESCRIPTION
Consolidating diskless followers had no way to truncate a stale classic tail past the seal: diskless records are produced with leader epoch 0, so appending them after a classic prefix broke epoch-cache monotonicity and disabled OffsetsForLeaderEpoch divergence truncation.

Introduce a captured, control-plane-owned diskless leader epoch (E_d):

- Persist E_d in KRaft metadata as a new tagged field (tag 102) on PartitionRegistration; the controller freezes the partition's current leader epoch at the initDisklessLog commit, where it is already greater than every classic-prefix epoch and robust to leader changes between the switch phases. merge() preserves it across later change records.
- Expose it on the broker via InklessMetadataView/ReplicaManager.
- Stamp E_d onto materialized batches in ConsolidationFetcherThread so the local log keeps a monotonic epoch lineage (in place, reusing the existing flatten; partitionLeaderEpoch is outside the batch CRC).
- Implement DisklessLeaderEndPoint.fetchEpochEndOffsets: a queried epoch below E_d returns the seal (truncating a stale tail back to it), while E_d / born-diskless returns the diskless LEO.

E_d lives only in KRaft metadata; no control-plane schema change is needed since both the stamping and epoch-query paths run on the broker.
