### PR TITLE
fix(inkless): reject topic creation with config conflicting with diskless regex

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/DisklessForceCreateTopicInterceptor.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/DisklessForceCreateTopicInterceptor.java
@@ -19,6 +19,7 @@ package org.apache.kafka.controller;
 
 import org.apache.kafka.clients.admin.AlterConfigOp.OpType;
 import org.apache.kafka.common.config.TopicConfig;
+import org.apache.kafka.common.errors.InvalidRequestException;
 
 import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.List;
@@ -59,6 +60,7 @@ final class DisklessForceCreateTopicInterceptor implements CreateTopicConfigInte
         final Map<String, Entry<OpType, String>> targetConfigOps
     ) {
         if (shouldForceDisklessEnable(topicName, requestConfigs)) {
+            rejectIfExplicitlyDisabled(topicName, requestConfigs);
             targetConfigOps.put(TopicConfig.DISKLESS_ENABLE_CONFIG, new SimpleImmutableEntry<>(SET, "true"));
             return true;
         }
@@ -71,10 +73,19 @@ final class DisklessForceCreateTopicInterceptor implements CreateTopicConfigInte
         final Map<String, String> targetConfigs
     ) {
         if (shouldForceDisklessEnable(topicName, targetConfigs)) {
+            rejectIfExplicitlyDisabled(topicName, targetConfigs);
             targetConfigs.put(TopicConfig.DISKLESS_ENABLE_CONFIG, "true");
             return true;
         }
         return false;
+    }
+
+    private void rejectIfExplicitlyDisabled(final String topicName, final Map<String, String> configs) {
+        String disklessEnableConfigValue = configs.getOrDefault(TopicConfig.DISKLESS_ENABLE_CONFIG, "").trim();
+        if (!disklessEnableConfigValue.isEmpty() && !Boolean.parseBoolean(disklessEnableConfigValue)) {
+            throw new InvalidRequestException(
+                "Topic '" + topicName + "' matches the diskless force include regexes and cannot set diskless.enable=false.");
+        }
     }
 
     private boolean shouldForceDisklessEnable(

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -779,11 +779,16 @@ public class ReplicationControlManager {
             } else {
                 keyToOps = new HashMap<>(keyToOps);
             }
-            createTopicConfigInterceptors.intercept(
-                topic.name(),
-                requestConfigs,
-                keyToOps
-            );
+            try {
+                createTopicConfigInterceptors.intercept(
+                    topic.name(),
+                    requestConfigs,
+                    keyToOps
+                );
+            } catch (ApiException e) {
+                topicErrors.put(topic.name(), ApiError.fromThrowable(e));
+                continue;
+            }
             if (keyToOps.isEmpty()) {
                 keyToOps = null;
             }

--- a/metadata/src/test/java/org/apache/kafka/controller/DisklessForceCreateTopicInterceptorTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/DisklessForceCreateTopicInterceptorTest.java
@@ -19,6 +19,7 @@ package org.apache.kafka.controller;
 
 import org.apache.kafka.clients.admin.AlterConfigOp.OpType;
 import org.apache.kafka.common.config.TopicConfig;
+import org.apache.kafka.common.errors.InvalidRequestException;
 import org.apache.kafka.common.internals.Topic;
 
 import org.junit.jupiter.api.Test;
@@ -32,6 +33,7 @@ import static org.apache.kafka.clients.admin.AlterConfigOp.OpType.SET;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class DisklessForceCreateTopicInterceptorTest {
 
@@ -50,17 +52,21 @@ public class DisklessForceCreateTopicInterceptorTest {
     }
 
     @Test
-    public void forcesDisklessEvenWhenRequestHadDisklessFalse() {
+    public void throwsWhenRequestHasDisklessFalseAndTopicMatchesRegex() {
         final var interceptor = new DisklessForceCreateTopicInterceptor(List.of("my-topic-.*"));
-        final Map<String, String> requestConfigs = new HashMap<>(Map.of(TopicConfig.DISKLESS_ENABLE_CONFIG, "false"));
-        final Map<String, Entry<OpType, String>> targetConfigOps = new HashMap<>();
-        final Map<String, String> targetConfigs = new HashMap<>(Map.of(TopicConfig.DISKLESS_ENABLE_CONFIG, "false"));
 
-        interceptor.intercept("my-topic-1", requestConfigs, targetConfigOps);
-        interceptor.intercept("my-topic-1", targetConfigs);
+        for (String falseValue : List.of("FALSE", "False", "false ", " false", " FALSE ")) {
+            final Map<String, String> requestConfigs = new HashMap<>(Map.of(TopicConfig.DISKLESS_ENABLE_CONFIG, falseValue));
+            final Map<String, Entry<OpType, String>> targetConfigOps = new HashMap<>();
+            final Map<String, String> targetConfigs = new HashMap<>(Map.of(TopicConfig.DISKLESS_ENABLE_CONFIG, falseValue));
 
-        assertEquals(Map.entry(SET, "true"), targetConfigOps.get(TopicConfig.DISKLESS_ENABLE_CONFIG));
-        assertEquals("true", targetConfigs.get(TopicConfig.DISKLESS_ENABLE_CONFIG));
+            assertThrows(InvalidRequestException.class,
+                () -> interceptor.intercept("my-topic-1", requestConfigs, targetConfigOps),
+                "Should reject value: '" + falseValue + "'");
+            assertThrows(InvalidRequestException.class,
+                () -> interceptor.intercept("my-topic-1", targetConfigs),
+                "Should reject value: '" + falseValue + "'");
+        }
     }
 
     @Test

--- a/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
@@ -194,6 +194,8 @@ public class ReplicationControlManagerTest {
             private boolean disklessRemoteStorageConsolidationEnabled = false;
             private boolean classicRemoteStorageForceEnabled = false;
             private List<String> classicRemoteStorageForceExcludeTopicRegexes = List.of();
+            private boolean disklessForceEnabled = false;
+            private List<String> disklessForceIncludeTopicRegexes = List.of();
 
             Builder setCreateTopicPolicy(CreateTopicPolicy createTopicPolicy) {
                 this.createTopicPolicy = Optional.of(createTopicPolicy);
@@ -250,6 +252,16 @@ public class ReplicationControlManagerTest {
                 return this;
             }
 
+            Builder setDisklessForceEnabled(boolean disklessForceEnabled) {
+                this.disklessForceEnabled = disklessForceEnabled;
+                return this;
+            }
+
+            Builder setDisklessForceIncludeTopicRegexes(List<String> disklessForceIncludeTopicRegexes) {
+                this.disklessForceIncludeTopicRegexes = disklessForceIncludeTopicRegexes;
+                return this;
+            }
+
             ReplicationControlTestContext build() {
                 return new ReplicationControlTestContext(metadataVersion,
                     createTopicPolicy,
@@ -261,7 +273,9 @@ public class ReplicationControlManagerTest {
                     disklessManagedReplicasEnable,
                     disklessRemoteStorageConsolidationEnabled,
                     classicRemoteStorageForceEnabled,
-                    classicRemoteStorageForceExcludeTopicRegexes);
+                    classicRemoteStorageForceExcludeTopicRegexes,
+                    disklessForceEnabled,
+                    disklessForceIncludeTopicRegexes);
             }
         }
 
@@ -292,7 +306,9 @@ public class ReplicationControlManagerTest {
             boolean disklessManagedReplicasEnable,
             boolean disklessRemoteStorageConsolidationEnabled,
             final boolean classicRemoteStorageForceEnabled,
-            final List<String> classicRemoteStorageForceExcludeTopicRegexes
+            final List<String> classicRemoteStorageForceExcludeTopicRegexes,
+            final boolean disklessForceEnabled,
+            final List<String> disklessForceIncludeTopicRegexes
         ) {
             this.time = time;
             this.featureControl = new FeatureControlManager.Builder().
@@ -342,6 +358,8 @@ public class ReplicationControlManagerTest {
                 setDisklessRemoteStorageConsolidationEnabled(disklessRemoteStorageConsolidationEnabled).
                 setClassicRemoteStorageForceEnabled(classicRemoteStorageForceEnabled).
                 setClassicRemoteStorageForceExcludeTopicRegexes(classicRemoteStorageForceExcludeTopicRegexes).
+                setDisklessForceEnabled(disklessForceEnabled).
+                setDisklessForceIncludeTopicRegexes(disklessForceIncludeTopicRegexes).
                 build();
             clusterControl.activate();
         }
@@ -3719,6 +3737,42 @@ public class ReplicationControlManagerTest {
             .filter(m -> m.message() instanceof ConfigRecord)
             .map(m -> (ConfigRecord) m.message())
             .noneMatch(r -> r.name().equals(REMOTE_LOG_STORAGE_ENABLE_CONFIG) && r.value().equals("true")));
+    }
+
+    @Test
+    void testDisklessForceInterceptorRejectsOnlyOffendingTopic() {
+        final ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder()
+            .setDisklessForceEnabled(true)
+            .setDisklessForceIncludeTopicRegexes(List.of("forced-.*"))
+            .setDisklessStorageSystemEnabled(true)
+            .build();
+        ctx.registerBrokers(0, 1, 2);
+        ctx.unfenceBrokers(0, 1, 2);
+
+        final CreateTopicsRequestData request = new CreateTopicsRequestData();
+
+        // Topic that matches the regex and explicitly sets diskless.enable=false — should be rejected
+        final CreateTopicsRequestData.CreatableTopicConfigCollection badConfigs = new CreateTopicsRequestData.CreatableTopicConfigCollection();
+        badConfigs.add(new CreateTopicsRequestData.CreatableTopicConfig()
+            .setName(DISKLESS_ENABLE_CONFIG)
+            .setValue("false"));
+        request.topics().add(new CreatableTopic()
+            .setName("forced-bad")
+            .setNumPartitions(1)
+            .setReplicationFactor((short) 1)
+            .setConfigs(badConfigs));
+
+        // Topic that does not match the regex — should succeed
+        request.topics().add(new CreatableTopic()
+            .setName("normal-topic")
+            .setNumPartitions(1)
+            .setReplicationFactor((short) 1));
+
+        final ControllerResult<CreateTopicsResponseData> result = ctx.replicationControl.createTopics(
+            anonymousContextFor(ApiKeys.CREATE_TOPICS), request, Set.of("forced-bad", "normal-topic"));
+
+        assertEquals(INVALID_REQUEST.code(), result.response().topics().find("forced-bad").errorCode());
+        assertEquals(NONE.code(), result.response().topics().find("normal-topic").errorCode());
     }
 
     @Nested


### PR DESCRIPTION
If a create topic request includes diskless.enable=false, but the topic name matches one of the diskless.force.include.topic.regexes, it is unclear what the real intent is.

Since this is mostly likely an user mistake, let's be stricter for now and reject the request to let the user know the topic would likely be created in a different way than they expected.