### PR TITLE
test(inkless:consolidation): add read-from-remote system tests, harness support

### DIFF
--- a/tests/kafkatest/services/inkless/consolidation_verifier.py
+++ b/tests/kafkatest/services/inkless/consolidation_verifier.py
@@ -25,8 +25,13 @@ harness (see ``.github/workflows/inkless-system-tests.yml`` and the Dockerfile).
 
 import csv
 import json
+import re
 import shlex
 import time
+
+from ducktape.utils.util import wait_until
+
+from kafkatest.services.verifiable_producer import VerifiableProducer
 
 
 class ConsolidationVerifier(object):
@@ -53,6 +58,21 @@ class ConsolidationVerifier(object):
     PG_DB = "inkless"
     PG_USER = "admin"
     PG_PASSWORD = "admin"
+
+    # Switch-completion JMX gauges (broker-side): on a classic-to-diskless switch the
+    # config flips to diskless.enable=true before leaders seal and before
+    # InitDisklessLogManager commits the diskless start, so tests gate on these, not
+    # config visibility. Wire them into the KafkaService constructor (the controller
+    # never exposes them, so scraping it would hang start_jmx_tool's --wait).
+    SEALED_LEADER_PARTITIONS_JMX_OBJECT = "kafka.server:type=ReplicaManager,name=SealedPartitionsCount"
+    INIT_DISKLESS_IN_FLIGHT_PARTITIONS_JMX_OBJECT = \
+        "kafka.server:type=InitDisklessLogManager,name=InFlightPartitions"
+    SWITCH_JMX_OBJECT_NAMES = [
+        SEALED_LEADER_PARTITIONS_JMX_OBJECT,
+        INIT_DISKLESS_IN_FLIGHT_PARTITIONS_JMX_OBJECT,
+    ]
+    SWITCH_JMX_ATTRIBUTES = ["Value"]
+    SWITCH_TIMEOUT_SEC = 180
 
     def __init__(self, kafka):
         self.kafka = kafka
@@ -116,11 +136,18 @@ class ConsolidationVerifier(object):
             return {}
         if not header or not last:
             return {}
+        # ssh_capture may yield bytes on some ducktape versions; csv.reader requires
+        # str, so decode here to match the verifier's other ssh_capture callers
+        # (offset_at, read_contiguous_from, read_records_with_values_from).
+        header_line = header[0]
+        header_line = header_line.decode("utf-8") if isinstance(header_line, bytes) else header_line
+        data_line = last[0]
+        data_line = data_line.decode("utf-8") if isinstance(data_line, bytes) else data_line
         # Parse with csv: JMX ObjectNames contain commas (property separators) and
         # are quoted in the header, so a naive comma split would misalign column
         # names with their values. Header: "time","<objectName>:<attr>",...
-        names = next(csv.reader([header[0].strip()]), [])
-        data_line = last[0].strip()
+        names = next(csv.reader([header_line.strip()]), [])
+        data_line = data_line.strip()
         if not data_line or data_line.startswith('"'):
             # Only the header has been written so far; no sample yet.
             return {}
@@ -270,3 +297,279 @@ class ConsolidationVerifier(object):
             "Missing client tool(s) %s on the broker node. Rebuild the ducker image "
             "(tests/docker/Dockerfile installs `mc` and `postgresql-client`) with "
             "`tests/docker/ducker-ak up` before running consolidation pipeline tests." % missing)
+
+    # --------------------- Topic / produce ---------------------
+
+    def create_classic_topic(self, topic, num_partitions, replication_factor,
+                             min_isr=2, segment_bytes=1048576, segment_ms=5000):
+        """Create a plain classic (non-diskless, non-tiered) topic with a small
+        ``segment.bytes`` so a produced prefix rolls several closed segments.
+        diskless/remote are left unset (the cluster default is classic); remote is
+        enabled only later by the consolidation transition, so segments tier (with
+        their classic epochs) only once consolidation starts. ``segment.bytes``
+        defaults to the enforced 1 MiB minimum and ``segment.ms`` to 5s so records
+        flow through closed segments before the size floor is reached."""
+        self.kafka.create_topic({
+            "topic": topic,
+            "partitions": num_partitions,
+            "replication-factor": replication_factor,
+            "configs": {
+                "min.insync.replicas": min_isr,
+                "segment.bytes": segment_bytes,
+                "segment.ms": segment_ms,
+            },
+        })
+
+    def produce(self, topic, num_records, label="", timeout_sec=180):
+        """Produce ``num_records`` to ``topic`` with a one-shot ``VerifiableProducer``
+        and return the acked count, asserting there were no worker errors. The
+        producer node is freed before returning so the slot can be reused."""
+        producer = VerifiableProducer(self.kafka.context, num_nodes=1, kafka=self.kafka,
+                                      topic=topic, max_messages=num_records, throughput=-1)
+        producer.start()
+        wait_until(lambda: producer.num_acked >= num_records or producer.worker_errors,
+                   timeout_sec=timeout_sec, backoff_sec=1,
+                   err_msg="Producer failed to produce %d %s records." % (num_records, label))
+        assert not producer.worker_errors, "Producer errors (%s): %s" % (label, producer.worker_errors)
+        producer.stop()
+        acked = producer.num_acked
+        producer.free()
+        return acked
+
+    # --------------------- Switch completion (JMX) ---------------------
+
+    def wait_for_switch_complete(self, topic, num_partitions, timeout_sec=None):
+        """Wait until the classic-to-diskless init work has drained. The config turns
+        visible before leaders seal and before InitDisklessLogManager commits the
+        diskless start, so gate on broker-side JMX (sealed leader partitions present,
+        zero in-flight init partitions) to keep a post-switch produce from racing the
+        switch-pending state. Requires the KafkaService to be wired with
+        ``SWITCH_JMX_OBJECT_NAMES``/``SWITCH_JMX_ATTRIBUTES``."""
+        if timeout_sec is None:
+            timeout_sec = self.SWITCH_TIMEOUT_SEC
+
+        wait_until(lambda: self.diskless_config_visible(topic),
+                   timeout_sec=timeout_sec, backoff_sec=2,
+                   err_msg="Topic %s did not show diskless.enable=true within %ds"
+                           % (topic, timeout_sec))
+
+        expected_sealed = num_partitions
+
+        def check():
+            try:
+                self.kafka.read_jmx_output_all_nodes()
+                sealed_key = "%s:Value" % self.SEALED_LEADER_PARTITIONS_JMX_OBJECT
+                in_flight_key = "%s:Value" % self.INIT_DISKLESS_IN_FLIGHT_PARTITIONS_JMX_OBJECT
+                sealed = 0.0
+                in_flight = 0.0
+                for time_to_stats in self.kafka.jmx_stats:
+                    if time_to_stats:
+                        latest = max(time_to_stats.keys())
+                        sealed += time_to_stats[latest].get(sealed_key, 0)
+                        in_flight += time_to_stats[latest].get(in_flight_key, 0)
+                self.logger.info("Switch state for %s: sealed leader partitions=%d/%d, "
+                                 "in-flight init partitions=%d"
+                                 % (topic, int(sealed), expected_sealed, int(in_flight)))
+                return sealed >= expected_sealed and in_flight == 0
+            except Exception as e:  # noqa: BLE001 - JMX reads race broker startup
+                self.logger.debug("Failed to read switch JMX state for %s: %s" % (topic, e))
+                return False
+
+        wait_until(check, timeout_sec=timeout_sec, backoff_sec=5,
+                   err_msg=("Topic %s did not finish the classic-to-diskless switch within %ds "
+                            "(expected >= %d sealed leader partitions and zero in-flight init "
+                            "partitions)" % (topic, timeout_sec, expected_sealed)))
+
+    def diskless_config_visible(self, topic):
+        try:
+            return self.kafka.describe_topic_config(topic).get("diskless.enable") == "true"
+        except Exception:  # noqa: BLE001 - describe can race the config propagation
+            return False
+
+    # --------------------- Wipe / offsets / reads ---------------------
+
+    def wipe_topic_local_logs(self, node, topic):
+        """Delete only the topic's partition dirs from both data dirs, keeping the
+        broker's KRaft identity and internal topics (__cluster_metadata,
+        __remote_log_metadata, __consumer_offsets) so it can rebuild the partition
+        and locate the remote segments. ``allow_fail``: a data dir may not hold a
+        replica of this partition."""
+        for data_dir in (self.kafka.DATA_LOG_DIR_1, self.kafka.DATA_LOG_DIR_2):
+            node.account.ssh("rm -rf -- %s/%s-*" % (data_dir, topic), allow_fail=True)
+        self.logger.info("Wiped local logs for %s on %s" % (topic, node.account.hostname))
+
+    def partition_has_leader(self, topic, partition=0):
+        try:
+            return self.kafka.leader(topic, partition=partition) is not None
+        except Exception as e:  # noqa: BLE001 - leader lookup races broker startup
+            self.logger.debug("Leader lookup for %s-%d not ready yet: %s" % (topic, partition, e))
+            return False
+
+    def offset_at(self, topic, time_spec, partition=0):
+        """Offset for the partition at a ``kafka-get-offsets.sh --time`` spec
+        (-1 latest, -2 earliest, -4 earliest-local, -5 latest-tiered). Returns -1 if
+        not parseable yet."""
+        node = self.kafka.nodes[0]
+        cmd = "%s --bootstrap-server %s --topic %s --partitions %d --time %s" % (
+            self.kafka.path.script("kafka-get-offsets.sh", node),
+            self.kafka.bootstrap_servers(),
+            topic,
+            partition,
+            time_spec,
+        )
+        try:
+            for line in node.account.ssh_capture(cmd, allow_fail=True):
+                line = line.decode("utf-8") if isinstance(line, bytes) else line
+                parts = line.strip().split(":")
+                if len(parts) == 3 and parts[0] == topic and parts[1] == str(partition):
+                    return int(parts[2])
+        except Exception as e:  # noqa: BLE001 - best effort; tool may not be ready
+            self.logger.warn("Failed to read offset (time=%s) for %s-%d: %s"
+                             % (time_spec, topic, partition, str(e)))
+        return -1
+
+    def wait_for_offset(self, topic, time_spec, partition=0, timeout_sec=60):
+        """Poll ``offset_at`` until it returns a real (>= 0) offset; offset reads race
+        broker startup after a restart, so retry rather than fail on -1."""
+        result = {"offset": -1}
+
+        def _ready():
+            result["offset"] = self.offset_at(topic, time_spec=time_spec, partition=partition)
+            return result["offset"] >= 0
+
+        wait_until(_ready, timeout_sec=timeout_sec, backoff_sec=2,
+                   err_msg="Could not read offset (time=%s) for %s-%d."
+                           % (time_spec, topic, partition))
+        return result["offset"]
+
+    def wait_for_local_log_truncation(self, topic, partition=0, timeout_sec=180):
+        """Wait until earliest-local advances past 0 and return it; proves some closed
+        segments were tiered AND locally deleted, so reads below this watermark come
+        from remote."""
+        result = {"offset": -1}
+
+        def check():
+            result["offset"] = self.offset_at(topic, time_spec=-4, partition=partition)
+            self.logger.info("Topic %s-%d earliest-local offset: %d"
+                             % (topic, partition, result["offset"]))
+            return result["offset"] > 0
+
+        wait_until(check, timeout_sec=timeout_sec, backoff_sec=2,
+                   err_msg=("earliest-local offset for %s-%d did not advance past 0 within %ds; "
+                            "classic tiering or local retention is not progressing"
+                            % (topic, partition, timeout_sec)))
+        return result["offset"]
+
+    def wait_for_tiered_offset_at_least(self, topic, min_offset, partition=0, timeout_sec=180):
+        """Wait until the latest-tiered offset (``kafka-get-offsets.sh --time -5``, i.e.
+        the broker's ``highestOffsetInRemoteStorage``) reaches at least ``min_offset``
+        and return it.
+
+        This is a *durability* signal, used after a classic->diskless switch to prove the
+        remote tier covers the requested range (here, through the seal). Once consolidation
+        appends a diskless record, its higher diskless leader epoch rolls a fresh segment
+        exactly at the seal, closing the boundary classic segment ``[.., seal)``; the
+        classic RLM then copies it to remote. Reaching the seal therefore proves the whole
+        classic prefix -- including the boundary tail -- is recoverable off-broker after a
+        wipe.
+
+        Deliberately NOT earliest-local (-4): that tracks deletion of the already-tiered
+        *local* copies, which only happens on the periodic retention sweep
+        (``log.retention.check.interval.ms``, 5min default) and is irrelevant to
+        durability -- gating on it makes the test hostage to retention timing."""
+        result = {"offset": -1}
+
+        def check():
+            result["offset"] = self.offset_at(topic, time_spec=-5, partition=partition)
+            self.logger.info("Topic %s-%d latest-tiered offset: %d (need >= %d)"
+                             % (topic, partition, result["offset"], min_offset))
+            return result["offset"] >= min_offset
+
+        wait_until(check, timeout_sec=timeout_sec, backoff_sec=2,
+                   err_msg=("latest-tiered offset for %s-%d did not reach %d within %ds; "
+                            "the classic prefix through the seal was not tiered to remote"
+                            % (topic, partition, min_offset, timeout_sec)))
+        return result["offset"]
+
+    def read_contiguous_from(self, topic, from_offset=0, max_messages=1, partition=0,
+                             timeout_ms=120000):
+        """Fetch up to ``max_messages`` records from ``from_offset`` and return
+        ``(first_offset, num_read)``; ``first_offset`` is -1 if nothing returns.
+        Unlike kafka-get-offsets.sh (advertised offset), an actual fetch reveals
+        whether the broker serves ``from_offset`` or skips ahead."""
+        node = self.kafka.nodes[0]
+        cmd = ("%s --bootstrap-server %s --topic %s --partition %d --offset %d "
+               "--max-messages %d --timeout-ms %d "
+               "--property print.offset=true --property print.key=false "
+               "--property print.value=false" % (
+                   self.kafka.path.script("kafka-console-consumer.sh", node),
+                   self.kafka.bootstrap_servers(),
+                   topic,
+                   partition,
+                   from_offset,
+                   max_messages,
+                   timeout_ms,
+               ))
+        first_offset = -1
+        num_read = 0
+        try:
+            for line in node.account.ssh_capture(cmd, allow_fail=True):
+                line = line.decode("utf-8") if isinstance(line, bytes) else line
+                # We always pass print.offset=true, so each record line is exactly
+                # "Offset:<n>". Anchor on that (or a digits-only line for legacy
+                # output) so a number inside a stray log/summary line can't be
+                # mistaken for an offset.
+                stripped = line.strip()
+                match = re.match(r"Offset:(\d+)$", stripped) or re.match(r"(\d+)$", stripped)
+                if match:
+                    if first_offset < 0:
+                        first_offset = int(match.group(1))
+                    num_read += 1
+        except Exception as e:  # noqa: BLE001 - best effort; tool may time out
+            self.logger.warn("Failed to read from %s-%d at offset %d: %s"
+                             % (topic, partition, from_offset, str(e)))
+        return first_offset, num_read
+
+    def first_served_offset(self, topic, partition=0, from_offset=0, timeout_ms=120000):
+        """Offset of the first record a real fetch from ``from_offset`` returns, or -1
+        if nothing returns within the timeout."""
+        first, _ = self.read_contiguous_from(topic, from_offset=from_offset,
+                                             max_messages=1, partition=partition,
+                                             timeout_ms=timeout_ms)
+        return first
+
+    def read_records_with_values_from(self, topic, from_offset, max_messages, partition=0,
+                                      timeout_ms=120000):
+        """Fetch up to ``max_messages`` records from ``from_offset`` and return them as a
+        list of ``(offset, value)`` tuples in returned order.
+
+        The VerifiableProducer default (``is_int``) writes each record's per-producer
+        sequence number as the value, so callers can assert payload content -- not just
+        offsets -- and detect gaps, duplicates, or reordering across the
+        classic->diskless boundary. Each output line is ``Offset:<n>\\t<value>``:
+        DefaultMessageFormatter prints the offset prefix, then key.separator '\\t', then
+        the value."""
+        node = self.kafka.nodes[0]
+        cmd = ("%s --bootstrap-server %s --topic %s --partition %d --offset %d "
+               "--max-messages %d --timeout-ms %d "
+               "--property print.offset=true --property print.key=false "
+               "--property print.value=true" % (
+                   self.kafka.path.script("kafka-console-consumer.sh", node),
+                   self.kafka.bootstrap_servers(),
+                   topic,
+                   partition,
+                   from_offset,
+                   max_messages,
+                   timeout_ms,
+               ))
+        records = []
+        try:
+            for line in node.account.ssh_capture(cmd, allow_fail=True):
+                line = line.decode("utf-8") if isinstance(line, bytes) else line
+                match = re.match(r"Offset:(\d+)\s+(-?\d+)\s*$", line.strip())
+                if match:
+                    records.append((int(match.group(1)), int(match.group(2))))
+        except Exception as e:  # noqa: BLE001 - best effort; tool may time out
+            self.logger.warn("Failed to read records from %s-%d at offset %d: %s"
+                             % (topic, partition, from_offset, str(e)))
+        return records

--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -1370,6 +1370,47 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
         self.logger.info("Running alter topic config command...\n%s" % cmd)
         node.account.ssh(cmd)
 
+    def alter_topic_configs(self, topic, configs, node=None):
+        """Atomically set multiple topic configs in a single ``--add-config`` alter.
+
+        ``configs`` is a dict of config name -> value. Combining configs into one
+        request matters for transitions that are only valid when applied together,
+        e.g. setting ``diskless.enable=true`` and ``remote.storage.enable=true`` at
+        once for a classic-to-consolidated switch (applying them in separate alters
+        either trips the mutual-exclusion validator or never starts consolidation).
+        kafka-configs uses commas to separate ``--add-config`` entries, so a value
+        that itself contains commas (e.g. a list like ``cleanup.policy=compact,delete``)
+        must use the bracket syntax ``cleanup.policy=[compact,delete]``; raw commas in
+        a value are rejected.
+        """
+        if node is None:
+            node = self.nodes[0]
+        self.logger.info("Altering topic %s configs %s", topic, configs)
+
+        assert configs, "alter_topic_configs requires at least one config to set"
+        for name, value in configs.items():
+            value_str = str(value)
+            # kafka-configs splits --add-config on commas, so a value with commas
+            # must be wrapped in [...] (e.g. cleanup.policy=[compact,delete]).
+            # Reject only raw, unbracketed commas that would corrupt the request.
+            if "," in value_str:
+                assert value_str.startswith("[") and value_str.endswith("]"), \
+                    ("alter_topic_configs value for '%s' contains a comma but is not wrapped "
+                     "in [...]; list values must use the bracket syntax "
+                     "(e.g. cleanup.policy=[compact,delete]): %s=%s"
+                     % (name, name, value_str))
+
+        force_use_zk_connection = not self.all_nodes_configs_command_uses_bootstrap_server()
+        # Sorted for a deterministic, easily-diffable command line.
+        add_config = ",".join("%s=%s" % (name, configs[name]) for name in sorted(configs))
+
+        cmd = fix_opts_for_new_jvm(node)
+        cmd += "%s --entity-name %s --entity-type topics --alter --add-config %s" % \
+              (self.kafka_configs_cmd_with_optional_security_settings(node, force_use_zk_connection),
+               topic, add_config)
+        self.logger.info("Running alter topic configs command...\n%s" % cmd)
+        node.account.ssh(cmd)
+
     def describe_topic_config(self, topic, node=None):
         if node is None:
             node = self.nodes[0]

--- a/tests/kafkatest/tests/inkless/consolidation_enable_on_untiered_diskless_test.py
+++ b/tests/kafkatest/tests/inkless/consolidation_enable_on_untiered_diskless_test.py
@@ -1,0 +1,359 @@
+# Inkless
+# Copyright (C) 2024 - 2026 Aiven OY
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import uuid
+
+from ducktape.mark import matrix
+from ducktape.mark.resource import cluster
+from ducktape.tests.test import Test
+from ducktape.utils.util import wait_until
+
+from kafkatest.services.kafka import KafkaService, quorum
+from kafkatest.services.inkless.consolidation_verifier import ConsolidationVerifier
+from kafkatest.services.verifiable_consumer import VerifiableConsumer
+
+
+class ConsolidationEnabledOnUntieredDisklessTest(Test):
+    """Upgrade test: a topic reaches the untiered-diskless state before
+    consolidation exists, then consolidation is turned on for it.
+
+    A topic can only be *untiered* diskless while the cluster-wide consolidation
+    feature (``diskless.remote.storage.consolidation.enable``) is off -- with it on,
+    ``validateDisklessRequiresRemoteStorage`` forces every diskless topic to enable
+    remote storage. So this is the realistic upgrade: run plain diskless (WAL only),
+    then flip the feature on cluster-wide and enable remote storage on the existing
+    diskless topic to start consolidating it. The feature is a static
+    ``ServerConfigs`` flag, so flipping it needs a restart (done in-flight).
+
+    Sequence (three cluster states):
+      A. Consolidation OFF. Create a classic topic, produce a prefix, switch
+         ``diskless.enable=true`` alone (sealing at ``S``), produce a diskless tail,
+         and assert the intermediate state (diskless, no remote, nothing tiered,
+         WAL holds data).
+      B. Flip the consolidation feature on cluster-wide and restart; the existing
+         untiered-diskless topic survives.
+      C. Alter ``remote.storage.enable=true`` (the "start consolidation" transition):
+         the TopicConfigHandler remote-flip hook starts the consolidation fetchers
+         without a leader change. Assert the remote tier grows, the WAL is pruned
+         above the seal, and reads stay contiguous and lossless across the seal
+         (nothing is wiped, so the upgrade must not lose data).
+
+    Read-from-remote-after-prune durability is covered by
+    :class:`ReadFromRemoteAfterPruneTest` and
+    :class:`SwitchedReadFromRemoteAfterPruneTest`; the novel behaviour here is the
+    upgrade transition itself.
+    """
+
+    # Unique per run: Postgres/MinIO persist across runs, so a stale name would
+    # mix old rows into the control-plane queries.
+    TOPIC_PREFIX = "enable-consolidation-on-untiered-diskless"
+    NUM_PARTITIONS = 1
+    REPLICATION_FACTOR = 3
+    # Classic prefix: enough to roll several segments (1 MiB floor) so a large
+    # contiguous part tiers once consolidation starts.
+    NUM_CLASSIC_RECORDS = 150000
+    # Diskless tail: enough that consolidation tiers it and the WAL pruner advances
+    # the diskless log-start above the seal.
+    NUM_DISKLESS_RECORDS = 150000
+
+    CONSOLIDATION_FEATURE_CONFIG = "diskless.remote.storage.consolidation.enable"
+
+    RESTART_TIMEOUT_SEC = 120
+
+    def __init__(self, test_context):
+        super(ConsolidationEnabledOnUntieredDisklessTest, self).__init__(test_context=test_context)
+        self.num_brokers = 3
+        self.TOPIC = "%s-%s" % (self.TOPIC_PREFIX, uuid.uuid4().hex[:8])
+
+    @cluster(num_nodes=6)
+    @matrix(metadata_quorum=[quorum.isolated_kraft])
+    def test_enable_consolidation_on_untiered_diskless(self, metadata_quorum):
+        self.kafka = KafkaService(
+            self.test_context,
+            num_nodes=self.num_brokers,
+            zk=None,
+            controller_num_nodes_override=1,
+            # Keep the remote-storage system + RSM plugin wired so phase C can tier
+            # without re-rendering config; the feature itself is OFF below for phase A.
+            consolidation=True,
+            # log.diskless.enable=false: keep the cluster default classic.
+            # diskless.allow.from.classic.enable=true: open the classic->diskless
+            #   switch bridge.
+            # diskless.remote.storage.consolidation.enable=false: feature off for
+            #   phase A so validateDisklessRequiresRemoteStorage allows an untiered
+            #   diskless topic; phase B flips it true.
+            # auto.leader.rebalance.enable=false: pin leadership so phase C proves the
+            #   remote-flip hook starts consolidation, not an incidental leader change.
+            # The rest run the WAL pruner / file cleaner fast; cache TTL <= retention/2.
+            server_prop_overrides=[
+                ["log.diskless.enable", "false"],
+                ["diskless.allow.from.classic.enable", "true"],
+                [self.CONSOLIDATION_FEATURE_CONFIG, "false"],
+                ["auto.leader.rebalance.enable", "false"],
+                ["inkless.consolidation.cleanup.interval.ms", "5000"],
+                ["inkless.file.cleaner.interval.ms", "5000"],
+                ["inkless.file.cleaner.retention.period.ms", "6000"],
+                ["inkless.consume.batch.coordinate.cache.ttl.ms", "2000"],
+            ],
+            # Switch-completion gauges live on the broker; the controller never
+            # exposes them, so scraping it would hang start_jmx_tool's --wait.
+            jmx_object_names=list(ConsolidationVerifier.SWITCH_JMX_OBJECT_NAMES),
+            jmx_attributes=list(ConsolidationVerifier.SWITCH_JMX_ATTRIBUTES),
+        )
+        # server_prop_overrides only reach the brokers; mirror the switch bridge,
+        # classic default, the (initially off) feature, and leader pinning onto the
+        # controller (KRaft drives preferred-leader rebalancing), and disable its JMX.
+        if getattr(self.kafka, "isolated_controller_quorum", None):
+            ctrl = self.kafka.isolated_controller_quorum
+            ctrl.server_prop_overrides = list(ctrl.server_prop_overrides) + [
+                ["log.diskless.enable", "false"],
+                ["diskless.allow.from.classic.enable", "true"],
+                [self.CONSOLIDATION_FEATURE_CONFIG, "false"],
+                ["auto.leader.rebalance.enable", "false"],
+            ]
+            ctrl.jmx_object_names = None
+            ctrl.jmx_attributes = []
+
+        # Collect broker data-dir logs to debug a post-restart failure.
+        self.kafka.logs["kafka_data_1"]["collect_default"] = True
+        self.kafka.logs["kafka_data_2"]["collect_default"] = True
+        self.kafka.start()
+
+        verifier = ConsolidationVerifier(self.kafka)
+        verifier.verify_tooling()
+
+        baseline_tiered = verifier.tiered_object_count()
+        self.logger.info("Baseline tiered-storage object count: %d" % baseline_tiered)
+
+        # =================================================================
+        # Phase A: consolidation OFF -- reach the untiered-diskless state
+        # =================================================================
+
+        # --- A1) Create a plain classic topic and produce a classic prefix ---
+        verifier.create_classic_topic(self.TOPIC, self.NUM_PARTITIONS, self.REPLICATION_FACTOR)
+        classic_acked = verifier.produce(self.TOPIC, self.NUM_CLASSIC_RECORDS, "classic")
+        seal_offset = classic_acked
+        self.logger.info("Produced classic prefix: acked=%d (seal offset will be %d)"
+                         % (classic_acked, seal_offset))
+
+        # --- A2) Switch classic -> *untiered* diskless (diskless.enable only) ---
+        #
+        # Legal only with consolidation off (else remote storage is forced too). The
+        # leader seals at `seal_offset`; the diskless interval is served from the WAL.
+        self.logger.info("Switching topic %s to UNTIERED diskless (diskless.enable only)" % self.TOPIC)
+        self.kafka.alter_topic_configs(self.TOPIC, {
+            "diskless.enable": "true",
+        })
+        verifier.wait_for_switch_complete(self.TOPIC, self.NUM_PARTITIONS)
+        self.logger.info("Classic-to-untiered-diskless switch completed for %s" % self.TOPIC)
+
+        # --- A3) Produce a diskless tail into the WAL ---
+        diskless_acked = verifier.produce(self.TOPIC, self.NUM_DISKLESS_RECORDS, "diskless")
+        self.logger.info("Produced diskless tail: acked=%d" % diskless_acked)
+
+        # --- A4) Assert the intermediate untiered-diskless state ---
+        config = self.kafka.describe_topic_config(self.TOPIC)
+        assert config.get("diskless.enable") == "true", \
+            "Topic %s is not diskless after the switch: %s" % (self.TOPIC, config)
+        assert config.get("remote.storage.enable") != "true", \
+            ("Topic %s already has remote storage enabled before phase C: %s" % (self.TOPIC, config))
+        # Nothing tiers while consolidation is off and no topic has remote storage.
+        untiered_count = verifier.tiered_object_count()
+        assert untiered_count == baseline_tiered, (
+            "tiered object count grew from %d to %d while consolidation was OFF: the untiered "
+            "intermediate state is not clean." % (baseline_tiered, untiered_count))
+        # The diskless tail must still be in the WAL: with no consolidation there is
+        # nothing to make it durable, so it cannot have been pruned.
+        wal_batches = verifier.wal_batch_count(self.TOPIC)
+        self.logger.info("Untiered-diskless state: tiered=%d (baseline), WAL batches=%d"
+                         % (untiered_count, wal_batches))
+        assert wal_batches > 0, (
+            "diskless WAL for %s is empty in the untiered state: the tail was not retained."
+            % self.TOPIC)
+
+        # =================================================================
+        # Phase B: flip the consolidation feature ON cluster-wide (restart)
+        # =================================================================
+        self.logger.info("Enabling the consolidation feature cluster-wide and restarting")
+        self._enable_consolidation_feature_and_restart()
+        wait_until(lambda: verifier.partition_has_leader(self.TOPIC, 0),
+                   timeout_sec=self.RESTART_TIMEOUT_SEC, backoff_sec=2,
+                   err_msg="Partition %s-0 did not get a leader after enabling consolidation." % self.TOPIC)
+        self.logger.info("Cluster restarted with consolidation enabled; %s still online" % self.TOPIC)
+
+        # The restart flipped only the cluster-wide consolidation feature; the topic's
+        # own config must be untouched. Assert it explicitly so a later Phase C timeout
+        # is attributable to consolidation not starting, not to a config lost across the
+        # restart (e.g. a dropped diskless.enable, or remote silently already on).
+        post_restart_config = self.kafka.describe_topic_config(self.TOPIC)
+        assert post_restart_config.get("diskless.enable") == "true", (
+            "diskless.enable is not true after the consolidation-feature restart (got %s): "
+            "the untiered-diskless topic did not survive the restart."
+            % post_restart_config.get("diskless.enable"))
+        assert post_restart_config.get("remote.storage.enable") != "true", (
+            "remote.storage.enable is already true before Phase C (got %s): the topic was not "
+            "untiered-diskless going into the consolidation start."
+            % post_restart_config.get("remote.storage.enable"))
+
+        # =================================================================
+        # Phase C: enable remote storage -> the topic starts consolidating
+        # =================================================================
+        pre_consolidation_tiered = verifier.tiered_object_count()
+        self.logger.info("Tiered-storage object count before enabling remote storage: %d"
+                         % pre_consolidation_tiered)
+
+        # The "start consolidation" transition (diskless stays on, remote storage
+        # turns on): the TopicConfigHandler remote-flip hook starts the consolidation
+        # fetchers without a leader change.
+        #
+        # Raise segment.bytes off the 1 MiB floor: consolidation appends each WAL
+        # batch to the local log, and a batch (max.request.size 1 MiB + framing) can
+        # exceed 1 MiB, which a 1 MiB segment rejects with RecordBatchTooLargeException
+        # and permanently fails the fetcher. 8 MiB clears it; segments still roll by
+        # segment.ms. (Test-only artifact of the tiny floor; prod defaults to 1 GiB.)
+        self.logger.info("Enabling remote storage on %s to start consolidation" % self.TOPIC)
+        self.kafka.alter_topic_configs(self.TOPIC, {
+            "remote.storage.enable": "true",
+            "local.retention.ms": "5000",
+            "segment.bytes": str(8 * 1024 * 1024),
+        })
+
+        # --- C1) The remote tier grows: classic prefix + diskless tail tier ---
+        wait_until(lambda: verifier.tiered_object_count() > pre_consolidation_tiered,
+                   timeout_sec=240, backoff_sec=2,
+                   err_msg=("Consolidation did not start after enabling remote storage on the "
+                            "previously-untiered diskless topic: the tiered-storage object count "
+                            "never grew above %d." % pre_consolidation_tiered))
+        self.logger.info("Tiered-storage object count grew to %d after enabling consolidation"
+                         % verifier.tiered_object_count())
+
+        # --- C2) The diskless WAL is pruned above the seal in the control plane ---
+        #
+        # The OR accepts either prune representation -- deleted batch rows (count -> 0)
+        # or an advanced log_start_offset -- so it must stay an OR, not an AND (a prune
+        # may only surface one). The count==0 leg can't fire prematurely: the C1
+        # tiered-count-grew gate above already proves batches were written, so 0 means
+        # pruned, not "not yet produced" (wal_batch_count returns -1 when unregistered).
+        wait_until(lambda: verifier.wal_batch_count(self.TOPIC) == 0
+                   or verifier.min_log_start_offset(self.TOPIC) > seal_offset,
+                   timeout_sec=240, backoff_sec=2,
+                   err_msg="Diskless WAL was not pruned above the seal after consolidation started.")
+        self.logger.info("Control plane pruned the diskless WAL: batch_count=%d, "
+                         "min_log_start_offset=%d, seal=%d" %
+                         (verifier.wal_batch_count(self.TOPIC),
+                          verifier.min_log_start_offset(self.TOPIC),
+                          seal_offset))
+
+        # --- C3) Data integrity: no data lost across the classic/diskless boundary ---
+        #
+        # Nothing is wiped, so the whole log [0, total) must stay readable end-to-end:
+        # earliest is still 0 (log_start_offset advancing above the seal is not the
+        # whole-log start), a fetch from 0 starts at 0, a window across the seal is
+        # strictly contiguous with correct content, and a full read-back returns every record.
+        total_produced = classic_acked + diskless_acked
+        earliest = verifier.wait_for_offset(self.TOPIC, time_spec=-2)
+        assert earliest == 0, (
+            "earliest offset is %d, not 0 after the upgrade: the classic prefix [0, %d) is no "
+            "longer addressable." % (earliest, seal_offset))
+
+        # A fetch from 0 must actually start at offset 0 (cheap single-record read).
+        first_served = verifier.first_served_offset(self.TOPIC, from_offset=0)
+        assert first_served == 0, (
+            "a fetch from offset 0 returned offset %d, not 0 after the upgrade." % first_served)
+
+        # A window straddling the seal must be strictly contiguous with matching content
+        # (no gap/dupe/reorder across the classic->diskless boundary). Each producer wrote
+        # its sequence as the value, so the series resets to 0 at the seal.
+        window = 5000
+        boundary_start = max(0, seal_offset - window)
+        boundary_count = min(2 * window, total_produced - boundary_start)
+        boundary_records = verifier.read_records_with_values_from(
+            self.TOPIC, from_offset=boundary_start, max_messages=boundary_count)
+        assert len(boundary_records) >= boundary_count, (
+            "cross-boundary read returned only %d of %d records spanning the seal (%d)."
+            % (len(boundary_records), boundary_count, seal_offset))
+        for i, (offset, value) in enumerate(boundary_records[:boundary_count]):
+            expected_offset = boundary_start + i
+            assert offset == expected_offset, (
+                "non-contiguous read across the seal at position %d: offset=%d, expected=%d "
+                "(gap/dupe/reorder near seal=%d)." % (i, offset, expected_offset, seal_offset))
+            expected_value = offset if offset < seal_offset else offset - seal_offset
+            assert value == expected_value, (
+                "content mismatch at offset %d: value=%d, expected=%d (seal=%d)."
+                % (offset, value, expected_value, seal_offset))
+        self.logger.info("Cross-boundary read OK: %d contiguous records [%d, %d) across seal=%d"
+                         % (boundary_count, boundary_start, boundary_start + boundary_count,
+                            seal_offset))
+
+        # Full-count read-back via VerifiableConsumer: it tolerates the large
+        # (~300k) record count where kafka-console-consumer can idle-timeout
+        # mid-stream, and its periodic summaries drive total_consumed().
+        consumer = VerifiableConsumer(self.test_context, num_nodes=1, kafka=self.kafka,
+                                      topic=self.TOPIC,
+                                      group_id="enable-consolidation-%s" % uuid.uuid4().hex[:8],
+                                      reset_policy="earliest")
+        consumer.start()
+        wait_until(lambda: consumer.total_consumed() >= total_produced or consumer.worker_errors,
+                   timeout_sec=240, backoff_sec=1,
+                   err_msg=("Consumer read back only %d of %d records after enabling consolidation; "
+                            "the classic prefix and diskless tail must both stay readable."
+                            % (consumer.total_consumed(), total_produced)))
+        assert not consumer.worker_errors, "Consumer errors: %s" % consumer.worker_errors
+        consumer.stop()
+        num_read = consumer.total_consumed()
+        consumer.free()
+        self.logger.info("Read back %d records after the upgrade (expected %d)"
+                         % (num_read, total_produced))
+        assert num_read >= total_produced, (
+            "read back only %d of %d records after the upgrade: enabling consolidation on the "
+            "untiered-diskless topic lost data." % (num_read, total_produced))
+
+    # -----------------------------------------------------------------------
+    # Helpers: cluster-wide consolidation feature flip (static config -> restart)
+    # -----------------------------------------------------------------------
+
+    def _enable_consolidation_feature_and_restart(self):
+        """Flip ``diskless.remote.storage.consolidation.enable`` true on brokers and
+        controller, then restart. It is a static ``ServerConfigs`` flag and
+        ``start_node`` re-renders config from ``server_prop_overrides``, so mutating
+        the list and restarting suffices. Stop brokers before the controller and
+        start the controller first so brokers always have one to talk to; on-disk
+        metadata survives, so the untiered-diskless topic is preserved."""
+        ctrl = getattr(self.kafka, "isolated_controller_quorum", None)
+
+        for node in self.kafka.nodes:
+            self.kafka.stop_node(node, clean_shutdown=True, timeout_sec=self.RESTART_TIMEOUT_SEC)
+        if ctrl:
+            for node in ctrl.nodes:
+                ctrl.stop_node(node, clean_shutdown=True, timeout_sec=self.RESTART_TIMEOUT_SEC)
+
+        self._set_override(self.kafka, self.CONSOLIDATION_FEATURE_CONFIG, "true")
+        if ctrl:
+            self._set_override(ctrl, self.CONSOLIDATION_FEATURE_CONFIG, "true")
+
+        if ctrl:
+            for node in ctrl.nodes:
+                ctrl.start_node(node, timeout_sec=self.RESTART_TIMEOUT_SEC)
+        for node in self.kafka.nodes:
+            self.kafka.start_node(node, timeout_sec=self.RESTART_TIMEOUT_SEC)
+
+    @staticmethod
+    def _set_override(service, key, value):
+        """Set ``key=value`` in ``server_prop_overrides``, replacing any existing
+        entry for ``key`` so the rendered config is unambiguous."""
+        service.server_prop_overrides = [
+            override for override in service.server_prop_overrides if override[0] != key
+        ] + [[key, value]]

--- a/tests/kafkatest/tests/inkless/consolidation_read_from_remote_after_prune_test.py
+++ b/tests/kafkatest/tests/inkless/consolidation_read_from_remote_after_prune_test.py
@@ -1,0 +1,228 @@
+# Inkless
+# Copyright (C) 2024 - 2026 Aiven OY
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import uuid
+
+from ducktape.mark import matrix
+from ducktape.mark.resource import cluster
+from ducktape.tests.test import Test
+from ducktape.utils.util import wait_until
+
+from kafkatest.services.kafka import KafkaService, quorum
+from kafkatest.services.inkless.consolidation_verifier import ConsolidationVerifier
+from kafkatest.services.verifiable_consumer import VerifiableConsumer
+
+
+class ReadFromRemoteAfterPruneTest(Test):
+    """Born-consolidated topic durability: after data is consolidated to remote and
+    the diskless WAL is pruned, reads must survive losing every local copy.
+
+    Stops all brokers, deletes the topic's partition dirs, and restarts, forcing
+    reads from the remote tier (MinIO) + diskless control plane (Postgres). Gates
+    post-wipe on: ListOffsets(earliest) reports 0 (not the pruned diskless start), a
+    fetch from 0 returns offset 0, a bounded read from 0 is strictly contiguous with
+    correct content, and a full read-back returns every record.
+    """
+
+    # Unique per run: Postgres/MinIO persist across runs, so a stale name would
+    # mix old rows into the control-plane queries.
+    TOPIC_PREFIX = "read-from-remote-after-prune"
+    NUM_PARTITIONS = 1
+    REPLICATION_FACTOR = 3
+    # Enough to roll several segments (1 MiB floor); only tiered closed segments
+    # can be served from remote after the wipe.
+    NUM_RECORDS = 300000
+
+    def __init__(self, test_context):
+        super(ReadFromRemoteAfterPruneTest, self).__init__(test_context=test_context)
+        self.num_brokers = 3
+        self.TOPIC = "%s-%s" % (self.TOPIC_PREFIX, uuid.uuid4().hex[:8])
+
+    @cluster(num_nodes=6)
+    @matrix(metadata_quorum=[quorum.isolated_kraft])
+    def test_read_from_remote_after_prune(self, metadata_quorum):
+        self.kafka = KafkaService(
+            self.test_context,
+            num_nodes=self.num_brokers,
+            zk=None,
+            controller_num_nodes_override=1,
+            consolidation=True,
+            # Run the WAL pruner / file cleaner fast; cache TTL must stay <= retention/2.
+            server_prop_overrides=[
+                ["inkless.consolidation.cleanup.interval.ms", "5000"],
+                ["inkless.file.cleaner.interval.ms", "5000"],
+                ["inkless.file.cleaner.retention.period.ms", "6000"],
+                ["inkless.consume.batch.coordinate.cache.ttl.ms", "2000"],
+            ],
+            topics={
+                self.TOPIC: {
+                    "partitions": self.NUM_PARTITIONS,
+                    "replication-factor": self.REPLICATION_FACTOR,
+                    "configs": {
+                        "diskless.enable": "true",
+                        "remote.storage.enable": "true",
+                        "min.insync.replicas": 2,
+                        # Roll segments by size/time so they close and get tiered.
+                        "segment.bytes": 1048576,
+                        "segment.ms": 5000,
+                        # Evict local segments soon after upload so data lives in
+                        # remote before the wipe.
+                        "local.retention.ms": 5000,
+                    },
+                },
+            },
+        )
+        # Collect broker data-dir logs to debug a post-restart failure.
+        self.kafka.logs["kafka_data_1"]["collect_default"] = True
+        self.kafka.logs["kafka_data_2"]["collect_default"] = True
+        self.kafka.start()
+
+        verifier = ConsolidationVerifier(self.kafka)
+        verifier.verify_tooling()
+
+        baseline_tiered = verifier.tiered_object_count()
+        self.logger.info("Baseline tiered-storage object count: %d" % baseline_tiered)
+
+        verifier.start_jmx()
+
+        acked = verifier.produce(self.TOPIC, self.NUM_RECORDS)
+        self.logger.info("Produced and acked %d records" % acked)
+
+        # 1) WAL -> local log fetcher catches up.
+        wait_until(lambda: verifier.local_lag() == 0,
+                   timeout_sec=180, backoff_sec=2,
+                   err_msg="Consolidation local lag did not drain to 0.")
+        self.logger.info("Consolidation local lag drained to 0")
+
+        # 2) Data reached remote: the tiered-storage prefix grew.
+        wait_until(lambda: verifier.tiered_object_count() > baseline_tiered,
+                   timeout_sec=180, backoff_sec=2,
+                   err_msg="Tiered-storage object count did not grow above baseline.")
+        self.logger.info("Tiered-storage object count grew to %d" % verifier.tiered_object_count())
+
+        # 3) WAL pruned: early (tiered) batches gone and diskless log-start advanced.
+        #    The WAL need not drain to zero; the durability proof only needs the
+        #    early offsets to be remote-only.
+        wait_until(lambda: verifier.wal_batch_count(self.TOPIC) == 0
+                   or verifier.min_log_start_offset(self.TOPIC) > 0,
+                   timeout_sec=180, backoff_sec=2,
+                   err_msg="WAL was not pruned in the Postgres control plane.")
+        self.logger.info("Control plane pruned the WAL: batch_count=%d, "
+                         "min_log_start_offset=%d, wal_object_count=%d" %
+                         (verifier.wal_batch_count(self.TOPIC),
+                          verifier.min_log_start_offset(self.TOPIC),
+                          verifier.wal_object_count()))
+
+        # Diagnostic only: born-consolidated topics tier via the consolidation
+        # pipeline, so earliest-local can stay at 0; the wipe below forces the
+        # remote read.
+        self.logger.info("Earliest-local offset before wipe: %d (diagnostic only)"
+                         % verifier.offset_at(self.TOPIC, time_spec=-4))
+
+        # Confirm the consolidation gauges were exported/scraped (diagnostic).
+        self.kafka.read_jmx_output_all_nodes()
+        jmx_keys = self.kafka.maximum_jmx_value
+        local_lag_key = ConsolidationVerifier.find_aggregate_key(jmx_keys, ConsolidationVerifier.LOCAL_LAG)
+        assert local_lag_key is not None, \
+            ("ConsolidationLocalLag was not exported/scraped via JMX. Expected a "
+             "%s 'name=ConsolidationLocalLag' Value column; got keys: %s"
+             % (ConsolidationVerifier.JMX_PACKAGE, sorted(jmx_keys)))
+
+        # --- Durability test: destroy every local copy, then read remote ---
+
+        # Stop ALL brokers before wiping so no surviving replica serves from a
+        # local log on restart (a spurious pass). The controller and internal
+        # topics on disk are left intact.
+        self.logger.info("Stopping all brokers to wipe local copies of %s" % self.TOPIC)
+        for node in self.kafka.nodes:
+            self.kafka.stop_node(node, clean_shutdown=True, timeout_sec=120)
+
+        for node in self.kafka.nodes:
+            verifier.wipe_topic_local_logs(node, self.TOPIC)
+
+        self.logger.info("Restarting all brokers with empty local logs for %s" % self.TOPIC)
+        for node in self.kafka.nodes:
+            self.kafka.start_node(node, timeout_sec=120)
+
+        # Wait until the partition has a leader again before reading.
+        wait_until(lambda: verifier.partition_has_leader(self.TOPIC, 0),
+                   timeout_sec=120, backoff_sec=2,
+                   err_msg="Partition %s-0 did not get a leader after the restart." % self.TOPIC)
+
+        # 1) earliest must read as 0: nothing was deleted by retention, so offset 0
+        #    is still durable in remote. The control-plane log_start_offset advanced
+        #    to the pruned diskless interval start; recovery must not adopt that as
+        #    the whole-log start.
+        earliest = verifier.wait_for_offset(self.TOPIC, time_spec=-2)
+        diskless_log_start = verifier.min_log_start_offset(self.TOPIC)
+        self.logger.info("After wipe+restart: earliest offset=%d, diskless log_start_offset=%d"
+                         % (earliest, diskless_log_start))
+        assert earliest == 0, (
+            "earliest offset is %d, not 0 after wipe+restart; diskless log_start_offset=%d. The "
+            "consolidated remote prefix below the diskless start is no longer readable."
+            % (earliest, diskless_log_start))
+
+        # 2) earliest=0 is only advertised; verify a fetch from 0 actually returns
+        #    offset 0 from remote rather than silently skipping to the diskless start.
+        first_served = verifier.first_served_offset(self.TOPIC, from_offset=0)
+        self.logger.info("First offset actually served by a fetch from 0: %d "
+                         "(diskless log_start_offset=%d)" % (first_served, diskless_log_start))
+        assert first_served == 0, (
+            "a fetch from offset 0 returned offset %d, not 0; diskless log_start_offset=%d. The "
+            "consolidated remote prefix [0, diskless_start) is durable but not served."
+            % (first_served, diskless_log_start))
+
+        # 2b) A bounded read from 0 is strictly contiguous with matching content: the single
+        #     producer wrote its sequence number as each value, so value == offset. Catches
+        #     gaps/dupes/reorder/corruption that the aggregate count below cannot.
+        spot_count = min(acked, 20000)
+        spot_records = verifier.read_records_with_values_from(
+            self.TOPIC, from_offset=0, max_messages=spot_count)
+        assert len(spot_records) >= spot_count, (
+            "bounded read from 0 returned only %d of %d records from remote; part of the "
+            "consolidated prefix is not readable." % (len(spot_records), spot_count))
+        for i, (offset, value) in enumerate(spot_records[:spot_count]):
+            assert offset == i, (
+                "non-contiguous read from 0 at position %d: offset=%d (gap/dupe/reorder)." % (i, offset))
+            assert value == offset, (
+                "content mismatch at offset %d: value=%d; the record served from remote does "
+                "not match what was produced." % (offset, value))
+        self.logger.info("Bounded contiguous read from 0 OK: %d records with correct content"
+                         % spot_count)
+
+        # 3) End-to-end: read every record back from remote + control plane.
+        #
+        # Do NOT pass on_record_consumed: it forces VerifiableConsumer --verbose
+        # (one JSON line/record) which the SSH worker can't keep up with for 300k
+        # records; the periodic records_consumed summaries still drive total_consumed().
+        consumer = VerifiableConsumer(self.test_context, num_nodes=1, kafka=self.kafka,
+                                      topic=self.TOPIC,
+                                      group_id="read-from-remote-%s" % uuid.uuid4().hex[:8],
+                                      reset_policy="earliest")
+        consumer.start()
+        wait_until(lambda: consumer.total_consumed() >= acked or consumer.worker_errors,
+                   timeout_sec=240, backoff_sec=1,
+                   err_msg=("Consumer read back only %d of %d records after wiping local logs; "
+                            "remaining records must be served from remote storage."
+                            % (consumer.total_consumed(), acked)))
+        assert not consumer.worker_errors, "Consumer errors: %s" % consumer.worker_errors
+        consumer.stop()
+        total = consumer.total_consumed()
+        consumer.free()
+        self.logger.info("Read back %d records from remote after wiping local logs (acked=%d)" %
+                         (total, acked))
+        assert total >= acked, \
+            "Data loss after wiping local logs: expected >= %d records from remote but got %d" % (acked, total)

--- a/tests/kafkatest/tests/inkless/consolidation_switched_read_from_remote_after_prune_test.py
+++ b/tests/kafkatest/tests/inkless/consolidation_switched_read_from_remote_after_prune_test.py
@@ -1,0 +1,342 @@
+# Inkless
+# Copyright (C) 2024 - 2026 Aiven OY
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import uuid
+
+from ducktape.mark import matrix
+from ducktape.mark.resource import cluster
+from ducktape.tests.test import Test
+from ducktape.utils.util import wait_until
+
+from kafkatest.services.kafka import KafkaService, quorum
+from kafkatest.services.inkless.consolidation_verifier import ConsolidationVerifier
+from kafkatest.services.verifiable_consumer import VerifiableConsumer
+
+
+class SwitchedReadFromRemoteAfterPruneTest(Test):
+    """Durability test for a *switched* (classic -> diskless) consolidated topic.
+
+    The switched-topic analogue of :class:`ReadFromRemoteAfterPruneTest`: offset 0 was
+    written by the classic log under the classic epoch (the diskless interval carries
+    ``last_classic_epoch + 1``), so serving it from remote after a local-log loss
+    requires resolving the classic epoch for the boundary offset.
+
+    Sequence: produce a classic prefix; switch to consolidating diskless (sealing at
+    ``S``); produce + consolidate a diskless tail and prune the WAL above the seal; wait
+    until the remote tier covers through the seal; then stop all brokers, wipe the
+    partition dirs, and restart empty. Post-wipe, assert earliest reads as 0, a fetch
+    from 0 is served, a window straddling the seal is contiguous with correct content,
+    and a full read-back returns every record from remote + the un-pruned WAL.
+
+    Requires at least one post-switch diskless append (its higher epoch rolls a fresh
+    segment at the seal, closing + tiering the boundary classic segment). A partition
+    that goes fully idle after the switch keeps its classic tail only on local disk;
+    out of scope here.
+    """
+
+    # Unique per run: Postgres/MinIO persist across runs, so a stale name would
+    # mix old rows into the control-plane queries.
+    TOPIC_PREFIX = "switched-read-from-remote-after-prune"
+    NUM_PARTITIONS = 1
+    REPLICATION_FACTOR = 3
+    # Classic prefix: enough to roll several segments (1 MiB floor) so a large
+    # contiguous part tiers and is locally deleted.
+    NUM_CLASSIC_RECORDS = 150000
+    # Diskless tail: ~13 B/record => ~4 MiB, exceeding segment.bytes (2 MiB) so the
+    # tail rolls an inactive segment. Only rolled segments tier, so this is what lifts
+    # highestOffsetInRemoteStorage past the seal and lets the WAL pruner advance.
+    NUM_DISKLESS_RECORDS = 300000
+
+    def __init__(self, test_context):
+        super(SwitchedReadFromRemoteAfterPruneTest, self).__init__(test_context=test_context)
+        self.num_brokers = 3
+        self.TOPIC = "%s-%s" % (self.TOPIC_PREFIX, uuid.uuid4().hex[:8])
+
+    @cluster(num_nodes=6)
+    @matrix(metadata_quorum=[quorum.isolated_kraft])
+    def test_switched_read_from_remote_after_prune(self, metadata_quorum):
+        self.kafka = KafkaService(
+            self.test_context,
+            num_nodes=self.num_brokers,
+            zk=None,
+            controller_num_nodes_override=1,
+            consolidation=True,
+            # log.diskless.enable=false: keep the cluster default classic (else new
+            #   topics are born diskless and trip the diskless/remote validator).
+            # diskless.allow.from.classic.enable=true: open the classic->diskless
+            #   switch bridge (validated on every node).
+            # The rest run the WAL pruner / file cleaner fast; cache TTL <= retention/2.
+            server_prop_overrides=[
+                ["log.diskless.enable", "false"],
+                ["diskless.allow.from.classic.enable", "true"],
+                ["inkless.consolidation.cleanup.interval.ms", "5000"],
+                ["inkless.file.cleaner.interval.ms", "5000"],
+                ["inkless.file.cleaner.retention.period.ms", "6000"],
+                ["inkless.consume.batch.coordinate.cache.ttl.ms", "2000"],
+            ],
+            # Switch-completion gauges live on the broker; the controller never
+            # exposes them, so scraping it would hang start_jmx_tool's --wait.
+            jmx_object_names=list(ConsolidationVerifier.SWITCH_JMX_OBJECT_NAMES),
+            jmx_attributes=list(ConsolidationVerifier.SWITCH_JMX_ATTRIBUTES),
+        )
+        # server_prop_overrides only reach the brokers, but the controller also
+        # validates the switch bridge: mirror it onto the controller and disable
+        # JMX there (it has no switch gauges).
+        if getattr(self.kafka, "isolated_controller_quorum", None):
+            ctrl = self.kafka.isolated_controller_quorum
+            ctrl.server_prop_overrides = list(ctrl.server_prop_overrides) + [
+                ["log.diskless.enable", "false"],
+                ["diskless.allow.from.classic.enable", "true"],
+            ]
+            ctrl.jmx_object_names = None
+            ctrl.jmx_attributes = []
+
+        # Collect broker data-dir logs to debug a post-restart failure.
+        self.kafka.logs["kafka_data_1"]["collect_default"] = True
+        self.kafka.logs["kafka_data_2"]["collect_default"] = True
+        self.kafka.start()
+
+        verifier = ConsolidationVerifier(self.kafka)
+        verifier.verify_tooling()
+
+        baseline_tiered = verifier.tiered_object_count()
+        self.logger.info("Baseline tiered-storage object count: %d" % baseline_tiered)
+
+        # --- 1) Classic phase: produce a classic prefix on a plain classic topic ---
+        verifier.create_classic_topic(self.TOPIC, self.NUM_PARTITIONS, self.REPLICATION_FACTOR)
+
+        classic_acked = verifier.produce(self.TOPIC, self.NUM_CLASSIC_RECORDS, "classic")
+        seal_offset = classic_acked
+        self.logger.info("Produced classic prefix: acked=%d (seal offset will be %d)"
+                         % (classic_acked, seal_offset))
+
+        # --- 2) Switch the classic topic straight to consolidating diskless ---
+        #
+        # One combined alter: the leader seals the classic log at `seal_offset` and
+        # starts the consolidation fetcher; short local.retention.ms lets the tiered
+        # classic prefix be deleted locally. Separate alters fail: remote-first trips
+        # the mutual-exclusion validator; remote after a diskless-only switch is a
+        # config-only delta that never starts consolidation.
+        #
+        # segment.bytes = 2 MiB (test-only; prod defaults to 1 GiB). It must be > the
+        # 1 MiB batch ceiling, else a consolidation append (a batch up to max.request.size
+        # 1 MiB + framing) fails with RecordBatchTooLargeException and kills the fetcher;
+        # and < the diskless tail, so the tail rolls an inactive segment (only rolled
+        # segments tier, which is what lets the WAL pruner advance past the seal.
+        # segment.ms can't help, it only rolls on a later append this bounded tail lacks).
+        self.logger.info("Switching topic %s to consolidating diskless (combined alter)" % self.TOPIC)
+        self.kafka.alter_topic_configs(self.TOPIC, {
+            "diskless.enable": "true",
+            "remote.storage.enable": "true",
+            "local.retention.ms": "5000",
+            "segment.bytes": str(2 * 1024 * 1024),
+        })
+        verifier.wait_for_switch_complete(self.TOPIC, self.NUM_PARTITIONS)
+        self.logger.info("Classic-to-consolidated switch completed for %s" % self.TOPIC)
+
+        # --- 3) Tier the classic prefix ---
+        #
+        # The classic RLM uploads the closed classic segments [0, seal) (with their
+        # classic epochs) to MinIO; local.retention.ms then deletes the local copies.
+        wait_until(lambda: verifier.tiered_object_count() > baseline_tiered,
+                   timeout_sec=180, backoff_sec=2,
+                   err_msg="Classic tiered-storage object count did not grow above baseline "
+                           "after enabling remote storage on the switched topic.")
+        self.logger.info("Classic tiered-storage object count grew to %d"
+                         % verifier.tiered_object_count())
+
+        # earliest-local past 0 proves the closed classic segments tiered AND were
+        # locally deleted. This is an intermediate signal; the gate that the whole
+        # prefix (incl. the boundary tail) is durable is computed after the diskless
+        # tail drives the boundary segment to roll (see step 4).
+        classic_remote_watermark = verifier.wait_for_local_log_truncation(self.TOPIC)
+        self.logger.info("Classic guaranteed-remote watermark (earliest-local): %d"
+                         % classic_remote_watermark)
+        assert classic_remote_watermark > 0, \
+            "Classic prefix never tiered: earliest-local stayed at 0 after enabling remote storage."
+
+        # --- 4) Diskless phase: produce the tail, consolidate, and prune the WAL ---
+        #
+        # Snapshot the tiered count BEFORE producing: consolidation tiers the diskless
+        # interval during the produce, so a baseline taken afterwards could already
+        # include the first diskless segment and the "grew above baseline" wait could
+        # never fire.
+        pre_diskless_tiered = verifier.tiered_object_count()
+        self.logger.info("Tiered-storage object count before diskless tail: %d" % pre_diskless_tiered)
+
+        diskless_acked = verifier.produce(self.TOPIC, self.NUM_DISKLESS_RECORDS, "diskless")
+        self.logger.info("Produced diskless tail: acked=%d" % diskless_acked)
+
+        # Consolidation tiered the diskless interval, growing the remote tier again.
+        wait_until(lambda: verifier.tiered_object_count() > pre_diskless_tiered,
+                   timeout_sec=180, backoff_sec=2,
+                   err_msg="Diskless consolidation did not grow the tiered-storage object count.")
+        self.logger.info("Tiered-storage object count grew to %d after consolidation"
+                         % verifier.tiered_object_count())
+
+        # The WAL pruner advances the diskless log-start above the seal (the diskless
+        # interval, and thus the control-plane log_start_offset, begins at the seal).
+        # The OR accepts either prune representation -- deleted batch rows (count -> 0)
+        # or an advanced log_start_offset -- so it must stay an OR, not an AND (a prune
+        # may only surface one). The count==0 leg can't fire prematurely here: the
+        # tiered-count-grew gate above already proves batches were written, so 0 means
+        # pruned, not "not yet produced" (wal_batch_count returns -1 when unregistered).
+        wait_until(lambda: verifier.wal_batch_count(self.TOPIC) == 0
+                   or verifier.min_log_start_offset(self.TOPIC) > seal_offset,
+                   timeout_sec=180, backoff_sec=2,
+                   err_msg="Diskless WAL was not pruned above the seal in the control plane.")
+        self.logger.info("Control plane pruned the diskless WAL: batch_count=%d, "
+                         "min_log_start_offset=%d, seal=%d" %
+                         (verifier.wal_batch_count(self.TOPIC),
+                          verifier.min_log_start_offset(self.TOPIC),
+                          seal_offset))
+
+        # Wait until the remote tier covers through the seal (latest-tiered/-5 =
+        # highestOffsetInRemoteStorage >= seal), proving the classic prefix incl. the
+        # boundary tail is durable and recoverable after the wipe. Not earliest-local/-4:
+        # that tracks local deletion (periodic retention sweep), not durability.
+        remote_watermark = verifier.wait_for_tiered_offset_at_least(self.TOPIC, seal_offset)
+        self.logger.info("Remote tier covers through the seal: latest-tiered=%d, seal=%d"
+                         % (remote_watermark, seal_offset))
+        assert remote_watermark >= seal_offset, (
+            "latest-tiered (%d) did not reach the seal (%d): the classic prefix incl. the "
+            "boundary tail is not durable in remote, so it would be lost on a local wipe."
+            % (remote_watermark, seal_offset))
+
+        # --- 5) Destroy every local copy, then read the classic remote prefix ---
+
+        # Stop ALL brokers before wiping so no surviving replica serves the classic
+        # prefix from a local log on restart. The controller and internal topics on
+        # disk are left intact.
+        self.logger.info("Stopping all brokers to wipe local copies of %s" % self.TOPIC)
+        for node in self.kafka.nodes:
+            self.kafka.stop_node(node, clean_shutdown=True, timeout_sec=120)
+
+        for node in self.kafka.nodes:
+            verifier.wipe_topic_local_logs(node, self.TOPIC)
+
+        self.logger.info("Restarting all brokers with empty local logs for %s" % self.TOPIC)
+        for node in self.kafka.nodes:
+            self.kafka.start_node(node, timeout_sec=120)
+
+        wait_until(lambda: verifier.partition_has_leader(self.TOPIC, 0),
+                   timeout_sec=120, backoff_sec=2,
+                   err_msg="Partition %s-0 did not get a leader after the restart." % self.TOPIC)
+
+        # --- 6a) earliest must read as 0 (the true whole-log start) ---
+        #
+        # Nothing was deleted by retention, so the classic prefix at offset 0 is still
+        # durable in remote. The control-plane log_start_offset advanced to the pruned
+        # diskless interval start; recovery must not adopt that as the whole-log start.
+        earliest = verifier.wait_for_offset(self.TOPIC, time_spec=-2)
+        diskless_log_start = verifier.min_log_start_offset(self.TOPIC)
+        self.logger.info("After wipe+restart: earliest offset=%d, diskless log_start_offset=%d, seal=%d"
+                         % (earliest, diskless_log_start, seal_offset))
+        assert earliest == 0, (
+            "earliest offset is %d, not 0 after wipe+restart; diskless log_start_offset=%d, seal=%d. "
+            "The classic remote prefix [0, seal) is no longer readable."
+            % (earliest, diskless_log_start, seal_offset))
+
+        # --- 6b) a fetch from offset 0 must actually return offset 0 from remote ---
+        #
+        # Switched-topic-specific: offset 0 lives in the classic interval under the
+        # classic leader epoch, so serving it after the wipe needs the rebuild to
+        # resolve that epoch and fetch the classic remote segment.
+        first_served = verifier.first_served_offset(self.TOPIC, from_offset=0)
+        self.logger.info("First offset actually served by a fetch from 0: %d "
+                         "(diskless log_start_offset=%d, seal=%d)"
+                         % (first_served, diskless_log_start, seal_offset))
+        assert first_served == 0, (
+            "a fetch from offset 0 returned offset %d, not 0 (seal=%d). The classic remote prefix "
+            "is durable but not served; the rebuild did not resolve the classic epoch."
+            % (first_served, seal_offset))
+
+        # --- 6c) a bounded contiguous read from 0 stays in the classic remote tier ---
+        #
+        # Cap the read well below both the seal and the watermark so these records come
+        # only from the classic remote tier.
+        read_count = min(remote_watermark, 20000)
+        first_offset, num_read = verifier.read_contiguous_from(self.TOPIC, from_offset=0,
+                                                              max_messages=read_count)
+        self.logger.info("Bounded contiguous read from 0: first_offset=%d, num_read=%d (requested %d)"
+                         % (first_offset, num_read, read_count))
+        assert first_offset == 0, (
+            "bounded read from offset 0 started at %d, not 0." % first_offset)
+        assert num_read >= read_count, (
+            "bounded read from 0 returned only %d of %d records below the remote watermark (%d): "
+            "part of the tiered classic prefix is not readable from remote."
+            % (num_read, read_count, remote_watermark))
+
+        # --- 6d) contiguous read straddling the seal: no gaps/dupes + correct content ---
+        #
+        # Frame a window around the seal, entirely below remote_watermark so every record
+        # is served from remote/WAL. Assert the offsets are strictly contiguous across
+        # the classic->diskless boundary (no gap, dupe, or reorder) and that each value
+        # matches what was produced: VerifiableProducer writes the per-producer sequence
+        # as the value, and a fresh producer wrote the diskless tail, so the value series
+        # resets to 0 exactly at the seal.
+        window = 5000
+        boundary_start = max(0, seal_offset - window)
+        boundary_count = min(2 * window, remote_watermark - boundary_start)
+        assert boundary_start < seal_offset < boundary_start + boundary_count, (
+            "cannot frame a cross-boundary read: seal=%d, start=%d, count=%d, watermark=%d"
+            % (seal_offset, boundary_start, boundary_count, remote_watermark))
+        boundary_records = verifier.read_records_with_values_from(
+            self.TOPIC, from_offset=boundary_start, max_messages=boundary_count)
+        assert len(boundary_records) >= boundary_count, (
+            "cross-boundary read returned only %d of %d records spanning the seal (%d); "
+            "part of the classic->diskless boundary is not readable from remote."
+            % (len(boundary_records), boundary_count, seal_offset))
+        for i, (offset, value) in enumerate(boundary_records[:boundary_count]):
+            expected_offset = boundary_start + i
+            assert offset == expected_offset, (
+                "non-contiguous read across the seal at position %d: offset=%d, expected=%d "
+                "(gap/dupe/reorder near seal=%d)." % (i, offset, expected_offset, seal_offset))
+            expected_value = offset if offset < seal_offset else offset - seal_offset
+            assert value == expected_value, (
+                "content mismatch at offset %d: value=%d, expected=%d (seal=%d); the record "
+                "served from remote does not match what was produced."
+                % (offset, value, expected_value, seal_offset))
+        self.logger.info("Cross-boundary read OK: %d contiguous records [%d, %d) with correct "
+                         "content across seal=%d" % (boundary_count, boundary_start,
+                          boundary_start + boundary_count, seal_offset))
+
+        # --- 6e) full read-back: every record returns from remote + WAL ---
+        #
+        # Read it all back: the classic prefix (remote) and the diskless interval (remote +
+        # un-pruned WAL) must survive the wipe. Periodic VerifiableConsumer summaries drive
+        # total_consumed (--verbose can't be sustained for 100k+ records).
+        expected_total = self.NUM_CLASSIC_RECORDS + self.NUM_DISKLESS_RECORDS
+        consumer = VerifiableConsumer(self.test_context, num_nodes=1, kafka=self.kafka,
+                                      topic=self.TOPIC,
+                                      group_id="switched-read-from-remote-%s" % uuid.uuid4().hex[:8],
+                                      reset_policy="earliest")
+        consumer.start()
+        wait_until(lambda: consumer.total_consumed() >= expected_total or consumer.worker_errors,
+                   timeout_sec=240, backoff_sec=1,
+                   err_msg=("Consumer read back only %d of %d records after wiping local logs; "
+                            "the classic prefix and diskless interval must both be served from "
+                            "remote/WAL." % (consumer.total_consumed(), expected_total)))
+        assert not consumer.worker_errors, "Consumer errors: %s" % consumer.worker_errors
+        consumer.stop()
+        total = consumer.total_consumed()
+        consumer.free()
+        self.logger.info("Read back %d records after wiping local logs (expected >= %d: classic %d + diskless %d)"
+                         % (total, expected_total, self.NUM_CLASSIC_RECORDS, self.NUM_DISKLESS_RECORDS))
+        assert total >= expected_total, (
+            "Data loss after wiping local logs: expected >= %d records (classic %d + diskless %d) "
+            "from remote/WAL but got %d." % (expected_total, self.NUM_CLASSIC_RECORDS,
+             self.NUM_DISKLESS_RECORDS, total))


### PR DESCRIPTION
Adds system tests proving consolidated diskless topics stay readable after every local copy is destroyed — reads must be served from the remote tier (MinIO) + control plane (Postgres) alone. Covers all three consolidation entry points, plus the KafkaService/ConsolidationVerifier harness support they depend on.

### Tests

**ReadFromRemoteAfterPruneTest**: born-consolidated. Produce, let consolidation tier and prune the WAL, wipe all local logs, restart empty, and assert remote-only reads are lossless (earliest == 0, fetch from 0 returns 0, contiguous content, full read-back).
**SwitchedReadFromRemoteAfterPruneTest**: classic→diskless (switched). Same wipe-and-read pattern; offset 0 lives in the classic interval under the classic epoch, so serving it from remote requires the rebuild to resolve that epoch. Also asserts a window straddling the seal is contiguous with correct content across the boundary.
**ConsolidationEnabledOnUntieredDisklessTest**: upgrade transition. Reach an untiered-diskless topic with consolidation OFF, flip the cluster-wide feature on via in-flight restart, then remote.storage.enable=true to start consolidating without a leader change. Asserts the remote tier grows, the WAL prunes above the seal, and reads stay lossless across the seal (nothing is wiped).

### Harness

KafkaService.alter_topic_configs for the atomic in-place config transitions the switched and upgrade tests rely on (combined diskless.enable + remote.storage.enable alter that seals and starts consolidation in one step; the remote-only flip that starts fetchers via the config hook).

ConsolidationVerifier extensions: MinIO tiered-object queries, Postgres WAL-batch / log-start queries, JMX consolidation-gauge scraping, remote-read and cross-boundary contiguity checks, and a local-log wipe helper.
