### PR TITLE
fix(inkless): create tiered topic when diskless.enable=false and system is disabled [KC-158]

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/CreateTopicConfigInterceptors.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/CreateTopicConfigInterceptors.java
@@ -31,8 +31,9 @@ import java.util.Map.Entry;
  * Container for CREATE_TOPICS config interceptors. Interceptors are chained and executed in order;
  * only the first interceptor that matches a topic is applied (first-match-wins).
  *
- * <p>The chain order is: diskless force interceptor first, then remote storage force interceptor.
- * This ensures that topics matching the diskless allow list are not also forced to remote storage.
+ * <p>The chain order is: diskless-disabled fallback first (converts explicit diskless.enable=false
+ * to tiered when the system is disabled), then diskless force interceptor, then remote storage
+ * force interceptor. This ensures system-level constraints are enforced before topic-level forcing.
  */
 final class CreateTopicConfigInterceptors {
     private static final Logger LOG = LoggerFactory.getLogger(CreateTopicConfigInterceptors.class);
@@ -47,8 +48,8 @@ final class CreateTopicConfigInterceptors {
 
     /**
      * Creates the interceptors chain based on the provided configuration.
-     * The diskless force interceptor is placed first in the chain so that matching topics
-     * are handled by it before the remote storage force interceptor is considered.
+     * The chain order is: diskless-disabled fallback (when system is disabled), then diskless
+     * force interceptor, then remote storage force interceptor. First-match-wins.
      *
      * @param classicRemoteStorageForceEnabled whether the remote storage force interceptor is enabled
      * @param classicRemoteStorageForceExcludeTopicRegexes topic regexes to exclude from remote storage forcing
@@ -67,7 +68,12 @@ final class CreateTopicConfigInterceptors {
         final List<String> disklessForceIncludeTopicRegexes
     ) {
         final List<CreateTopicConfigInterceptor> chain = new ArrayList<>();
-        // Diskless interceptor is first in the chain (higher priority)
+        // Fallback interceptor is first: when diskless system is disabled, convert explicit
+        // diskless.enable=false to tiered (remote.storage.enable=true) instead of failing.
+        if (!disklessStorageSystemEnabled) {
+            chain.add(new DisklessDisabledFallbackCreateTopicInterceptor());
+        }
+        // Diskless force interceptor is next in the chain
         if (disklessForceEnabled) {
             if (disklessStorageSystemEnabled) {
                 chain.add(new DisklessForceCreateTopicInterceptor(disklessForceIncludeTopicRegexes));

--- a/metadata/src/main/java/org/apache/kafka/controller/DisklessDisabledFallbackCreateTopicInterceptor.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/DisklessDisabledFallbackCreateTopicInterceptor.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.controller;
+
+import org.apache.kafka.clients.admin.AlterConfigOp.OpType;
+import org.apache.kafka.common.config.TopicConfig;
+
+import java.util.AbstractMap.SimpleImmutableEntry;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import static org.apache.kafka.clients.admin.AlterConfigOp.OpType.SET;
+
+/**
+ * A {@link CreateTopicConfigInterceptor} that converts topics with explicit {@code diskless.enable=false}
+ * into tiered topics ({@code remote.storage.enable=true}) when the diskless storage system is globally
+ * disabled.
+ *
+ * <p>This prevents topic creation from failing with "It is invalid to set diskless.enable if diskless
+ * storage system is not enabled" when a client explicitly opts out of diskless. Instead, the topic is
+ * transparently created as a tiered topic.
+ *
+ * <p>Only activates when {@code diskless.storage.system.enable=false}. Excluded: system topics.
+ */
+final class DisklessDisabledFallbackCreateTopicInterceptor implements CreateTopicConfigInterceptor {
+
+    @Override
+    public boolean intercept(
+        final String topicName,
+        final Map<String, String> requestConfigs,
+        final Map<String, Entry<OpType, String>> targetConfigOps
+    ) {
+        if (shouldConvertToTiered(topicName, requestConfigs)) {
+            targetConfigOps.remove(TopicConfig.DISKLESS_ENABLE_CONFIG);
+            targetConfigOps.put(TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG, new SimpleImmutableEntry<>(SET, "true"));
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public boolean intercept(
+        final String topicName,
+        final Map<String, String> targetConfigs
+    ) {
+        if (shouldConvertToTiered(topicName, targetConfigs)) {
+            targetConfigs.remove(TopicConfig.DISKLESS_ENABLE_CONFIG);
+            targetConfigs.put(TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG, "true");
+            return true;
+        }
+        return false;
+    }
+
+    private boolean shouldConvertToTiered(final String topicName, final Map<String, String> configs) {
+        if (ReplicationControlManager.isSystemTopic(topicName)) {
+            return false;
+        }
+        String disklessValue = configs.get(TopicConfig.DISKLESS_ENABLE_CONFIG);
+        return disklessValue != null && "false".equalsIgnoreCase(disklessValue.trim());
+    }
+}

--- a/metadata/src/test/java/org/apache/kafka/controller/CreateTopicConfigInterceptorsTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/CreateTopicConfigInterceptorsTest.java
@@ -152,4 +152,69 @@ public class CreateTopicConfigInterceptorsTest {
 
         assertNull(targetConfigs.get(TopicConfig.DISKLESS_ENABLE_CONFIG));
     }
+
+    @Test
+    public void disklessDisabledFallbackConvertsTieredWhenExplicitlyFalse() {
+        // disklessStorageSystemEnabled=false, no other interceptors
+        final var interceptors = CreateTopicConfigInterceptors.create(false, List.of(), false, false, false, List.of());
+        final Map<String, String> targetConfigs = new HashMap<>();
+        targetConfigs.put(TopicConfig.DISKLESS_ENABLE_CONFIG, "false");
+
+        interceptors.intercept("my-topic", targetConfigs);
+
+        assertNull(targetConfigs.get(TopicConfig.DISKLESS_ENABLE_CONFIG));
+        assertEquals("true", targetConfigs.get(TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG));
+    }
+
+    @Test
+    public void disklessDisabledFallbackConvertsTieredViaConfigOps() {
+        final var interceptors = CreateTopicConfigInterceptors.create(false, List.of(), false, false, false, List.of());
+        final Map<String, String> requestConfigs = new HashMap<>();
+        requestConfigs.put(TopicConfig.DISKLESS_ENABLE_CONFIG, "false");
+        final Map<String, Entry<OpType, String>> targetConfigOps = new HashMap<>();
+        targetConfigOps.put(TopicConfig.DISKLESS_ENABLE_CONFIG, Map.entry(SET, "false"));
+
+        interceptors.intercept("my-topic", requestConfigs, targetConfigOps);
+
+        assertFalse(targetConfigOps.containsKey(TopicConfig.DISKLESS_ENABLE_CONFIG));
+        assertEquals(Map.entry(SET, "true"), targetConfigOps.get(TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG));
+    }
+
+    @Test
+    public void disklessDisabledFallbackDoesNotApplyWithoutExplicitConfig() {
+        // No diskless.enable in configs — fallback should not match
+        final var interceptors = CreateTopicConfigInterceptors.create(false, List.of(), false, false, false, List.of());
+        final Map<String, String> targetConfigs = new HashMap<>();
+
+        interceptors.intercept("my-topic", targetConfigs);
+
+        assertNull(targetConfigs.get(TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG));
+    }
+
+    @Test
+    public void disklessDisabledFallbackDoesNotApplyForSystemTopics() {
+        final var interceptors = CreateTopicConfigInterceptors.create(false, List.of(), false, false, false, List.of());
+        final Map<String, String> targetConfigs = new HashMap<>();
+        targetConfigs.put(TopicConfig.DISKLESS_ENABLE_CONFIG, "false");
+
+        interceptors.intercept("__consumer_offsets", targetConfigs);
+
+        // System topic should not be converted — diskless.enable stays
+        assertEquals("false", targetConfigs.get(TopicConfig.DISKLESS_ENABLE_CONFIG));
+        assertNull(targetConfigs.get(TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG));
+    }
+
+    @Test
+    public void disklessDisabledFallbackNotActiveWhenSystemEnabled() {
+        // disklessStorageSystemEnabled=true — fallback should NOT be in the chain
+        final var interceptors = CreateTopicConfigInterceptors.create(false, List.of(), false, true, false, List.of());
+        final Map<String, String> targetConfigs = new HashMap<>();
+        targetConfigs.put(TopicConfig.DISKLESS_ENABLE_CONFIG, "false");
+
+        interceptors.intercept("my-topic", targetConfigs);
+
+        // diskless.enable=false should remain untouched (no conversion to tiered)
+        assertEquals("false", targetConfigs.get(TopicConfig.DISKLESS_ENABLE_CONFIG));
+        assertNull(targetConfigs.get(TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG));
+    }
 }

--- a/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
@@ -4310,6 +4310,61 @@ public class ReplicationControlManagerTest {
         }
 
         @Test
+        public void testCreateTopicWithDisklessExplicitlyDisabledWhenSystemDisabledCreatesTieredTopic() {
+            // Given diskless storage system is globally disabled
+            ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder()
+                .setDisklessStorageSystemEnabled(false)
+                .setDefaultDisklessEnable(false)
+                .build();
+            ReplicationControlManager replicationControl = ctx.replicationControl;
+
+            // Given a topic creation request with diskless.enable=false explicitly
+            CreateTopicsRequestData request = new CreateTopicsRequestData();
+            CreateTopicsRequestData.CreatableTopicConfigCollection topicConfigs = new CreateTopicsRequestData.CreatableTopicConfigCollection();
+            topicConfigs.add(new CreateTopicsRequestData.CreatableTopicConfig()
+                .setName(DISKLESS_ENABLE_CONFIG)
+                .setValue("false"));
+            request.topics().add(new CreatableTopic().setName("foo")
+                .setNumPartitions(-1).setReplicationFactor((short) -1)
+                .setConfigs(topicConfigs));
+
+            // Given all brokers unfenced
+            ctx.registerBrokers(0, 1, 2);
+            ctx.unfenceBrokers(0, 1, 2);
+
+            // When creating the topic
+            ControllerRequestContext requestContext = anonymousContextFor(ApiKeys.CREATE_TOPICS);
+            ControllerResult<CreateTopicsResponseData> result =
+                replicationControl.createTopics(requestContext, request, Collections.singleton("foo"));
+
+            // Then the topic creation should succeed by enabling tiered storage instead of diskless
+            CreatableTopicResult topicResult = result.response().topics().find("foo");
+            assertNotNull(topicResult);
+            assertEquals(NONE.code(), topicResult.errorCode(),
+                "Topic creation should succeed as a tiered topic when diskless is explicitly disabled and system is disabled");
+
+            // And it should be created as a tiered topic (remote.storage.enable=true)
+            List<ConfigRecord> remoteStorageConfigRecords = result.records().stream()
+                .filter(m -> m.message() instanceof ConfigRecord)
+                .map(m -> (ConfigRecord) m.message())
+                .filter(c -> c.name().equals(REMOTE_LOG_STORAGE_ENABLE_CONFIG))
+                .toList();
+            assertFalse(remoteStorageConfigRecords.isEmpty(),
+                "Expected remote.storage.enable config record for tiered topic");
+            assertTrue(remoteStorageConfigRecords.stream().allMatch(c -> c.value().equals("true")),
+                "Expected remote.storage.enable=true for tiered topic");
+
+            // And diskless.enable should not be persisted (it was stripped)
+            List<ConfigRecord> disklessConfigRecords = result.records().stream()
+                .filter(m -> m.message() instanceof ConfigRecord)
+                .map(m -> (ConfigRecord) m.message())
+                .filter(c -> c.name().equals(DISKLESS_ENABLE_CONFIG))
+                .toList();
+            assertTrue(disklessConfigRecords.isEmpty(),
+                    "Expected no diskless.enable config record when diskless system is disabled");
+        }
+
+        @Test
         public void testReassignDisklessPartitions() {
             MetadataVersion metadataVersion = MetadataVersion.latestTesting();
             ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder()


### PR DESCRIPTION
Prior to this change, topic creation will fail when:
- The `diskless.storage.system.enable` config is set to `false`
- The request explicitly sets `diskless.enable` to `false`

Now the topic creation will succeed and the topic gets configured as tiered.