### PR TITLE
test(inkless:systest): run ducktape system tests against consolidated topics [KC-153]

### DIFF
--- a/.github/workflows/inkless-system-tests.yml
+++ b/.github/workflows/inkless-system-tests.yml
@@ -8,7 +8,7 @@ on:
       test-target:
         description: "Ducktape test target"
         required: true
-        default: "tests/kafkatest/tests/inkless/inkless_topic_switch_test.py"
+        default: "tests/kafkatest/tests/inkless/"
         type: string
 
 concurrency:
@@ -19,8 +19,8 @@ permissions:
   contents: read
 
 jobs:
-  classic-to-diskless-switch:
-    name: Classic to diskless switch system tests
+  inkless-system-tests:
+    name: Inkless system tests
     runs-on: ubuntu-latest
     timeout-minutes: 120
 
@@ -69,10 +69,10 @@ jobs:
             /usr/bin/mc mb -p local/inkless
           '
 
-      - name: Run diskless switch system tests
+      - name: Run inkless system tests
         id: system-tests
         env:
-          DEFAULT_TEST_TARGET: tests/kafkatest/tests/inkless/inkless_topic_switch_test.py
+          DEFAULT_TEST_TARGET: tests/kafkatest/tests/inkless/
           REQUESTED_TEST_TARGET: ${{ github.event.inputs['test-target'] }}
         run: |
           set +e
@@ -85,7 +85,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: inkless-switch-to-diskless-results
+          name: inkless-system-tests-results
           path: |
             results/**
             tests/results/**

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -120,6 +120,18 @@ RUN curl -s "$KAFKA_MIRROR/kafka-streams-3.9.1-test.jar" -o /opt/kafka-3.9.1/lib
 RUN curl -s "$KAFKA_MIRROR/kafka-streams-4.0.0-test.jar" -o /opt/kafka-4.0.0/libs/kafka-streams-4.0.0-test.jar
 RUN curl -s "$KAFKA_MIRROR/kafka-streams-4.1.1-test.jar" -o /opt/kafka-4.1.1/libs/kafka-streams-4.1.1-test.jar
 
+# Aiven Tiered Storage plugin (for consolidation/remote storage in system tests).
+# Download explicitly with curl (-f fails on HTTP errors, -L follows the GitHub
+# release redirect, --retry tolerates transient network hiccups).
+ARG ts_plugin_version=1.1.1
+ARG ts_plugin_base_url=https://github.com/Aiven-Open/tiered-storage-for-apache-kafka/releases/download/v${ts_plugin_version}
+RUN mkdir -p /opt/tiered-storage-plugin/core /opt/tiered-storage-plugin/s3 && \
+    curl -fsSL --retry 5 --retry-delay 5 "${ts_plugin_base_url}/core-${ts_plugin_version}.tgz" -o /tmp/core.tgz && \
+    curl -fsSL --retry 5 --retry-delay 5 "${ts_plugin_base_url}/s3-${ts_plugin_version}.tgz" -o /tmp/s3.tgz && \
+    tar xzf /tmp/core.tgz -C /opt/tiered-storage-plugin/core --strip-components=1 && \
+    tar xzf /tmp/s3.tgz -C /opt/tiered-storage-plugin/s3 --strip-components=1 && \
+    rm /tmp/*.tgz
+
 # To ensure the Kafka cluster starts successfully under JDK 17, we need to update the Zookeeper 
 # client from version 3.4.x to 3.5.7 in Kafka versions 2.1.1, 2.2.2, and 2.3.1, as the older Zookeeper 
 # client is incompatible with JDK 17. See KAFKA-17888 for more details.

--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -207,7 +207,8 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
                  dynamicRaftQuorum=False,
                  use_transactions_v2=False,
                  use_share_groups=None,
-                 use_streams_groups=False
+                 use_streams_groups=False,
+                 consolidation=None
                  ):
         """
         :param context: test context
@@ -299,6 +300,14 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
         self.use_transactions_v2 = use_transactions_v2
         self.use_share_groups = use_share_groups
         self.use_streams_groups = use_streams_groups
+        # Enable inkless consolidation (diskless + remote tiering) for this
+        # service. When None, fall back to the run-wide `--globals consolidation`
+        # flag so existing global-driven runs keep working. Setting it
+        # explicitly per-test lets consolidating and non-consolidating clusters
+        # coexist in a single ducktape session (e.g. the classic->diskless
+        # switch tests, which require the classic default, alongside the
+        # consolidation tests).
+        self.consolidation = consolidation
 
         # Set consumer_group_migration_policy based on context and arguments.
         if consumer_group_migration_policy is None:
@@ -358,7 +367,8 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
                     extra_kafka_opts=extra_kafka_opts, tls_version=tls_version,
                     isolated_kafka=self, allow_zk_with_kraft=self.allow_zk_with_kraft,
                     server_prop_overrides=server_prop_overrides, dynamicRaftQuorum=self.dynamicRaftQuorum,
-                    use_streams_groups=self.use_streams_groups
+                    use_streams_groups=self.use_streams_groups,
+                    consolidation=consolidation
                 )
                 self.controller_quorum = self.isolated_controller_quorum
 
@@ -754,7 +764,9 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
         config_template = self.render('kafka.properties', node=node, broker_id=self.idx(node),
                                       security_config=self.security_config, num_nodes=self.num_nodes,
                                       listener_security_config=self.listener_security_config,
-                                      use_share_groups=self.use_share_groups)
+                                      use_share_groups=self.use_share_groups,
+                                      consolidation=(self.consolidation if self.consolidation is not None
+                                                     else self.context.globals.get("consolidation", False)))
 
         configs = dict( l.rstrip().split('=', 1) for l in config_template.split('\n')
                         if not l.startswith("#") and "=" in l )

--- a/tests/kafkatest/services/kafka/templates/kafka.properties
+++ b/tests/kafkatest/services/kafka/templates/kafka.properties
@@ -144,3 +144,36 @@ inkless.storage.s3.endpoint.url=http://storage:9000
 inkless.storage.aws.access.key.id=minioadmin
 inkless.storage.aws.secret.access.key=minioadmin
 inkless.storage.s3.path.style.access.enabled=true
+
+{% if consolidation %}
+# Diskless/consolidation feature toggles
+log.diskless.enable=true
+diskless.managed.rf.enable=true
+diskless.remote.storage.consolidation.enable=true
+remote.log.storage.system.enable=true
+{% if quorum_info.using_zk or quorum_info.has_brokers %}
+# Remote log manager wiring is broker-only
+remote.log.manager.task.interval.ms=5000
+remote.log.metadata.manager.class.name=org.apache.kafka.server.log.remote.metadata.storage.TopicBasedRemoteLogMetadataManager
+remote.log.metadata.manager.listener.name={{ interbroker_listener.name }}
+rlmm.config.remote.log.metadata.topic.replication.factor={{ 3 if num_nodes > 3 else num_nodes }}
+remote.log.storage.manager.class.path=/opt/tiered-storage-plugin/core/*:/opt/tiered-storage-plugin/s3/*
+remote.log.storage.manager.class.name=io.aiven.kafka.tieredstorage.RemoteStorageManager
+rsm.config.chunk.size=4194304
+rsm.config.storage.backend.class=io.aiven.kafka.tieredstorage.storage.s3.S3Storage
+rsm.config.storage.s3.endpoint.url=http://storage:9000
+rsm.config.storage.s3.bucket.name=inkless
+rsm.config.key.prefix=tiered-storage/
+rsm.config.storage.s3.region=us-east-1
+rsm.config.storage.s3.path.style.access.enabled=true
+rsm.config.storage.aws.access.key.id=minioadmin
+rsm.config.storage.aws.secret.access.key=minioadmin
+{% else %}
+# Controller-only (isolated KRaft) fallback. remote.log.storage.system.enable is
+# validated on every node, but the RemoteLogManager is only instantiated on
+# brokers, so referencing NoOp class names here lets config validation pass
+# without the tiered-storage plugin on the controller classpath.
+remote.log.storage.manager.class.name=org.apache.kafka.server.log.remote.storage.NoOpRemoteStorageManager
+remote.log.metadata.manager.class.name=org.apache.kafka.server.log.remote.storage.NoOpRemoteLogMetadataManager
+{% endif %}
+{% endif %}

--- a/tests/kafkatest/tests/core/produce_bench_test.py
+++ b/tests/kafkatest/tests/core/produce_bench_test.py
@@ -41,6 +41,11 @@ class ProduceBenchTest(Test):
         self.trogdor.stop()
         self.kafka.stop()
 
+    def producer_config(self):
+        # Overridable hook so subclasses (e.g. the inkless consolidation variant)
+        # can tune the producer; the base benchmark uses defaults.
+        return {}
+
     @cluster(num_nodes=8)
     @matrix(metadata_quorum=quorum.all_non_upgrade)
     def test_produce_bench(self, metadata_quorum):
@@ -49,7 +54,7 @@ class ProduceBenchTest(Test):
                                         self.workload_service.bootstrap_servers,
                                         target_messages_per_sec=1000,
                                         max_messages=100000,
-                                        producer_conf={},
+                                        producer_conf=self.producer_config(),
                                         admin_client_conf={},
                                         common_client_conf={},
                                         inactive_topics=self.inactive_topics,
@@ -67,7 +72,7 @@ class ProduceBenchTest(Test):
                                         self.workload_service.bootstrap_servers,
                                         target_messages_per_sec=1000,
                                         max_messages=100000,
-                                        producer_conf={},
+                                        producer_conf=self.producer_config(),
                                         admin_client_conf={},
                                         common_client_conf={},
                                         inactive_topics=self.inactive_topics,

--- a/tests/kafkatest/tests/inkless/consolidation_compression_test.py
+++ b/tests/kafkatest/tests/inkless/consolidation_compression_test.py
@@ -1,0 +1,41 @@
+# Inkless
+# Copyright (C) 2024 - 2026 Aiven OY
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from kafkatest.tests.client.compression_test import CompressionTest
+
+
+class ConsolidationCompressionTest(CompressionTest):
+    """Codec coverage for consolidating (diskless + remote) topics.
+
+    Reuses the upstream ``CompressionTest`` produce/consume/validate flow but
+    flips the cluster into consolidation mode *per-test* rather than via the
+    run-wide ``--globals consolidation`` flag, so it runs in the same ducktape
+    session as the classic-to-diskless switch tests (which need the classic
+    default). With consolidation enabled the controller auto-enables
+    ``remote.storage.enable=true`` on the created topic, so every compression
+    codec (snappy/gzip/lz4/zstd/none) is exercised through the consolidation
+    write path -- coverage the single-codec pipeline test does not provide.
+    """
+
+    def __init__(self, test_context):
+        super(ConsolidationCompressionTest, self).__init__(test_context)
+        # prop_file reads these at render time, so mutating the already-built
+        # services here (before start()) is enough. The controller is flipped
+        # too so its config validation matches the brokers.
+        self.kafka.consolidation = True
+        controller = getattr(self.kafka, "isolated_controller_quorum", None)
+        if controller is not None:
+            controller.consolidation = True

--- a/tests/kafkatest/tests/inkless/consolidation_get_offset_shell_test.py
+++ b/tests/kafkatest/tests/inkless/consolidation_get_offset_shell_test.py
@@ -1,0 +1,41 @@
+# Inkless
+# Copyright (C) 2024 - 2026 Aiven OY
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from kafkatest.services.kafka import KafkaService
+from kafkatest.tests.core.get_offset_shell_test import GetOffsetShellTest
+
+
+class ConsolidationGetOffsetShellTest(GetOffsetShellTest):
+    """GetOffsetShell (ListOffsets) coverage for consolidating topics.
+
+    Reuses the upstream ``GetOffsetShellTest`` cases but builds the cluster in
+    consolidation mode *per-test* rather than via the run-wide ``--globals
+    consolidation`` flag, so it runs alongside the classic-to-diskless switch
+    tests. With consolidation enabled the controller auto-enables
+    ``remote.storage.enable=true`` on the created topics, so the tool's
+    earliest/latest offset queries are exercised against consolidating topics.
+    """
+
+    def start_kafka(self, security_protocol, interbroker_security_protocol):
+        # Same construction as the base, but with consolidation enabled. Passing
+        # the kwarg here (rather than mutating afterwards) lets KafkaService
+        # forward the flag to the isolated controller quorum automatically.
+        self.kafka = KafkaService(
+            self.test_context, self.num_brokers,
+            None, security_protocol=security_protocol,
+            interbroker_security_protocol=interbroker_security_protocol,
+            topics=self.topics, consolidation=True)
+        self.kafka.start()

--- a/tests/kafkatest/tests/inkless/consolidation_produce_bench_test.py
+++ b/tests/kafkatest/tests/inkless/consolidation_produce_bench_test.py
@@ -1,0 +1,66 @@
+# Inkless
+# Copyright (C) 2024 - 2026 Aiven OY
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from ducktape.mark import ignore, matrix
+from ducktape.mark.resource import cluster
+
+from kafkatest.services.kafka import quorum
+from kafkatest.tests.core.produce_bench_test import ProduceBenchTest
+
+
+class ConsolidationProduceBenchTest(ProduceBenchTest):
+    """Throughput canary for consolidating (diskless + remote) topics.
+
+    Reuses the upstream ``ProduceBenchTest`` workload but flips the cluster
+    into consolidation mode *per-test* (``KafkaService.consolidation``) rather
+    than via the run-wide ``--globals consolidation`` flag. That makes this
+    test discoverable and runnable in the same ducktape session as the
+    classic-to-diskless switch tests, which require the classic default
+    (``log.diskless.enable=false``) and would break under a run-wide global.
+
+    The workload auto-creates its topics with no per-topic config, so the only
+    way to make them consolidating is the broker-level ``log.diskless.enable``
+    default that the consolidation broker config sets.
+    """
+
+    def __init__(self, test_context):
+        super(ConsolidationProduceBenchTest, self).__init__(test_context)
+        # Enable consolidation on the brokers and the isolated controller
+        # (kept consistent so controller-side config validation matches the
+        # brokers). prop_file reads these at render time, so mutating the
+        # already-constructed services here -- before start() -- is enough.
+        self.kafka.consolidation = True
+        controller = getattr(self.kafka, "isolated_controller_quorum", None)
+        if controller is not None:
+            controller.consolidation = True
+
+    def producer_config(self):
+        # The diskless write path batches large object-store WAL writes, so the
+        # producer needs bigger batches/buffers and a larger max request size.
+        # Applied unconditionally here (the cluster is always consolidating).
+        return {
+            "batch.size": 1000000,
+            "buffer.memory": 128000000,
+            "max.request.size": 64000000,
+        }
+
+    @ignore
+    @cluster(num_nodes=8)
+    @matrix(metadata_quorum=quorum.all_non_upgrade)
+    def test_produce_bench_transactions(self, metadata_quorum):
+        # Transactions are not supported on consolidating (diskless) topics, so
+        # the inherited transactional variant is intentionally ignored.
+        pass

--- a/tests/kafkatest/version.py
+++ b/tests/kafkatest/version.py
@@ -101,12 +101,18 @@ class KafkaVersion(LooseVersion):
         return self >= V_3_8_0
 
     def supports_command_config(self):
+        # VerifiableProducer/Consumer and the console/perf tools switched to the
+        # unified --command-config flag (from --producer.config/--consumer.config).
         return self >= V_4_2_0
 
     def supports_formatter_property(self):
+        # The console consumer/share consumer switched to the --formatter-property
+        # flag (deprecating --property) as part of the tools options overhaul.
         return self >= V_4_2_0
 
     def supports_command_property(self):
+        # The console consumer/share consumer switched to the --command-property
+        # flag (deprecating --consumer-property) as part of the tools options overhaul.
         return self >= V_4_2_0
 
 def get_version(node=None):


### PR DESCRIPTION
This commit adds the ability to run the ducktape system tests against consolidating topics, and a few consolidation-specific variants, in the same run as the existing diskless and classic->diskless switch tests.

Per-test switch: KafkaService gains a `consolidation` flag (forwarded to the isolated controller) that renders a consolidation broker config in kafka.properties (diskless default + remote tiering via the Aiven tiered-storage plugin, S3/MinIO + Postgres backend). It falls back to the run-wide `--globals consolidation` flag when unset since theswitch tests require the classic default.

Tests and infra: three thin subclasses under tests/kafkatest/tests/inkless reuse upstream test bodies with consolidation enabled (produce-bench, compression, get-offset-shell).