### PR TITLE
fix(inkless:consolidation): complete the classic-to-consolidated switch by always sealing and registering

### DIFF
--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -3561,7 +3561,15 @@ class ReplicaManager(val config: KafkaConfig,
         config.disklessRemoteStorageConsolidationEnabled &&
           _inklessMetadataView.isConsolidatingDisklessTopic(tp.topic)
       val existingPartition = onlinePartition(tp)
-      if (!isDiskless || isConsolidatingDisklessTopic) {
+      // A pending classic-to-diskless switch must always seal+register below, even for a
+      // consolidating topic (where isConsolidatingDisklessTopic is already true), or the
+      // consolidating branch would claim the partition, skip the seal, and strand the switch
+      // in CLASSIC_TO_DISKLESS_SWITCH_PENDING. Consolidation starts later: the seal commit bumps
+      // the partition epoch, re-entering this method via localChanges.leaders, no longer pending.
+      val isSwitchPending =
+        info.partition.classicToDisklessStartOffset == PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING
+      val isPendingSwitchOfExistingPartition = existingPartition.isDefined && isSwitchPending
+      if ((!isDiskless || isConsolidatingDisklessTopic) && !isPendingSwitchOfExistingPartition) {
         getOrCreatePartition(tp, delta, info.topicId).foreach { case (partition, isNew) =>
           try {
             val partitionAssignedDirectoryId = directoryIds.find(_._1.topicPartition() == tp).map(_._2)
@@ -3583,12 +3591,14 @@ class ReplicaManager(val config: KafkaConfig,
               markPartitionOffline(tp)
           }
         }
-      } else if (existingPartition.isDefined && !isConsolidatingDisklessTopic) {
+      } else if (existingPartition.isDefined && (isSwitchPending || !isConsolidatingDisklessTopic)) {
         // Classic-to-diskless switch. The controller writes the diskless.enable=true
         // ConfigRecord and the per-partition PartitionChangeRecord (with
         // classicToDisklessStartOffset = CLASSIC_TO_DISKLESS_SWITCH_PENDING) in the
         // same atomic op so the partition shows up here in localChanges.leaders whenever
-        // this broker is (or just became) the leader.
+        // this broker is (or just became) the leader. A consolidating switch (diskless.enable
+        // and remote.storage.enable flipped together) also lands here while the seal is pending
+        // (isSwitchPending), so the seal+register runs before consolidation can start.
         if (initDisklessLogManager.isEmpty) {
           error(s"Cannot proceed with classic to diskless switch for partition $tp: InitDisklessLogManager is not enabled.")
           return

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerInklessTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerInklessTest.scala
@@ -7054,4 +7054,127 @@ class ReplicaManagerInklessTest {
       consolidationCtor.close()
     }
   }
+
+  @Test
+  def testConsolidatingSwitchSealsRegistersThenStartsConsolidationOnSealCommit(): Unit = {
+    // Drives a consolidating classic-to-diskless switch on the *leader* across three deltas:
+    //   delta 1: bring the partition online so delta 2 sees an existing online partition.
+    //   delta 2: pending switch (epoch bumped) on an already-consolidating topic must seal+register,
+    //     NOT take the consolidating become-leader branch (which would skip the seal and strand the
+    //     switch in CLASSIC_TO_DISKLESS_SWITCH_PENDING). No consolidation fetcher starts yet.
+    //   delta 3: seal commit (no leader field, so leader epoch unchanged but partition epoch bumped)
+    //     re-enters applyLocalLeadersDelta via localChanges.leaders and, no longer pending, takes
+    //     the consolidating become-leader branch to start the fetcher from the local LEO (== seal).
+    val topicName = disklessTopicPartition.topic()
+    val topicId = disklessTopicPartition.topicId
+    val tp = disklessTopicPartition.topicPartition()
+    val brokerId = 1
+    val otherReplica = 2
+    val sealOffset = 10L
+
+    val mockIdlm = mock(classOf[InitDisklessLogManager])
+    val mockReplicaFetcherManager = mock(classOf[ReplicaFetcherManager])
+    when(mockReplicaFetcherManager.removeFetcherForPartitions(any()))
+      .thenReturn(Map.empty[TopicPartition, PartitionFetchState])
+
+    val ctorInit: MockedConstruction.MockInitializer[ConsolidationFetcherManager] = {
+      case (mock, _) =>
+        when(mock.removeFetcherForPartitions(any())).thenReturn(Map.empty[TopicPartition, PartitionFetchState])
+    }
+    val consolidationCtor = mockConstruction(classOf[ConsolidationFetcherManager], ctorInit)
+    try {
+      val replicaManager = spy(createReplicaManager(
+        List(topicName),
+        disklessRemoteStorageConsolidationEnabled = true,
+        consolidatingDisklessTopics = Set(topicName),
+        mockReplicaFetcherManager = Some(mockReplicaFetcherManager),
+        initDisklessLogManager = Some(mockIdlm)
+      ))
+      try {
+        val mockCfm = consolidationCtor.constructed().get(0)
+
+        // The classic prefix is already fully on local disk: LEO == HW == seal.
+        val log = replicaManager.logManager.getOrCreateLog(tp, isNew = true, topicId = Optional.of(topicId))
+        populateLocalLogAtLeoAndCheckpointedHwm(replicaManager, tp, log, leo = sealOffset, hw = sealOffset)
+
+        when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(tp))
+          .thenReturn(PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING)
+
+        // --- delta 1: bring the partition online as a (still pending) leader on this broker ---
+        val onlineDelta = new TopicsDelta(TopicsImage.EMPTY)
+        onlineDelta.replay(new TopicRecord().setName(topicName).setTopicId(topicId))
+        val onlineRecord = new PartitionRecord()
+          .setPartitionId(0)
+          .setTopicId(topicId)
+          .setReplicas(util.Arrays.asList(brokerId, otherReplica))
+          .setIsr(util.Arrays.asList(brokerId, otherReplica))
+          .setLeader(brokerId)
+          .setLeaderEpoch(0)
+          .setPartitionEpoch(0)
+        onlineRecord.unknownTaggedFields().add(
+          InitDisklessLogFields.encodeClassicToDisklessStartOffset(
+            PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING))
+        onlineDelta.replay(onlineRecord)
+        val onlineImage = imageFromTopics(onlineDelta.apply())
+        replicaManager.applyDelta(onlineDelta, onlineImage)
+        assertTrue(replicaManager.getPartition(tp).isInstanceOf[HostedPartition.Online],
+          "Partition should be online after the first delta")
+
+        // --- delta 2: pending switch with a leader-epoch bump -> seal + register ---
+        clearInvocations(mockCfm)
+        val pendingDelta = new TopicsDelta(onlineImage.topics())
+        val pendingRecord = new PartitionChangeRecord()
+          .setTopicId(topicId)
+          .setPartitionId(0)
+          .setLeader(brokerId) // forces a leader-epoch bump so it lands in localChanges.leaders
+        pendingRecord.unknownTaggedFields().add(
+          InitDisklessLogFields.encodeClassicToDisklessStartOffset(
+            PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING))
+        pendingDelta.replay(pendingRecord)
+        val pendingImage = imageFromTopics(pendingDelta.apply())
+        assertTrue(pendingDelta.localChanges(brokerId).leaders.containsKey(tp),
+          "Epoch bump should put the pending switch in localChanges.leaders")
+        replicaManager.applyDelta(pendingDelta, pendingImage)
+
+        // Seal+register ran (not the consolidating become-leader branch), and no consolidation
+        // fetcher was started for the partition while the seal is still pending.
+        verify(mockIdlm).registerPartition(any(classOf[Partition]), ArgumentMatchers.eq(topicId))
+        val leaderEpochAfterSeal = replicaManager.getPartition(tp)
+          .asInstanceOf[HostedPartition.Online].partition.getLeaderEpoch
+        verify(mockCfm, never()).addFetcherForPartitions(any())
+
+        // --- delta 3: seal commit (PENDING -> committed seal), no leader-epoch bump ---
+        clearInvocations(mockCfm)
+        when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(tp)).thenReturn(sealOffset)
+        val sealDelta = new TopicsDelta(pendingImage.topics())
+        val sealRecord = new PartitionChangeRecord()
+          .setTopicId(topicId)
+          .setPartitionId(0)
+        sealRecord.unknownTaggedFields().add(
+          InitDisklessLogFields.encodeClassicToDisklessStartOffset(sealOffset))
+        sealDelta.replay(sealRecord)
+        // The seal commit leaves the leader epoch unchanged but bumps the partition epoch, so the
+        // led partition still re-enters applyLocalLeadersDelta through localChanges.leaders.
+        assertTrue(sealDelta.localChanges(brokerId).leaders.containsKey(tp),
+          "Seal commit should re-enter applyLocalLeadersDelta via the partition-epoch bump")
+        replicaManager.applyDelta(sealDelta, imageFromTopics(sealDelta.apply()))
+
+        // Consolidation now starts from the local LEO (== seal) via the consolidating become-leader
+        // branch, because the partition is no longer pending.
+        verify(mockCfm).addFetcherForPartitions(
+          Map(tp -> InitialFetchState(
+            topicId = Some(topicId),
+            leader = new BrokerEndPoint(-1, "diskless", -1),
+            currentLeaderEpoch = leaderEpochAfterSeal,
+            initOffset = sealOffset
+          ))
+        )
+      } finally {
+        replicaManager.shutdown(checkpointHW = false)
+        verify(consolidationCtor.constructed().get(0)).shutdown()
+      }
+    } finally {
+      consolidationCtor.close()
+    }
+  }
 }


### PR DESCRIPTION
A switch-pending partition must take the seal+register branch in ReplicaManager.applyLocalLeadersDelta even when the topic is already a consolidating diskless topic. Otherwise consolidation claims the partition and the classic log is never sealed, leaving classicToDisklessStartOffset stuck at CLASSIC_TO_DISKLESS_SWITCH_PENDING and the switch deadlocked.