### PR TITLE
feat(inkless:consolidation): make fetch quota config dynamic

### DIFF
--- a/core/src/main/java/kafka/server/QuotaFactory.java
+++ b/core/src/main/java/kafka/server/QuotaFactory.java
@@ -19,6 +19,7 @@ package kafka.server;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.internals.Plugin;
 import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.metrics.Quota;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.server.config.ClientQuotaManagerConfig;
@@ -58,6 +59,7 @@ public class QuotaFactory {
                                 ReplicationQuotaManager leader,
                                 ReplicationQuotaManager follower,
                                 ReplicationQuotaManager alterLogDirs,
+                                ReplicationQuotaManager disklessConsolidationFetch,
                                 Optional<Plugin<ClientQuotaCallback>> clientQuotaCallbackPlugin) {
 
         public void shutdown() {
@@ -66,6 +68,7 @@ public class QuotaFactory {
             request.shutdown();
             controllerMutation.shutdown();
             clientQuotaCallbackPlugin.ifPresent(plugin -> Utils.closeQuietly(plugin, "client quota callback plugin"));
+            // ReplicationQuotaManagers are not closed — they hold no threads or closeable resources.
         }
     }
 
@@ -78,6 +81,11 @@ public class QuotaFactory {
     ) {
         Optional<Plugin<ClientQuotaCallback>> clientQuotaCallbackPlugin = createClientQuotaCallback(cfg, metrics, role);
 
+        ReplicationQuotaManager disklessConsolidationFetch =
+            new ReplicationQuotaManager(replicationConfig(cfg), metrics, QuotaType.DISKLESS_CONSOLIDATION_FETCH, time);
+        disklessConsolidationFetch.updateQuota(
+            new Quota(cfg.disklessConsolidationFetchRateLimitBytesPerSecond(), true));
+
         return new QuotaManagers(
             new ClientQuotaManager(clientConfig(cfg), metrics, QuotaType.FETCH, time, threadNamePrefix, clientQuotaCallbackPlugin),
             new ClientQuotaManager(clientConfig(cfg), metrics, QuotaType.PRODUCE, time, threadNamePrefix, clientQuotaCallbackPlugin),
@@ -86,6 +94,7 @@ public class QuotaFactory {
             new ReplicationQuotaManager(replicationConfig(cfg), metrics, QuotaType.LEADER_REPLICATION, time),
             new ReplicationQuotaManager(replicationConfig(cfg), metrics, QuotaType.FOLLOWER_REPLICATION, time),
             new ReplicationQuotaManager(alterLogDirsReplicationConfig(cfg), metrics, QuotaType.ALTER_LOG_DIRS_REPLICATION, time),
+            disklessConsolidationFetch,
             clientQuotaCallbackPlugin
         );
     }

--- a/core/src/main/scala/kafka/server/ConfigHandler.scala
+++ b/core/src/main/scala/kafka/server/ConfigHandler.scala
@@ -169,6 +169,8 @@ class BrokerConfigHandler(private val brokerConfig: KafkaConfig,
     quotaManagers.leader.updateQuota(upperBound(getOrDefault(QuotaConfig.LEADER_REPLICATION_THROTTLED_RATE_CONFIG).toDouble))
     quotaManagers.follower.updateQuota(upperBound(getOrDefault(QuotaConfig.FOLLOWER_REPLICATION_THROTTLED_RATE_CONFIG).toDouble))
     quotaManagers.alterLogDirs.updateQuota(upperBound(getOrDefault(QuotaConfig.REPLICA_ALTER_LOG_DIRS_IO_MAX_BYTES_PER_SECOND_CONFIG).toDouble))
+    quotaManagers.disklessConsolidationFetch.updateQuota(
+      upperBound(brokerConfig.dynamicConfig.currentKafkaConfig.disklessConsolidationFetchRateLimitBytesPerSecond.toDouble))
   }
 }
 

--- a/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
+++ b/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
@@ -100,7 +100,8 @@ object DynamicBrokerConfig {
     SocketServer.ReconfigurableConfigs ++
     DynamicProducerStateManagerConfig ++
     DynamicRemoteLogConfig.ReconfigurableConfigs ++
-    Set(AbstractConfig.CONFIG_PROVIDERS_CONFIG)
+    Set(AbstractConfig.CONFIG_PROVIDERS_CONFIG) ++
+    Set(ServerConfigs.DISKLESS_CONSOLIDATION_FETCH_RATE_LIMIT_BYTES_PER_SECOND_CONFIG)
 
   private val ClusterLevelListenerConfigs = Set(SocketServerConfigs.MAX_CONNECTIONS_CONFIG, SocketServerConfigs.MAX_CONNECTION_CREATION_RATE_CONFIG, SocketServerConfigs.NUM_NETWORK_THREADS_CONFIG)
   private val PerBrokerConfigs = (DynamicSecurityConfigs ++ DynamicListenerConfig.ReconfigurableConfigs).diff(

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -60,9 +60,7 @@ import org.apache.kafka.metadata.{LeaderAndIsr, MetadataCache, PartitionRegistra
 import org.apache.kafka.metadata.LeaderConstants.NO_LEADER
 import org.apache.kafka.server.common.{DirectoryEventHandler, RequestLocal, StopPartition, TransactionVersion}
 import org.apache.kafka.server.log.remote.TopicPartitionLog
-import org.apache.kafka.server.config.{ReplicationConfigs, ReplicationQuotaManagerConfig}
-import org.apache.kafka.common.metrics.Quota
-import org.apache.kafka.server.quota.QuotaType
+import org.apache.kafka.server.config.ReplicationConfigs
 import org.apache.kafka.server.log.remote.storage.RemoteLogManager
 import org.apache.kafka.server.metrics.KafkaMetricsGroup
 import org.apache.kafka.server.network.BrokerEndPoint
@@ -323,14 +321,7 @@ class ReplicaManager(val config: KafkaConfig,
     }
   private val consolidationQuotaManager: Option[ReplicationQuotaManager] =
     if (config.disklessRemoteStorageConsolidationEnabled) {
-      val quotaConfig = new ReplicationQuotaManagerConfig(
-        config.quotaConfig.numReplicationQuotaSamples,
-        config.quotaConfig.replicationQuotaWindowSizeSeconds
-      )
-      val manager = new ReplicationQuotaManager(quotaConfig, metrics, QuotaType.DISKLESS_CONSOLIDATION_FETCH, time)
-      val rateLimitBytesPerSec = config.disklessConsolidationFetchRateLimitBytesPerSecond
-      manager.updateQuota(new Quota(rateLimitBytesPerSec, true))
-      Some(manager)
+      Some(quotaManagers.disklessConsolidationFetch)
     } else {
       None
     }

--- a/core/src/test/scala/unit/kafka/server/ControllerApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ControllerApisTest.scala
@@ -142,6 +142,7 @@ class ControllerApisTest {
     replicaQuotaManager,
     replicaQuotaManager,
     replicaQuotaManager,
+    replicaQuotaManager,
     Optional.empty())
 
   private val quotasAlwaysThrottleControllerMutations = new QuotaManagers(
@@ -149,6 +150,7 @@ class ControllerApisTest {
     clientQuotaManager,
     clientRequestQuotaManager,
     alwaysThrottlingClientControllerQuotaManager,
+    replicaQuotaManager,
     replicaQuotaManager,
     replicaQuotaManager,
     replicaQuotaManager,

--- a/core/src/test/scala/unit/kafka/server/DynamicConfigChangeTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DynamicConfigChangeTest.scala
@@ -33,7 +33,7 @@ import org.apache.kafka.common.security.auth.KafkaPrincipal
 import org.apache.kafka.common.{TopicPartition, Uuid}
 import org.apache.kafka.coordinator.group.GroupConfig
 import org.apache.kafka.metadata.MetadataCache
-import org.apache.kafka.server.config.{QuotaConfig, ServerLogConfigs}
+import org.apache.kafka.server.config.{QuotaConfig, ServerConfigs, ServerLogConfigs}
 import org.apache.kafka.server.log.remote.TopicPartitionLog
 import org.apache.kafka.server.log.remote.storage.RemoteLogManager
 import org.apache.kafka.storage.internals.log.{LogConfig, UnifiedLog}
@@ -644,5 +644,68 @@ class DynamicConfigChangeUnitTest {
     configHandler.processConfigChanges(topic, topicConfig)
 
     verify(inklessMetadataView, never()).updateTopicConfig(any(), any())
+  }
+
+  /**
+   * Builds a BrokerConfigHandler whose QuotaManagers carry a real consolidation quota manager
+   * (so we can assert on upperBound) and mocked replication quota managers (irrelevant here).
+   */
+  private def brokerConfigHandlerWithConsolidationQuota(
+    kafkaConfig: KafkaConfig
+  ): (BrokerConfigHandler, ReplicationQuotaManager) = {
+    // processConfigChanges routes through DynamicBrokerConfig.updateBrokerConfig which calls
+    // processReconfiguration; that reads currentConfig, which is null until initialize() is called.
+    kafkaConfig.dynamicConfig.initialize(None)
+    val metrics = new org.apache.kafka.common.metrics.Metrics()
+    val quotaConfig = new org.apache.kafka.server.config.ReplicationQuotaManagerConfig(
+      kafkaConfig.quotaConfig.numReplicationQuotaSamples,
+      kafkaConfig.quotaConfig.replicationQuotaWindowSizeSeconds)
+    val consolidationQuota = new ReplicationQuotaManager(
+      quotaConfig, metrics, org.apache.kafka.server.quota.QuotaType.DISKLESS_CONSOLIDATION_FETCH,
+      org.apache.kafka.common.utils.Time.SYSTEM)
+    // Seed from the static config value, mirroring QuotaFactory.instantiate.
+    consolidationQuota.updateQuota(new Quota(kafkaConfig.disklessConsolidationFetchRateLimitBytesPerSecond.toDouble, true))
+
+    val replicaQuota = mock(classOf[ReplicationQuotaManager])
+    val quotas = mock(classOf[QuotaFactory.QuotaManagers])
+    when(quotas.leader).thenReturn(replicaQuota)
+    when(quotas.follower).thenReturn(replicaQuota)
+    when(quotas.alterLogDirs).thenReturn(replicaQuota)
+    when(quotas.disklessConsolidationFetch).thenReturn(consolidationQuota)
+
+    (new BrokerConfigHandler(kafkaConfig, quotas), consolidationQuota)
+  }
+
+  @Test
+  def testConsolidationFetchRateLimitDynamicUpdate(): Unit = {
+    val kafkaConfig = KafkaConfig.fromProps(TestUtils.createBrokerConfig(0, port = 9092))
+    val (handler, consolidationQuota) = brokerConfigHandlerWithConsolidationQuota(kafkaConfig)
+    // Default static value: rate limiting disabled.
+    assertEquals(ServerConfigs.DISKLESS_CONSOLIDATION_FETCH_RATE_LIMIT_BYTES_PER_SECOND_DEFAULT,
+      consolidationQuota.upperBound)
+
+    val props = new Properties()
+    props.put(ServerConfigs.DISKLESS_CONSOLIDATION_FETCH_RATE_LIMIT_BYTES_PER_SECOND_CONFIG, "1048576")
+    handler.processConfigChanges(kafkaConfig.brokerId.toString, props)
+
+    assertEquals(1048576L, consolidationQuota.upperBound)
+  }
+
+  @Test
+  def testConsolidationFetchRateLimitStaticValuePreservedOnUnrelatedDynamicChange(): Unit = {
+    // Static config sets a non-default limit; mirrors operator setting it in server.properties.
+    val cfg = TestUtils.createBrokerConfig(0, port = 9092)
+    cfg.put(ServerConfigs.DISKLESS_CONSOLIDATION_FETCH_RATE_LIMIT_BYTES_PER_SECOND_CONFIG, "2097152")
+    val kafkaConfig = KafkaConfig.fromProps(cfg)
+    val (handler, consolidationQuota) = brokerConfigHandlerWithConsolidationQuota(kafkaConfig)
+    assertEquals(2097152L, consolidationQuota.upperBound)
+
+    // An unrelated dynamic config change must NOT clobber the statically-configured limit.
+    // (Reading via getOrDefault->MAX_VALUE, as the replication throttles do, would break this.)
+    val props = new Properties()
+    props.put(QuotaConfig.LEADER_REPLICATION_THROTTLED_RATE_CONFIG, "500000")
+    handler.processConfigChanges(kafkaConfig.brokerId.toString, props)
+
+    assertEquals(2097152L, consolidationQuota.upperBound)
   }
 }

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -147,7 +147,8 @@ class KafkaApisTest extends Logging {
   private val clientControllerQuotaManager: ControllerMutationQuotaManager = mock(classOf[ControllerMutationQuotaManager])
   private val replicaQuotaManager: ReplicationQuotaManager = mock(classOf[ReplicationQuotaManager])
   private val quotas = new QuotaManagers(clientQuotaManager, clientQuotaManager, clientRequestQuotaManager,
-    clientControllerQuotaManager, replicaQuotaManager, replicaQuotaManager, replicaQuotaManager, util.Optional.empty())
+    clientControllerQuotaManager, replicaQuotaManager, replicaQuotaManager, replicaQuotaManager, replicaQuotaManager,
+    util.Optional.empty())
   private val fetchManager: FetchManager = mock(classOf[FetchManager])
   private val sharePartitionManager: SharePartitionManager = mock(classOf[SharePartitionManager])
   private val clientMetricsManager: ClientMetricsManager = mock(classOf[ClientMetricsManager])

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/metadata/KRaftMetadataRequestBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/metadata/KRaftMetadataRequestBenchmark.java
@@ -114,7 +114,7 @@ public class KRaftMetadataRequestBenchmark {
     private final ReplicationQuotaManager replicaQuotaManager = Mockito.mock(ReplicationQuotaManager.class);
     private final QuotaFactory.QuotaManagers quotaManagers = new QuotaFactory.QuotaManagers(clientQuotaManager,
             clientQuotaManager, clientRequestQuotaManager, controllerMutationQuotaManager, replicaQuotaManager,
-            replicaQuotaManager, replicaQuotaManager, Optional.empty());
+            replicaQuotaManager, replicaQuotaManager, replicaQuotaManager, Optional.empty());
     private final FetchManager fetchManager = Mockito.mock(FetchManager.class);
     private final SharePartitionManager sharePartitionManager = Mockito.mock(SharePartitionManager.class);
     private final ClientMetricsManager clientMetricsManager = Mockito.mock(ClientMetricsManager.class);

--- a/server-common/src/main/java/org/apache/kafka/server/config/ServerConfigs.java
+++ b/server-common/src/main/java/org/apache/kafka/server/config/ServerConfigs.java
@@ -207,7 +207,8 @@ public class ServerConfigs {
     public static final long DISKLESS_CONSOLIDATION_FETCH_RATE_LIMIT_BYTES_PER_SECOND_DEFAULT = Long.MAX_VALUE;
     public static final String DISKLESS_CONSOLIDATION_FETCH_RATE_LIMIT_BYTES_PER_SECOND_DOC = "The maximum rate in bytes per second " +
         "at which consolidation fetches data from object storage. Limits aggregate bandwidth across all consolidation fetcher threads " +
-        "on the broker. Set to " + Long.MAX_VALUE + " (default) to disable rate limiting.";
+        "on the broker. Set to 0 to pause all consolidation fetches. " +
+        "Set to " + Long.MAX_VALUE + " (default) to disable rate limiting. This config can be updated dynamically.";
 
     public static final String CLASSIC_REMOTE_STORAGE_FORCE_ENABLE_CONFIG = "classic.remote.storage.force.enable";
     public static final boolean CLASSIC_REMOTE_STORAGE_FORCE_ENABLE_DEFAULT = false;
@@ -301,8 +302,10 @@ public class ServerConfigs {
                 atLeast(1), LOW, DISKLESS_CONSOLIDATION_FETCH_MIN_BYTES_DOC)
             .define(DISKLESS_CONSOLIDATION_FETCH_MAX_WAIT_MS_CONFIG, INT, DISKLESS_CONSOLIDATION_FETCH_MAX_WAIT_MS_DEFAULT,
                 atLeast(0), LOW, DISKLESS_CONSOLIDATION_FETCH_MAX_WAIT_MS_DOC)
+            // atLeast(0): 0 is a valid value (pauses all consolidation fetches), consistent with
+            // leader/follower replication throttle semantics (QuotaConfig.brokerQuotaConfigs).
             .define(DISKLESS_CONSOLIDATION_FETCH_RATE_LIMIT_BYTES_PER_SECOND_CONFIG, LONG, DISKLESS_CONSOLIDATION_FETCH_RATE_LIMIT_BYTES_PER_SECOND_DEFAULT,
-                atLeast(1), LOW, DISKLESS_CONSOLIDATION_FETCH_RATE_LIMIT_BYTES_PER_SECOND_DOC)
+                atLeast(0), LOW, DISKLESS_CONSOLIDATION_FETCH_RATE_LIMIT_BYTES_PER_SECOND_DOC)
             .define(CLASSIC_REMOTE_STORAGE_FORCE_ENABLE_CONFIG, BOOLEAN, CLASSIC_REMOTE_STORAGE_FORCE_ENABLE_DEFAULT, LOW,
                 CLASSIC_REMOTE_STORAGE_FORCE_ENABLE_DOC)
             .define(CLASSIC_REMOTE_STORAGE_FORCE_EXCLUDE_TOPIC_REGEXES_CONFIG, LIST, CLASSIC_REMOTE_STORAGE_FORCE_EXCLUDE_TOPIC_REGEXES_DEFAULT,


### PR DESCRIPTION
Make diskless.consolidation.fetch.rate.limit.bytes.per.second a dynamic broker config, aligned with the leader/follower replication throttle pattern:

- Add to AllDynamicConfigs so KAdmin accepts it as a dynamic update
- Move ReplicationQuotaManager ownership to QuotaManagers (seeded from static config on startup via QuotaFactory.instantiate)
- Apply dynamic updates in BrokerConfigHandler.processConfigChanges, reading from currentKafkaConfig to pick up the merged static+dynamic value (avoids clobbering a static limit on unrelated config changes)
- Relax atLeast(1) to atLeast(0) and document as dynamically updatable
- Add DynamicConfigChangeUnitTest cases covering dynamic update and static-value-preserved-on-unrelated-change scenarios