### PR TITLE
feat(inkless): add dedicated rate limit for consolidation fetch [KC-145]

### DIFF
--- a/core/src/main/scala/io/aiven/inkless/consolidation/ConsolidationReconciler.scala
+++ b/core/src/main/scala/io/aiven/inkless/consolidation/ConsolidationReconciler.scala
@@ -19,7 +19,7 @@
 package io.aiven.inkless.consolidation
 
 import kafka.cluster.Partition
-import kafka.server.{InitialFetchState, ReplicaManager}
+import kafka.server.{InitialFetchState, ReplicaManager, ReplicationQuotaManager}
 import kafka.server.metadata.InklessMetadataView
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.logger.StateChangeLogger
@@ -51,7 +51,8 @@ class ConsolidationReconciler(replicaManager: ReplicaManager,
                               consolidationMetrics: ConsolidationMetrics,
                               inklessMetadataView: InklessMetadataView,
                               initialFetchOffset: UnifiedLog => Long,
-                              consolidationFetcherManager: ConsolidationFetcherManager) {
+                              consolidationFetcherManager: ConsolidationFetcherManager,
+                              consolidationQuotaManager: ReplicationQuotaManager) {
 
   /**
    * Starts the consolidation fetchers for the given partitions in the parameter. These partitions
@@ -67,6 +68,10 @@ class ConsolidationReconciler(replicaManager: ReplicaManager,
         initConsolidatingPartitionFetching(consolidatingPartitions)
 
       consolidationFetcherManager.addFetcherForPartitions(consolidatingPartitionAndOffsets)
+      // Unlike classic replication (where throttled replicas are set via topic config during
+      // reassignment), consolidation marks all topics unconditionally — every consolidating
+      // partition's bytes must count toward the dedicated bandwidth quota.
+      consolidatingPartitionAndOffsets.keys.map(_.topic).toSet.foreach((topic: String) => consolidationQuotaManager.markThrottled(topic))
       consolidatingPartitionAndOffsets.keys.foreach(tp => consolidationMetrics.registerPartition(tp))
     }
   }

--- a/core/src/main/scala/io/aiven/inkless/consolidation/ConsolidationReconciler.scala
+++ b/core/src/main/scala/io/aiven/inkless/consolidation/ConsolidationReconciler.scala
@@ -67,11 +67,14 @@ class ConsolidationReconciler(replicaManager: ReplicaManager,
       val consolidatingPartitionAndOffsets: mutable.HashMap[TopicPartition, InitialFetchState] =
         initConsolidatingPartitionFetching(consolidatingPartitions)
 
-      consolidationFetcherManager.addFetcherForPartitions(consolidatingPartitionAndOffsets)
-      // Unlike classic replication (where throttled replicas are set via topic config during
-      // reassignment), consolidation marks all topics unconditionally — every consolidating
-      // partition's bytes must count toward the dedicated bandwidth quota.
+      // Mark topics throttled BEFORE starting fetchers: addFetcherForPartitions starts the
+      // fetcher threads immediately, and ReplicaFetcherThread only records bytes to the quota
+      // when the partition is already throttled. Marking after would let the first fetch/append
+      // bypass the quota. Unlike classic replication (where throttled replicas are set via topic
+      // config during reassignment), consolidation marks all topics unconditionally — every
+      // consolidating partition's bytes must count toward the dedicated bandwidth quota.
       consolidatingPartitionAndOffsets.keys.map(_.topic).toSet.foreach((topic: String) => consolidationQuotaManager.markThrottled(topic))
+      consolidationFetcherManager.addFetcherForPartitions(consolidatingPartitionAndOffsets)
       consolidatingPartitionAndOffsets.keys.foreach(tp => consolidationMetrics.registerPartition(tp))
     }
   }

--- a/core/src/main/scala/io/aiven/inkless/consolidation/ConsolidationReconciler.scala
+++ b/core/src/main/scala/io/aiven/inkless/consolidation/ConsolidationReconciler.scala
@@ -73,6 +73,11 @@ class ConsolidationReconciler(replicaManager: ReplicaManager,
       // bypass the quota. Unlike classic replication (where throttled replicas are set via topic
       // config during reassignment), consolidation marks all topics unconditionally — every
       // consolidating partition's bytes must count toward the dedicated bandwidth quota.
+      //
+      // We never removeThrottle on stop: this follows the classic ReplicaFetcher pattern, where
+      // the topic-keyed throttle map is only cleared via config changes (ConfigHandler), not on
+      // per-partition fetcher removal. Entries are tiny (topic -> List(-1)) and bounded by the
+      // set of topics that have ever consolidated on this broker, so the residue is benign.
       consolidatingPartitionAndOffsets.keys.map(_.topic).toSet.foreach((topic: String) => consolidationQuotaManager.markThrottled(topic))
       consolidationFetcherManager.addFetcherForPartitions(consolidatingPartitionAndOffsets)
       consolidatingPartitionAndOffsets.keys.foreach(tp => consolidationMetrics.registerPartition(tp))

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -435,6 +435,7 @@ class KafkaConfig private(doLog: Boolean, val props: util.Map[_, _])
   val disklessConsolidationNumFetchers: Int = getInt(ServerConfigs.DISKLESS_CONSOLIDATION_NUM_FETCHERS_CONFIG)
   val disklessConsolidationFetchMaxWaitMs: Int = getInt(ServerConfigs.DISKLESS_CONSOLIDATION_FETCH_MAX_WAIT_MS_CONFIG)
   val disklessConsolidationFindBatchesMaxPerPartition: Int = getInt(ServerConfigs.DISKLESS_CONSOLIDATION_FIND_BATCHES_MAX_PER_PARTITION_CONFIG)
+  val disklessConsolidationFetchRateLimitBytesPerSecond: Long = getLong(ServerConfigs.DISKLESS_CONSOLIDATION_FETCH_RATE_LIMIT_BYTES_PER_SECOND_CONFIG)
   val classicRemoteStorageForceEnabled: Boolean = getBoolean(ServerConfigs.CLASSIC_REMOTE_STORAGE_FORCE_ENABLE_CONFIG)
   val classicRemoteStorageForceExcludeTopicRegexes: java.util.List[String] =
     getList(ServerConfigs.CLASSIC_REMOTE_STORAGE_FORCE_EXCLUDE_TOPIC_REGEXES_CONFIG)

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -60,7 +60,9 @@ import org.apache.kafka.metadata.{LeaderAndIsr, MetadataCache, PartitionRegistra
 import org.apache.kafka.metadata.LeaderConstants.NO_LEADER
 import org.apache.kafka.server.common.{DirectoryEventHandler, RequestLocal, StopPartition, TransactionVersion}
 import org.apache.kafka.server.log.remote.TopicPartitionLog
-import org.apache.kafka.server.config.ReplicationConfigs
+import org.apache.kafka.server.config.{ReplicationConfigs, ReplicationQuotaManagerConfig}
+import org.apache.kafka.common.metrics.Quota
+import org.apache.kafka.server.quota.QuotaType
 import org.apache.kafka.server.log.remote.storage.RemoteLogManager
 import org.apache.kafka.server.metrics.KafkaMetricsGroup
 import org.apache.kafka.server.network.BrokerEndPoint
@@ -319,15 +321,38 @@ class ReplicaManager(val config: KafkaConfig,
     } else {
       None
     }
+  private val consolidationQuotaManager: Option[ReplicationQuotaManager] =
+    if (config.disklessRemoteStorageConsolidationEnabled) {
+      val quotaConfig = new ReplicationQuotaManagerConfig(
+        config.quotaConfig.numReplicationQuotaSamples,
+        config.quotaConfig.replicationQuotaWindowSizeSeconds
+      )
+      val manager = new ReplicationQuotaManager(quotaConfig, metrics, QuotaType.DISKLESS_CONSOLIDATION_FETCH, time)
+      val rateLimitBytesPerSec = config.disklessConsolidationFetchRateLimitBytesPerSecond
+      manager.updateQuota(new Quota(rateLimitBytesPerSec, true))
+      Some(manager)
+    } else {
+      None
+    }
+
   private val consolidationFetcherManager: Option[ConsolidationFetcherManager] =
     if (config.disklessRemoteStorageConsolidationEnabled) {
-      if (consolidationFetchHandler.isEmpty || inklessFetchOffsetHandler.isEmpty) {
+      if (consolidationFetchHandler.isEmpty || inklessFetchOffsetHandler.isEmpty || consolidationQuotaManager.isEmpty) {
         throw new KafkaException("Remote storage consolidation is enabled, however Inkless doesn't seem to have " +
-          "configured fetch handler or fetch offset handler ready.")
+          "configured fetch handler, fetch offset handler or quota manager ready.")
       }
-      consolidationFetchHandler.zip(inklessFetchOffsetHandler).map { case (fetchHandler, fetchOffsetHandler) =>
-        new ConsolidationFetcherManager(config, this, quotaManagers.follower, fetchHandler, fetchOffsetHandler, consolidationMetrics)
-      }
+      consolidationFetchHandler.zip(inklessFetchOffsetHandler)
+        .zip(consolidationQuotaManager)
+        .map { case ((fetchHandler, fetchOffsetHandler), quotaMgr) =>
+          new ConsolidationFetcherManager(
+            config,
+            this,
+            quotaMgr,
+            fetchHandler,
+            fetchOffsetHandler,
+            consolidationMetrics
+          )
+        }
     } else {
       None
     }
@@ -354,7 +379,7 @@ class ReplicaManager(val config: KafkaConfig,
         throw new KafkaException("Remote storage consolidation is enabled, however Inkless doesn't seem to " +
           "have configured consolidation fetch manager or metrics ready.")
       }
-      Some(new ConsolidationReconciler(this, stateChangeLogger, consolidationMetrics.get, _inklessMetadataView, initialFetchOffset, consolidationFetcherManager.get))
+      Some(new ConsolidationReconciler(this, stateChangeLogger, consolidationMetrics.get, _inklessMetadataView, initialFetchOffset, consolidationFetcherManager.get, consolidationQuotaManager.get))
     } else {
       None
     }

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -337,9 +337,11 @@ class ReplicaManager(val config: KafkaConfig,
 
   private val consolidationFetcherManager: Option[ConsolidationFetcherManager] =
     if (config.disklessRemoteStorageConsolidationEnabled) {
-      if (consolidationFetchHandler.isEmpty || inklessFetchOffsetHandler.isEmpty || consolidationQuotaManager.isEmpty) {
+      // consolidationQuotaManager is unconditionally Some(...) under this same flag (unlike the
+      // handlers, which depend on inklessSharedState), so it needs no emptiness check here.
+      if (consolidationFetchHandler.isEmpty || inklessFetchOffsetHandler.isEmpty) {
         throw new KafkaException("Remote storage consolidation is enabled, however Inkless doesn't seem to have " +
-          "configured fetch handler, fetch offset handler or quota manager ready.")
+          "configured fetch handler or fetch offset handler ready.")
       }
       consolidationFetchHandler.zip(inklessFetchOffsetHandler)
         .zip(consolidationQuotaManager)

--- a/core/src/test/scala/io/aiven/inkless/consolidation/ConsolidationQuotaManagerTest.scala
+++ b/core/src/test/scala/io/aiven/inkless/consolidation/ConsolidationQuotaManagerTest.scala
@@ -1,0 +1,237 @@
+/*
+ * Inkless
+ * Copyright (C) 2024 - 2026 Aiven OY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package io.aiven.inkless.consolidation
+
+import io.aiven.inkless.consume.{FetchHandler, FetchOffsetHandler}
+import kafka.server.{KafkaConfig, ReplicaManager, ReplicationQuotaManager}
+import kafka.utils.TestUtils
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.metrics.{MetricConfig, Metrics, Quota}
+import org.apache.kafka.common.utils.MockTime
+import org.apache.kafka.common.Uuid
+import org.apache.kafka.server.common.MetadataVersion
+import org.apache.kafka.server.config.ReplicationQuotaManagerConfig
+import org.apache.kafka.server.network.BrokerEndPoint
+import org.apache.kafka.server.quota.QuotaType
+import org.apache.kafka.server.{PartitionFetchState, ReplicaState}
+import org.apache.kafka.storage.internals.log.UnifiedLog
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
+import org.mockito.Mockito.{mock, when}
+
+import java.util
+import java.util.{Collections, Optional}
+
+class ConsolidationQuotaManagerTest {
+  private val brokerEndPoint = new BrokerEndPoint(1, "localhost", 9092)
+  private val tp = new TopicPartition("consolidating-topic", 0)
+  private val topicId = Uuid.randomUuid()
+
+  private var time: MockTime = _
+  private var metrics: Metrics = _
+
+  @BeforeEach
+  def setUp(): Unit = {
+    time = new MockTime
+    metrics = new Metrics(new MetricConfig(), Collections.emptyList(), time)
+  }
+
+  @AfterEach
+  def tearDown(): Unit = {
+    metrics.close()
+  }
+
+  private def createConsolidationQuota(rateBytesPerSec: Long): ReplicationQuotaManager = {
+    val config = new ReplicationQuotaManagerConfig(10, 1)
+    val manager = new ReplicationQuotaManager(config, metrics, QuotaType.DISKLESS_CONSOLIDATION_FETCH, time)
+    manager.updateQuota(new Quota(rateBytesPerSec.toDouble, true))
+    manager.markThrottled("consolidating-topic")
+    manager
+  }
+
+  private def createEndPoint(quota: ReplicationQuotaManager): DisklessLeaderEndPoint = {
+    val fetchHandler = mock(classOf[FetchHandler])
+    val fetchOffsetHandler = mock(classOf[FetchOffsetHandler])
+    val replicaManager = mock(classOf[ReplicaManager])
+    val log = mock(classOf[UnifiedLog])
+    when(log.logStartOffset).thenReturn(0L)
+    when(replicaManager.localLogOrException(tp)).thenReturn(log)
+
+    val props = TestUtils.createBrokerConfig(brokerEndPoint.id, port = brokerEndPoint.port)
+    val kafkaConfig = KafkaConfig.fromProps(props)
+
+    new DisklessLeaderEndPoint(
+      brokerEndPoint,
+      fetchHandler,
+      fetchOffsetHandler,
+      replicaManager,
+      kafkaConfig,
+      quota,
+      () => MetadataVersion.LATEST_PRODUCTION,
+      () => 7L
+    )
+  }
+
+  private def buildFetchSucceeds(endPoint: DisklessLeaderEndPoint): Boolean = {
+    val fetchState = new PartitionFetchState(
+      Optional.of(topicId),
+      0L,
+      Optional.empty(),
+      1,
+      Optional.empty(),
+      ReplicaState.FETCHING,
+      Optional.empty()
+    )
+    endPoint.buildFetch(util.Map.of(tp, fetchState)).result.isPresent
+  }
+
+  @Test
+  def shouldNotExceedQuotaWhenUnlimited(): Unit = {
+    val quota = createConsolidationQuota(Long.MaxValue)
+
+    quota.record(100 * 1024 * 1024)
+    assertFalse(quota.isQuotaExceeded)
+    assertTrue(buildFetchSucceeds(createEndPoint(quota)))
+  }
+
+  @Test
+  def shouldExceedQuotaWhenRateExceeded(): Unit = {
+    val quota = createConsolidationQuota(100) // 100 bytes/sec
+
+    assertFalse(quota.isQuotaExceeded)
+
+    // First window is fixed, skip it
+    time.sleep(1000)
+
+    // Record 150 bytes in 1.5 seconds → rate = 100 B/s (at quota)
+    time.sleep(500)
+    quota.record(1)
+    quota.record(149)
+    assertFalse(quota.isQuotaExceeded)
+
+    // One more byte pushes over quota: 151B / 1.5s > 100 B/s
+    quota.record(1)
+    assertTrue(quota.isQuotaExceeded)
+    assertFalse(buildFetchSucceeds(createEndPoint(quota)))
+  }
+
+  @Test
+  def shouldRecoverAfterTimePasses(): Unit = {
+    val quota = createConsolidationQuota(100) // 100 bytes/sec
+    val endPoint = createEndPoint(quota)
+
+    time.sleep(1000)
+
+    // Exceed the quota
+    time.sleep(500)
+    quota.record(1)
+    quota.record(150)
+    assertTrue(quota.isQuotaExceeded)
+    assertFalse(buildFetchSucceeds(endPoint))
+
+    // Sleep enough for the sample containing the burst to expire
+    time.sleep(10000)
+    assertFalse(quota.isQuotaExceeded)
+    assertTrue(buildFetchSucceeds(endPoint))
+  }
+
+  @Test
+  def shouldBeIndependentFromFollowerReplicationQuota(): Unit = {
+    val consolidationQuota = createConsolidationQuota(100) // 100 bytes/sec
+
+    val followerQuota = new ReplicationQuotaManager(
+      new ReplicationQuotaManagerConfig(10, 1), metrics, QuotaType.FOLLOWER_REPLICATION, time
+    )
+    followerQuota.updateQuota(new Quota(Long.MaxValue.toDouble, true))
+    followerQuota.markThrottled("consolidating-topic")
+
+    time.sleep(1000)
+
+    // Exceed consolidation quota
+    time.sleep(500)
+    consolidationQuota.record(151)
+    assertTrue(consolidationQuota.isQuotaExceeded)
+
+    // Follower quota should be unaffected
+    assertFalse(followerQuota.isQuotaExceeded)
+  }
+
+  @Test
+  def shouldOnlyRecordForThrottledPartitions(): Unit = {
+    val quota = createConsolidationQuota(1024)
+
+    assertTrue(quota.isThrottled(tp))
+    assertFalse(quota.isThrottled(new TopicPartition("other-topic", 0)))
+  }
+
+  @Test
+  def shouldExposeByteRateMetric(): Unit = {
+    val quota = createConsolidationQuota(10 * 1024 * 1024)
+
+    // Trigger sensor creation (sensors are lazily initialized)
+    quota.record(1)
+
+    val metricName = metrics.metricName("byte-rate", QuotaType.DISKLESS_CONSOLIDATION_FETCH.toString,
+      "Tracking byte-rate for " + QuotaType.DISKLESS_CONSOLIDATION_FETCH)
+    val metric = metrics.metrics.get(metricName)
+    assertNotNull(metric, "DisklessConsolidationFetch byte-rate metric should exist")
+  }
+
+  @Test
+  def shouldSupportDynamicQuotaUpdate(): Unit = {
+    val quota = createConsolidationQuota(1000) // 1000 bytes/sec
+    val endPoint = createEndPoint(quota)
+
+    time.sleep(1000)
+
+    // Record 500B in 1s → under 1000 B/s
+    time.sleep(500)
+    quota.record(500)
+    time.sleep(500)
+    assertFalse(quota.isQuotaExceeded)
+    assertTrue(buildFetchSucceeds(endPoint))
+
+    // Tighten quota to 100 B/s
+    quota.updateQuota(new Quota(100, true))
+
+    // Record another 500B → now well over 100 B/s
+    time.sleep(500)
+    quota.record(500)
+    time.sleep(500)
+    assertTrue(quota.isQuotaExceeded)
+    assertFalse(buildFetchSucceeds(endPoint))
+  }
+
+  @Test
+  def shouldBlockFetchWhenRecordedBytesExceedQuota(): Unit = {
+    val quota = createConsolidationQuota(100) // 100 bytes/sec
+    val endPoint = createEndPoint(quota)
+
+    time.sleep(1000)
+
+    // Simulate what processPartitionData does: check isThrottled then record
+    assertTrue(quota.isThrottled(tp))
+    time.sleep(500)
+    quota.record(151)
+    assertTrue(quota.isQuotaExceeded)
+
+    // Next buildFetch call should be blocked
+    assertFalse(buildFetchSucceeds(endPoint))
+  }
+}

--- a/core/src/test/scala/io/aiven/inkless/consolidation/ConsolidationReconcilerTest.scala
+++ b/core/src/test/scala/io/aiven/inkless/consolidation/ConsolidationReconcilerTest.scala
@@ -20,7 +20,7 @@ package io.aiven.inkless.consolidation
 
 import kafka.cluster.Partition
 import kafka.server.metadata.InklessMetadataView
-import kafka.server.{InitialFetchState, ReplicaManager}
+import kafka.server.{InitialFetchState, ReplicaManager, ReplicationQuotaManager}
 import org.apache.kafka.common.{TopicPartition, Uuid}
 import org.apache.kafka.logger.StateChangeLogger
 import org.apache.kafka.metadata.PartitionRegistration
@@ -49,7 +49,8 @@ class ConsolidationReconcilerTest {
       mock(classOf[ConsolidationMetrics]),
       metadataView,
       initialFetchOffset,
-      fetcherManager
+      fetcherManager,
+      mock(classOf[ReplicationQuotaManager])
     )
   }
 

--- a/core/src/test/scala/io/aiven/inkless/consolidation/ConsolidationReconcilerTest.scala
+++ b/core/src/test/scala/io/aiven/inkless/consolidation/ConsolidationReconcilerTest.scala
@@ -27,7 +27,8 @@ import org.apache.kafka.metadata.PartitionRegistration
 import org.apache.kafka.storage.internals.log.UnifiedLog
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.Test
-import org.mockito.ArgumentMatchers.{anyBoolean, anyLong}
+import org.mockito.ArgumentMatchers.{any, anyBoolean, anyLong}
+import org.mockito.Mockito
 import org.mockito.Mockito._
 
 import java.util.Optional
@@ -41,7 +42,8 @@ class ConsolidationReconcilerTest {
   private def newReconciler(
     metadataView: InklessMetadataView,
     fetcherManager: ConsolidationFetcherManager = mock(classOf[ConsolidationFetcherManager]),
-    initialFetchOffset: UnifiedLog => Long = _.highWatermark
+    initialFetchOffset: UnifiedLog => Long = _.highWatermark,
+    quotaManager: ReplicationQuotaManager = mock(classOf[ReplicationQuotaManager])
   ): ConsolidationReconciler = {
     new ConsolidationReconciler(
       mock(classOf[ReplicaManager]),
@@ -50,7 +52,7 @@ class ConsolidationReconcilerTest {
       metadataView,
       initialFetchOffset,
       fetcherManager,
-      mock(classOf[ReplicationQuotaManager])
+      quotaManager
     )
   }
 
@@ -209,6 +211,24 @@ class ConsolidationReconcilerTest {
     assertTrue(fetchStates.isEmpty)
     verify(partition, never()).truncateTo(anyLong(), anyBoolean())
     verify(fetcherManager, never()).addFailedPartition(topicPartition)
+  }
+
+  @Test
+  def testStartConsolidationFetchersMarksThrottledBeforeStartingFetchers(): Unit = {
+    // The fetcher only records bytes to the quota when the partition is already throttled, and
+    // addFetcherForPartitions starts the threads immediately. Marking must therefore happen first,
+    // otherwise the first fetch/append bypasses the dedicated bandwidth quota.
+    val view = mockMetadataView(classicToDisklessStartOffset = 100L)
+    val fetcherManager = mock(classOf[ConsolidationFetcherManager])
+    val quotaManager = mock(classOf[ReplicationQuotaManager])
+    val (partition, _) = mockPartition(logStartOffset = 0L, logEndOffset = 100L)
+    val reconciler = newReconciler(view, fetcherManager, quotaManager = quotaManager)
+
+    reconciler.startConsolidationFetchers(mutable.HashMap(topicPartition -> partition))
+
+    val inOrder = Mockito.inOrder(quotaManager, fetcherManager)
+    inOrder.verify(quotaManager).markThrottled(topicPartition.topic)
+    inOrder.verify(fetcherManager).addFetcherForPartitions(any())
   }
 
 }

--- a/server-common/src/main/java/org/apache/kafka/server/config/ServerConfigs.java
+++ b/server-common/src/main/java/org/apache/kafka/server/config/ServerConfigs.java
@@ -203,6 +203,11 @@ public class ServerConfigs {
     public static final int DISKLESS_CONSOLIDATION_FETCH_MAX_WAIT_MS_DEFAULT = 500;
     public static final String DISKLESS_CONSOLIDATION_FETCH_MAX_WAIT_MS_DOC = "The maximum time the consolidation fetcher will wait " +
         "for minBytes of data before returning. Higher values reduce iteration frequency when there is little new data.";
+    public static final String DISKLESS_CONSOLIDATION_FETCH_RATE_LIMIT_BYTES_PER_SECOND_CONFIG = "diskless.consolidation.fetch.rate.limit.bytes.per.second";
+    public static final long DISKLESS_CONSOLIDATION_FETCH_RATE_LIMIT_BYTES_PER_SECOND_DEFAULT = Long.MAX_VALUE;
+    public static final String DISKLESS_CONSOLIDATION_FETCH_RATE_LIMIT_BYTES_PER_SECOND_DOC = "The maximum rate in bytes per second " +
+        "at which consolidation fetches data from object storage. Limits aggregate bandwidth across all consolidation fetcher threads " +
+        "on the broker. Set to " + Long.MAX_VALUE + " (default) to disable rate limiting.";
 
     public static final String CLASSIC_REMOTE_STORAGE_FORCE_ENABLE_CONFIG = "classic.remote.storage.force.enable";
     public static final boolean CLASSIC_REMOTE_STORAGE_FORCE_ENABLE_DEFAULT = false;
@@ -296,6 +301,8 @@ public class ServerConfigs {
                 atLeast(1), LOW, DISKLESS_CONSOLIDATION_FETCH_MIN_BYTES_DOC)
             .define(DISKLESS_CONSOLIDATION_FETCH_MAX_WAIT_MS_CONFIG, INT, DISKLESS_CONSOLIDATION_FETCH_MAX_WAIT_MS_DEFAULT,
                 atLeast(0), LOW, DISKLESS_CONSOLIDATION_FETCH_MAX_WAIT_MS_DOC)
+            .define(DISKLESS_CONSOLIDATION_FETCH_RATE_LIMIT_BYTES_PER_SECOND_CONFIG, LONG, DISKLESS_CONSOLIDATION_FETCH_RATE_LIMIT_BYTES_PER_SECOND_DEFAULT,
+                atLeast(1), LOW, DISKLESS_CONSOLIDATION_FETCH_RATE_LIMIT_BYTES_PER_SECOND_DOC)
             .define(CLASSIC_REMOTE_STORAGE_FORCE_ENABLE_CONFIG, BOOLEAN, CLASSIC_REMOTE_STORAGE_FORCE_ENABLE_DEFAULT, LOW,
                 CLASSIC_REMOTE_STORAGE_FORCE_ENABLE_DOC)
             .define(CLASSIC_REMOTE_STORAGE_FORCE_EXCLUDE_TOPIC_REGEXES_CONFIG, LIST, CLASSIC_REMOTE_STORAGE_FORCE_EXCLUDE_TOPIC_REGEXES_DEFAULT,

--- a/server-common/src/main/java/org/apache/kafka/server/quota/QuotaType.java
+++ b/server-common/src/main/java/org/apache/kafka/server/quota/QuotaType.java
@@ -25,7 +25,8 @@ public enum QuotaType {
     FOLLOWER_REPLICATION("FollowerReplication"),
     ALTER_LOG_DIRS_REPLICATION("AlterLogDirsReplication"),
     RLM_COPY("RLMCopy"),
-    RLM_FETCH("RLMFetch");
+    RLM_FETCH("RLMFetch"),
+    DISKLESS_CONSOLIDATION_FETCH("DisklessConsolidationFetch");
 
     private final String name;
 


### PR DESCRIPTION
Introduce a separate ReplicationQuotaManager for consolidation fetchers, decoupled from the follower replication quota. This allows operators to cap object-storage read bandwidth (bytes/sec) without affecting regular replication.

Key changes:
- Add DISKLESS_CONSOLIDATION_FETCH QuotaType (JMX: DisklessConsolidationFetch)
- Add diskless.consolidation.fetch.rate.limit.bytes.per.second config
- Wire dedicated quota manager via ConsolidationReconciler (marks topics throttled on partition add, ensuring bytes are recorded to the sensor)
- Zip consolidationQuotaManager into fetcher manager creation (no silent fallback to shared follower quota)

Config lives in ServerConfigs (not InklessConfig) because:
- It is a broker-level config accessed through KafkaConfig, same layer as num.replica.fetchers and leader.replication.throttled.rate
- It uses the diskless.consolidation.* namespace alongside the existing diskless.remote.storage.consolidation.enable config
- InklessConfig is for storage module internals (fetch pools, cache, upload) consumed by SharedState/Reader/Writer — not for fetcher-layer wiring
