### PR TITLE
docs(inkless): fix rendering of release sync prompt

### DIFF
--- a/inkless-sync/RELEASE-SYNC-PROMPT.md
+++ b/inkless-sync/RELEASE-SYNC-PROMPT.md
@@ -10,7 +10,7 @@ Copy and paste this prompt to start a release sync session:
 
 **PROMPT:**
 
-```
+````
 I need to sync the inkless release branch with an upstream Apache Kafka release.
 
 ## Context
@@ -69,7 +69,7 @@ I need to sync the inkless release branch with an upstream Apache Kafka release.
 10. **Push**: When verified, push the sync branch for PR review
 
 Please help me execute this release sync process.
-```
+````
 
 ---
 


### PR DESCRIPTION
The code block for the prompt was broken because its content also included code blocks defined by triple backticks:

https://github.com/aiven/inkless/blob/4f65a91461cc8397d0258e429fd6d7eecfdc032a/inkless-sync/RELEASE-SYNC-PROMPT.md