### PR TITLE
feat(inkless): add controller guards for classic-to-diskless switch [POD-2464]

### DIFF
--- a/core/src/test/java/kafka/server/InklessTopicTypeSwitcherClusterTest.java
+++ b/core/src/test/java/kafka/server/InklessTopicTypeSwitcherClusterTest.java
@@ -34,6 +34,7 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.config.TopicConfig;
+import org.apache.kafka.common.errors.InvalidConfigurationException;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.AlterConfigsRequest;
@@ -50,6 +51,7 @@ import org.apache.kafka.server.log.remote.storage.RemoteLogManagerConfig;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -83,6 +85,8 @@ import io.aiven.inkless.test_utils.PostgreSQLTestContainer;
 import io.aiven.inkless.test_utils.S3TestContainer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Testcontainers
@@ -399,6 +403,39 @@ public class InklessTopicTypeSwitcherClusterTest {
         admin.incrementalAlterConfigs(Map.of(topicResource, operations)).all().get(20, TimeUnit.SECONDS);
     }
 
+    @Test
+    public void testSwitchRejectedWhenPartitionIsOfflineOrUnderReplicated() throws Exception {
+        final String topic = "switch-unhealthy-" + UUID.randomUUID().toString().substring(0, 8);
+
+        try (Admin admin = AdminClient.create(baseClientConfigs())) {
+            // Create a classic topic with RF=3
+            admin.createTopics(List.of(
+                new NewTopic(topic, 1, (short) 3)
+                    .configs(Map.of(TopicConfig.DISKLESS_ENABLE_CONFIG, "false"))
+            )).all().get(30, TimeUnit.SECONDS);
+
+            // Shut down a broker to make the partition under-replicated
+            final int brokerToShutdown = 2;
+            cluster.brokers().get(brokerToShutdown).shutdown();
+            waitForIsrShrink(admin, topic, 0, 3);
+
+            // Attempt to switch to diskless (should fail with INVALID_CONFIG due to under-replication)
+            final ExecutionException ex = assertThrows(ExecutionException.class, () ->
+                alterTopicConfigWithIncrementalAlterConfigs(admin, topic, Map.of(TopicConfig.DISKLESS_ENABLE_CONFIG, "true")));
+            assertInstanceOf(InvalidConfigurationException.class, ex.getCause());
+            assertTrue(ex.getCause().getMessage().contains("under-replicated"),
+                "Expected 'under-replicated' in: " + ex.getCause().getMessage());
+
+            // Restart the broker and wait for ISR to recover
+            cluster.brokers().get(brokerToShutdown).startup();
+            waitForIsrRecovery(admin, topic, 0, 3);
+
+            // Now the switch should succeed
+            alterTopicConfigWithIncrementalAlterConfigs(admin, topic, Map.of(TopicConfig.DISKLESS_ENABLE_CONFIG, "true"));
+            assertEquals("true", getTopicConfig(admin, topic).get(TopicConfig.DISKLESS_ENABLE_CONFIG));
+        }
+    }
+
     private void alterTopicConfigWithLegacyAlterConfigs(final String topic,
                                                        final Map<String, String> newConfigs) throws Exception {
         final ConfigResource topicResource = new ConfigResource(ConfigResource.Type.TOPIC, topic);
@@ -417,6 +454,38 @@ public class InklessTopicTypeSwitcherClusterTest {
     private int firstBrokerPort() {
         final String firstBootstrapServer = cluster.bootstrapServers().split(",")[0];
         return Integer.parseInt(firstBootstrapServer.substring(firstBootstrapServer.lastIndexOf(':') + 1));
+    }
+
+    private void waitForIsrShrink(final Admin admin, final String topic,
+                                   final int partition, final int maxIsrSize) throws Exception {
+        final long deadline = System.currentTimeMillis() + Duration.ofSeconds(30).toMillis();
+        while (System.currentTimeMillis() < deadline) {
+            final var description = admin.describeTopics(List.of(topic)).allTopicNames()
+                .get(10, TimeUnit.SECONDS).get(topic);
+            final int isrSize = description.partitions().get(partition).isr().size();
+            if (isrSize < maxIsrSize) {
+                return;
+            }
+            Thread.sleep(200);
+        }
+        throw new AssertionError("ISR for " + topic + "-" + partition +
+            " did not shrink below " + maxIsrSize + " within timeout");
+    }
+
+    private void waitForIsrRecovery(final Admin admin, final String topic,
+                                    final int partition, final int expectedIsrSize) throws Exception {
+        final long deadline = System.currentTimeMillis() + Duration.ofSeconds(60).toMillis();
+        while (System.currentTimeMillis() < deadline) {
+            final var description = admin.describeTopics(List.of(topic)).allTopicNames()
+                .get(10, TimeUnit.SECONDS).get(topic);
+            final int isrSize = description.partitions().get(partition).isr().size();
+            if (isrSize >= expectedIsrSize) {
+                return;
+            }
+            Thread.sleep(200);
+        }
+        throw new AssertionError("ISR for " + topic + "-" + partition +
+            " did not recover to " + expectedIsrSize + " within timeout");
     }
 
     private Map<String, String> getTopicConfig(final Admin admin, final String topic) throws Exception {

--- a/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
@@ -54,6 +54,7 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 import static org.apache.kafka.clients.admin.AlterConfigOp.OpType.APPEND;
 import static org.apache.kafka.common.config.ConfigResource.Type.BROKER;
@@ -201,6 +202,14 @@ public class ConfigurationControlManager {
         Map<ConfigResource, Map<String, Entry<OpType, String>>> configChanges,
         boolean newlyCreatedResource
     ) {
+        return incrementalAlterConfigs(configChanges, newlyCreatedResource, null);
+    }
+
+    ControllerResult<Map<ConfigResource, ApiError>> incrementalAlterConfigs(
+        Map<ConfigResource, Map<String, Entry<OpType, String>>> configChanges,
+        boolean newlyCreatedResource,
+        Function<ConfigResource, ApiError> postConfigValidation
+    ) {
         List<ApiMessageAndVersion> outputRecords =
                 BoundedList.newArrayBacked(MAX_RECORDS_PER_USER_OP);
         Map<ConfigResource, ApiError> outputResults = new HashMap<>();
@@ -209,7 +218,8 @@ public class ConfigurationControlManager {
             ApiError apiError = incrementalAlterConfigResource(resourceEntry.getKey(),
                 resourceEntry.getValue(),
                 newlyCreatedResource,
-                outputRecords);
+                outputRecords,
+                postConfigValidation);
             outputResults.put(resourceEntry.getKey(), apiError);
         }
         outputRecords.addAll(createClearElrRecordsAsNeeded(outputRecords));
@@ -248,7 +258,8 @@ public class ConfigurationControlManager {
         ApiError apiError = incrementalAlterConfigResource(configResource,
             keyToOps,
             newlyCreatedResource,
-            outputRecords);
+            outputRecords,
+            null);
 
         outputRecords.addAll(createClearElrRecordsAsNeeded(outputRecords));
         return ControllerResult.atomicOf(outputRecords, apiError);
@@ -258,7 +269,8 @@ public class ConfigurationControlManager {
         ConfigResource configResource,
         Map<String, Entry<OpType, String>> keysToOps,
         boolean newlyCreatedResource,
-        List<ApiMessageAndVersion> outputRecords
+        List<ApiMessageAndVersion> outputRecords,
+        Function<ConfigResource, ApiError> postConfigValidation
     ) {
         List<ApiMessageAndVersion> newRecords = new ArrayList<>();
         for (Entry<String, Entry<OpType, String>> keysToOpsEntry : keysToOps.entrySet()) {
@@ -328,6 +340,12 @@ public class ConfigurationControlManager {
         ApiError error = validateAlterConfig(configResource, newRecords, List.of(), newlyCreatedResource);
         if (error.isFailure()) {
             return error;
+        }
+        if (postConfigValidation != null) {
+            error = postConfigValidation.apply(configResource);
+            if (error.isFailure()) {
+                return error;
+            }
         }
         outputRecords.addAll(newRecords);
         return ApiError.NONE;
@@ -450,6 +468,14 @@ public class ConfigurationControlManager {
         Map<ConfigResource, Map<String, String>> newConfigs,
         boolean newlyCreatedResource
     ) {
+        return legacyAlterConfigs(newConfigs, newlyCreatedResource, null);
+    }
+
+    ControllerResult<Map<ConfigResource, ApiError>> legacyAlterConfigs(
+        Map<ConfigResource, Map<String, String>> newConfigs,
+        boolean newlyCreatedResource,
+        Function<ConfigResource, ApiError> postConfigValidation
+    ) {
         List<ApiMessageAndVersion> outputRecords =
                 BoundedList.newArrayBacked(MAX_RECORDS_PER_USER_OP);
         Map<ConfigResource, ApiError> outputResults = new HashMap<>();
@@ -459,7 +485,8 @@ public class ConfigurationControlManager {
                 resourceEntry.getValue(),
                 newlyCreatedResource,
                 outputRecords,
-                outputResults);
+                outputResults,
+                postConfigValidation);
         }
         outputRecords.addAll(createClearElrRecordsAsNeeded(outputRecords));
         return ControllerResult.atomicOf(outputRecords, outputResults);
@@ -469,7 +496,8 @@ public class ConfigurationControlManager {
                                            Map<String, String> newConfigs,
                                            boolean newlyCreatedResource,
                                            List<ApiMessageAndVersion> outputRecords,
-                                           Map<ConfigResource, ApiError> outputResults) {
+                                           Map<ConfigResource, ApiError> outputResults,
+                                           Function<ConfigResource, ApiError> postConfigValidation) {
         List<ApiMessageAndVersion> recordsExplicitlyAltered = new ArrayList<>();
         Map<String, String> currentConfigs = configData.get(configResource);
         if (currentConfigs == null) {
@@ -502,6 +530,13 @@ public class ConfigurationControlManager {
         if (error.isFailure()) {
             outputResults.put(configResource, error);
             return;
+        }
+        if (postConfigValidation != null) {
+            error = postConfigValidation.apply(configResource);
+            if (error.isFailure()) {
+                outputResults.put(configResource, error);
+                return;
+            }
         }
         outputRecords.addAll(recordsExplicitlyAltered);
         outputRecords.addAll(recordsImplicitlyDeleted);

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -1953,7 +1953,9 @@ public final class QuorumController implements Controller {
         }
         return appendWriteEvent("incrementalAlterConfigs", context.deadlineNs(), () -> {
             ControllerResult<Map<ConfigResource, ApiError>> result =
-                configurationControl.incrementalAlterConfigs(configChanges, false);
+                configurationControl.incrementalAlterConfigs(configChanges, false,
+                    resource -> replicationControl.validateClassicToDisklessSwitchPrecondition(
+                        resource, configChanges));
             if (validateOnly) {
                 return result.withoutRecords();
             } else {
@@ -2006,7 +2008,9 @@ public final class QuorumController implements Controller {
         }
         return appendWriteEvent("legacyAlterConfigs", context.deadlineNs(), () -> {
             ControllerResult<Map<ConfigResource, ApiError>> result =
-                configurationControl.legacyAlterConfigs(newConfigs, false);
+                configurationControl.legacyAlterConfigs(newConfigs, false,
+                    resource -> replicationControl.validateClassicToDisklessSwitchPreconditionForLegacy(
+                        resource, newConfigs));
             if (validateOnly) {
                 return result.withoutRecords();
             } else {

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -3008,6 +3008,9 @@ public class ReplicationControlManager {
 
     /**
      * Per-resource precondition check for legacy AlterConfigs enabling diskless.
+     * Covers both explicit {@code diskless.enable=true} in the request and implicit
+     * enabling via deletion of a {@code diskless.enable=false} override when the broker
+     * default is {@code true}.
      */
     ApiError validateClassicToDisklessSwitchPreconditionForLegacy(
         ConfigResource resource,
@@ -3015,7 +3018,13 @@ public class ReplicationControlManager {
     ) {
         if (resource.type() != TOPIC) return ApiError.NONE;
         Map<String, String> configs = newConfigs.get(resource);
-        if (configs == null || !Boolean.parseBoolean(configs.get(DISKLESS_ENABLE_CONFIG))) return ApiError.NONE;
+        if (configs == null) return ApiError.NONE;
+        boolean explicitlyEnabling = Boolean.parseBoolean(configs.get(DISKLESS_ENABLE_CONFIG));
+        boolean implicitlyEnabling = !configs.containsKey(DISKLESS_ENABLE_CONFIG)
+            && defaultDisklessEnable
+            && !isDisklessTopic(resource.name())
+            && "false".equals(configurationControl.currentTopicConfig(resource.name()).get(DISKLESS_ENABLE_CONFIG));
+        if (!explicitlyEnabling && !implicitlyEnabling) return ApiError.NONE;
         if (isDisklessTopic(resource.name())) return ApiError.NONE;
         Uuid topicId = topicsByName.get(resource.name());
         if (topicId == null) return ApiError.NONE;
@@ -3148,11 +3157,21 @@ public class ReplicationControlManager {
     ) {
         Map<ConfigResource, Map<String, Entry<OpType, String>>> configChanges = new HashMap<>();
         for (Entry<ConfigResource, Map<String, String>> entry : newConfigs.entrySet()) {
-            String disklessEnable = entry.getValue().get(DISKLESS_ENABLE_CONFIG);
+            ConfigResource resource = entry.getKey();
+            Map<String, String> configs = entry.getValue();
+            String disklessEnable = configs.get(DISKLESS_ENABLE_CONFIG);
             if (disklessEnable != null) {
-                configChanges.put(entry.getKey(), Map.of(
+                configChanges.put(resource, Map.of(
                     DISKLESS_ENABLE_CONFIG,
                     new SimpleImmutableEntry<>(SET, disklessEnable)
+                ));
+            } else if (defaultDisklessEnable
+                && resource.type() == TOPIC
+                && !isDisklessTopic(resource.name())
+                && "false".equals(configurationControl.currentTopicConfig(resource.name()).get(DISKLESS_ENABLE_CONFIG))) {
+                configChanges.put(resource, Map.of(
+                    DISKLESS_ENABLE_CONFIG,
+                    new SimpleImmutableEntry<>(SET, "true")
                 ));
             }
         }

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -136,6 +136,7 @@ import static org.apache.kafka.common.config.TopicConfig.REMOTE_LOG_STORAGE_ENAB
 import static org.apache.kafka.common.internals.Topic.CLUSTER_METADATA_TOPIC_NAME;
 import static org.apache.kafka.common.protocol.Errors.FENCED_LEADER_EPOCH;
 import static org.apache.kafka.common.protocol.Errors.INELIGIBLE_REPLICA;
+import static org.apache.kafka.common.protocol.Errors.INVALID_CONFIG;
 import static org.apache.kafka.common.protocol.Errors.INVALID_REQUEST;
 import static org.apache.kafka.common.protocol.Errors.INVALID_UPDATE_VERSION;
 import static org.apache.kafka.common.protocol.Errors.NEW_LEADER_ELECTED;
@@ -1151,7 +1152,7 @@ public class ReplicationControlManager {
 
     /**
      * Create a topic assignment for a diskless topic.
-     * @return the assignment or {@code null} if there are no brokers avaiable.
+     * @return the assignment or {@code null} if there are no brokers available.
      */
     private TopicAssignment createDisklessAssignment(int numPartitions) {
         final Iterator<UsableBroker> usableBrokers = clusterControl.usableBrokers();
@@ -1448,7 +1449,11 @@ public class ReplicationControlManager {
                 )
                     .setEligibleLeaderReplicasEnabled(featureControl.isElrFeatureEnabled());
                 if (configurationControl.uncleanLeaderElectionEnabledForTopic(topic.name())) {
-                    builder.setElection(PartitionChangeBuilder.Election.UNCLEAN);
+                    if (hasClassicToDisklessSwitchPending(partition)) {
+                        warnSkippingUncleanElectionForPendingSwitch(topic.name, partitionId);
+                    } else {
+                        builder.setElection(PartitionChangeBuilder.Election.UNCLEAN);
+                    }
                 }
                 Optional<ApiMessageAndVersion> record = builder
                     .setTargetIsrWithBrokerStates(partitionData.newIsrWithEpochs())
@@ -2251,6 +2256,11 @@ public class ReplicationControlManager {
         while (iterator.hasNext() && records.size() < maxElections) {
             TopicIdPartition topicIdPartition = iterator.next();
             TopicControlInfo topic = topics.get(topicIdPartition.topicId());
+            PartitionRegistration partition = topic.parts.get(topicIdPartition.partitionId());
+            if (partition != null && hasClassicToDisklessSwitchPending(partition)) {
+                warnSkippingUncleanElectionForPendingSwitch(topic.name, topicIdPartition.partitionId());
+                continue;
+            }
             if (configurationControl.uncleanLeaderElectionEnabledForTopic(topic.name)) {
                 ApiError result = electLeader(topic.name, topicIdPartition.partitionId(),
                         ElectionType.UNCLEAN, records);
@@ -2267,6 +2277,16 @@ public class ReplicationControlManager {
                         topic.name, topicIdPartition.partitionId());
             }
         }
+    }
+
+    private static boolean hasClassicToDisklessSwitchPending(PartitionRegistration partition) {
+        return partition.classicToDisklessStartOffset == PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING;
+    }
+
+    private void warnSkippingUncleanElectionForPendingSwitch(String topicName, int partitionId) {
+        log.warn("Skipping unclean leader election for partition {}-{} " +
+                "because it has a pending classic-to-diskless switch.",
+            topicName, partitionId);
     }
 
     ControllerResult<List<CreatePartitionsTopicResult>> createPartitions(
@@ -2500,7 +2520,11 @@ public class ReplicationControlManager {
             );
             builder.setEligibleLeaderReplicasEnabled(featureControl.isElrFeatureEnabled());
             if (configurationControl.uncleanLeaderElectionEnabledForTopic(topic.name)) {
-                builder.setElection(PartitionChangeBuilder.Election.UNCLEAN);
+                if (hasClassicToDisklessSwitchPending(partition)) {
+                    warnSkippingUncleanElectionForPendingSwitch(topic.name, topicIdPart.partitionId());
+                } else {
+                    builder.setElection(PartitionChangeBuilder.Election.UNCLEAN);
+                }
             }
             if (brokerWithUncleanShutdown != NO_LEADER) {
                 builder.setUncleanShutdownReplicas(List.of(brokerWithUncleanShutdown));
@@ -2957,6 +2981,105 @@ public class ReplicationControlManager {
     }
 
     /**
+     * Per-resource precondition check for incremental AlterConfigs enabling diskless.
+     * Returns {@link ApiError#NONE} if the resource is not a topic enabling diskless or
+     * if all partition preconditions are met.
+     */
+    ApiError validateClassicToDisklessSwitchPrecondition(
+        ConfigResource resource,
+        Map<ConfigResource, Map<String, Entry<OpType, String>>> configChanges
+    ) {
+        if (resource.type() != TOPIC) return ApiError.NONE;
+        Map<String, Entry<OpType, String>> changes = configChanges.get(resource);
+        if (changes == null || !isSettingConfigToTrue(changes, DISKLESS_ENABLE_CONFIG)) return ApiError.NONE;
+        if (isDisklessTopic(resource.name())) return ApiError.NONE;
+        Uuid topicId = topicsByName.get(resource.name());
+        if (topicId == null) return ApiError.NONE;
+        TopicControlInfo topicInfo = topics.get(topicId);
+        if (topicInfo == null) return ApiError.NONE;
+        return validatePartitionsForSwitch(topicInfo).orElse(ApiError.NONE);
+    }
+
+    /**
+     * Per-resource precondition check for legacy AlterConfigs enabling diskless.
+     */
+    ApiError validateClassicToDisklessSwitchPreconditionForLegacy(
+        ConfigResource resource,
+        Map<ConfigResource, Map<String, String>> newConfigs
+    ) {
+        if (resource.type() != TOPIC) return ApiError.NONE;
+        Map<String, String> configs = newConfigs.get(resource);
+        if (configs == null || !Boolean.parseBoolean(configs.get(DISKLESS_ENABLE_CONFIG))) return ApiError.NONE;
+        if (isDisklessTopic(resource.name())) return ApiError.NONE;
+        Uuid topicId = topicsByName.get(resource.name());
+        if (topicId == null) return ApiError.NONE;
+        TopicControlInfo topicInfo = topics.get(topicId);
+        if (topicInfo == null) return ApiError.NONE;
+        return validatePartitionsForSwitch(topicInfo).orElse(ApiError.NONE);
+    }
+
+    Map<ConfigResource, ApiError> validateClassicToDisklessSwitchPreconditions(Set<ConfigResource> topicResources) {
+        Map<ConfigResource, ApiError> errors = new HashMap<>();
+        for (ConfigResource resource : topicResources) {
+            String topicName = resource.name();
+            if (isDisklessTopic(topicName)) continue;
+            Uuid topicId = topicsByName.get(topicName);
+            if (topicId == null) continue;
+            TopicControlInfo topicInfo = topics.get(topicId);
+            if (topicInfo == null) continue;
+            validatePartitionsForSwitch(topicInfo)
+                .ifPresent(error -> errors.put(resource, error));
+        }
+        return errors;
+    }
+
+    private Optional<ApiError> validatePartitionsForSwitch(TopicControlInfo topicInfo) {
+        String topicName = topicInfo.name;
+        for (Entry<Integer, PartitionRegistration> partEntry : topicInfo.parts.entrySet()) {
+            int partitionId = partEntry.getKey();
+            PartitionRegistration partition = partEntry.getValue();
+
+            if (!partition.hasLeader()) {
+                return Optional.of(new ApiError(INVALID_CONFIG,
+                    "Cannot switch topic " + topicName + " to diskless: " +
+                    "partition " + partitionId + " is offline (has no leader)."));
+            }
+
+            if (partition.leaderRecoveryState == LeaderRecoveryState.RECOVERING) {
+                return Optional.of(new ApiError(INVALID_CONFIG,
+                    "Cannot switch topic " + topicName + " to diskless: " +
+                    "partition " + partitionId + " is recovering from an unclean leader election."));
+            }
+
+            if (isReassignmentInProgress(partition)) {
+                return Optional.of(new ApiError(INVALID_CONFIG,
+                    "Cannot switch topic " + topicName + " to diskless: " +
+                    "partition " + partitionId + " has a reassignment in progress."));
+            }
+
+            if (partition.elr.length > 0) {
+                return Optional.of(new ApiError(INVALID_CONFIG,
+                    "Cannot switch topic " + topicName + " to diskless: " +
+                    "partition " + partitionId + " has a non-empty ELR."));
+            }
+
+            if (partition.lastKnownElr.length > 0) {
+                return Optional.of(new ApiError(INVALID_CONFIG,
+                    "Cannot switch topic " + topicName + " to diskless: " +
+                    "partition " + partitionId + " has a non-empty last-known ELR."));
+            }
+
+            if (partition.isr.length < partition.replicas.length) {
+                return Optional.of(new ApiError(INVALID_CONFIG,
+                    "Cannot switch topic " + topicName + " to diskless: " +
+                    "partition " + partitionId + " is under-replicated " +
+                    "(ISR size " + partition.isr.length + " < replicas " + partition.replicas.length + ")."));
+            }
+        }
+        return Optional.empty();
+    }
+
+    /**
      * For every topic whose {@code diskless.enable} flips from {@code false} to {@code true},
      * emit a {@link PartitionChangeRecord} per partition marking
      * {@code classicToDisklessStartOffset = CLASSIC_TO_DISKLESS_SWITCH_PENDING} (-2).
@@ -2969,19 +3092,17 @@ public class ReplicationControlManager {
         Map<ConfigResource, ApiError> configResults
     ) {
         List<ApiMessageAndVersion> records = BoundedList.newArrayBacked(MAX_RECORDS_PER_USER_OP);
-        for (Entry<ConfigResource, Map<String, Entry<OpType, String>>> entry : configChanges.entrySet()) {
-            ConfigResource resource = entry.getKey();
+        for (Entry<ConfigResource, Map<String, Entry<OpType, String>>> configEntry : configChanges.entrySet()) {
+            ConfigResource resource = configEntry.getKey();
             if (resource.type() != TOPIC) continue;
+            if (!isSettingConfigToTrue(configEntry.getValue(), DISKLESS_ENABLE_CONFIG)) continue;
+            // Skip topics whose config change failed
             ApiError error = configResults.get(resource);
             if (error != null && error != ApiError.NONE) continue;
-            Map<String, Entry<OpType, String>> changes = entry.getValue();
-            Entry<OpType, String> disklessChange = changes.get(DISKLESS_ENABLE_CONFIG);
-            if (disklessChange == null) continue;
-            if (disklessChange.getKey() != SET || !Boolean.parseBoolean(disklessChange.getValue())) continue;
+            // Skip topics that are already diskless
             if (isDisklessTopic(resource.name())) continue;
 
-            String topicName = resource.name();
-            Uuid topicId = topicsByName.get(topicName);
+            Uuid topicId = topicsByName.get(resource.name());
             if (topicId == null) continue;
             TopicControlInfo topicInfo = topics.get(topicId);
             if (topicInfo == null) continue;
@@ -2992,10 +3113,10 @@ public class ReplicationControlManager {
                 if (partition.classicToDisklessStartOffset == PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET) {
                     if (partition.leader == NO_LEADER) {
                         log.warn("Partition {}-{} has no leader; classic-to-diskless switch will " +
-                            "remain pending until a leader is elected", topicName, partEntry.getKey());
+                            "remain pending until a leader is elected", topicInfo.name, partEntry.getKey());
                     }
                     PartitionChangeRecord record = new PartitionChangeRecord()
-                        .setTopicId(topicId)
+                        .setTopicId(topicInfo.id)
                         .setPartitionId(partEntry.getKey())
                         .setLeader(partition.leader); // Force leader epoch bump to trigger makeLeader on broker
                     record.unknownTaggedFields().add(
@@ -3005,7 +3126,7 @@ public class ReplicationControlManager {
                 }
             }
             log.info("Marked {} partition(s) for topic {} as classic-to-diskless switch pending",
-                records.size() - sizeBefore, topicName);
+                records.size() - sizeBefore, topicInfo.name);
         }
         return records;
     }
@@ -3030,6 +3151,11 @@ public class ReplicationControlManager {
             }
         }
         return markClassicToDisklessSwitchStarted(configChanges, configResults);
+    }
+
+    private static boolean isSettingConfigToTrue(Map<String, Entry<OpType, String>> changes, String configKey) {
+        Entry<OpType, String> change = changes.get(configKey);
+        return change != null && change.getKey() == SET && Boolean.parseBoolean(change.getValue());
     }
 
     private boolean isDisklessTopic(String topicName) {

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -2034,6 +2034,12 @@ public class ReplicationControlManager {
             || (electionType == ElectionType.UNCLEAN && partition.hasLeader())) {
             return new ApiError(Errors.ELECTION_NOT_NEEDED);
         }
+        if (electionType == ElectionType.UNCLEAN && hasClassicToDisklessSwitchPending(partition)) {
+            warnSkippingUncleanElectionForPendingSwitch(topic, partitionId);
+            return new ApiError(INVALID_REQUEST,
+                "Cannot perform unclean leader election for partition " + topic + "-" + partitionId +
+                " because it has a pending classic-to-diskless switch.");
+        }
 
         PartitionChangeBuilder.Election election = PartitionChangeBuilder.Election.PREFERRED;
         if (electionType == ElectionType.UNCLEAN) {

--- a/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
@@ -6900,6 +6900,84 @@ public class ReplicationControlManagerTest {
         }
 
         @Test
+        public void testLegacyAlterConfigsRejectsImplicitSwitchWhenUnderReplicated() {
+            // Legacy AlterConfigs replaces the entire config map. If a topic has
+            // diskless.enable=false and the request omits it, the override would be deleted,
+            // switching to diskless via broker default. The precondition check must
+            // detect this implicit switch and reject it when partitions are unhealthy.
+            ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder()
+                .setStaticConfig(ServerConfigs.DISKLESS_ALLOW_FROM_CLASSIC_ENABLE_CONFIG, true)
+                .setDisklessStorageSystemEnabled(true)
+                .setDefaultDisklessEnable(true)
+                .build();
+            ctx.registerBrokers(0, 1, 2);
+            ctx.unfenceBrokers(0, 1, 2);
+            Uuid fooId = ctx.createTestTopic("foo", new int[][] {new int[] {0, 1, 2}},
+                Map.of(DISKLESS_ENABLE_CONFIG, "false"), (short) 0).topicId();
+
+            ConfigResource resource = new ConfigResource(ConfigResource.Type.TOPIC, "foo");
+            assertEquals("false", ctx.configurationControl.currentTopicConfig("foo").get(DISKLESS_ENABLE_CONFIG));
+
+            // Make the partition under-replicated
+            ctx.fenceBrokers(2);
+            PartitionRegistration partition = ctx.replicationControl.getPartition(fooId, 0);
+            assertTrue(partition.isr.length < partition.replicas.length);
+
+            // Legacy AlterConfigs with only retention.ms (omits diskless.enable).
+            // Since this would implicitly switch via broker default and the partition
+            // is under-replicated, it must be rejected.
+            ControllerResult<Map<ConfigResource, ApiError>> legacyResult =
+                ctx.configurationControl.legacyAlterConfigs(
+                    Map.of(resource, Map.of("retention.ms", "86400000")),
+                    false,
+                    r -> ctx.replicationControl.validateClassicToDisklessSwitchPreconditionForLegacy(
+                        r, Map.of(resource, Map.of("retention.ms", "86400000"))));
+
+            assertEquals(Errors.INVALID_CONFIG, legacyResult.response().get(resource).error(),
+                "Legacy AlterConfigs should reject implicit diskless switch when under-replicated");
+            assertTrue(legacyResult.response().get(resource).message().contains("under-replicated"),
+                "Expected 'under-replicated' in: " + legacyResult.response().get(resource).message());
+        }
+
+        @Test
+        public void testLegacyAlterConfigsEmitsSwitchRecordsForImplicitSwitch() {
+            // When partitions are healthy and legacy AlterConfigs implicitly enables diskless
+            // via override deletion, switch-pending records must be emitted.
+            ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder()
+                .setStaticConfig(ServerConfigs.DISKLESS_ALLOW_FROM_CLASSIC_ENABLE_CONFIG, true)
+                .setDisklessStorageSystemEnabled(true)
+                .setDefaultDisklessEnable(true)
+                .build();
+            ctx.registerBrokers(0, 1, 2);
+            ctx.unfenceBrokers(0, 1, 2);
+            ctx.createTestTopic("foo", new int[][] {new int[] {0, 1, 2}},
+                Map.of(DISKLESS_ENABLE_CONFIG, "false"), (short) 0);
+
+            ConfigResource resource = new ConfigResource(ConfigResource.Type.TOPIC, "foo");
+
+            // Legacy AlterConfigs with only retention.ms (omits diskless.enable).
+            // Partitions are healthy, so the implicit switch should succeed and produce
+            // switch-pending records.
+            Map<ConfigResource, Map<String, String>> newConfigs =
+                Map.of(resource, Map.of("retention.ms", "86400000"));
+            ControllerResult<Map<ConfigResource, ApiError>> legacyResult =
+                ctx.configurationControl.legacyAlterConfigs(newConfigs, false,
+                    r -> ctx.replicationControl.validateClassicToDisklessSwitchPreconditionForLegacy(
+                        r, newConfigs));
+            assertEquals(ApiError.NONE, legacyResult.response().get(resource));
+
+            // Call before replay (same order as QuorumController) — the override still
+            // exists in configData at this point.
+            List<ApiMessageAndVersion> switchRecords =
+                ctx.replicationControl.markClassicToDisklessSwitchStartedForLegacyAlterConfigs(
+                    newConfigs, legacyResult.response());
+            assertFalse(switchRecords.isEmpty(), "Expected switch-pending records for implicit diskless switch");
+
+            ctx.replay(legacyResult.records());
+            ctx.replay(switchRecords);
+        }
+
+        @Test
         public void testElectLeadersRejectsUncleanElectionForPendingSwitchPartition() {
             ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder()
                 .setStaticConfig(TopicConfig.UNCLEAN_LEADER_ELECTION_ENABLE_CONFIG, "true")

--- a/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
@@ -6899,6 +6899,59 @@ public class ReplicationControlManagerTest {
                 "Expected no unclean election for partition with pending switch");
         }
 
+        @Test
+        public void testElectLeadersRejectsUncleanElectionForPendingSwitchPartition() {
+            ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder()
+                .setStaticConfig(TopicConfig.UNCLEAN_LEADER_ELECTION_ENABLE_CONFIG, "true")
+                .build();
+            ctx.registerBrokers(0, 1, 2);
+            ctx.unfenceBrokers(0, 1, 2);
+            Uuid fooId = ctx.createTestTopic("foo", new int[][] {new int[] {0, 1, 2}}).topicId();
+
+            // Shrink ISR to just [0] by fencing brokers 1 and 2, then unfence them
+            ctx.fenceBrokers(1, 2);
+            ctx.unfenceBrokers(1, 2);
+            PartitionRegistration partitionBefore = ctx.replicationControl.getPartition(fooId, 0);
+            assertEquals(0, partitionBefore.leader);
+            assertEquals(1, partitionBefore.isr.length);
+
+            // Mark the partition as switch pending
+            ConfigResource resource = new ConfigResource(ConfigResource.Type.TOPIC, "foo");
+            Map<ConfigResource, Map<String, Map.Entry<AlterConfigOp.OpType, String>>> disklessChanges = Map.of(
+                resource, Map.of(DISKLESS_ENABLE_CONFIG,
+                    new AbstractMap.SimpleImmutableEntry<>(AlterConfigOp.OpType.SET, "true")));
+            List<ApiMessageAndVersion> switchRecords =
+                ctx.replicationControl.markClassicToDisklessSwitchStarted(
+                    disklessChanges, Map.of(resource, ApiError.NONE));
+            ctx.replay(switchRecords);
+
+            // Fence the leader to make partition leaderless
+            ctx.fenceBrokers(0);
+            PartitionRegistration partitionAfterFence = ctx.replicationControl.getPartition(fooId, 0);
+            assertFalse(partitionAfterFence.hasLeader());
+
+            // Attempt explicit unclean election via electLeaders API — should be rejected
+            ElectLeadersRequestData request = new ElectLeadersRequestData()
+                .setElectionType(ElectionType.UNCLEAN.value);
+            request.topicPartitions().add(new TopicPartitions()
+                .setTopic("foo")
+                .setPartitions(List.of(0)));
+
+            ControllerResult<ElectLeadersResponseData> result =
+                ctx.replicationControl.electLeaders(request);
+
+            assertEquals(0, result.records().size(),
+                "Expected no election records for partition with pending switch");
+
+            ReplicaElectionResult topicResult = result.response().replicaElectionResults().get(0);
+            assertEquals("foo", topicResult.topic());
+            PartitionResult partitionResult = topicResult.partitionResult().get(0);
+            assertEquals(0, partitionResult.partitionId());
+            assertEquals(Errors.INVALID_REQUEST.code(), partitionResult.errorCode());
+            assertTrue(partitionResult.errorMessage().contains("pending classic-to-diskless switch"),
+                "Expected pending switch message in: " + partitionResult.errorMessage());
+        }
+
     }
 
 }

--- a/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
@@ -6640,6 +6640,265 @@ public class ReplicationControlManagerTest {
                 InitDisklessLogFields.decodeClassicToDisklessStartOffset(record.unknownTaggedFields()));
         }
 
+        @Test
+        public void testSwitchRejectedWhenPartitionIsOffline() {
+            ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder()
+                .setStaticConfig(ServerConfigs.DISKLESS_ALLOW_FROM_CLASSIC_ENABLE_CONFIG, true)
+                .build();
+            ctx.registerBrokers(0, 1, 2);
+            ctx.unfenceBrokers(0, 1, 2);
+            ctx.createTestTopic("foo", new int[][] {new int[] {0, 1, 2}});
+
+            // Fence all brokers to make the partition offline
+            ctx.fenceBrokers(0, 1, 2);
+
+            ConfigResource resource = new ConfigResource(ConfigResource.Type.TOPIC, "foo");
+
+            Map<ConfigResource, ApiError> errors =
+                ctx.replicationControl.validateClassicToDisklessSwitchPreconditions(Set.of(resource));
+
+            assertEquals(1, errors.size());
+            ApiError error = errors.get(resource);
+            assertEquals(Errors.INVALID_CONFIG, error.error());
+            assertTrue(error.message().contains("offline"), "Expected 'offline' in: " + error.message());
+        }
+
+        @Test
+        public void testSwitchRejectedWhenReassignmentInProgress() {
+            ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder()
+                .setStaticConfig(ServerConfigs.DISKLESS_ALLOW_FROM_CLASSIC_ENABLE_CONFIG, true)
+                .build();
+            ctx.registerBrokers(0, 1, 2, 3);
+            ctx.unfenceBrokers(0, 1, 2, 3);
+            ctx.createTestTopic("foo", new int[][] {new int[] {0, 1, 2}});
+
+            // Start a reassignment
+            ControllerResult<AlterPartitionReassignmentsResponseData> alterResult =
+                ctx.replicationControl.alterPartitionReassignments(
+                    new AlterPartitionReassignmentsRequestData().setTopics(List.of(
+                        new ReassignableTopic().setName("foo").setPartitions(List.of(
+                            new ReassignablePartition().setPartitionIndex(0).
+                                setReplicas(List.of(1, 2, 3)))))));
+            ctx.replay(alterResult.records());
+
+            ConfigResource resource = new ConfigResource(ConfigResource.Type.TOPIC, "foo");
+
+            Map<ConfigResource, ApiError> errors =
+                ctx.replicationControl.validateClassicToDisklessSwitchPreconditions(Set.of(resource));
+
+            assertEquals(1, errors.size());
+            ApiError error = errors.get(resource);
+            assertEquals(Errors.INVALID_CONFIG, error.error());
+            assertTrue(error.message().contains("reassignment"), "Expected 'reassignment' in: " + error.message());
+        }
+
+        @Test
+        public void testSwitchRejectedWhenUnderReplicated() {
+            ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder()
+                .setStaticConfig(ServerConfigs.DISKLESS_ALLOW_FROM_CLASSIC_ENABLE_CONFIG, true)
+                .build();
+            ctx.registerBrokers(0, 1, 2);
+            ctx.unfenceBrokers(0, 1, 2);
+            Uuid fooId = ctx.createTestTopic("foo", new int[][] {new int[] {0, 1, 2}}).topicId();
+
+            // Shrink ISR to make it under-replicated (fence one broker then unfence it without rejoining ISR)
+            ctx.fenceBrokers(2);
+            // Now partition has ISR < replicas but still has a leader
+            PartitionRegistration partition = ctx.replicationControl.getPartition(fooId, 0);
+            assertTrue(partition.hasLeader());
+            assertTrue(partition.isr.length < partition.replicas.length);
+
+            ConfigResource resource = new ConfigResource(ConfigResource.Type.TOPIC, "foo");
+
+            Map<ConfigResource, ApiError> errors =
+                ctx.replicationControl.validateClassicToDisklessSwitchPreconditions(Set.of(resource));
+
+            assertEquals(1, errors.size());
+            ApiError error = errors.get(resource);
+            assertEquals(Errors.INVALID_CONFIG, error.error());
+            assertTrue(error.message().contains("under-replicated"), "Expected 'under-replicated' in: " + error.message());
+        }
+
+        @Test
+        public void testSwitchRejectedWhenElrIsNonEmpty() {
+            ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder()
+                .setStaticConfig(ServerConfigs.DISKLESS_ALLOW_FROM_CLASSIC_ENABLE_CONFIG, true)
+                .setStaticConfig(TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG, "3")
+                .setIsElrEnabled(true)
+                .build();
+            ctx.registerBrokers(0, 1, 2);
+            ctx.unfenceBrokers(0, 1, 2);
+            Uuid fooId = ctx.createTestTopic("foo", new int[][] {new int[] {0, 1, 2}}).topicId();
+
+            // Fence broker 2 — ISR drops below minISR (3), so broker 2 goes to ELR
+            ctx.fenceBrokers(2);
+            PartitionRegistration partition = ctx.replicationControl.getPartition(fooId, 0);
+            assertTrue(partition.elr.length > 0,
+                "Expected ELR to be non-empty after fencing with minISR=3, got elr=" +
+                Arrays.toString(partition.elr));
+
+            ConfigResource resource = new ConfigResource(ConfigResource.Type.TOPIC, "foo");
+
+            Map<ConfigResource, ApiError> errors =
+                ctx.replicationControl.validateClassicToDisklessSwitchPreconditions(Set.of(resource));
+
+            assertEquals(1, errors.size());
+            ApiError error = errors.get(resource);
+            assertEquals(Errors.INVALID_CONFIG, error.error());
+            assertTrue(error.message().contains("non-empty ELR"),
+                "Expected 'non-empty ELR' in: " + error.message());
+        }
+
+        @Test
+        public void testSwitchRejectedWhenLastKnownElrIsNonEmpty() {
+            ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder()
+                .setStaticConfig(ServerConfigs.DISKLESS_ALLOW_FROM_CLASSIC_ENABLE_CONFIG, true)
+                .setStaticConfig(TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG, "3")
+                .setIsElrEnabled(true)
+                .build();
+            ctx.registerBrokers(0, 1, 2);
+            ctx.unfenceBrokers(0, 1, 2);
+            Uuid fooId = ctx.createTestTopic("foo", new int[][] {new int[] {0, 1, 2}}).topicId();
+
+            // Fence broker 2 — ISR drops below minISR (3), so broker 2 goes to ELR
+            ctx.fenceBrokers(2);
+            PartitionRegistration partition = ctx.replicationControl.getPartition(fooId, 0);
+            assertTrue(partition.elr.length > 0 || partition.lastKnownElr.length > 0,
+                "Expected ELR or lastKnownElr to be non-empty after fencing, got elr=" +
+                Arrays.toString(partition.elr) + " lastKnownElr=" + Arrays.toString(partition.lastKnownElr));
+
+            ConfigResource resource = new ConfigResource(ConfigResource.Type.TOPIC, "foo");
+
+            Map<ConfigResource, ApiError> errors =
+                ctx.replicationControl.validateClassicToDisklessSwitchPreconditions(Set.of(resource));
+
+            assertEquals(1, errors.size());
+            ApiError error = errors.get(resource);
+            assertEquals(Errors.INVALID_CONFIG, error.error());
+            assertTrue(error.message().contains("ELR") || error.message().contains("last-known ELR"),
+                "Expected 'ELR' or 'last-known ELR' in: " + error.message());
+        }
+
+        @Test
+        public void testSwitchRejectedWhenRecovering() {
+            ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder()
+                .setStaticConfig(ServerConfigs.DISKLESS_ALLOW_FROM_CLASSIC_ENABLE_CONFIG, true)
+                .setStaticConfig(TopicConfig.UNCLEAN_LEADER_ELECTION_ENABLE_CONFIG, "true")
+                .build();
+            ctx.registerBrokers(0, 1, 2);
+            ctx.unfenceBrokers(0, 1, 2);
+            Uuid fooId = ctx.createTestTopic("foo", new int[][] {new int[] {0, 1, 2}}).topicId();
+
+            // Fence brokers 1, 2 to shrink ISR to [0]
+            ctx.fenceBrokers(1, 2);
+            // Fence broker 0 to make partition leaderless
+            ctx.fenceBrokers(0, 1, 2);
+            // Unfence broker 1 to trigger unclean election (RECOVERING state)
+            ctx.unfenceBrokers(1);
+
+            PartitionRegistration partition = ctx.replicationControl.getPartition(fooId, 0);
+            assertEquals(LeaderRecoveryState.RECOVERING, partition.leaderRecoveryState);
+
+            // Disable unclean leader election so the unclean check doesn't fire first
+            ctx.replay(ctx.configurationControl.incrementalAlterConfigs(
+                Map.of(new ConfigResource(ConfigResource.Type.TOPIC, "foo"),
+                    Map.of(TopicConfig.UNCLEAN_LEADER_ELECTION_ENABLE_CONFIG,
+                        new AbstractMap.SimpleImmutableEntry<>(AlterConfigOp.OpType.SET, "false"))),
+                false).records());
+
+            ConfigResource resource = new ConfigResource(ConfigResource.Type.TOPIC, "foo");
+
+            Map<ConfigResource, ApiError> errors =
+                ctx.replicationControl.validateClassicToDisklessSwitchPreconditions(Set.of(resource));
+
+            assertEquals(1, errors.size());
+            ApiError error = errors.get(resource);
+            assertEquals(Errors.INVALID_CONFIG, error.error());
+            assertTrue(error.message().contains("recovering"),
+                "Expected 'recovering' in: " + error.message());
+        }
+
+        @Test
+        public void testMaybeTriggerUncleanElectionSkipsPendingSwitchPartition() {
+            ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder()
+                .setStaticConfig(TopicConfig.UNCLEAN_LEADER_ELECTION_ENABLE_CONFIG, "true")
+                .build();
+            ctx.registerBrokers(0, 1, 2);
+            ctx.unfenceBrokers(0, 1, 2);
+            Uuid fooId = ctx.createTestTopic("foo", new int[][] {new int[] {0, 1, 2}}).topicId();
+
+            // Shrink ISR to just [0] by fencing brokers 1 and 2, then unfence them
+            // so they are unfenced replicas (non-ISR) eligible for unclean election.
+            ctx.fenceBrokers(1, 2);
+            ctx.unfenceBrokers(1, 2);
+            PartitionRegistration partitionBefore = ctx.replicationControl.getPartition(fooId, 0);
+            assertEquals(0, partitionBefore.leader);
+            assertEquals(1, partitionBefore.isr.length, "ISR should be shrunk to just the leader");
+
+            // Mark the partition as switch pending
+            ConfigResource resource = new ConfigResource(ConfigResource.Type.TOPIC, "foo");
+            Map<ConfigResource, Map<String, Map.Entry<AlterConfigOp.OpType, String>>> disklessChanges = Map.of(
+                resource, Map.of(DISKLESS_ENABLE_CONFIG,
+                    new AbstractMap.SimpleImmutableEntry<>(AlterConfigOp.OpType.SET, "true")));
+            List<ApiMessageAndVersion> switchRecords =
+                ctx.replicationControl.markClassicToDisklessSwitchStarted(
+                    disklessChanges, Map.of(resource, ApiError.NONE));
+            ctx.replay(switchRecords);
+
+            // Fence the leader (broker 0) — partition becomes leaderless.
+            // Brokers 1 and 2 are unfenced replicas eligible for unclean election.
+            ctx.fenceBrokers(0);
+            PartitionRegistration partitionAfterFence = ctx.replicationControl.getPartition(fooId, 0);
+            assertFalse(partitionAfterFence.hasLeader(),
+                "Partition should be leaderless because the pending-switch guard " +
+                "prevented unclean election during fencing");
+
+            // Explicitly call maybeTriggerUncleanLeaderElection — should also be skipped
+            List<ApiMessageAndVersion> electionRecords = new ArrayList<>();
+            ctx.replicationControl.maybeTriggerUncleanLeaderElectionForLeaderlessPartitions(
+                electionRecords, Integer.MAX_VALUE);
+
+            assertEquals(0, electionRecords.size(),
+                "Expected no unclean election for partition with pending switch");
+        }
+
+        @Test
+        public void testBrokerFencingDoesNotTriggerUncleanElectionForPendingSwitchPartition() {
+            ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder()
+                .setStaticConfig(TopicConfig.UNCLEAN_LEADER_ELECTION_ENABLE_CONFIG, "true")
+                .build();
+            ctx.registerBrokers(0, 1, 2);
+            ctx.unfenceBrokers(0, 1, 2);
+            Uuid fooId = ctx.createTestTopic("foo", new int[][] {new int[] {0, 1, 2}}).topicId();
+
+            // Shrink ISR to just [0] by fencing brokers 1 and 2, then unfence them
+            // so they are replicas but not in ISR.
+            ctx.fenceBrokers(1, 2);
+            ctx.unfenceBrokers(1, 2);
+            PartitionRegistration partitionBefore = ctx.replicationControl.getPartition(fooId, 0);
+            assertEquals(0, partitionBefore.leader);
+            assertEquals(1, partitionBefore.isr.length, "ISR should be shrunk to just the leader");
+
+            // Mark the partition as switch pending
+            ConfigResource resource = new ConfigResource(ConfigResource.Type.TOPIC, "foo");
+            Map<ConfigResource, Map<String, Map.Entry<AlterConfigOp.OpType, String>>> disklessChanges = Map.of(
+                resource, Map.of(DISKLESS_ENABLE_CONFIG,
+                    new AbstractMap.SimpleImmutableEntry<>(AlterConfigOp.OpType.SET, "true")));
+            List<ApiMessageAndVersion> switchRecords =
+                ctx.replicationControl.markClassicToDisklessSwitchStarted(
+                    disklessChanges, Map.of(resource, ApiError.NONE));
+            ctx.replay(switchRecords);
+
+            // Fence the leader (broker 0) — brokers 1, 2 are unfenced replicas (non-ISR).
+            // With unclean enabled but pending switch, should NOT do unclean election.
+            ctx.fenceBrokers(0);
+            PartitionRegistration partition = ctx.replicationControl.getPartition(fooId, 0);
+
+            // Partition should be leaderless, not unclean-elected
+            assertFalse(partition.hasLeader(),
+                "Expected no unclean election for partition with pending switch");
+        }
+
     }
 
 }


### PR DESCRIPTION
Enforce the following guards when altering the topic config to use diskless.enable=true:
  - Partitions are online
  - No reassignment in progress
  - Enough ISRs