### PR TITLE
fix(inkless:consolidation): recover a switched consolidated leader after local-log loss

### DIFF
--- a/core/src/main/scala/io/aiven/inkless/consolidation/ConsolidationReconciler.scala
+++ b/core/src/main/scala/io/aiven/inkless/consolidation/ConsolidationReconciler.scala
@@ -67,17 +67,11 @@ class ConsolidationReconciler(replicaManager: ReplicaManager,
       val consolidatingPartitionAndOffsets: mutable.HashMap[TopicPartition, InitialFetchState] =
         initConsolidatingPartitionFetching(consolidatingPartitions)
 
-      // Mark topics throttled BEFORE starting fetchers: addFetcherForPartitions starts the
-      // fetcher threads immediately, and ReplicaFetcherThread only records bytes to the quota
-      // when the partition is already throttled. Marking after would let the first fetch/append
-      // bypass the quota. Unlike classic replication (where throttled replicas are set via topic
-      // config during reassignment), consolidation marks all topics unconditionally — every
-      // consolidating partition's bytes must count toward the dedicated bandwidth quota.
-      //
-      // We never removeThrottle on stop: this follows the classic ReplicaFetcher pattern, where
-      // the topic-keyed throttle map is only cleared via config changes (ConfigHandler), not on
-      // per-partition fetcher removal. Entries are tiny (topic -> List(-1)) and bounded by the
-      // set of topics that have ever consolidated on this broker, so the residue is benign.
+      // Mark topics throttled BEFORE starting fetchers: addFetcherForPartitions starts the threads
+      // immediately and bytes only count toward the quota while the partition is already throttled,
+      // so marking after would let the first fetch bypass the quota. All consolidating topics are
+      // marked unconditionally. We never removeThrottle on stop (matching the classic ReplicaFetcher
+      // pattern); the leftover topic -> List(-1) entries are tiny and bounded, so the residue is benign.
       consolidatingPartitionAndOffsets.keys.map(_.topic).toSet.foreach((topic: String) => consolidationQuotaManager.markThrottled(topic))
       consolidationFetcherManager.addFetcherForPartitions(consolidatingPartitionAndOffsets)
       consolidatingPartitionAndOffsets.keys.foreach(tp => consolidationMetrics.registerPartition(tp))
@@ -165,10 +159,6 @@ class ConsolidationReconciler(replicaManager: ReplicaManager,
     }
   }
 
-  // Arms consolidation from the current LEO, gating pruning at the higher of the seal and the
-  // current log start offset: at first switch the floor is the seal (blocking pruning of the
-  // diskless region until consolidation has tiered past the boundary), while on resume
-  // logStartOffset has advanced past the seal and reflects real pruning progress.
   private def armConsolidationAtLeo(partition: Partition, log: UnifiedLog, seal: Long): ConsolidationStartState = {
     partition.ensureConsolidationPruneFloorAtLeast(math.max(seal, log.logStartOffset))
     ConsolidationStartState.Ready(log.logEndOffset)

--- a/core/src/main/scala/io/aiven/inkless/consolidation/ConsolidationReconciler.scala
+++ b/core/src/main/scala/io/aiven/inkless/consolidation/ConsolidationReconciler.scala
@@ -87,8 +87,22 @@ class ConsolidationReconciler(replicaManager: ReplicaManager,
   def startConsolidationFetchersForCaughtUpClassicPartitions(topicPartitions: Set[TopicPartition]): Unit = {
     val consolidatingDisklessPartitionsToStartFetching = new mutable.HashMap[TopicPartition, Partition]
     topicPartitions.foreach { tp =>
-      if (inklessMetadataView.isConsolidatingDisklessTopic(tp.topic)) {
-        replicaManager.onlinePartition(tp).foreach(partition => consolidatingDisklessPartitionsToStartFetching.put(tp, partition))
+      replicaManager.onlinePartition(tp).foreach { partition =>
+        // This hook is the only trigger for a classic/untiered-diskless -> consolidated config flip:
+        // remote.storage.enable=true arrives as a config-only metadata change that the leader-delta
+        // path never re-enters, so if we skip the partition here it never starts consolidating.
+        // The broker metadata cache backing isConsolidatingDisklessTopic can lag the config record
+        // that has *already* updated this partition's local log -- the cache image and the dynamic
+        // config publisher are applied by separate publishers within the same metadata delta -- so
+        // gating solely on the cache can spuriously drop a partition that has, in fact, just become
+        // consolidating. The partition's own log config was updated synchronously before this hook
+        // ran, so trust it too: a diskless topic whose local log now has remote storage enabled is
+        // consolidating.
+        val isConsolidating = inklessMetadataView.isConsolidatingDisklessTopic(tp.topic) ||
+          (inklessMetadataView.isDisklessTopic(tp.topic) && partition.log.exists(_.remoteLogEnabled()))
+        if (isConsolidating) {
+          consolidatingDisklessPartitionsToStartFetching.put(tp, partition)
+        }
       }
     }
     startConsolidationFetchers(consolidatingDisklessPartitionsToStartFetching)
@@ -129,12 +143,31 @@ class ConsolidationReconciler(replicaManager: ReplicaManager,
       case seal if seal >= 0 =>
         val log = partition.localLogOrException
         if (log.logEndOffset < seal) {
-          // The classic prefix hasn't been fully replicated locally yet; a classic catch-up
-          // fetcher must finish bringing the local log up to the seal before consolidation
-          // can take over.
-          ConsolidationStartState.Retry(
-            s"Skipping consolidation for $tp because local LEO ${log.logEndOffset} is below " +
-              s"classic-to-diskless start offset $seal")
+          if (partition.isLeader && log.remoteLogEnabled()) {
+            // Leader with a below-seal local log. A healthy leader is never below the seal: the
+            // seal is taken from the leader's own LEO when the classic log finishes draining, and
+            // consolidation only ever appends above it. The only way to observe this is local-log
+            // loss on the elected leader -- a full local-storage wipe / disaster-recovery restart
+            // where the controller (whose metadata survived) elects a replica that came back with
+            // an empty log. Unlike a follower (which can still replicate the classic prefix from a
+            // live leader, hence the Retry below), a leader has no peer source: the classic prefix
+            // [0, seal) lives only in the remote tier. Start consolidation anyway, armed at the
+            // current (post-loss) LEO, so the fetcher's first request lands below the diskless WAL
+            // start and DisklessLeaderEndPoint answers OFFSET_MOVED_TO_TIERED_STORAGE. That drives
+            // the stock tier-state machine to rebuild the leader-epoch cache + producer snapshot
+            // and the whole-log start from remote before resuming the WAL fetch; without this the
+            // partition would wait forever for a classic catch-up that can never happen.
+            val pruneFloor = math.max(seal, log.logStartOffset)
+            partition.ensureConsolidationPruneFloorAtLeast(pruneFloor)
+            ConsolidationStartState.Ready(log.logEndOffset)
+          } else {
+            // Follower (or remote storage not yet enabled) whose classic prefix hasn't been fully
+            // replicated locally yet; a classic catch-up fetcher must finish bringing the local log
+            // up to the seal before consolidation can take over.
+            ConsolidationStartState.Retry(
+              s"Skipping consolidation for $tp because local LEO ${log.logEndOffset} is below " +
+                s"classic-to-diskless start offset $seal")
+          }
         } else {
           // LEO >= seal. This covers both the initial switch (LEO == seal, nothing consolidated
           // yet) and resuming an already-progressed partition after a restart, leadership

--- a/core/src/main/scala/io/aiven/inkless/consolidation/ConsolidationReconciler.scala
+++ b/core/src/main/scala/io/aiven/inkless/consolidation/ConsolidationReconciler.scala
@@ -88,16 +88,11 @@ class ConsolidationReconciler(replicaManager: ReplicaManager,
     val consolidatingDisklessPartitionsToStartFetching = new mutable.HashMap[TopicPartition, Partition]
     topicPartitions.foreach { tp =>
       replicaManager.onlinePartition(tp).foreach { partition =>
-        // This hook is the only trigger for a classic/untiered-diskless -> consolidated config flip:
-        // remote.storage.enable=true arrives as a config-only metadata change that the leader-delta
-        // path never re-enters, so if we skip the partition here it never starts consolidating.
-        // The broker metadata cache backing isConsolidatingDisklessTopic can lag the config record
-        // that has *already* updated this partition's local log -- the cache image and the dynamic
-        // config publisher are applied by separate publishers within the same metadata delta -- so
-        // gating solely on the cache can spuriously drop a partition that has, in fact, just become
-        // consolidating. The partition's own log config was updated synchronously before this hook
-        // ran, so trust it too: a diskless topic whose local log now has remote storage enabled is
-        // consolidating.
+        // This hook is the only trigger for an untiered-diskless -> consolidated flip, since
+        // remote.storage.enable=true is a config-only change the leader-delta path never re-enters.
+        // The metadata cache behind isConsolidatingDisklessTopic can lag the config record that has
+        // already enabled remote on the local log, so also trust the partition's own log: a diskless
+        // topic whose local log has remote storage enabled is consolidating.
         val isConsolidating = inklessMetadataView.isConsolidatingDisklessTopic(tp.topic) ||
           (inklessMetadataView.isDisklessTopic(tp.topic) && partition.log.exists(_.remoteLogEnabled()))
         if (isConsolidating) {
@@ -144,49 +139,38 @@ class ConsolidationReconciler(replicaManager: ReplicaManager,
         val log = partition.localLogOrException
         if (log.logEndOffset < seal) {
           if (partition.isLeader && log.remoteLogEnabled()) {
-            // Leader with a below-seal local log. A healthy leader is never below the seal: the
-            // seal is taken from the leader's own LEO when the classic log finishes draining, and
-            // consolidation only ever appends above it. The only way to observe this is local-log
-            // loss on the elected leader -- a full local-storage wipe / disaster-recovery restart
-            // where the controller (whose metadata survived) elects a replica that came back with
-            // an empty log. Unlike a follower (which can still replicate the classic prefix from a
-            // live leader, hence the Retry below), a leader has no peer source: the classic prefix
-            // [0, seal) lives only in the remote tier. Start consolidation anyway, armed at the
-            // current (post-loss) LEO, so the fetcher's first request lands below the diskless WAL
-            // start and DisklessLeaderEndPoint answers OFFSET_MOVED_TO_TIERED_STORAGE. That drives
-            // the stock tier-state machine to rebuild the leader-epoch cache + producer snapshot
-            // and the whole-log start from remote before resuming the WAL fetch; without this the
-            // partition would wait forever for a classic catch-up that can never happen.
-            val pruneFloor = math.max(seal, log.logStartOffset)
-            partition.ensureConsolidationPruneFloorAtLeast(pruneFloor)
-            ConsolidationStartState.Ready(log.logEndOffset)
+            // A leader below the seal means its local log was lost (e.g. a wiped replica promoted
+            // by the controller, whose metadata survived). Unlike a follower it has no peer to
+            // replicate the classic prefix [0, seal) from -- that prefix lives only in remote.
+            // Arm consolidation at the current LEO so the first fetch lands below the diskless WAL
+            // start, DisklessLeaderEndPoint answers OFFSET_MOVED_TO_TIERED_STORAGE, and the
+            // tier-state machine rebuilds the whole log from remote. Otherwise the partition would
+            // wait forever for a classic catch-up that can never happen.
+            armConsolidationAtLeo(partition, log, seal)
           } else {
-            // Follower (or remote storage not yet enabled) whose classic prefix hasn't been fully
-            // replicated locally yet; a classic catch-up fetcher must finish bringing the local log
-            // up to the seal before consolidation can take over.
+            // Follower (or remote not yet enabled) below the seal: a classic catch-up fetcher must
+            // still bring the local log up to the seal before consolidation can take over.
             ConsolidationStartState.Retry(
               s"Skipping consolidation for $tp because local LEO ${log.logEndOffset} is below " +
                 s"classic-to-diskless start offset $seal")
           }
         } else {
-          // LEO >= seal. This covers both the initial switch (LEO == seal, nothing consolidated
-          // yet) and resuming an already-progressed partition after a restart, leadership
-          // failover, or reassignment (the local log either kept its consolidated frontier or
-          // was rehydrated from tiered storage). In every case we resume from the current local
-          // LEO so we never re-consolidate or skip data the local log already holds.
-          //
-          // The prune floor is the higher of the seal and the current log start offset:
-          //  - at first switch logStartOffset is still the classic prefix start, so the floor is
-          //    the seal, which blocks pruning the diskless region until consolidation has tiered
-          //    past the boundary;
-          //  - on resume logStartOffset has advanced past the seal as consolidated segments were
-          //    tiered and deleted, so it reflects real pruning progress.
-          val pruneFloor = math.max(seal, log.logStartOffset)
-          partition.ensureConsolidationPruneFloorAtLeast(pruneFloor)
-          ConsolidationStartState.Ready(log.logEndOffset)
+          // LEO >= seal: the initial switch (LEO == seal) or a resume after restart, failover, or
+          // reassignment, where the local log kept or rehydrated its consolidated frontier. Resume
+          // from the current LEO so we neither re-consolidate nor skip data already held locally.
+          armConsolidationAtLeo(partition, log, seal)
         }
       case unexpected =>
         ConsolidationStartState.Failed(new ReconciliationException(s"Skipping consolidation for $tp due to unexpected classic-to-diskless start offset: $unexpected"))
     }
+  }
+
+  // Arms consolidation from the current LEO, gating pruning at the higher of the seal and the
+  // current log start offset: at first switch the floor is the seal (blocking pruning of the
+  // diskless region until consolidation has tiered past the boundary), while on resume
+  // logStartOffset has advanced past the seal and reflects real pruning progress.
+  private def armConsolidationAtLeo(partition: Partition, log: UnifiedLog, seal: Long): ConsolidationStartState = {
+    partition.ensureConsolidationPruneFloorAtLeast(math.max(seal, log.logStartOffset))
+    ConsolidationStartState.Ready(log.logEndOffset)
   }
 }

--- a/core/src/main/scala/kafka/server/ConfigHandler.scala
+++ b/core/src/main/scala/kafka/server/ConfigHandler.scala
@@ -83,6 +83,17 @@ class TopicConfigHandler(private val replicaManager: ReplicaManager,
         rlm.onLeadershipChange((leaderPartitions.toSet: Set[TopicPartitionLog]).asJava, (followerPartitions.toSet: Set[TopicPartitionLog]).asJava, topicIds))
     }
 
+    // Start consolidation on a classic -> consolidated switch. remote.storage.enable=true arrives as a
+    // config-only delta after the seal, with no partition/leader change, so applyLocalLeadersDelta never
+    // starts the consolidation fetcher. Kick it off here for the topic's online partitions; the reconciler
+    // skips any not yet at the seal (they resume via the classic fetcher's hand-off) and is a no-op for
+    // non-consolidating topics.
+    if (isRemoteLogEnabled && !wasRemoteLogEnabled &&
+        replicaManager.inklessMetadataView().isDisklessTopic(topic)) {
+      val consolidatingPartitions = (leaderPartitions ++ followerPartitions).map(_.topicPartition).toSet
+      replicaManager.startConsolidationFetchersForCaughtUpClassicPartitions(consolidatingPartitions)
+    }
+
     // When copy disabled, we should stop leaderCopyRLMTask, but keep expirationTask
     if (isRemoteLogEnabled && !wasCopyDisabled && isCopyDisabled) {
       replicaManager.remoteLogManager.foreach(rlm => {

--- a/core/src/test/scala/io/aiven/inkless/consolidation/ConsolidationReconcilerTest.scala
+++ b/core/src/test/scala/io/aiven/inkless/consolidation/ConsolidationReconcilerTest.scala
@@ -43,10 +43,11 @@ class ConsolidationReconcilerTest {
     metadataView: InklessMetadataView,
     fetcherManager: ConsolidationFetcherManager = mock(classOf[ConsolidationFetcherManager]),
     initialFetchOffset: UnifiedLog => Long = _.highWatermark,
-    quotaManager: ReplicationQuotaManager = mock(classOf[ReplicationQuotaManager])
+    quotaManager: ReplicationQuotaManager = mock(classOf[ReplicationQuotaManager]),
+    replicaManager: ReplicaManager = mock(classOf[ReplicaManager])
   ): ConsolidationReconciler = {
     new ConsolidationReconciler(
-      mock(classOf[ReplicaManager]),
+      replicaManager,
       new StateChangeLogger(0),
       mock(classOf[ConsolidationMetrics]),
       metadataView,
@@ -68,13 +69,16 @@ class ConsolidationReconcilerTest {
     logStartOffset: Long,
     logEndOffset: Long,
     highWatermark: Long = 0L,
-    highestRemoteOffset: Long = -1L
+    highestRemoteOffset: Long = -1L,
+    isLeader: Boolean = false,
+    remoteLogEnabled: Boolean = false
   ): (Partition, UnifiedLog) = {
     val log = mock(classOf[UnifiedLog])
     when(log.logStartOffset).thenReturn(logStartOffset)
     when(log.logEndOffset).thenReturn(logEndOffset)
     when(log.highWatermark).thenReturn(highWatermark)
     when(log.highestOffsetInRemoteStorage).thenReturn(highestRemoteOffset)
+    when(log.remoteLogEnabled()).thenReturn(remoteLogEnabled)
     when(log.topicId).thenReturn(Optional.of(topicId))
 
     val partition = mock(classOf[Partition])
@@ -82,7 +86,9 @@ class ConsolidationReconcilerTest {
     when(partition.topic).thenReturn(topicPartition.topic)
     when(partition.topicId).thenReturn(Some(topicId))
     when(partition.localLogOrException).thenReturn(log)
+    when(partition.log).thenReturn(Some(log))
     when(partition.getLeaderEpoch).thenReturn(7)
+    when(partition.isLeader).thenReturn(isLeader)
     (partition, log)
   }
 
@@ -200,16 +206,60 @@ class ConsolidationReconcilerTest {
   }
 
   @Test
-  def testMigratedPartitionBelowClassicToDisklessStartOffsetIsRetriedWithoutMarkingFailed(): Unit = {
+  def testFollowerBelowClassicToDisklessStartOffsetIsRetriedWithoutMarkingFailed(): Unit = {
+    // A *follower* whose local log is still below the seal can replicate the classic prefix from
+    // the live leader, so it must keep retrying (not start consolidation, not be marked failed).
     val view = mockMetadataView(classicToDisklessStartOffset = 100L)
     val fetcherManager = mock(classOf[ConsolidationFetcherManager])
-    val (partition, _) = mockPartition(logStartOffset = 0L, logEndOffset = 90L)
+    val (partition, _) = mockPartition(logStartOffset = 0L, logEndOffset = 90L,
+      isLeader = false, remoteLogEnabled = true)
     val reconciler = newReconciler(view, fetcherManager)
 
     val fetchStates = initFetchState(reconciler, partition)
 
     assertTrue(fetchStates.isEmpty)
     verify(partition, never()).truncateTo(anyLong(), anyBoolean())
+    verify(partition, never()).ensureConsolidationPruneFloorAtLeast(anyLong())
+    verify(fetcherManager, never()).addFailedPartition(topicPartition)
+  }
+
+  @Test
+  def testLeaderBelowSealWithRemoteStartsConsolidationToTriggerRemoteRebuild(): Unit = {
+    // A *leader* below the seal can only happen after local-log loss (full wipe / DR restart):
+    // the classic prefix [0, seal) lives only in the remote tier and there is no peer to replicate
+    // it from. Start consolidation armed at the (empty) LEO so the fetcher's first request lands
+    // below the diskless WAL start, DisklessLeaderEndPoint answers OFFSET_MOVED_TO_TIERED_STORAGE,
+    // and the tier-state machine rebuilds the whole-log state from remote. Gate pruning at the seal.
+    val view = mockMetadataView(classicToDisklessStartOffset = 100L)
+    val fetcherManager = mock(classOf[ConsolidationFetcherManager])
+    val (partition, _) = mockPartition(logStartOffset = 0L, logEndOffset = 0L,
+      isLeader = true, remoteLogEnabled = true)
+    val reconciler = newReconciler(view, fetcherManager)
+
+    val fetchStates = initFetchState(reconciler, partition)
+
+    assertEquals(0L, fetchStates(topicPartition).initOffset)
+    assertEquals(7, fetchStates(topicPartition).currentLeaderEpoch)
+    verify(partition, never()).truncateTo(anyLong(), anyBoolean())
+    verify(partition).ensureConsolidationPruneFloorAtLeast(100L)
+    verify(fetcherManager, never()).addFailedPartition(topicPartition)
+  }
+
+  @Test
+  def testLeaderBelowSealWithoutRemoteIsRetried(): Unit = {
+    // Defensive: a leader below the seal but without remote storage enabled has no remote tier to
+    // rebuild from, so there is nothing to do but retry (this should not occur for a consolidating
+    // topic, where remote storage is always enabled).
+    val view = mockMetadataView(classicToDisklessStartOffset = 100L)
+    val fetcherManager = mock(classOf[ConsolidationFetcherManager])
+    val (partition, _) = mockPartition(logStartOffset = 0L, logEndOffset = 90L,
+      isLeader = true, remoteLogEnabled = false)
+    val reconciler = newReconciler(view, fetcherManager)
+
+    val fetchStates = initFetchState(reconciler, partition)
+
+    assertTrue(fetchStates.isEmpty)
+    verify(partition, never()).ensureConsolidationPruneFloorAtLeast(anyLong())
     verify(fetcherManager, never()).addFailedPartition(topicPartition)
   }
 
@@ -229,6 +279,48 @@ class ConsolidationReconcilerTest {
     val inOrder = Mockito.inOrder(quotaManager, fetcherManager)
     inOrder.verify(quotaManager).markThrottled(topicPartition.topic)
     inOrder.verify(fetcherManager).addFetcherForPartitions(any())
+  }
+
+  @Test
+  def testStartConsolidationFetchersForCaughtUpClassicPartitionsStartsWhenMetadataCacheLagsRemoteFlip(): Unit = {
+    // Regression for the untiered-diskless -> consolidated upgrade: remote.storage.enable=true is a
+    // config-only metadata change with no leader-delta re-entry, so this hook is the sole trigger.
+    // The metadata cache backing isConsolidatingDisklessTopic can still report false at hook time
+    // (it lags the config record that already flipped remote on the local log), so the reconciler
+    // must fall back to the partition's own log and still start consolidation rather than silently
+    // drop the partition forever.
+    val view = mockMetadataView(classicToDisklessStartOffset = 100L)
+    when(view.isConsolidatingDisklessTopic(topicPartition.topic)).thenReturn(false)
+    when(view.isDisklessTopic(topicPartition.topic)).thenReturn(true)
+    val fetcherManager = mock(classOf[ConsolidationFetcherManager])
+    val replicaManager = mock(classOf[ReplicaManager])
+    val (partition, _) = mockPartition(logStartOffset = 0L, logEndOffset = 100L,
+      isLeader = true, remoteLogEnabled = true)
+    when(replicaManager.onlinePartition(topicPartition)).thenReturn(Some(partition))
+    val reconciler = newReconciler(view, fetcherManager, replicaManager = replicaManager)
+
+    reconciler.startConsolidationFetchersForCaughtUpClassicPartitions(Set(topicPartition))
+
+    verify(fetcherManager).addFetcherForPartitions(any())
+  }
+
+  @Test
+  def testStartConsolidationFetchersForCaughtUpClassicPartitionsSkipsNonConsolidatingTopic(): Unit = {
+    // A non-consolidating topic must never be routed to the consolidation fetcher: neither the
+    // metadata cache nor the local log reports it as a consolidating diskless topic.
+    val view = mockMetadataView(classicToDisklessStartOffset = 100L)
+    when(view.isConsolidatingDisklessTopic(topicPartition.topic)).thenReturn(false)
+    when(view.isDisklessTopic(topicPartition.topic)).thenReturn(false)
+    val fetcherManager = mock(classOf[ConsolidationFetcherManager])
+    val replicaManager = mock(classOf[ReplicaManager])
+    val (partition, _) = mockPartition(logStartOffset = 0L, logEndOffset = 100L,
+      isLeader = true, remoteLogEnabled = false)
+    when(replicaManager.onlinePartition(topicPartition)).thenReturn(Some(partition))
+    val reconciler = newReconciler(view, fetcherManager, replicaManager = replicaManager)
+
+    reconciler.startConsolidationFetchersForCaughtUpClassicPartitions(Set(topicPartition))
+
+    verify(fetcherManager, never()).addFetcherForPartitions(any())
   }
 
 }

--- a/core/src/test/scala/unit/kafka/server/DynamicConfigChangeTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DynamicConfigChangeTest.scala
@@ -536,6 +536,10 @@ class DynamicConfigChangeUnitTest {
     when(replicaManager.remoteLogManager).thenReturn(Some(rlm))
     when(replicaManager.metadataCache).thenReturn(metadataCache)
     when(metadataCache.getTopicId(topic)).thenReturn(topicUuid)
+    // Classic-tiered topic: the consolidation hook must not fire for a non-diskless topic.
+    val inklessMetadataView = mock(classOf[kafka.server.metadata.InklessMetadataView])
+    when(inklessMetadataView.isDisklessTopic(topic)).thenReturn(false)
+    when(replicaManager.inklessMetadataView()).thenReturn(inklessMetadataView)
 
     val tp0 = new TopicPartition(topic, 0)
     val log0: UnifiedLog = mock(classOf[UnifiedLog])
@@ -564,6 +568,87 @@ class DynamicConfigChangeUnitTest {
     configHandler.maybeUpdateRemoteLogComponents(topic, Seq(log0, log1), isRemoteLogEnabledBeforeUpdate, false)
     assertEquals(Collections.singleton(partition0), leaderPartitionsArg.getValue)
     assertEquals(Collections.singleton(partition1), followerPartitionsArg.getValue)
+    verify(replicaManager, never()).startConsolidationFetchersForCaughtUpClassicPartitions(any())
+  }
+
+  @Test
+  def testEnableRemoteLogStorageOnDisklessTopicStartsConsolidation(): Unit = {
+    // A classic -> consolidated switch flips diskless.enable=true (sealing the classic log) and
+    // remote.storage.enable=true in separate controller deltas, with remote storage landing after
+    // the seal as a config-only change. This hook starts consolidation when remote storage flips on
+    // for a (now consolidating) diskless topic, since the leader-delta path no longer re-runs.
+    val topic = "diskless-topic"
+    val topicUuid = Uuid.randomUuid()
+    val rlm: RemoteLogManager = mock(classOf[RemoteLogManager])
+    val replicaManager: ReplicaManager = mock(classOf[ReplicaManager])
+    val metadataCache = mock(classOf[MetadataCache])
+    when(replicaManager.remoteLogManager).thenReturn(Some(rlm))
+    when(replicaManager.metadataCache).thenReturn(metadataCache)
+    when(metadataCache.getTopicId(topic)).thenReturn(topicUuid)
+    val inklessMetadataView = mock(classOf[kafka.server.metadata.InklessMetadataView])
+    when(inklessMetadataView.isDisklessTopic(topic)).thenReturn(true)
+    when(replicaManager.inklessMetadataView()).thenReturn(inklessMetadataView)
+
+    val tp0 = new TopicPartition(topic, 0)
+    val log0: UnifiedLog = mock(classOf[UnifiedLog])
+    val partition0: Partition = mock(classOf[Partition])
+    when(log0.topicPartition).thenReturn(tp0)
+    when(log0.remoteLogEnabled()).thenReturn(true)
+    when(partition0.isLeader).thenReturn(true)
+    when(partition0.topicPartition).thenReturn(tp0)
+    when(replicaManager.onlinePartition(tp0)).thenReturn(Some(partition0))
+    when(log0.config).thenReturn(new LogConfig(Collections.emptyMap()))
+
+    val tp1 = new TopicPartition(topic, 1)
+    val log1: UnifiedLog = mock(classOf[UnifiedLog])
+    val partition1: Partition = mock(classOf[Partition])
+    when(log1.topicPartition).thenReturn(tp1)
+    when(log1.remoteLogEnabled()).thenReturn(true)
+    when(partition1.isLeader).thenReturn(false)
+    when(partition1.topicPartition).thenReturn(tp1)
+    when(replicaManager.onlinePartition(tp1)).thenReturn(Some(partition1))
+    when(log1.config).thenReturn(new LogConfig(Collections.emptyMap()))
+
+    doNothing().when(rlm).onLeadershipChange(any(), any(), any())
+
+    val consolidatingArg: ArgumentCaptor[Set[TopicPartition]] = ArgumentCaptor.forClass(classOf[Set[TopicPartition]])
+    doNothing().when(replicaManager).startConsolidationFetchersForCaughtUpClassicPartitions(consolidatingArg.capture())
+
+    val isRemoteLogEnabledBeforeUpdate = false
+    val configHandler: TopicConfigHandler = new TopicConfigHandler(replicaManager, null, null)
+    configHandler.maybeUpdateRemoteLogComponents(topic, Seq(log0, log1), isRemoteLogEnabledBeforeUpdate, false)
+
+    // Both the leader and the follower partition are handed to the reconciler, which decides per
+    // partition whether they are ready to consolidate (at/above the seal) or must keep replicating.
+    assertEquals(Set(tp0, tp1), consolidatingArg.getValue)
+  }
+
+  @Test
+  def testEnableRemoteLogStorageOnAlreadyEnabledDisklessTopicDoesNotStartConsolidation(): Unit = {
+    // Remote storage was already on (e.g. the leader-delta path already started consolidation at the
+    // seal commit, or this is an unrelated config edit): the false->true transition guard must keep
+    // this from redundantly kicking off consolidation again.
+    val topic = "diskless-topic"
+    val rlm: RemoteLogManager = mock(classOf[RemoteLogManager])
+    val replicaManager: ReplicaManager = mock(classOf[ReplicaManager])
+    when(replicaManager.remoteLogManager).thenReturn(Some(rlm))
+    val inklessMetadataView = mock(classOf[kafka.server.metadata.InklessMetadataView])
+    when(inklessMetadataView.isDisklessTopic(topic)).thenReturn(true)
+    when(replicaManager.inklessMetadataView()).thenReturn(inklessMetadataView)
+
+    val tp0 = new TopicPartition(topic, 0)
+    val log0: UnifiedLog = mock(classOf[UnifiedLog])
+    val partition0: Partition = mock(classOf[Partition])
+    when(log0.topicPartition).thenReturn(tp0)
+    when(log0.remoteLogEnabled()).thenReturn(true)
+    when(partition0.isLeader).thenReturn(true)
+    when(replicaManager.onlinePartition(tp0)).thenReturn(Some(partition0))
+    when(log0.config).thenReturn(new LogConfig(Collections.emptyMap()))
+
+    val isRemoteLogEnabledBeforeUpdate = true
+    val configHandler: TopicConfigHandler = new TopicConfigHandler(replicaManager, null, null)
+    configHandler.maybeUpdateRemoteLogComponents(topic, Seq(log0), isRemoteLogEnabledBeforeUpdate, false)
+    verify(replicaManager, never()).startConsolidationFetchersForCaughtUpClassicPartitions(any())
   }
 
   @Test


### PR DESCRIPTION
A leader that comes up below the seal with an empty local log (a full local-storage wipe / disaster recovery where the controller, whose metadata survived, elects a replica that came back empty) has no peer to replicate the classic prefix from -- that prefix lives only in the remote tier. The ConsolidationReconciler now starts consolidation for such a leader (when remote storage is enabled) instead of retrying forever, so the fetcher lands below the diskless WAL start, hits OFFSET_MOVED_TO_TIERED_STORAGE, and rebuilds the leader-epoch cache and producer snapshot from remote.