### PR TITLE
Update 4.1 branch with latest main commits

### DIFF
--- a/.github/workflows/inkless-system-tests.yml
+++ b/.github/workflows/inkless-system-tests.yml
@@ -1,0 +1,104 @@
+# Copyright (c) 2026 Aiven, Helsinki, Finland. https://aiven.io/
+# Workflow for Inkless ducktape system tests
+name: Inkless System Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      test-target:
+        description: "Ducktape test target"
+        required: true
+        default: "tests/kafkatest/tests/inkless/inkless_topic_switch_test.py"
+        type: string
+
+concurrency:
+  group: inkless-system-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  classic-to-diskless-switch:
+    name: Classic to diskless switch system tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: ./.github/actions/setup-python
+
+      - name: Setup Gradle
+        uses: ./.github/actions/setup-gradle
+        with:
+          java-version: 17
+          gradle-cache-read-only: true
+          develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+
+      - name: Build system test libraries
+        run: ./gradlew --build-cache --no-scan -PcommitId=xxxxxxxxxxxxxxxx systemTestLibs
+
+      - name: Start ducker cluster
+        run: bash tests/docker/ducker-ak up -n 11
+
+      - name: Start Postgres and MinIO
+        run: |
+          docker run -d --name postgres --network ducknet --network-alias postgres \
+            -e POSTGRES_DB=inkless \
+            -e POSTGRES_USER=admin \
+            -e POSTGRES_PASSWORD=admin \
+            postgres:17.2
+
+          until docker exec postgres pg_isready --dbname=inkless -U admin; do
+            echo "waiting for postgres"
+            sleep 2
+          done
+
+          docker run -d --name storage --network ducknet --network-alias storage \
+            quay.io/minio/minio server /data --console-address ":9001"
+
+          docker run --rm --network ducknet --entrypoint /bin/sh quay.io/minio/mc -c '
+            until /usr/bin/mc alias set local http://storage:9000 minioadmin minioadmin; do
+              echo "waiting for minio"; sleep 2;
+            done;
+            /usr/bin/mc mb -p local/inkless
+          '
+
+      - name: Run diskless switch system tests
+        id: system-tests
+        env:
+          DEFAULT_TEST_TARGET: tests/kafkatest/tests/inkless/inkless_topic_switch_test.py
+          REQUESTED_TEST_TARGET: ${{ github.event.inputs['test-target'] }}
+        run: |
+          set +e
+          test_target="${REQUESTED_TEST_TARGET:-${DEFAULT_TEST_TARGET}}"
+          timeout 100m bash tests/docker/ducker-ak test "$test_target" -- --test-runner-timeout 7200000
+          exitcode="$?"
+          echo "exitcode=$exitcode" >> "$GITHUB_OUTPUT"
+
+      - name: Archive ducktape results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: inkless-switch-to-diskless-results
+          path: |
+            results/**
+            tests/results/**
+            **/build/reports/**
+          compression-level: 9
+          if-no-files-found: ignore
+
+      - name: Cleanup Docker
+        if: always()
+        run: |
+          docker rm -f postgres storage || true
+          bash tests/docker/ducker-ak down -f || true
+
+      - name: Check test result
+        if: always() && steps.system-tests.outputs.exitcode != '0'
+        run: exit 1

--- a/build.gradle
+++ b/build.gradle
@@ -2413,6 +2413,10 @@ project(':storage') {
   checkstyle {
     configProperties = checkstyleConfigProperties("import-control-storage.xml")
   }
+
+  systemTestLibs {
+    dependsOn testJar
+  }
 }
 
 project(':storage:inkless') {

--- a/core/src/main/scala/io/aiven/inkless/consolidation/ConsolidationFetcherThread.scala
+++ b/core/src/main/scala/io/aiven/inkless/consolidation/ConsolidationFetcherThread.scala
@@ -22,6 +22,8 @@ import io.aiven.inkless.consume.ConcatenatedRecords
 import kafka.server.{FailedPartitions, KafkaConfig, ReplicaFetcherThread, ReplicaManager, ReplicaQuota}
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.record.{MemoryRecords, Records}
+import org.apache.kafka.common.requests.FetchResponse
+import org.apache.kafka.metadata.PartitionRegistration
 import org.apache.kafka.server.LeaderEndPoint
 import org.apache.kafka.storage.internals.log.LogAppendInfo
 
@@ -51,6 +53,7 @@ class ConsolidationFetcherThread(name: String,
     partitionLeaderEpoch: Int,
     partitionData: FetchData
   ): Option[LogAppendInfo] = {
+    maybeStampDisklessLeaderEpoch(topicPartition, partitionData)
     val result = super.processPartitionData(topicPartition, fetchOffset, partitionLeaderEpoch, partitionData)
 
     consolidationMetrics.foreach { metrics =>
@@ -69,5 +72,27 @@ class ConsolidationFetcherThread(name: String,
     }
 
     result
+  }
+
+  /**
+   * Stamp the captured diskless leader epoch (E_d) onto materialized batches so the local log keeps a
+   * monotonic epoch lineage (diskless records are produced with epoch 0, which would otherwise break
+   * the LeaderEpochFileCache after a switched partition's higher classic epochs and disable divergence
+   * truncation). Born-diskless / not-yet-switched partitions (E_d == NO_DISKLESS_LEADER_EPOCH) are left
+   * at epoch 0. Done in place to reuse the append path's single flatten; partitionLeaderEpoch is outside
+   * the batch CRC, so no checksum recompute is needed.
+   */
+  private def maybeStampDisklessLeaderEpoch(topicPartition: TopicPartition, partitionData: FetchData): Unit = {
+    val disklessLeaderEpoch = replicaMgr.disklessLeaderEpoch(topicPartition)
+    if (disklessLeaderEpoch == PartitionRegistration.NO_DISKLESS_LEADER_EPOCH) {
+      return
+    }
+    FetchResponse.recordsOrFail(partitionData) match {
+      case records: ConcatenatedRecords =>
+        records.batches().forEach(batch => batch.setPartitionLeaderEpoch(disklessLeaderEpoch))
+      case records: MemoryRecords =>
+        records.batches().forEach(batch => batch.setPartitionLeaderEpoch(disklessLeaderEpoch))
+      case _ =>
+    }
   }
 }

--- a/core/src/main/scala/io/aiven/inkless/consolidation/DisklessLeaderEndPoint.scala
+++ b/core/src/main/scala/io/aiven/inkless/consolidation/DisklessLeaderEndPoint.scala
@@ -30,7 +30,7 @@ import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.record.FileRecords.TimestampAndOffset
 import org.apache.kafka.common.requests.{FetchRequest, FetchResponse, ListOffsetsRequest, OffsetsForLeaderEpochResponse}
 import org.apache.kafka.common.TopicPartition
-import org.apache.kafka.metadata.LeaderAndIsr
+import org.apache.kafka.metadata.{LeaderAndIsr, PartitionRegistration}
 import org.apache.kafka.server.common.{MetadataVersion, OffsetAndEpoch}
 import org.apache.kafka.server.network.BrokerEndPoint
 import org.apache.kafka.server.storage.log.{FetchIsolation, FetchParams}
@@ -169,6 +169,22 @@ class DisklessLeaderEndPoint(
     new OffsetAndEpoch(tao.offset, tao.leaderEpoch.orElse(0))
   }
 
+  /**
+   * Answers OffsetsForLeaderEpoch for diskless consolidating partitions so followers can perform
+   * standard divergence truncation against the diskless leader.
+   *
+   * A switched partition's local log is laid out as a classic prefix `[logStart, seal)` carrying the
+   * original classic leader epochs, followed by the diskless region `[seal, LEO)` stamped with the
+   * diskless leader epoch `E_d` captured at the switch (see [[ConsolidationFetcherThread]]). Two cases:
+   *   - queried epoch `< E_d`: the epoch belongs to the classic prefix, whose lineage on the diskless
+   *     leader ends at the seal, so the end offset is the seal. A follower whose stale classic tail
+   *     runs past the seal truncates back to it. Collapsing every classic epoch to the seal (rather
+   *     than the start of the next epoch, as standard OffsetsForLeaderEpoch would) is correct only
+   *     because the classic prefix `[logStart, seal)` is committed and identical across all replicas,
+   *     so intra-prefix divergence cannot occur.
+   *   - queried epoch `>= E_d` (or a born-diskless partition with no captured epoch): the end offset is
+   *     the current diskless LEO, fetched via a LATEST list-offsets call.
+   */
   override def fetchEpochEndOffsets(
     partitions: util.Map[TopicPartition, OffsetForLeaderEpochRequestData.OffsetForLeaderPartition]
   ): util.Map[TopicPartition, EpochEndOffset] = {
@@ -178,14 +194,27 @@ class DisklessLeaderEndPoint(
 
     val job = fetchOffsetHandler.createJob()
     val futures = mutable.Map.empty[TopicPartition, CompletableFuture[FileRecordsOrError]]
+    // Partitions whose queried epoch resolves to the seal without needing a diskless list-offsets call.
+    val sealEndOffsets = mutable.Map.empty[TopicPartition, Long]
 
     partitions.forEach { (tp, epochData) =>
       if (epochData.leaderEpoch != OffsetsForLeaderEpochResponse.UNDEFINED_EPOCH && job.mustHandle(tp.topic)) {
-        val partitionRequest = new ListOffsetsPartition()
-          .setPartitionIndex(tp.partition)
-          .setCurrentLeaderEpoch(LeaderAndIsr.INITIAL_LEADER_EPOCH)
-          .setTimestamp(ListOffsetsRequest.LATEST_TIMESTAMP)
-        futures.put(tp, job.add(tp, partitionRequest))
+        val seal = replicaManager.classicToDisklessStartOffset(tp)
+        val disklessLeaderEpoch = replicaManager.disklessLeaderEpoch(tp)
+        // Upgrade caveat: partitions switched before this change carry a seal but no E_d (no tag 102),
+        // so they fall through to the LATEST-LEO branch and keep the old (no divergence truncation)
+        // behavior until they are re-switched. This is a safe fallback, not a correctness regression.
+        if (seal >= 0 &&
+            disklessLeaderEpoch != PartitionRegistration.NO_DISKLESS_LEADER_EPOCH &&
+            epochData.leaderEpoch < disklessLeaderEpoch) {
+          sealEndOffsets.put(tp, seal)
+        } else {
+          val partitionRequest = new ListOffsetsPartition()
+            .setPartitionIndex(tp.partition)
+            .setCurrentLeaderEpoch(LeaderAndIsr.INITIAL_LEADER_EPOCH)
+            .setTimestamp(ListOffsetsRequest.LATEST_TIMESTAMP)
+          futures.put(tp, job.add(tp, partitionRequest))
+        }
       }
     }
 
@@ -196,6 +225,12 @@ class DisklessLeaderEndPoint(
         tp -> new EpochEndOffset()
           .setPartition(tp.partition)
           .setErrorCode(Errors.NONE.code)
+      } else if (sealEndOffsets.contains(tp)) {
+        tp -> new EpochEndOffset()
+          .setPartition(tp.partition)
+          .setErrorCode(Errors.NONE.code)
+          .setLeaderEpoch(epochData.leaderEpoch)
+          .setEndOffset(sealEndOffsets(tp))
       } else if (!futures.contains(tp)) {
         tp -> new EpochEndOffset()
           .setPartition(tp.partition)

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -3575,6 +3575,12 @@ class ReplicaManager(val config: KafkaConfig,
     consolidationReconciler.foreach(_.startConsolidationFetchersForCaughtUpClassicPartitions(topicPartitions))
   }
 
+  def classicToDisklessStartOffset(topicPartition: TopicPartition): Long =
+    _inklessMetadataView.getClassicToDisklessStartOffset(topicPartition)
+
+  def disklessLeaderEpoch(topicPartition: TopicPartition): Int =
+    _inklessMetadataView.getDisklessLeaderEpoch(topicPartition)
+
   /**
    * Whether a follower of a consolidating diskless topic is ready to be handed to the consolidation
    * fetcher rather than the classic ReplicaFetcher:

--- a/core/src/main/scala/kafka/server/metadata/InklessMetadataView.scala
+++ b/core/src/main/scala/kafka/server/metadata/InklessMetadataView.scala
@@ -102,6 +102,18 @@ class InklessMetadataView(val metadataCache: KRaftMetadataCache, val defaultConf
       .getOrElse(PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET)
   }
 
+  /**
+   * The diskless leader epoch (E_d) captured at the classic-to-diskless switch, or
+   * [[PartitionRegistration.NO_DISKLESS_LEADER_EPOCH]] when the partition never switched (born-diskless
+   * or switch still pending). It is strictly greater than every classic-prefix leader epoch.
+   */
+  def getDisklessLeaderEpoch(topicPartition: TopicPartition): Int = {
+    Option(metadataCache.currentImage().topics().getTopic(topicPartition.topic()))
+      .flatMap(topicImage => Option(topicImage.partitions().get(topicPartition.partition())))
+      .map(_.disklessLeaderEpoch)
+      .getOrElse(PartitionRegistration.NO_DISKLESS_LEADER_EPOCH)
+  }
+
   override def getTopicConfig(topicName: String): LogConfig = topicConfigs.computeIfAbsent(topicName, t => {
     val props = metadataCache.topicConfig(t)
     if (props.isEmpty) new LogConfig(getDefaultConfig)

--- a/core/src/test/java/kafka/server/InklessConsolidatedDisklessTopicsTest.java
+++ b/core/src/test/java/kafka/server/InklessConsolidatedDisklessTopicsTest.java
@@ -19,6 +19,9 @@ package kafka.server;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AlterConfigOp;
+import org.apache.kafka.clients.admin.Config;
+import org.apache.kafka.clients.admin.ConfigEntry;
 import org.apache.kafka.clients.admin.CreateTopicsResult;
 import org.apache.kafka.clients.admin.ListOffsetsResult;
 import org.apache.kafka.clients.admin.NewTopic;
@@ -34,6 +37,7 @@ import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.TopicPartitionInfo;
 import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
@@ -45,6 +49,7 @@ import org.apache.kafka.server.config.ServerConfigs;
 import org.apache.kafka.server.log.remote.metadata.storage.TopicBasedRemoteLogMetadataManager;
 import org.apache.kafka.server.log.remote.metadata.storage.TopicBasedRemoteLogMetadataManagerConfig;
 import org.apache.kafka.server.log.remote.storage.RemoteLogManagerConfig;
+import org.apache.kafka.test.NoRetryException;
 import org.apache.kafka.test.TestUtils;
 
 import org.junit.jupiter.api.AfterEach;
@@ -74,6 +79,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.IntFunction;
 import java.util.stream.Collectors;
 
@@ -96,6 +102,7 @@ import static org.apache.kafka.common.config.TopicConfig.DISKLESS_ENABLE_CONFIG;
 import static org.apache.kafka.common.config.TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG;
 import static org.apache.kafka.common.config.TopicConfig.SEGMENT_BYTES_CONFIG;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 @Testcontainers
 public class InklessConsolidatedDisklessTopicsTest {
@@ -138,6 +145,8 @@ public class InklessConsolidatedDisklessTopicsTest {
             // Enable managed replicas with RF=2 (one replica per AZ)
             .setConfigProp(ServerConfigs.DISKLESS_MANAGED_REPLICAS_ENABLE_CONFIG, "true")
             .setConfigProp(ReplicationConfigs.DEFAULT_REPLICATION_FACTOR_CONFIG, "2")
+            // Allow enabling diskless on an already existing (classic) topic, i.e. classic -> diskless migration
+            .setConfigProp(ServerConfigs.DISKLESS_ALLOW_FROM_CLASSIC_ENABLE_CONFIG, "true")
             // Enable diskless topic consolidation (diskless.enable + remote.storage.enable on new topics)
             .setConfigProp(ServerConfigs.DISKLESS_REMOTE_STORAGE_CONSOLIDATION_ENABLE_CONFIG, "true")
             // Run consolidated diskless WAL pruning frequently enough for the test wait windows
@@ -262,6 +271,181 @@ public class InklessConsolidatedDisklessTopicsTest {
         waitUntilTieredDisklessDataPrunedFromControlPlane(topicUuid, beforeConsumeSnapshot);
 
         consumeAndVerify(commonConfigs, recordsToSendAndReceive);
+    }
+
+    @Test
+    public void testClassicToDisklessToConsolidatedTopics() throws Exception {
+        Map<String, Object> commonConfigs = new HashMap<>();
+        commonConfigs.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers());
+
+        // Records produced into the topic as a classic topic, before any migration.
+        final int preMigrationRecords = 10;
+        // Records produced concurrently while the topic is being consolidated.
+        final int duringConsolidationRecords = 50;
+        final int totalRecords = preMigrationRecords + duringConsolidationRecords;
+        // Large values to force segment rolls so the consolidated WAL is actually tiered to remote storage.
+        final IntFunction<ProducerRecord<String, String>> recordFactory = i ->
+            new ProducerRecord<>(topicName, i % numPartitions, null, TestUtils.randomString(104_857));
+
+        final Uuid topicUuid;
+        try (Admin admin = AdminClient.create(commonConfigs)) {
+            // Phase 1: create a CLASSIC topic (diskless.enable=false, remote.storage.enable=false).
+            topicUuid = createClassicTopic(admin);
+            assertEquals("false", getTopicConfigValue(admin, DISKLESS_ENABLE_CONFIG),
+                "Topic should start as a classic (non-diskless) topic");
+            assertEquals("false", getTopicConfigValue(admin, REMOTE_LOG_STORAGE_ENABLE_CONFIG),
+                "Classic topic should not have remote storage enabled");
+
+            // Produce a baseline of records into the classic topic. These offsets form the classic
+            // prefix that must remain readable after the topic is migrated and consolidated.
+            produceRecords(commonConfigs, preMigrationRecords, recordFactory);
+
+            // Phase 2: migrate the classic topic to diskless. With the consolidation flag enabled at the
+            // broker level the alter path does NOT auto-enable remote storage, so the topic becomes a
+            // plain (non-consolidated) diskless topic at this point.
+            log.info("Migrating classic topic {} to diskless", topicName);
+            incrementalAlterTopicConfigs(admin, Map.of(DISKLESS_ENABLE_CONFIG, "true"));
+            waitForTopicConfigValue(admin, DISKLESS_ENABLE_CONFIG, "true");
+            assertEquals("false", getTopicConfigValue(admin, REMOTE_LOG_STORAGE_ENABLE_CONFIG),
+                "Diskless topic should not be consolidated yet (remote storage still disabled)");
+
+            // Phase 3: consolidate the diskless topic (remote.storage.enable=true) while a producer keeps
+            // sending records to it. The producer runs on a background thread so its sends overlap both the
+            // config change and the background consolidation (WAL -> tiered storage) that follows.
+            final AtomicReference<Throwable> producerFailure = new AtomicReference<>(null);
+            final Thread producerThread = new Thread(() -> {
+                try {
+                    produceRecords(commonConfigs, duringConsolidationRecords, recordFactory);
+                } catch (Throwable t) {
+                    producerFailure.set(t);
+                }
+            }, "consolidation-producer");
+            producerThread.setDaemon(true);
+
+            producerThread.start();
+            try {
+                log.info("Consolidating diskless topic {} (enabling remote storage)", topicName);
+                incrementalAlterTopicConfigs(admin, Map.of(REMOTE_LOG_STORAGE_ENABLE_CONFIG, "true"));
+                waitForTopicConfigValue(admin, REMOTE_LOG_STORAGE_ENABLE_CONFIG, "true");
+            } finally {
+                producerThread.join(TimeUnit.SECONDS.toMillis(120));
+                // If the producer is still running (e.g. a send blocked), interrupt it so it unwinds
+                // instead of lingering. produceRecords propagates the interrupt and closes the producer.
+                if (producerThread.isAlive()) {
+                    producerThread.interrupt();
+                    producerThread.join(TimeUnit.SECONDS.toMillis(10));
+                }
+            }
+            assertFalse(producerThread.isAlive(), "Producer thread did not finish in time");
+            if (producerFailure.get() != null) {
+                throw new RuntimeException("Producer failed while the topic was being consolidated", producerFailure.get());
+            }
+
+            assertEquals("true", getTopicConfigValue(admin, DISKLESS_ENABLE_CONFIG),
+                "Topic should remain diskless after consolidation");
+            assertEquals("true", getTopicConfigValue(admin, REMOTE_LOG_STORAGE_ENABLE_CONFIG),
+                "Topic should be consolidated (remote storage enabled) after the alter");
+        }
+
+        // Consolidation copies the diskless WAL data into Kafka tiered storage; wait until at least one
+        // object lands in the bucket as evidence that consolidation made progress.
+        try (S3Client s3 = s3Container.getS3Client()) {
+            final String bucket = s3Container.getBucketName();
+            TestUtils.waitForCondition(() -> countObjectsWithPrefix(s3, bucket, RSM_OBJECT_KEY_PREFIX) > 0,
+                120_000,
+                () -> "Expected at least one tiered object in the Minio bucket after consolidation");
+        }
+
+        ControlPlaneDisklessSnapshot beforeConsumeSnapshot = readControlPlaneDisklessSnapshot(topicUuid);
+        log.info("Control plane snapshot before first consume: {}", beforeConsumeSnapshot);
+
+        // Everything (classic prefix + consolidated diskless records) must be readable from the beginning.
+        assertBrokerEarliestOffsetsEqual(commonConfigs, 0L,
+            "after consolidation (expect full 0..N-1 readable with auto.offset.reset=earliest)");
+
+        consumeAndVerify(commonConfigs, totalRecords);
+
+        // Once the consolidated WAL has been tiered and pruned, the same data must still be fully readable.
+        waitUntilTieredDisklessDataPrunedFromControlPlane(topicUuid, beforeConsumeSnapshot);
+
+        consumeAndVerify(commonConfigs, totalRecords);
+    }
+
+    private Uuid createClassicTopic(Admin admin) throws Exception {
+        // Create the topic as a classic topic by relying on the broker defaults (diskless.enable=false,
+        // remote.storage.enable=false). Setting both keys explicitly at creation time — even to false —
+        // trips the diskless/remote-storage mutual-exclusion validation, so we deliberately omit them.
+        final Map<String, String> classicConfigs = Map.of(
+            CLEANUP_POLICY_CONFIG, CLEANUP_POLICY_DELETE,
+            SEGMENT_BYTES_CONFIG, "1048576"
+        );
+        final NewTopic topic = new NewTopic(topicName, numPartitions, (short) -1).configs(classicConfigs);
+        admin.createTopics(Collections.singletonList(topic)).all().get(30, TimeUnit.SECONDS);
+
+        final TopicDescription[] descriptionHolder = new TopicDescription[1];
+        TestUtils.waitForCondition(() -> {
+            try {
+                descriptionHolder[0] = admin.describeTopics(Collections.singletonList(topicName))
+                    .allTopicNames().get(30, TimeUnit.SECONDS).get(topicName);
+                return descriptionHolder[0].partitions().size() == numPartitions;
+            } catch (ExecutionException e) {
+                if (e.getCause() instanceof UnknownTopicOrPartitionException) {
+                    return false;
+                }
+                throw new RuntimeException(e);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            }
+        }, 60_000, () -> "Classic topic should become visible with " + numPartitions + " partitions");
+        return descriptionHolder[0].topicId();
+    }
+
+    private void incrementalAlterTopicConfigs(Admin admin, Map<String, String> configs)
+        throws ExecutionException, InterruptedException, TimeoutException {
+        final ConfigResource resource = new ConfigResource(ConfigResource.Type.TOPIC, topicName);
+        final List<AlterConfigOp> ops = configs.entrySet().stream()
+            .map(e -> new AlterConfigOp(new ConfigEntry(e.getKey(), e.getValue()), AlterConfigOp.OpType.SET))
+            .collect(Collectors.toList());
+        admin.incrementalAlterConfigs(Map.of(resource, ops)).all().get(30, TimeUnit.SECONDS);
+    }
+
+    private String getTopicConfigValue(Admin admin, String key)
+        throws ExecutionException, InterruptedException, TimeoutException {
+        final ConfigResource resource = new ConfigResource(ConfigResource.Type.TOPIC, topicName);
+        // Shorter timeout because this is invoked from polling loops (waitForTopicConfigValue).
+        final Config config = admin.describeConfigs(Collections.singletonList(resource))
+            .all().get(10, TimeUnit.SECONDS)
+            .get(resource);
+        if (config == null) {
+            throw new IllegalStateException("describeConfigs returned no config for topic " + topicName);
+        }
+        final ConfigEntry entry = config.get(key);
+        if (entry == null) {
+            throw new IllegalStateException("Config '" + key + "' is missing for topic " + topicName);
+        }
+        return entry.value();
+    }
+
+    private void waitForTopicConfigValue(Admin admin, String key, String expectedValue) throws InterruptedException {
+        TestUtils.waitForCondition(() -> {
+            try {
+                return expectedValue.equals(getTopicConfigValue(admin, key));
+            } catch (ExecutionException e) {
+                // Right after create/alter the topic metadata may not have propagated to the broker serving
+                // the describeConfigs request yet; that is the only case worth retrying.
+                if (e.getCause() instanceof UnknownTopicOrPartitionException) {
+                    return false;
+                }
+                throw new NoRetryException(e.getCause() != null ? e.getCause() : e);
+            } catch (TimeoutException e) {
+                // A describeConfigs request timing out is transient under load; keep polling.
+                return false;
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new NoRetryException(e);
+            }
+        }, 60_000, () -> "Topic config " + key + " should become " + expectedValue);
     }
 
     /**

--- a/core/src/test/java/kafka/server/InklessTopicTypeSwitcherClusterTest.java
+++ b/core/src/test/java/kafka/server/InklessTopicTypeSwitcherClusterTest.java
@@ -34,6 +34,7 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.config.TopicConfig;
+import org.apache.kafka.common.errors.InvalidConfigurationException;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.AlterConfigsRequest;
@@ -49,6 +50,7 @@ import org.apache.kafka.server.log.remote.storage.RemoteLogManagerConfig;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -82,6 +84,8 @@ import io.aiven.inkless.test_utils.PostgreSQLTestContainer;
 import io.aiven.inkless.test_utils.S3TestContainer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Testcontainers
@@ -398,6 +402,39 @@ public class InklessTopicTypeSwitcherClusterTest {
         admin.incrementalAlterConfigs(Map.of(topicResource, operations)).all().get(20, TimeUnit.SECONDS);
     }
 
+    @Test
+    public void testSwitchRejectedWhenPartitionIsOfflineOrUnderReplicated() throws Exception {
+        final String topic = "switch-unhealthy-" + UUID.randomUUID().toString().substring(0, 8);
+
+        try (Admin admin = AdminClient.create(baseClientConfigs())) {
+            // Create a classic topic with RF=3
+            admin.createTopics(List.of(
+                new NewTopic(topic, 1, (short) 3)
+                    .configs(Map.of(TopicConfig.DISKLESS_ENABLE_CONFIG, "false"))
+            )).all().get(30, TimeUnit.SECONDS);
+
+            // Shut down a broker to make the partition under-replicated
+            final int brokerToShutdown = 2;
+            cluster.brokers().get(brokerToShutdown).shutdown();
+            waitForIsrShrink(admin, topic, 0, 3);
+
+            // Attempt to switch to diskless (should fail with INVALID_CONFIG due to under-replication)
+            final ExecutionException ex = assertThrows(ExecutionException.class, () ->
+                alterTopicConfigWithIncrementalAlterConfigs(admin, topic, Map.of(TopicConfig.DISKLESS_ENABLE_CONFIG, "true")));
+            assertInstanceOf(InvalidConfigurationException.class, ex.getCause());
+            assertTrue(ex.getCause().getMessage().contains("under-replicated"),
+                "Expected 'under-replicated' in: " + ex.getCause().getMessage());
+
+            // Restart the broker and wait for ISR to recover
+            cluster.brokers().get(brokerToShutdown).startup();
+            waitForIsrRecovery(admin, topic, 0, 3);
+
+            // Now the switch should succeed
+            alterTopicConfigWithIncrementalAlterConfigs(admin, topic, Map.of(TopicConfig.DISKLESS_ENABLE_CONFIG, "true"));
+            assertEquals("true", getTopicConfig(admin, topic).get(TopicConfig.DISKLESS_ENABLE_CONFIG));
+        }
+    }
+
     private void alterTopicConfigWithLegacyAlterConfigs(final String topic,
                                                        final Map<String, String> newConfigs) throws Exception {
         final ConfigResource topicResource = new ConfigResource(ConfigResource.Type.TOPIC, topic);
@@ -416,6 +453,38 @@ public class InklessTopicTypeSwitcherClusterTest {
         final var apiError = response.errors().get(topicResource);
         assertTrue(apiError != null, "Legacy AlterConfigs response did not contain topic resource " + topicResource);
         assertEquals(Errors.NONE, apiError.error(), "Legacy AlterConfigs failed: " + apiError.message());
+    }
+
+    private void waitForIsrShrink(final Admin admin, final String topic,
+                                   final int partition, final int maxIsrSize) throws Exception {
+        final long deadline = System.currentTimeMillis() + Duration.ofSeconds(30).toMillis();
+        while (System.currentTimeMillis() < deadline) {
+            final var description = admin.describeTopics(List.of(topic)).allTopicNames()
+                .get(10, TimeUnit.SECONDS).get(topic);
+            final int isrSize = description.partitions().get(partition).isr().size();
+            if (isrSize < maxIsrSize) {
+                return;
+            }
+            Thread.sleep(200);
+        }
+        throw new AssertionError("ISR for " + topic + "-" + partition +
+            " did not shrink below " + maxIsrSize + " within timeout");
+    }
+
+    private void waitForIsrRecovery(final Admin admin, final String topic,
+                                    final int partition, final int expectedIsrSize) throws Exception {
+        final long deadline = System.currentTimeMillis() + Duration.ofSeconds(60).toMillis();
+        while (System.currentTimeMillis() < deadline) {
+            final var description = admin.describeTopics(List.of(topic)).allTopicNames()
+                .get(10, TimeUnit.SECONDS).get(topic);
+            final int isrSize = description.partitions().get(partition).isr().size();
+            if (isrSize >= expectedIsrSize) {
+                return;
+            }
+            Thread.sleep(200);
+        }
+        throw new AssertionError("ISR for " + topic + "-" + partition +
+            " did not recover to " + expectedIsrSize + " within timeout");
     }
 
     private Map<String, String> getTopicConfig(final Admin admin, final String topic) throws Exception {

--- a/core/src/test/scala/io/aiven/inkless/consolidation/ConsolidationFetcherThreadTest.scala
+++ b/core/src/test/scala/io/aiven/inkless/consolidation/ConsolidationFetcherThreadTest.scala
@@ -18,6 +18,7 @@
 
 package io.aiven.inkless.consolidation
 
+import io.aiven.inkless.consume.{ConcatenatedRecords, FetchHandler, FetchOffsetHandler}
 import kafka.cluster.Partition
 import kafka.server._
 import kafka.server.metadata.InklessMetadataView
@@ -25,17 +26,19 @@ import kafka.utils.TestUtils
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.compress.Compression
 import org.apache.kafka.common.message.FetchResponseData
-import org.apache.kafka.common.record.{MemoryRecords, SimpleRecord}
+import org.apache.kafka.common.record.{BaseRecords, MemoryRecords, SimpleRecord}
 import org.apache.kafka.metadata.PartitionRegistration
 import org.apache.kafka.server.LeaderEndPoint
+import org.apache.kafka.server.common.{MetadataVersion, OffsetAndEpoch}
 import org.apache.kafka.server.network.BrokerEndPoint
 import org.apache.kafka.server.metrics.KafkaYammerMetrics
 import org.apache.kafka.storage.internals.log.{LogAppendInfo, UnifiedLog}
 import org.apache.kafka.storage.log.metrics.BrokerTopicStats
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
+import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.{any, anyLong}
-import org.mockito.Mockito.{mock, when}
+import org.mockito.Mockito.{RETURNS_DEEP_STUBS, doNothing, mock, verify, when}
 
 import java.nio.charset.StandardCharsets
 import java.util.Optional
@@ -122,6 +125,153 @@ class ConsolidationFetcherThreadTest {
       .setRecords(records)
       .setHighWatermark(highWatermark)
       .setLogStartOffset(0)
+  }
+
+  private def recordsWithEpoch(baseOffset: Long, epoch: Int, value: String): MemoryRecords =
+    MemoryRecords.withRecords(baseOffset, Compression.NONE, epoch,
+      new SimpleRecord(1000, value.getBytes(StandardCharsets.UTF_8)))
+
+  private def partitionDataWith(records: BaseRecords): FetchResponseData.PartitionData =
+    new FetchResponseData.PartitionData()
+      .setPartitionIndex(topicPartition.partition)
+      .setRecords(records)
+      .setHighWatermark(10L)
+      .setLogStartOffset(0)
+
+  // Capture the records actually appended to the local log and return each batch's leader epoch.
+  private def appendedBatchEpochs(partition: Partition): List[Int] = {
+    val captor = ArgumentCaptor.forClass(classOf[MemoryRecords])
+    verify(partition).appendRecordsToFollowerOrFutureReplica(captor.capture(), any[Boolean], any[Int])
+    captor.getValue.batches().asScala.map(_.partitionLeaderEpoch).toList
+  }
+
+  @Test
+  def testStampsDisklessLeaderEpochOnConcatenatedRecords(): Unit = {
+    val disklessLeaderEpoch = 7
+    val partition = mockPartitionWithLog(logEndOffset = 0L, highestOffsetInRemoteStorage = -1L)
+    val replicaManager = mockReplicaManager(partition)
+    when(replicaManager.disklessLeaderEpoch(any[TopicPartition])).thenReturn(disklessLeaderEpoch)
+    val thread = createConsolidationFetcherThread(replicaManager, None)
+
+    val records = new ConcatenatedRecords(java.util.List.of(
+      recordsWithEpoch(0L, 0, "a"),
+      recordsWithEpoch(1L, 0, "b")
+    ))
+
+    thread.processPartitionData(topicPartition, 0L, Int.MaxValue, partitionDataWith(records))
+
+    assertEquals(List(disklessLeaderEpoch, disklessLeaderEpoch), appendedBatchEpochs(partition))
+  }
+
+  @Test
+  def testStampsDisklessLeaderEpochOnMemoryRecords(): Unit = {
+    val disklessLeaderEpoch = 7
+    val partition = mockPartitionWithLog(logEndOffset = 0L, highestOffsetInRemoteStorage = -1L)
+    val replicaManager = mockReplicaManager(partition)
+    when(replicaManager.disklessLeaderEpoch(any[TopicPartition])).thenReturn(disklessLeaderEpoch)
+    val thread = createConsolidationFetcherThread(replicaManager, None)
+
+    thread.processPartitionData(topicPartition, 0L, Int.MaxValue, partitionDataWith(recordsWithEpoch(0L, 0, "a")))
+
+    assertEquals(List(disklessLeaderEpoch), appendedBatchEpochs(partition))
+  }
+
+  @Test
+  def testBornDisklessLeavesEpochUntouched(): Unit = {
+    val partition = mockPartitionWithLog(logEndOffset = 0L, highestOffsetInRemoteStorage = -1L)
+    val replicaManager = mockReplicaManager(partition)
+    when(replicaManager.disklessLeaderEpoch(any[TopicPartition]))
+      .thenReturn(PartitionRegistration.NO_DISKLESS_LEADER_EPOCH)
+    val thread = createConsolidationFetcherThread(replicaManager, None)
+
+    thread.processPartitionData(topicPartition, 0L, Int.MaxValue, partitionDataWith(recordsWithEpoch(0L, 0, "a")))
+
+    // The guard short-circuits: had stamping run with E_d == -1 it would have written -1, not left 0.
+    assertEquals(List(0), appendedBatchEpochs(partition))
+  }
+
+  /**
+   * Scenario: a partition switched classic->diskless at seal offset 100 with a diskless leader epoch
+   * E_d=5 captured at the switch. After a leader failover this follower still has a STALE classic tail past the seal:
+   * its local log runs to LEO 130 and its latest local epoch is a classic epoch (2 < E_d). The
+   * diskless region [100, ...) on the (new) diskless leader is authoritative, so the follower must
+   * truncate its divergent tail back to the seal.
+   */
+  @Test
+  def testFollowerTruncatesStaleClassicTailToSealAfterFailover(): Unit = {
+    val seal = 100L
+    val disklessLeaderEpoch = 5
+    val staleClassicEpoch = 2
+    val divergentLeo = 130L
+
+    val log = mock(classOf[UnifiedLog])
+    when(log.latestEpoch).thenReturn(Optional.of(Int.box(staleClassicEpoch)))
+    when(log.logStartOffset).thenReturn(0L)
+    when(log.logEndOffset).thenReturn(divergentLeo)
+    when(log.endOffsetForEpoch(staleClassicEpoch))
+      .thenReturn(Optional.of(new OffsetAndEpoch(divergentLeo, staleClassicEpoch)))
+
+    val partition = mock(classOf[Partition])
+
+    // Deep stubs so the truncation-complete callback (replicaAlterLogDirsManager.markPartitionsForTruncation,
+    // a kafka.server-private member we cannot reference from here) is auto-stubbed to a no-op.
+    val replicaManager = mock(classOf[ReplicaManager], RETURNS_DEEP_STUBS)
+    when(replicaManager.localLogOrException(topicPartition)).thenReturn(log)
+    when(replicaManager.getPartitionOrException(topicPartition)).thenReturn(partition)
+    when(replicaManager.brokerTopicStats).thenReturn(new BrokerTopicStats)
+    // Committed metadata for the switched partition: seal at 100, captured diskless epoch E_d=5.
+    when(replicaManager.classicToDisklessStartOffset(topicPartition)).thenReturn(seal)
+    when(replicaManager.disklessLeaderEpoch(topicPartition)).thenReturn(disklessLeaderEpoch)
+
+    // Real diskless leader endpoint backing OffsetsForLeaderEpoch for the consolidating follower.
+    val fetchHandler = mock(classOf[FetchHandler])
+    val fetchOffsetHandler = mock(classOf[FetchOffsetHandler])
+    val job = mock(classOf[FetchOffsetHandler.Job])
+    when(fetchOffsetHandler.createJob()).thenReturn(job)
+    when(job.mustHandle(topicPartition.topic())).thenReturn(true)
+    doNothing().when(job).start()
+
+    val brokerEndPoint = new BrokerEndPoint(0, "localhost", 9092)
+    // Quota "exceeded" so the post-truncation fetch round (buildFetch) is a no-op and the test stays
+    // focused on truncation.
+    val endpointQuota = mock(classOf[ReplicaQuota])
+    when(endpointQuota.isQuotaExceeded).thenReturn(true)
+
+    val props = TestUtils.createBrokerConfig(nodeId = 1)
+    props.put("replica.fetch.backoff.ms", "1")
+    val config = KafkaConfig.fromProps(props)
+
+    val endpoint = new DisklessLeaderEndPoint(
+      brokerEndPoint,
+      fetchHandler,
+      fetchOffsetHandler,
+      replicaManager,
+      config,
+      endpointQuota,
+      () => MetadataVersion.LATEST_PRODUCTION,
+      () => 1L
+    )
+
+    val thread = new ConsolidationFetcherThread(
+      "consolidation-fetcher-truncation-test",
+      endpoint,
+      config,
+      failedPartitions,
+      replicaManager,
+      QuotaFactory.UNBOUNDED_QUOTA,
+      "[ConsolidationFetcherTruncationTest] ",
+      None
+    )
+
+    // Follower joins the consolidation fetcher in the Truncating phase (isTruncationOnFetchSupported=false).
+    thread.addPartitions(Map(
+      topicPartition -> InitialFetchState(None, brokerEndPoint, currentLeaderEpoch = 8, initOffset = divergentLeo)
+    ))
+
+    thread.doWork()
+
+    // The stale tail [seal, LEO) is truncated away: the follower truncates back to the committed seal.
+    verify(partition).truncateTo(seal, isFuture = false)
   }
 
   @Test

--- a/core/src/test/scala/io/aiven/inkless/consolidation/DisklessLeaderEndPointTest.scala
+++ b/core/src/test/scala/io/aiven/inkless/consolidation/DisklessLeaderEndPointTest.scala
@@ -363,6 +363,112 @@ class DisklessLeaderEndPointTest {
   }
 
   @Test
+  def testFetchEpochEndOffsetsBelowDisklessEpochReturnsSeal(): Unit = {
+    val fetchHandler = mock(classOf[FetchHandler])
+    val fetchOffsetHandler = mock(classOf[FetchOffsetHandler])
+    val replicaManager = mock(classOf[ReplicaManager])
+    val job = mock(classOf[FetchOffsetHandler.Job])
+
+    when(fetchOffsetHandler.createJob()).thenReturn(job)
+    when(job.mustHandle(topicPartition.topic())).thenReturn(true)
+    doNothing().when(job).start()
+    // Switched partition: classic prefix ends at the seal (100), diskless region carries epoch 5.
+    when(replicaManager.classicToDisklessStartOffset(topicPartition)).thenReturn(100L)
+    when(replicaManager.disklessLeaderEpoch(topicPartition)).thenReturn(5)
+
+    val endPoint = newEndPoint(fetchHandler, fetchOffsetHandler, replicaManager)
+    // A classic-prefix epoch (3 < 5) must resolve to the seal, without a diskless list-offsets call.
+    val queriedEpoch = 3
+    val result = endPoint.fetchEpochEndOffsets(
+      util.Map.of(
+        topicPartition,
+        new OffsetForLeaderPartition()
+          .setPartition(topicPartition.partition)
+          .setLeaderEpoch(queriedEpoch)
+      )
+    ).asScala
+
+    val expected = new EpochEndOffset()
+      .setPartition(topicPartition.partition)
+      .setErrorCode(Errors.NONE.code)
+      .setLeaderEpoch(queriedEpoch)
+      .setEndOffset(100L)
+    assertEquals(Map(topicPartition -> expected), result)
+    verify(job, org.mockito.Mockito.never()).add(eqTo(topicPartition), any())
+  }
+
+  @Test
+  def testFetchEpochEndOffsetsAtOrAboveDisklessEpochReturnsDisklessLeo(): Unit = {
+    val fetchHandler = mock(classOf[FetchHandler])
+    val fetchOffsetHandler = mock(classOf[FetchOffsetHandler])
+    val replicaManager = mock(classOf[ReplicaManager])
+    val job = mock(classOf[FetchOffsetHandler.Job])
+
+    val holder = new FileRecordsOrError(
+      Optional.empty(),
+      Optional.of(new TimestampAndOffset(0L, 250L, Optional.of(5)))
+    )
+    when(fetchOffsetHandler.createJob()).thenReturn(job)
+    when(job.mustHandle(topicPartition.topic())).thenReturn(true)
+    when(job.add(eqTo(topicPartition), any())).thenReturn(CompletableFuture.completedFuture(holder))
+    when(replicaManager.classicToDisklessStartOffset(topicPartition)).thenReturn(100L)
+    when(replicaManager.disklessLeaderEpoch(topicPartition)).thenReturn(5)
+
+    val endPoint = newEndPoint(fetchHandler, fetchOffsetHandler, replicaManager)
+    // The diskless epoch itself (5 >= 5) resolves to the current diskless LEO.
+    val queriedEpoch = 5
+    val result = endPoint.fetchEpochEndOffsets(
+      util.Map.of(
+        topicPartition,
+        new OffsetForLeaderPartition()
+          .setPartition(topicPartition.partition)
+          .setLeaderEpoch(queriedEpoch)
+      )
+    ).asScala
+
+    val expected = new EpochEndOffset()
+      .setPartition(topicPartition.partition)
+      .setErrorCode(Errors.NONE.code)
+      .setLeaderEpoch(queriedEpoch)
+      .setEndOffset(250L)
+    assertEquals(Map(topicPartition -> expected), result)
+  }
+
+  @Test
+  def testFetchEpochEndOffsetsBornDisklessReturnsDisklessLeo(): Unit = {
+    val fetchHandler = mock(classOf[FetchHandler])
+    val fetchOffsetHandler = mock(classOf[FetchOffsetHandler])
+    val replicaManager = mock(classOf[ReplicaManager])
+    val job = mock(classOf[FetchOffsetHandler.Job])
+
+    val holder = new FileRecordsOrError(
+      Optional.empty(),
+      Optional.of(new TimestampAndOffset(0L, 42L, Optional.of(0)))
+    )
+    when(fetchOffsetHandler.createJob()).thenReturn(job)
+    when(job.mustHandle(topicPartition.topic())).thenReturn(true)
+    when(job.add(eqTo(topicPartition), any())).thenReturn(CompletableFuture.completedFuture(holder))
+    // Born-diskless / never switched: no classic seal and no captured diskless epoch.
+    when(replicaManager.classicToDisklessStartOffset(topicPartition))
+      .thenReturn(org.apache.kafka.metadata.PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET)
+    when(replicaManager.disklessLeaderEpoch(topicPartition))
+      .thenReturn(org.apache.kafka.metadata.PartitionRegistration.NO_DISKLESS_LEADER_EPOCH)
+
+    val endPoint = newEndPoint(fetchHandler, fetchOffsetHandler, replicaManager)
+    val result = endPoint.fetchEpochEndOffsets(
+      util.Map.of(
+        topicPartition,
+        new OffsetForLeaderPartition()
+          .setPartition(topicPartition.partition)
+          .setLeaderEpoch(0)
+      )
+    ).asScala
+
+    assertEquals(42L, result(topicPartition).endOffset)
+    assertEquals(Errors.NONE.code, result(topicPartition).errorCode)
+  }
+
+  @Test
   def testFetchEpochEndOffsetsHolderException(): Unit = {
     val fetchHandler = mock(classOf[FetchHandler])
     val fetchOffsetHandler = mock(classOf[FetchOffsetHandler])

--- a/core/src/test/scala/kafka/server/metadata/InklessMetadataViewTest.scala
+++ b/core/src/test/scala/kafka/server/metadata/InklessMetadataViewTest.scala
@@ -19,7 +19,9 @@
 package kafka.server.metadata
 
 import org.apache.kafka.common.config.TopicConfig
-import org.apache.kafka.common.{TopicIdPartition, Uuid}
+import org.apache.kafka.common.{DirectoryId, TopicIdPartition, TopicPartition, Uuid}
+import org.apache.kafka.image.{MetadataImage, TopicImage, TopicsImage}
+import org.apache.kafka.metadata.{LeaderRecoveryState, PartitionRegistration}
 import org.junit.jupiter.api.{BeforeEach, Nested, Test}
 import org.junit.jupiter.api.Assertions._
 import org.mockito.ArgumentMatchers.anyString
@@ -214,6 +216,84 @@ class InklessMetadataViewTest {
     diskless.foreach(v => props.put(TopicConfig.DISKLESS_ENABLE_CONFIG, v))
     remoteStorageEnable.foreach(v => props.put(TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG, v))
     props
+  }
+
+  private def partitionRegistration(disklessLeaderEpoch: Option[Int] = None, seal: Option[Long] = None): PartitionRegistration = {
+    val builder = new PartitionRegistration.Builder()
+      .setReplicas(Array(1))
+      .setDirectories(DirectoryId.unassignedArray(1))
+      .setIsr(Array(1))
+      .setLeader(1)
+      .setLeaderRecoveryState(LeaderRecoveryState.RECOVERED)
+      .setLeaderEpoch(3)
+      .setPartitionEpoch(0)
+    disklessLeaderEpoch.foreach(builder.setDisklessLeaderEpoch)
+    seal.foreach(builder.setClassicToDisklessStartOffset)
+    builder.build()
+  }
+
+  // Wires metadataCache.currentImage().topics().getTopic(topic) -> topicImage holding the given partitions.
+  private def stubImageTopic(topic: String, partitions: util.Map[Integer, PartitionRegistration]): Unit = {
+    val image = mock(classOf[MetadataImage])
+    val topicsImage = mock(classOf[TopicsImage])
+    val topicImage = mock(classOf[TopicImage])
+    when(metadataCache.currentImage()).thenReturn(image)
+    when(image.topics()).thenReturn(topicsImage)
+    when(topicsImage.getTopic(topic)).thenReturn(topicImage)
+    when(topicImage.partitions()).thenReturn(partitions)
+  }
+
+  // Wires metadataCache.currentImage().topics().getTopic(topic) -> null (topic absent from the image).
+  private def stubImageWithoutTopic(topic: String): Unit = {
+    val image = mock(classOf[MetadataImage])
+    val topicsImage = mock(classOf[TopicsImage])
+    when(metadataCache.currentImage()).thenReturn(image)
+    when(image.topics()).thenReturn(topicsImage)
+    when(topicsImage.getTopic(topic)).thenReturn(null.asInstanceOf[TopicImage])
+  }
+
+  @Test
+  def testGetDisklessLeaderEpochReturnsValueFromImage(): Unit = {
+    val tp = new TopicPartition("switched", 0)
+    stubImageTopic(tp.topic(), util.Map.of(Integer.valueOf(0), partitionRegistration(disklessLeaderEpoch = Some(7))))
+    assertEquals(7, metadataView.getDisklessLeaderEpoch(tp))
+  }
+
+  @Test
+  def testGetDisklessLeaderEpochReturnsSentinelWhenUnset(): Unit = {
+    // Born-diskless / never-switched partition carries no diskless epoch.
+    val tp = new TopicPartition("born-diskless", 0)
+    stubImageTopic(tp.topic(), util.Map.of(Integer.valueOf(0), partitionRegistration()))
+    assertEquals(PartitionRegistration.NO_DISKLESS_LEADER_EPOCH, metadataView.getDisklessLeaderEpoch(tp))
+  }
+
+  @Test
+  def testGetDisklessLeaderEpochReturnsSentinelWhenTopicMissing(): Unit = {
+    val tp = new TopicPartition("missing", 0)
+    stubImageWithoutTopic(tp.topic())
+    assertEquals(PartitionRegistration.NO_DISKLESS_LEADER_EPOCH, metadataView.getDisklessLeaderEpoch(tp))
+  }
+
+  @Test
+  def testGetDisklessLeaderEpochReturnsSentinelWhenPartitionMissing(): Unit = {
+    val tp = new TopicPartition("switched", 1)
+    // Topic present, but only partition 0 exists in the image.
+    stubImageTopic(tp.topic(), util.Map.of(Integer.valueOf(0), partitionRegistration(disklessLeaderEpoch = Some(7))))
+    assertEquals(PartitionRegistration.NO_DISKLESS_LEADER_EPOCH, metadataView.getDisklessLeaderEpoch(tp))
+  }
+
+  @Test
+  def testGetClassicToDisklessStartOffsetReturnsValueFromImage(): Unit = {
+    val tp = new TopicPartition("switched", 0)
+    stubImageTopic(tp.topic(), util.Map.of(Integer.valueOf(0), partitionRegistration(seal = Some(42L))))
+    assertEquals(42L, metadataView.getClassicToDisklessStartOffset(tp))
+  }
+
+  @Test
+  def testGetClassicToDisklessStartOffsetReturnsSentinelWhenTopicMissing(): Unit = {
+    val tp = new TopicPartition("missing", 0)
+    stubImageWithoutTopic(tp.topic())
+    assertEquals(PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET, metadataView.getClassicToDisklessStartOffset(tp))
   }
 
   @Nested

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerInklessTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerInklessTest.scala
@@ -139,6 +139,33 @@ class ReplicaManagerInklessTest {
   }
 
   @Test
+  def testDisklessLeaderEpochDelegatesToMetadataView(): Unit = {
+    val replicaManager = createReplicaManager(List(disklessTopicPartition.topic()))
+    try {
+      when(replicaManager.inklessMetadataView().getDisklessLeaderEpoch(disklessTopicPartition.topicPartition()))
+        .thenReturn(7)
+
+      assertEquals(7, replicaManager.disklessLeaderEpoch(disklessTopicPartition.topicPartition()))
+      verify(replicaManager.inklessMetadataView()).getDisklessLeaderEpoch(disklessTopicPartition.topicPartition())
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
+  def testClassicToDisklessStartOffsetDelegatesToMetadataView(): Unit = {
+    val replicaManager = createReplicaManager(List(disklessTopicPartition.topic()))
+    try {
+      when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
+        .thenReturn(42L)
+
+      assertEquals(42L, replicaManager.classicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
   def testAppendValidDisklessAndInvalidClassic(): Unit = {
     val entriesPerPartition = Map(
       disklessTopicPartition -> RECORDS,

--- a/docs/inkless/SYSTEM_TESTS.md
+++ b/docs/inkless/SYSTEM_TESTS.md
@@ -27,7 +27,7 @@ This creates:
 - `ducker02` through `ducker11` -- worker nodes where Kafka brokers, producers, and consumers run
 
 **How many nodes?** The number must be at least 1 + the `@cluster(num_nodes=N)` declared in the test.
-The inkless topic migration tests declare up to `@cluster(num_nodes=10)`, so 11 total nodes is the minimum.
+The inkless topic switch tests declare up to `@cluster(num_nodes=10)`, so 11 total nodes is the minimum.
 The upstream default of 14 covers the entire Kafka test suite; for inkless tests alone, 11 is sufficient.
 
 ### 2. Start Postgres on the ducker network
@@ -69,31 +69,31 @@ docker run --rm --network ducknet --entrypoint /bin/sh quay.io/minio/mc -c '
 Run a specific test file:
 
 ```shell
-bash tests/docker/ducker-ak test tests/kafkatest/tests/inkless/inkless_topic_migration_test.py
+bash tests/docker/ducker-ak test tests/kafkatest/tests/inkless/inkless_topic_switch_test.py
 ```
 
 Run a specific test class:
 
 ```shell
-bash tests/docker/ducker-ak test tests/kafkatest/tests/inkless/inkless_topic_migration_test.py::InklessTopicMigrationTest
+bash tests/docker/ducker-ak test tests/kafkatest/tests/inkless/inkless_topic_switch_test.py::InklessClassicToDisklessSwitchTest
 ```
 
 Run a specific test method:
 
 ```shell
-bash tests/docker/ducker-ak test tests/kafkatest/tests/inkless/inkless_topic_migration_test.py::InklessTopicMigrationTest.test_migration_happy_path
+bash tests/docker/ducker-ak test tests/kafkatest/tests/inkless/inkless_topic_switch_test.py::InklessClassicToDisklessSwitchTest.test_classic_data_available_after_restarts
 ```
 
 Pass additional ducktape arguments after `--`:
 
 ```shell
-bash tests/docker/ducker-ak test tests/kafkatest/tests/inkless/inkless_topic_migration_test.py -- --test-runner-timeout 1800000
+bash tests/docker/ducker-ak test tests/kafkatest/tests/inkless/inkless_topic_switch_test.py -- --test-runner-timeout 1800000
 ```
 
 Run with debug logging:
 
 ```shell
-bash tests/docker/ducker-ak test tests/kafkatest/tests/inkless/inkless_topic_migration_test.py -- --debug
+bash tests/docker/ducker-ak test tests/kafkatest/tests/inkless/inkless_topic_switch_test.py -- --debug
 ```
 
 ### 6. Teardown

--- a/inkless-sync/RELEASE-SYNC-PROMPT.md
+++ b/inkless-sync/RELEASE-SYNC-PROMPT.md
@@ -10,7 +10,7 @@ Copy and paste this prompt to start a release sync session:
 
 **PROMPT:**
 
-```
+````
 I need to sync the inkless release branch with an upstream Apache Kafka release.
 
 ## Context
@@ -69,7 +69,7 @@ I need to sync the inkless release branch with an upstream Apache Kafka release.
 10. **Push**: When verified, push the sync branch for PR review
 
 Please help me execute this release sync process.
-```
+````
 
 ---
 

--- a/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
@@ -54,6 +54,7 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 import static org.apache.kafka.clients.admin.AlterConfigOp.OpType.APPEND;
 import static org.apache.kafka.common.config.ConfigResource.Type.BROKER;
@@ -201,6 +202,14 @@ public class ConfigurationControlManager {
         Map<ConfigResource, Map<String, Entry<OpType, String>>> configChanges,
         boolean newlyCreatedResource
     ) {
+        return incrementalAlterConfigs(configChanges, newlyCreatedResource, null);
+    }
+
+    ControllerResult<Map<ConfigResource, ApiError>> incrementalAlterConfigs(
+        Map<ConfigResource, Map<String, Entry<OpType, String>>> configChanges,
+        boolean newlyCreatedResource,
+        Function<ConfigResource, ApiError> postConfigValidation
+    ) {
         List<ApiMessageAndVersion> outputRecords =
                 BoundedList.newArrayBacked(MAX_RECORDS_PER_USER_OP);
         Map<ConfigResource, ApiError> outputResults = new HashMap<>();
@@ -209,7 +218,8 @@ public class ConfigurationControlManager {
             ApiError apiError = incrementalAlterConfigResource(resourceEntry.getKey(),
                 resourceEntry.getValue(),
                 newlyCreatedResource,
-                outputRecords);
+                outputRecords,
+                postConfigValidation);
             outputResults.put(resourceEntry.getKey(), apiError);
         }
         outputRecords.addAll(createClearElrRecordsAsNeeded(outputRecords));
@@ -248,7 +258,8 @@ public class ConfigurationControlManager {
         ApiError apiError = incrementalAlterConfigResource(configResource,
             keyToOps,
             newlyCreatedResource,
-            outputRecords);
+            outputRecords,
+            null);
 
         outputRecords.addAll(createClearElrRecordsAsNeeded(outputRecords));
         return ControllerResult.atomicOf(outputRecords, apiError);
@@ -258,7 +269,8 @@ public class ConfigurationControlManager {
         ConfigResource configResource,
         Map<String, Entry<OpType, String>> keysToOps,
         boolean newlyCreatedResource,
-        List<ApiMessageAndVersion> outputRecords
+        List<ApiMessageAndVersion> outputRecords,
+        Function<ConfigResource, ApiError> postConfigValidation
     ) {
         List<ApiMessageAndVersion> newRecords = new ArrayList<>();
         for (Entry<String, Entry<OpType, String>> keysToOpsEntry : keysToOps.entrySet()) {
@@ -328,6 +340,12 @@ public class ConfigurationControlManager {
         ApiError error = validateAlterConfig(configResource, newRecords, List.of(), newlyCreatedResource);
         if (error.isFailure()) {
             return error;
+        }
+        if (postConfigValidation != null) {
+            error = postConfigValidation.apply(configResource);
+            if (error.isFailure()) {
+                return error;
+            }
         }
         outputRecords.addAll(newRecords);
         return ApiError.NONE;
@@ -452,6 +470,14 @@ public class ConfigurationControlManager {
         Map<ConfigResource, Map<String, String>> newConfigs,
         boolean newlyCreatedResource
     ) {
+        return legacyAlterConfigs(newConfigs, newlyCreatedResource, null);
+    }
+
+    ControllerResult<Map<ConfigResource, ApiError>> legacyAlterConfigs(
+        Map<ConfigResource, Map<String, String>> newConfigs,
+        boolean newlyCreatedResource,
+        Function<ConfigResource, ApiError> postConfigValidation
+    ) {
         List<ApiMessageAndVersion> outputRecords =
                 BoundedList.newArrayBacked(MAX_RECORDS_PER_USER_OP);
         Map<ConfigResource, ApiError> outputResults = new HashMap<>();
@@ -461,7 +487,8 @@ public class ConfigurationControlManager {
                 resourceEntry.getValue(),
                 newlyCreatedResource,
                 outputRecords,
-                outputResults);
+                outputResults,
+                postConfigValidation);
         }
         outputRecords.addAll(createClearElrRecordsAsNeeded(outputRecords));
         return ControllerResult.atomicOf(outputRecords, outputResults);
@@ -471,7 +498,8 @@ public class ConfigurationControlManager {
                                            Map<String, String> newConfigs,
                                            boolean newlyCreatedResource,
                                            List<ApiMessageAndVersion> outputRecords,
-                                           Map<ConfigResource, ApiError> outputResults) {
+                                           Map<ConfigResource, ApiError> outputResults,
+                                           Function<ConfigResource, ApiError> postConfigValidation) {
         List<ApiMessageAndVersion> recordsExplicitlyAltered = new ArrayList<>();
         Map<String, String> currentConfigs = configData.get(configResource);
         if (currentConfigs == null) {
@@ -504,6 +532,13 @@ public class ConfigurationControlManager {
         if (error.isFailure()) {
             outputResults.put(configResource, error);
             return;
+        }
+        if (postConfigValidation != null) {
+            error = postConfigValidation.apply(configResource);
+            if (error.isFailure()) {
+                outputResults.put(configResource, error);
+                return;
+            }
         }
         outputRecords.addAll(recordsExplicitlyAltered);
         outputRecords.addAll(recordsImplicitlyDeleted);

--- a/metadata/src/main/java/org/apache/kafka/controller/CreateTopicConfigInterceptors.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/CreateTopicConfigInterceptors.java
@@ -31,8 +31,9 @@ import java.util.Map.Entry;
  * Container for CREATE_TOPICS config interceptors. Interceptors are chained and executed in order;
  * only the first interceptor that matches a topic is applied (first-match-wins).
  *
- * <p>The chain order is: diskless force interceptor first, then remote storage force interceptor.
- * This ensures that topics matching the diskless allow list are not also forced to remote storage.
+ * <p>The chain order is: diskless-disabled fallback first (converts explicit diskless.enable=false
+ * to tiered when the system is disabled), then diskless force interceptor, then remote storage
+ * force interceptor. This ensures system-level constraints are enforced before topic-level forcing.
  */
 final class CreateTopicConfigInterceptors {
     private static final Logger LOG = LoggerFactory.getLogger(CreateTopicConfigInterceptors.class);
@@ -47,8 +48,8 @@ final class CreateTopicConfigInterceptors {
 
     /**
      * Creates the interceptors chain based on the provided configuration.
-     * The diskless force interceptor is placed first in the chain so that matching topics
-     * are handled by it before the remote storage force interceptor is considered.
+     * The chain order is: diskless-disabled fallback (when system is disabled), then diskless
+     * force interceptor, then remote storage force interceptor. First-match-wins.
      *
      * @param classicRemoteStorageForceEnabled whether the remote storage force interceptor is enabled
      * @param classicRemoteStorageForceExcludeTopicRegexes topic regexes to exclude from remote storage forcing
@@ -67,7 +68,12 @@ final class CreateTopicConfigInterceptors {
         final List<String> disklessForceIncludeTopicRegexes
     ) {
         final List<CreateTopicConfigInterceptor> chain = new ArrayList<>();
-        // Diskless interceptor is first in the chain (higher priority)
+        // Fallback interceptor is first: when diskless system is disabled, convert explicit
+        // diskless.enable=false to tiered (remote.storage.enable=true) instead of failing.
+        if (!disklessStorageSystemEnabled) {
+            chain.add(new DisklessDisabledFallbackCreateTopicInterceptor());
+        }
+        // Diskless force interceptor is next in the chain
         if (disklessForceEnabled) {
             if (disklessStorageSystemEnabled) {
                 chain.add(new DisklessForceCreateTopicInterceptor(disklessForceIncludeTopicRegexes));

--- a/metadata/src/main/java/org/apache/kafka/controller/DisklessDisabledFallbackCreateTopicInterceptor.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/DisklessDisabledFallbackCreateTopicInterceptor.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.controller;
+
+import org.apache.kafka.clients.admin.AlterConfigOp.OpType;
+import org.apache.kafka.common.config.TopicConfig;
+
+import java.util.AbstractMap.SimpleImmutableEntry;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import static org.apache.kafka.clients.admin.AlterConfigOp.OpType.SET;
+
+/**
+ * A {@link CreateTopicConfigInterceptor} that converts topics with explicit {@code diskless.enable=false}
+ * into tiered topics ({@code remote.storage.enable=true}) when the diskless storage system is globally
+ * disabled.
+ *
+ * <p>This prevents topic creation from failing with "It is invalid to set diskless.enable if diskless
+ * storage system is not enabled" when a client explicitly opts out of diskless. Instead, the topic is
+ * transparently created as a tiered topic.
+ *
+ * <p>Only activates when {@code diskless.storage.system.enable=false}. Excluded: system topics.
+ */
+final class DisklessDisabledFallbackCreateTopicInterceptor implements CreateTopicConfigInterceptor {
+
+    @Override
+    public boolean intercept(
+        final String topicName,
+        final Map<String, String> requestConfigs,
+        final Map<String, Entry<OpType, String>> targetConfigOps
+    ) {
+        if (shouldConvertToTiered(topicName, requestConfigs)) {
+            targetConfigOps.remove(TopicConfig.DISKLESS_ENABLE_CONFIG);
+            targetConfigOps.put(TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG, new SimpleImmutableEntry<>(SET, "true"));
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public boolean intercept(
+        final String topicName,
+        final Map<String, String> targetConfigs
+    ) {
+        if (shouldConvertToTiered(topicName, targetConfigs)) {
+            targetConfigs.remove(TopicConfig.DISKLESS_ENABLE_CONFIG);
+            targetConfigs.put(TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG, "true");
+            return true;
+        }
+        return false;
+    }
+
+    private boolean shouldConvertToTiered(final String topicName, final Map<String, String> configs) {
+        if (ReplicationControlManager.isSystemTopic(topicName)) {
+            return false;
+        }
+        String disklessValue = configs.get(TopicConfig.DISKLESS_ENABLE_CONFIG);
+        return disklessValue != null && "false".equalsIgnoreCase(disklessValue.trim());
+    }
+}

--- a/metadata/src/main/java/org/apache/kafka/controller/DisklessForceCreateTopicInterceptor.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/DisklessForceCreateTopicInterceptor.java
@@ -19,6 +19,7 @@ package org.apache.kafka.controller;
 
 import org.apache.kafka.clients.admin.AlterConfigOp.OpType;
 import org.apache.kafka.common.config.TopicConfig;
+import org.apache.kafka.common.errors.InvalidRequestException;
 
 import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.List;
@@ -59,6 +60,7 @@ final class DisklessForceCreateTopicInterceptor implements CreateTopicConfigInte
         final Map<String, Entry<OpType, String>> targetConfigOps
     ) {
         if (shouldForceDisklessEnable(topicName, requestConfigs)) {
+            rejectIfExplicitlyDisabled(topicName, requestConfigs);
             targetConfigOps.put(TopicConfig.DISKLESS_ENABLE_CONFIG, new SimpleImmutableEntry<>(SET, "true"));
             return true;
         }
@@ -71,10 +73,19 @@ final class DisklessForceCreateTopicInterceptor implements CreateTopicConfigInte
         final Map<String, String> targetConfigs
     ) {
         if (shouldForceDisklessEnable(topicName, targetConfigs)) {
+            rejectIfExplicitlyDisabled(topicName, targetConfigs);
             targetConfigs.put(TopicConfig.DISKLESS_ENABLE_CONFIG, "true");
             return true;
         }
         return false;
+    }
+
+    private void rejectIfExplicitlyDisabled(final String topicName, final Map<String, String> configs) {
+        String disklessEnableConfigValue = configs.getOrDefault(TopicConfig.DISKLESS_ENABLE_CONFIG, "").trim();
+        if (!disklessEnableConfigValue.isEmpty() && !Boolean.parseBoolean(disklessEnableConfigValue)) {
+            throw new InvalidRequestException(
+                "Topic '" + topicName + "' matches the diskless force include regexes and cannot set diskless.enable=false.");
+        }
     }
 
     private boolean shouldForceDisklessEnable(

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -1951,7 +1951,9 @@ public final class QuorumController implements Controller {
         }
         return appendWriteEvent("incrementalAlterConfigs", context.deadlineNs(), () -> {
             ControllerResult<Map<ConfigResource, ApiError>> result =
-                configurationControl.incrementalAlterConfigs(configChanges, false);
+                configurationControl.incrementalAlterConfigs(configChanges, false,
+                    resource -> replicationControl.validateClassicToDisklessSwitchPrecondition(
+                        resource, configChanges));
             if (validateOnly) {
                 return result.withoutRecords();
             } else {
@@ -2004,7 +2006,9 @@ public final class QuorumController implements Controller {
         }
         return appendWriteEvent("legacyAlterConfigs", context.deadlineNs(), () -> {
             ControllerResult<Map<ConfigResource, ApiError>> result =
-                configurationControl.legacyAlterConfigs(newConfigs, false);
+                configurationControl.legacyAlterConfigs(newConfigs, false,
+                    resource -> replicationControl.validateClassicToDisklessSwitchPreconditionForLegacy(
+                        resource, newConfigs));
             if (validateOnly) {
                 return result.withoutRecords();
             } else {

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -136,6 +136,7 @@ import static org.apache.kafka.common.config.TopicConfig.REMOTE_LOG_STORAGE_ENAB
 import static org.apache.kafka.common.internals.Topic.CLUSTER_METADATA_TOPIC_NAME;
 import static org.apache.kafka.common.protocol.Errors.FENCED_LEADER_EPOCH;
 import static org.apache.kafka.common.protocol.Errors.INELIGIBLE_REPLICA;
+import static org.apache.kafka.common.protocol.Errors.INVALID_CONFIG;
 import static org.apache.kafka.common.protocol.Errors.INVALID_REQUEST;
 import static org.apache.kafka.common.protocol.Errors.INVALID_UPDATE_VERSION;
 import static org.apache.kafka.common.protocol.Errors.NEW_LEADER_ELECTED;
@@ -1151,7 +1152,7 @@ public class ReplicationControlManager {
 
     /**
      * Create a topic assignment for a diskless topic.
-     * @return the assignment or {@code null} if there are no brokers avaiable.
+     * @return the assignment or {@code null} if there are no brokers available.
      */
     private TopicAssignment createDisklessAssignment(int numPartitions) {
         final Iterator<UsableBroker> usableBrokers = clusterControl.usableBrokers();
@@ -1442,7 +1443,11 @@ public class ReplicationControlManager {
                 )
                     .setEligibleLeaderReplicasEnabled(featureControl.isElrFeatureEnabled());
                 if (configurationControl.uncleanLeaderElectionEnabledForTopic(topic.name())) {
-                    builder.setElection(PartitionChangeBuilder.Election.UNCLEAN);
+                    if (hasClassicToDisklessSwitchPending(partition)) {
+                        warnSkippingUncleanElectionForPendingSwitch(topic.name, partitionId);
+                    } else {
+                        builder.setElection(PartitionChangeBuilder.Election.UNCLEAN);
+                    }
                 }
                 Optional<ApiMessageAndVersion> record = builder
                     .setTargetIsrWithBrokerStates(partitionData.newIsrWithEpochs())
@@ -2024,6 +2029,12 @@ public class ReplicationControlManager {
             || (electionType == ElectionType.UNCLEAN && partition.hasLeader())) {
             return new ApiError(Errors.ELECTION_NOT_NEEDED);
         }
+        if (electionType == ElectionType.UNCLEAN && hasClassicToDisklessSwitchPending(partition)) {
+            warnSkippingUncleanElectionForPendingSwitch(topic, partitionId);
+            return new ApiError(INVALID_REQUEST,
+                "Cannot perform unclean leader election for partition " + topic + "-" + partitionId +
+                " because it has a pending classic-to-diskless switch.");
+        }
 
         PartitionChangeBuilder.Election election = PartitionChangeBuilder.Election.PREFERRED;
         if (electionType == ElectionType.UNCLEAN) {
@@ -2246,6 +2257,11 @@ public class ReplicationControlManager {
         while (iterator.hasNext() && records.size() < maxElections) {
             TopicIdPartition topicIdPartition = iterator.next();
             TopicControlInfo topic = topics.get(topicIdPartition.topicId());
+            PartitionRegistration partition = topic.parts.get(topicIdPartition.partitionId());
+            if (partition != null && hasClassicToDisklessSwitchPending(partition)) {
+                warnSkippingUncleanElectionForPendingSwitch(topic.name, topicIdPartition.partitionId());
+                continue;
+            }
             if (configurationControl.uncleanLeaderElectionEnabledForTopic(topic.name)) {
                 ApiError result = electLeader(topic.name, topicIdPartition.partitionId(),
                         ElectionType.UNCLEAN, records);
@@ -2262,6 +2278,16 @@ public class ReplicationControlManager {
                         topic.name, topicIdPartition.partitionId());
             }
         }
+    }
+
+    private static boolean hasClassicToDisklessSwitchPending(PartitionRegistration partition) {
+        return partition.classicToDisklessStartOffset == PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING;
+    }
+
+    private void warnSkippingUncleanElectionForPendingSwitch(String topicName, int partitionId) {
+        log.warn("Skipping unclean leader election for partition {}-{} " +
+                "because it has a pending classic-to-diskless switch.",
+            topicName, partitionId);
     }
 
     ControllerResult<List<CreatePartitionsTopicResult>> createPartitions(
@@ -2495,7 +2521,11 @@ public class ReplicationControlManager {
             );
             builder.setEligibleLeaderReplicasEnabled(featureControl.isElrFeatureEnabled());
             if (configurationControl.uncleanLeaderElectionEnabledForTopic(topic.name)) {
-                builder.setElection(PartitionChangeBuilder.Election.UNCLEAN);
+                if (hasClassicToDisklessSwitchPending(partition)) {
+                    warnSkippingUncleanElectionForPendingSwitch(topic.name, topicIdPart.partitionId());
+                } else {
+                    builder.setElection(PartitionChangeBuilder.Election.UNCLEAN);
+                }
             }
             if (brokerWithUncleanShutdown != NO_LEADER) {
                 builder.setUncleanShutdownReplicas(List.of(brokerWithUncleanShutdown));
@@ -2952,6 +2982,114 @@ public class ReplicationControlManager {
     }
 
     /**
+     * Per-resource precondition check for incremental AlterConfigs enabling diskless.
+     * Returns {@link ApiError#NONE} if the resource is not a topic enabling diskless or
+     * if all partition preconditions are met.
+     */
+    ApiError validateClassicToDisklessSwitchPrecondition(
+        ConfigResource resource,
+        Map<ConfigResource, Map<String, Entry<OpType, String>>> configChanges
+    ) {
+        if (resource.type() != TOPIC) return ApiError.NONE;
+        Map<String, Entry<OpType, String>> changes = configChanges.get(resource);
+        if (changes == null || !isSettingConfigToTrue(changes, DISKLESS_ENABLE_CONFIG)) return ApiError.NONE;
+        if (isDisklessTopic(resource.name())) return ApiError.NONE;
+        Uuid topicId = topicsByName.get(resource.name());
+        if (topicId == null) return ApiError.NONE;
+        TopicControlInfo topicInfo = topics.get(topicId);
+        if (topicInfo == null) return ApiError.NONE;
+        return validatePartitionsForSwitch(topicInfo).orElse(ApiError.NONE);
+    }
+
+    /**
+     * Per-resource precondition check for legacy AlterConfigs enabling diskless.
+     * Covers both explicit {@code diskless.enable=true} in the request and implicit
+     * enabling via deletion of a {@code diskless.enable=false} override when the broker
+     * default is {@code true}.
+     */
+    ApiError validateClassicToDisklessSwitchPreconditionForLegacy(
+        ConfigResource resource,
+        Map<ConfigResource, Map<String, String>> newConfigs
+    ) {
+        if (resource.type() != TOPIC) return ApiError.NONE;
+        Map<String, String> configs = newConfigs.get(resource);
+        if (configs == null) return ApiError.NONE;
+        boolean explicitlyEnabling = Boolean.parseBoolean(configs.get(DISKLESS_ENABLE_CONFIG));
+        boolean implicitlyEnabling = !configs.containsKey(DISKLESS_ENABLE_CONFIG)
+            && defaultDisklessEnable
+            && !isDisklessTopic(resource.name())
+            && "false".equals(configurationControl.currentTopicConfig(resource.name()).get(DISKLESS_ENABLE_CONFIG));
+        if (!explicitlyEnabling && !implicitlyEnabling) return ApiError.NONE;
+        if (isDisklessTopic(resource.name())) return ApiError.NONE;
+        Uuid topicId = topicsByName.get(resource.name());
+        if (topicId == null) return ApiError.NONE;
+        TopicControlInfo topicInfo = topics.get(topicId);
+        if (topicInfo == null) return ApiError.NONE;
+        return validatePartitionsForSwitch(topicInfo).orElse(ApiError.NONE);
+    }
+
+    Map<ConfigResource, ApiError> validateClassicToDisklessSwitchPreconditions(Set<ConfigResource> topicResources) {
+        Map<ConfigResource, ApiError> errors = new HashMap<>();
+        for (ConfigResource resource : topicResources) {
+            String topicName = resource.name();
+            if (isDisklessTopic(topicName)) continue;
+            Uuid topicId = topicsByName.get(topicName);
+            if (topicId == null) continue;
+            TopicControlInfo topicInfo = topics.get(topicId);
+            if (topicInfo == null) continue;
+            validatePartitionsForSwitch(topicInfo)
+                .ifPresent(error -> errors.put(resource, error));
+        }
+        return errors;
+    }
+
+    private Optional<ApiError> validatePartitionsForSwitch(TopicControlInfo topicInfo) {
+        String topicName = topicInfo.name;
+        for (Entry<Integer, PartitionRegistration> partEntry : topicInfo.parts.entrySet()) {
+            int partitionId = partEntry.getKey();
+            PartitionRegistration partition = partEntry.getValue();
+
+            if (!partition.hasLeader()) {
+                return Optional.of(new ApiError(INVALID_CONFIG,
+                    "Cannot switch topic " + topicName + " to diskless: " +
+                    "partition " + partitionId + " is offline (has no leader)."));
+            }
+
+            if (partition.leaderRecoveryState == LeaderRecoveryState.RECOVERING) {
+                return Optional.of(new ApiError(INVALID_CONFIG,
+                    "Cannot switch topic " + topicName + " to diskless: " +
+                    "partition " + partitionId + " is recovering from an unclean leader election."));
+            }
+
+            if (isReassignmentInProgress(partition)) {
+                return Optional.of(new ApiError(INVALID_CONFIG,
+                    "Cannot switch topic " + topicName + " to diskless: " +
+                    "partition " + partitionId + " has a reassignment in progress."));
+            }
+
+            if (partition.elr.length > 0) {
+                return Optional.of(new ApiError(INVALID_CONFIG,
+                    "Cannot switch topic " + topicName + " to diskless: " +
+                    "partition " + partitionId + " has a non-empty ELR."));
+            }
+
+            if (partition.lastKnownElr.length > 0) {
+                return Optional.of(new ApiError(INVALID_CONFIG,
+                    "Cannot switch topic " + topicName + " to diskless: " +
+                    "partition " + partitionId + " has a non-empty last-known ELR."));
+            }
+
+            if (partition.isr.length < partition.replicas.length) {
+                return Optional.of(new ApiError(INVALID_CONFIG,
+                    "Cannot switch topic " + topicName + " to diskless: " +
+                    "partition " + partitionId + " is under-replicated " +
+                    "(ISR size " + partition.isr.length + " < replicas " + partition.replicas.length + ")."));
+            }
+        }
+        return Optional.empty();
+    }
+
+    /**
      * For every topic whose {@code diskless.enable} flips from {@code false} to {@code true},
      * emit a {@link PartitionChangeRecord} per partition marking
      * {@code classicToDisklessStartOffset = CLASSIC_TO_DISKLESS_SWITCH_PENDING} (-2).
@@ -2964,19 +3102,17 @@ public class ReplicationControlManager {
         Map<ConfigResource, ApiError> configResults
     ) {
         List<ApiMessageAndVersion> records = BoundedList.newArrayBacked(MAX_RECORDS_PER_USER_OP);
-        for (Entry<ConfigResource, Map<String, Entry<OpType, String>>> entry : configChanges.entrySet()) {
-            ConfigResource resource = entry.getKey();
+        for (Entry<ConfigResource, Map<String, Entry<OpType, String>>> configEntry : configChanges.entrySet()) {
+            ConfigResource resource = configEntry.getKey();
             if (resource.type() != TOPIC) continue;
+            if (!isSettingConfigToTrue(configEntry.getValue(), DISKLESS_ENABLE_CONFIG)) continue;
+            // Skip topics whose config change failed
             ApiError error = configResults.get(resource);
             if (error != null && error != ApiError.NONE) continue;
-            Map<String, Entry<OpType, String>> changes = entry.getValue();
-            Entry<OpType, String> disklessChange = changes.get(DISKLESS_ENABLE_CONFIG);
-            if (disklessChange == null) continue;
-            if (disklessChange.getKey() != SET || !Boolean.parseBoolean(disklessChange.getValue())) continue;
+            // Skip topics that are already diskless
             if (isDisklessTopic(resource.name())) continue;
 
-            String topicName = resource.name();
-            Uuid topicId = topicsByName.get(topicName);
+            Uuid topicId = topicsByName.get(resource.name());
             if (topicId == null) continue;
             TopicControlInfo topicInfo = topics.get(topicId);
             if (topicInfo == null) continue;
@@ -2987,10 +3123,10 @@ public class ReplicationControlManager {
                 if (partition.classicToDisklessStartOffset == PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET) {
                     if (partition.leader == NO_LEADER) {
                         log.warn("Partition {}-{} has no leader; classic-to-diskless switch will " +
-                            "remain pending until a leader is elected", topicName, partEntry.getKey());
+                            "remain pending until a leader is elected", topicInfo.name, partEntry.getKey());
                     }
                     PartitionChangeRecord record = new PartitionChangeRecord()
-                        .setTopicId(topicId)
+                        .setTopicId(topicInfo.id)
                         .setPartitionId(partEntry.getKey())
                         .setLeader(partition.leader); // Force leader epoch bump to trigger makeLeader on broker
                     record.unknownTaggedFields().add(
@@ -3000,7 +3136,7 @@ public class ReplicationControlManager {
                 }
             }
             log.info("Marked {} partition(s) for topic {} as classic-to-diskless switch pending",
-                records.size() - sizeBefore, topicName);
+                records.size() - sizeBefore, topicInfo.name);
         }
         return records;
     }
@@ -3016,15 +3152,30 @@ public class ReplicationControlManager {
     ) {
         Map<ConfigResource, Map<String, Entry<OpType, String>>> configChanges = new HashMap<>();
         for (Entry<ConfigResource, Map<String, String>> entry : newConfigs.entrySet()) {
-            String disklessEnable = entry.getValue().get(DISKLESS_ENABLE_CONFIG);
+            ConfigResource resource = entry.getKey();
+            Map<String, String> configs = entry.getValue();
+            String disklessEnable = configs.get(DISKLESS_ENABLE_CONFIG);
             if (disklessEnable != null) {
-                configChanges.put(entry.getKey(), Map.of(
+                configChanges.put(resource, Map.of(
                     DISKLESS_ENABLE_CONFIG,
                     new SimpleImmutableEntry<>(SET, disklessEnable)
+                ));
+            } else if (defaultDisklessEnable
+                && resource.type() == TOPIC
+                && !isDisklessTopic(resource.name())
+                && "false".equals(configurationControl.currentTopicConfig(resource.name()).get(DISKLESS_ENABLE_CONFIG))) {
+                configChanges.put(resource, Map.of(
+                    DISKLESS_ENABLE_CONFIG,
+                    new SimpleImmutableEntry<>(SET, "true")
                 ));
             }
         }
         return markClassicToDisklessSwitchStarted(configChanges, configResults);
+    }
+
+    private static boolean isSettingConfigToTrue(Map<String, Entry<OpType, String>> changes, String configKey) {
+        Entry<OpType, String> change = changes.get(configKey);
+        return change != null && change.getKey() == SET && Boolean.parseBoolean(change.getValue());
     }
 
     private boolean isDisklessTopic(String topicName) {

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -780,11 +780,16 @@ public class ReplicationControlManager {
             } else {
                 keyToOps = new HashMap<>(keyToOps);
             }
-            createTopicConfigInterceptors.intercept(
-                topic.name(),
-                requestConfigs,
-                keyToOps
-            );
+            try {
+                createTopicConfigInterceptors.intercept(
+                    topic.name(),
+                    requestConfigs,
+                    keyToOps
+                );
+            } catch (ApiException e) {
+                topicErrors.put(topic.name(), ApiError.fromThrowable(e));
+                continue;
+            }
             if (keyToOps.isEmpty()) {
                 keyToOps = null;
             }

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -1621,6 +1621,14 @@ public class ReplicationControlManager {
                             ps.batchMaxTimestamp()))
                         .toList();
 
+                // Capture the partition's current leader epoch as the diskless leader epoch (E_d). The
+                // classic-to-diskless switch already bumped the leader epoch, so this value is strictly
+                // greater than every classic-prefix epoch. Capturing it here, at the commit, keeps it
+                // correct even if a leader change landed in the meantime. E_d is stamped onto materialized
+                // diskless batches and answers OffsetsForLeaderEpoch so that a stale classic tail truncates
+                // back to the seal.
+                int disklessLeaderEpoch = partition.leaderEpoch;
+
                 PartitionChangeRecord record = new PartitionChangeRecord()
                     .setTopicId(topicId)
                     .setPartitionId(partitionId);
@@ -1630,11 +1638,13 @@ public class ReplicationControlManager {
                     record.unknownTaggedFields().add(
                         InitDisklessLogFields.encodeProducerStates(producerStates));
                 }
+                record.unknownTaggedFields().add(
+                    InitDisklessLogFields.encodeDisklessLeaderEpoch(disklessLeaderEpoch));
 
                 records.add(new ApiMessageAndVersion(record, (short) 0));
 
-                log.info("InitDisklessLog for {}-{}: classicToDisklessStartOffset={}, producerStates.size={}",
-                    topic.name, partitionId, partitionData.disklessStartOffset(),
+                log.info("InitDisklessLog for {}-{}: classicToDisklessStartOffset={}, disklessLeaderEpoch={}, producerStates.size={}",
+                    topic.name, partitionId, partitionData.disklessStartOffset(), disklessLeaderEpoch,
                     producerStates.size());
 
                 partitionResponses.add(new InitDisklessLogResponseData.PartitionResponse()

--- a/metadata/src/main/java/org/apache/kafka/metadata/InitDisklessLogFields.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/InitDisklessLogFields.java
@@ -33,6 +33,7 @@ public final class InitDisklessLogFields {
 
     public static final int CLASSIC_TO_DISKLESS_START_OFFSET_TAG = 100;
     public static final int PRODUCER_STATES_TAG = 101;
+    public static final int DISKLESS_LEADER_EPOCH_TAG = 102;
 
     private InitDisklessLogFields() {}
 
@@ -51,6 +52,26 @@ public final class InitDisklessLogFields {
             }
         }
         return PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET;
+    }
+
+    // --- disklessLeaderEpoch (tag 102): a single int32 ---
+    // The leader epoch captured for the diskless region at the classic-to-diskless switch.
+    // Strictly greater than every classic-prefix epoch, it lets standard OffsetsForLeaderEpoch
+    // truncation distinguish a stale classic tail from authoritative consolidated data.
+
+    public static RawTaggedField encodeDisklessLeaderEpoch(int disklessLeaderEpoch) {
+        byte[] data = new byte[4];
+        ByteBuffer.wrap(data).putInt(disklessLeaderEpoch);
+        return new RawTaggedField(DISKLESS_LEADER_EPOCH_TAG, data);
+    }
+
+    public static int decodeDisklessLeaderEpoch(List<RawTaggedField> taggedFields) {
+        for (RawTaggedField field : taggedFields) {
+            if (field.tag() == DISKLESS_LEADER_EPOCH_TAG) {
+                return ByteBuffer.wrap(field.data()).getInt();
+            }
+        }
+        return PartitionRegistration.NO_DISKLESS_LEADER_EPOCH;
     }
 
     // --- producerStates (tag 101): count + fixed-size entries ---

--- a/metadata/src/main/java/org/apache/kafka/metadata/PartitionRegistration.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/PartitionRegistration.java
@@ -55,6 +55,7 @@ public class PartitionRegistration {
         private Integer partitionEpoch;
         private long classicToDisklessStartOffset = -1L;
         private List<InitDisklessLogFields.ProducerStateEntry> disklessProducerStates = List.of();
+        private int disklessLeaderEpoch = NO_DISKLESS_LEADER_EPOCH;
 
         public Builder setReplicas(int[] replicas) {
             this.replicas = replicas;
@@ -121,6 +122,11 @@ public class PartitionRegistration {
             return this;
         }
 
+        public Builder setDisklessLeaderEpoch(int disklessLeaderEpoch) {
+            this.disklessLeaderEpoch = disklessLeaderEpoch;
+            return this;
+        }
+
         public PartitionRegistration build() {
             if (replicas == null) {
                 throw new IllegalStateException("You must set replicas.");
@@ -161,13 +167,17 @@ public class PartitionRegistration {
                 elr,
                 lastKnownElr,
                 classicToDisklessStartOffset,
-                disklessProducerStates
+                disklessProducerStates,
+                disklessLeaderEpoch
             );
         }
     }
 
     public static final long NO_CLASSIC_TO_DISKLESS_START_OFFSET = -1L;
     public static final long CLASSIC_TO_DISKLESS_SWITCH_PENDING = -2L;
+    // Sentinel for a partition that has no captured diskless leader epoch (never switched, born-diskless,
+    // or switch still pending). A real diskless leader epoch is always >= 0.
+    public static final int NO_DISKLESS_LEADER_EPOCH = -1;
 
     public final int[] replicas;
     public final Uuid[] directories;
@@ -182,6 +192,7 @@ public class PartitionRegistration {
     public final int partitionEpoch;
     public final long classicToDisklessStartOffset;
     public final List<InitDisklessLogFields.ProducerStateEntry> disklessProducerStates;
+    public final int disklessLeaderEpoch;
 
     public static boolean electionWasUnclean(byte leaderRecoveryState) {
         return leaderRecoveryState == LeaderRecoveryState.RECOVERING.value();
@@ -233,14 +244,17 @@ public class PartitionRegistration {
             Replicas.toArray(record.eligibleLeaderReplicas()),
             Replicas.toArray(record.lastKnownElr()),
             InitDisklessLogFields.decodeClassicToDisklessStartOffset(record.unknownTaggedFields()),
-            InitDisklessLogFields.decodeProducerStates(record.unknownTaggedFields()));
+            InitDisklessLogFields.decodeProducerStates(record.unknownTaggedFields()),
+            InitDisklessLogFields.decodeDisklessLeaderEpoch(record.unknownTaggedFields()));
     }
 
+    @SuppressWarnings("checkstyle:ParameterNumber")
     private PartitionRegistration(int[] replicas, Uuid[] directories, int[] isr, int[] removingReplicas,
                                   int[] addingReplicas, int leader, LeaderRecoveryState leaderRecoveryState,
                                   int leaderEpoch, int partitionEpoch, int[] elr, int[] lastKnownElr,
                                   long classicToDisklessStartOffset,
-                                  List<InitDisklessLogFields.ProducerStateEntry> disklessProducerStates) {
+                                  List<InitDisklessLogFields.ProducerStateEntry> disklessProducerStates,
+                                  int disklessLeaderEpoch) {
         Objects.requireNonNull(directories);
         if (directories.length > 0 && directories.length != replicas.length) {
             throw new IllegalArgumentException("The lengths for replicas and directories do not match.");
@@ -256,6 +270,7 @@ public class PartitionRegistration {
         this.partitionEpoch = partitionEpoch;
         this.classicToDisklessStartOffset = classicToDisklessStartOffset;
         this.disklessProducerStates = disklessProducerStates != null ? disklessProducerStates : List.of();
+        this.disklessLeaderEpoch = disklessLeaderEpoch;
 
         // We could parse a lower version record without elr/lastKnownElr.
         this.elr = elr == null ? new int[0] : elr;
@@ -297,6 +312,12 @@ public class PartitionRegistration {
             newClassicToDisklessStartOffset = classicToDisklessStartOffset;
             newDisklessProducerStates = disklessProducerStates;
         }
+        // The diskless leader epoch is captured at the classic-to-diskless switch and only carried by that
+        // single change record; every other change record omits the tag, so keep the existing value.
+        int newDisklessLeaderEpoch = InitDisklessLogFields.decodeDisklessLeaderEpoch(record.unknownTaggedFields());
+        if (newDisklessLeaderEpoch == NO_DISKLESS_LEADER_EPOCH) {
+            newDisklessLeaderEpoch = disklessLeaderEpoch;
+        }
         return new PartitionRegistration(newReplicas,
             newDirectories,
             newIsr,
@@ -309,13 +330,14 @@ public class PartitionRegistration {
             newElr,
             newLastKnownElr,
             newClassicToDisklessStartOffset,
-            newDisklessProducerStates);
+            newDisklessProducerStates,
+            newDisklessLeaderEpoch);
     }
 
     public PartitionRegistration withClassicToDisklessStartOffset(long classicToDisklessStartOffset) {
         return new PartitionRegistration(replicas, directories, isr, removingReplicas,
             addingReplicas, leader, leaderRecoveryState, leaderEpoch, partitionEpoch,
-            elr, lastKnownElr, classicToDisklessStartOffset, disklessProducerStates);
+            elr, lastKnownElr, classicToDisklessStartOffset, disklessProducerStates, disklessLeaderEpoch);
     }
 
     public String diff(PartitionRegistration prev) {
@@ -392,6 +414,11 @@ public class PartitionRegistration {
             builder.append(prefix).append("disklessProducerStates: ").
                 append(prev.disklessProducerStates.size()).append(" entries -> ").
                 append(disklessProducerStates.size()).append(" entries");
+            prefix = ", ";
+        }
+        if (disklessLeaderEpoch != prev.disklessLeaderEpoch) {
+            builder.append(prefix).append("disklessLeaderEpoch: ").
+                append(prev.disklessLeaderEpoch).append(" -> ").append(disklessLeaderEpoch);
         }
         return builder.toString();
     }
@@ -451,6 +478,10 @@ public class PartitionRegistration {
                     InitDisklessLogFields.encodeProducerStates(disklessProducerStates));
             }
         }
+        if (disklessLeaderEpoch != NO_DISKLESS_LEADER_EPOCH) {
+            record.unknownTaggedFields().add(
+                InitDisklessLogFields.encodeDisklessLeaderEpoch(disklessLeaderEpoch));
+        }
 
         if (options.metadataVersion() == null) {
             options.handleLoss("the metadata version");
@@ -491,7 +522,7 @@ public class PartitionRegistration {
         return Objects.hash(Arrays.hashCode(replicas), Arrays.hashCode(isr), Arrays.hashCode(removingReplicas),
             Arrays.hashCode(directories), Arrays.hashCode(elr), Arrays.hashCode(lastKnownElr),
             Arrays.hashCode(addingReplicas), leader, leaderRecoveryState, leaderEpoch, partitionEpoch,
-            classicToDisklessStartOffset, disklessProducerStates);
+            classicToDisklessStartOffset, disklessProducerStates, disklessLeaderEpoch);
     }
 
     @Override
@@ -509,7 +540,8 @@ public class PartitionRegistration {
             leaderEpoch == other.leaderEpoch &&
             partitionEpoch == other.partitionEpoch &&
             classicToDisklessStartOffset == other.classicToDisklessStartOffset &&
-            Objects.equals(disklessProducerStates, other.disklessProducerStates);
+            Objects.equals(disklessProducerStates, other.disklessProducerStates) &&
+            disklessLeaderEpoch == other.disklessLeaderEpoch;
     }
 
     @Override
@@ -527,6 +559,7 @@ public class PartitionRegistration {
                 ", partitionEpoch=" + partitionEpoch +
                 ", classicToDisklessStartOffset=" + classicToDisklessStartOffset +
                 ", disklessProducerStates=" + disklessProducerStates +
+                ", disklessLeaderEpoch=" + disklessLeaderEpoch +
                 ")";
     }
 }

--- a/metadata/src/test/java/org/apache/kafka/controller/CreateTopicConfigInterceptorsTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/CreateTopicConfigInterceptorsTest.java
@@ -152,4 +152,69 @@ public class CreateTopicConfigInterceptorsTest {
 
         assertNull(targetConfigs.get(TopicConfig.DISKLESS_ENABLE_CONFIG));
     }
+
+    @Test
+    public void disklessDisabledFallbackConvertsTieredWhenExplicitlyFalse() {
+        // disklessStorageSystemEnabled=false, no other interceptors
+        final var interceptors = CreateTopicConfigInterceptors.create(false, List.of(), false, false, false, List.of());
+        final Map<String, String> targetConfigs = new HashMap<>();
+        targetConfigs.put(TopicConfig.DISKLESS_ENABLE_CONFIG, "false");
+
+        interceptors.intercept("my-topic", targetConfigs);
+
+        assertNull(targetConfigs.get(TopicConfig.DISKLESS_ENABLE_CONFIG));
+        assertEquals("true", targetConfigs.get(TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG));
+    }
+
+    @Test
+    public void disklessDisabledFallbackConvertsTieredViaConfigOps() {
+        final var interceptors = CreateTopicConfigInterceptors.create(false, List.of(), false, false, false, List.of());
+        final Map<String, String> requestConfigs = new HashMap<>();
+        requestConfigs.put(TopicConfig.DISKLESS_ENABLE_CONFIG, "false");
+        final Map<String, Entry<OpType, String>> targetConfigOps = new HashMap<>();
+        targetConfigOps.put(TopicConfig.DISKLESS_ENABLE_CONFIG, Map.entry(SET, "false"));
+
+        interceptors.intercept("my-topic", requestConfigs, targetConfigOps);
+
+        assertFalse(targetConfigOps.containsKey(TopicConfig.DISKLESS_ENABLE_CONFIG));
+        assertEquals(Map.entry(SET, "true"), targetConfigOps.get(TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG));
+    }
+
+    @Test
+    public void disklessDisabledFallbackDoesNotApplyWithoutExplicitConfig() {
+        // No diskless.enable in configs — fallback should not match
+        final var interceptors = CreateTopicConfigInterceptors.create(false, List.of(), false, false, false, List.of());
+        final Map<String, String> targetConfigs = new HashMap<>();
+
+        interceptors.intercept("my-topic", targetConfigs);
+
+        assertNull(targetConfigs.get(TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG));
+    }
+
+    @Test
+    public void disklessDisabledFallbackDoesNotApplyForSystemTopics() {
+        final var interceptors = CreateTopicConfigInterceptors.create(false, List.of(), false, false, false, List.of());
+        final Map<String, String> targetConfigs = new HashMap<>();
+        targetConfigs.put(TopicConfig.DISKLESS_ENABLE_CONFIG, "false");
+
+        interceptors.intercept("__consumer_offsets", targetConfigs);
+
+        // System topic should not be converted — diskless.enable stays
+        assertEquals("false", targetConfigs.get(TopicConfig.DISKLESS_ENABLE_CONFIG));
+        assertNull(targetConfigs.get(TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG));
+    }
+
+    @Test
+    public void disklessDisabledFallbackNotActiveWhenSystemEnabled() {
+        // disklessStorageSystemEnabled=true — fallback should NOT be in the chain
+        final var interceptors = CreateTopicConfigInterceptors.create(false, List.of(), false, true, false, List.of());
+        final Map<String, String> targetConfigs = new HashMap<>();
+        targetConfigs.put(TopicConfig.DISKLESS_ENABLE_CONFIG, "false");
+
+        interceptors.intercept("my-topic", targetConfigs);
+
+        // diskless.enable=false should remain untouched (no conversion to tiered)
+        assertEquals("false", targetConfigs.get(TopicConfig.DISKLESS_ENABLE_CONFIG));
+        assertNull(targetConfigs.get(TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG));
+    }
 }

--- a/metadata/src/test/java/org/apache/kafka/controller/DisklessForceCreateTopicInterceptorTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/DisklessForceCreateTopicInterceptorTest.java
@@ -19,6 +19,7 @@ package org.apache.kafka.controller;
 
 import org.apache.kafka.clients.admin.AlterConfigOp.OpType;
 import org.apache.kafka.common.config.TopicConfig;
+import org.apache.kafka.common.errors.InvalidRequestException;
 import org.apache.kafka.common.internals.Topic;
 
 import org.junit.jupiter.api.Test;
@@ -32,6 +33,7 @@ import static org.apache.kafka.clients.admin.AlterConfigOp.OpType.SET;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class DisklessForceCreateTopicInterceptorTest {
 
@@ -50,17 +52,21 @@ public class DisklessForceCreateTopicInterceptorTest {
     }
 
     @Test
-    public void forcesDisklessEvenWhenRequestHadDisklessFalse() {
+    public void throwsWhenRequestHasDisklessFalseAndTopicMatchesRegex() {
         final var interceptor = new DisklessForceCreateTopicInterceptor(List.of("my-topic-.*"));
-        final Map<String, String> requestConfigs = new HashMap<>(Map.of(TopicConfig.DISKLESS_ENABLE_CONFIG, "false"));
-        final Map<String, Entry<OpType, String>> targetConfigOps = new HashMap<>();
-        final Map<String, String> targetConfigs = new HashMap<>(Map.of(TopicConfig.DISKLESS_ENABLE_CONFIG, "false"));
 
-        interceptor.intercept("my-topic-1", requestConfigs, targetConfigOps);
-        interceptor.intercept("my-topic-1", targetConfigs);
+        for (String falseValue : List.of("FALSE", "False", "false ", " false", " FALSE ")) {
+            final Map<String, String> requestConfigs = new HashMap<>(Map.of(TopicConfig.DISKLESS_ENABLE_CONFIG, falseValue));
+            final Map<String, Entry<OpType, String>> targetConfigOps = new HashMap<>();
+            final Map<String, String> targetConfigs = new HashMap<>(Map.of(TopicConfig.DISKLESS_ENABLE_CONFIG, falseValue));
 
-        assertEquals(Map.entry(SET, "true"), targetConfigOps.get(TopicConfig.DISKLESS_ENABLE_CONFIG));
-        assertEquals("true", targetConfigs.get(TopicConfig.DISKLESS_ENABLE_CONFIG));
+            assertThrows(InvalidRequestException.class,
+                () -> interceptor.intercept("my-topic-1", requestConfigs, targetConfigOps),
+                "Should reject value: '" + falseValue + "'");
+            assertThrows(InvalidRequestException.class,
+                () -> interceptor.intercept("my-topic-1", targetConfigs),
+                "Should reject value: '" + falseValue + "'");
+        }
     }
 
     @Test

--- a/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
@@ -4334,6 +4334,61 @@ public class ReplicationControlManagerTest {
         }
 
         @Test
+        public void testCreateTopicWithDisklessExplicitlyDisabledWhenSystemDisabledCreatesTieredTopic() {
+            // Given diskless storage system is globally disabled
+            ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder()
+                .setDisklessStorageSystemEnabled(false)
+                .setDefaultDisklessEnable(false)
+                .build();
+            ReplicationControlManager replicationControl = ctx.replicationControl;
+
+            // Given a topic creation request with diskless.enable=false explicitly
+            CreateTopicsRequestData request = new CreateTopicsRequestData();
+            CreateTopicsRequestData.CreatableTopicConfigCollection topicConfigs = new CreateTopicsRequestData.CreatableTopicConfigCollection();
+            topicConfigs.add(new CreateTopicsRequestData.CreatableTopicConfig()
+                .setName(DISKLESS_ENABLE_CONFIG)
+                .setValue("false"));
+            request.topics().add(new CreatableTopic().setName("foo")
+                .setNumPartitions(-1).setReplicationFactor((short) -1)
+                .setConfigs(topicConfigs));
+
+            // Given all brokers unfenced
+            ctx.registerBrokers(0, 1, 2);
+            ctx.unfenceBrokers(0, 1, 2);
+
+            // When creating the topic
+            ControllerRequestContext requestContext = anonymousContextFor(ApiKeys.CREATE_TOPICS);
+            ControllerResult<CreateTopicsResponseData> result =
+                replicationControl.createTopics(requestContext, request, Collections.singleton("foo"));
+
+            // Then the topic creation should succeed by enabling tiered storage instead of diskless
+            CreatableTopicResult topicResult = result.response().topics().find("foo");
+            assertNotNull(topicResult);
+            assertEquals(NONE.code(), topicResult.errorCode(),
+                "Topic creation should succeed as a tiered topic when diskless is explicitly disabled and system is disabled");
+
+            // And it should be created as a tiered topic (remote.storage.enable=true)
+            List<ConfigRecord> remoteStorageConfigRecords = result.records().stream()
+                .filter(m -> m.message() instanceof ConfigRecord)
+                .map(m -> (ConfigRecord) m.message())
+                .filter(c -> c.name().equals(REMOTE_LOG_STORAGE_ENABLE_CONFIG))
+                .toList();
+            assertFalse(remoteStorageConfigRecords.isEmpty(),
+                "Expected remote.storage.enable config record for tiered topic");
+            assertTrue(remoteStorageConfigRecords.stream().allMatch(c -> c.value().equals("true")),
+                "Expected remote.storage.enable=true for tiered topic");
+
+            // And diskless.enable should not be persisted (it was stripped)
+            List<ConfigRecord> disklessConfigRecords = result.records().stream()
+                .filter(m -> m.message() instanceof ConfigRecord)
+                .map(m -> (ConfigRecord) m.message())
+                .filter(c -> c.name().equals(DISKLESS_ENABLE_CONFIG))
+                .toList();
+            assertTrue(disklessConfigRecords.isEmpty(),
+                    "Expected no diskless.enable config record when diskless system is disabled");
+        }
+
+        @Test
         public void testReassignDisklessPartitions() {
             MetadataVersion metadataVersion = MetadataVersion.latestTesting();
             ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder()

--- a/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
@@ -6160,6 +6160,9 @@ public class ReplicationControlManagerTest {
             assertEquals(topicId, record.topicId());
             assertEquals(0, record.partitionId());
             assertEquals(100L, InitDisklessLogFields.decodeClassicToDisklessStartOffset(record.unknownTaggedFields()));
+            // The change record captures the partition's current leader epoch as the diskless leader epoch.
+            assertEquals(partition.leaderEpoch,
+                InitDisklessLogFields.decodeDisklessLeaderEpoch(record.unknownTaggedFields()));
 
             List<InitDisklessLogFields.ProducerStateEntry> producerStates =
                 InitDisklessLogFields.decodeProducerStates(record.unknownTaggedFields());
@@ -6202,6 +6205,7 @@ public class ReplicationControlManagerTest {
             PartitionRegistration updatedPartition = replicationControl.getPartition(topicId, 0);
             assertEquals(42L, updatedPartition.classicToDisklessStartOffset);
             assertTrue(updatedPartition.disklessProducerStates.isEmpty());
+            assertEquals(partition.leaderEpoch, updatedPartition.disklessLeaderEpoch);
         }
 
         @Test

--- a/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
@@ -6610,6 +6610,396 @@ public class ReplicationControlManagerTest {
                 InitDisklessLogFields.decodeClassicToDisklessStartOffset(record.unknownTaggedFields()));
         }
 
+        @Test
+        public void testSwitchRejectedWhenPartitionIsOffline() {
+            ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder()
+                .setStaticConfig(ServerConfigs.DISKLESS_ALLOW_FROM_CLASSIC_ENABLE_CONFIG, true)
+                .build();
+            ctx.registerBrokers(0, 1, 2);
+            ctx.unfenceBrokers(0, 1, 2);
+            ctx.createTestTopic("foo", new int[][] {new int[] {0, 1, 2}});
+
+            // Fence all brokers to make the partition offline
+            ctx.fenceBrokers(0, 1, 2);
+
+            ConfigResource resource = new ConfigResource(ConfigResource.Type.TOPIC, "foo");
+
+            Map<ConfigResource, ApiError> errors =
+                ctx.replicationControl.validateClassicToDisklessSwitchPreconditions(Set.of(resource));
+
+            assertEquals(1, errors.size());
+            ApiError error = errors.get(resource);
+            assertEquals(Errors.INVALID_CONFIG, error.error());
+            assertTrue(error.message().contains("offline"), "Expected 'offline' in: " + error.message());
+        }
+
+        @Test
+        public void testSwitchRejectedWhenReassignmentInProgress() {
+            ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder()
+                .setStaticConfig(ServerConfigs.DISKLESS_ALLOW_FROM_CLASSIC_ENABLE_CONFIG, true)
+                .build();
+            ctx.registerBrokers(0, 1, 2, 3);
+            ctx.unfenceBrokers(0, 1, 2, 3);
+            ctx.createTestTopic("foo", new int[][] {new int[] {0, 1, 2}});
+
+            // Start a reassignment
+            ControllerResult<AlterPartitionReassignmentsResponseData> alterResult =
+                ctx.replicationControl.alterPartitionReassignments(
+                    new AlterPartitionReassignmentsRequestData().setTopics(List.of(
+                        new ReassignableTopic().setName("foo").setPartitions(List.of(
+                            new ReassignablePartition().setPartitionIndex(0).
+                                setReplicas(List.of(1, 2, 3)))))));
+            ctx.replay(alterResult.records());
+
+            ConfigResource resource = new ConfigResource(ConfigResource.Type.TOPIC, "foo");
+
+            Map<ConfigResource, ApiError> errors =
+                ctx.replicationControl.validateClassicToDisklessSwitchPreconditions(Set.of(resource));
+
+            assertEquals(1, errors.size());
+            ApiError error = errors.get(resource);
+            assertEquals(Errors.INVALID_CONFIG, error.error());
+            assertTrue(error.message().contains("reassignment"), "Expected 'reassignment' in: " + error.message());
+        }
+
+        @Test
+        public void testSwitchRejectedWhenUnderReplicated() {
+            ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder()
+                .setStaticConfig(ServerConfigs.DISKLESS_ALLOW_FROM_CLASSIC_ENABLE_CONFIG, true)
+                .build();
+            ctx.registerBrokers(0, 1, 2);
+            ctx.unfenceBrokers(0, 1, 2);
+            Uuid fooId = ctx.createTestTopic("foo", new int[][] {new int[] {0, 1, 2}}).topicId();
+
+            // Shrink ISR to make it under-replicated (fence one broker then unfence it without rejoining ISR)
+            ctx.fenceBrokers(2);
+            // Now partition has ISR < replicas but still has a leader
+            PartitionRegistration partition = ctx.replicationControl.getPartition(fooId, 0);
+            assertTrue(partition.hasLeader());
+            assertTrue(partition.isr.length < partition.replicas.length);
+
+            ConfigResource resource = new ConfigResource(ConfigResource.Type.TOPIC, "foo");
+
+            Map<ConfigResource, ApiError> errors =
+                ctx.replicationControl.validateClassicToDisklessSwitchPreconditions(Set.of(resource));
+
+            assertEquals(1, errors.size());
+            ApiError error = errors.get(resource);
+            assertEquals(Errors.INVALID_CONFIG, error.error());
+            assertTrue(error.message().contains("under-replicated"), "Expected 'under-replicated' in: " + error.message());
+        }
+
+        @Test
+        public void testSwitchRejectedWhenElrIsNonEmpty() {
+            ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder()
+                .setStaticConfig(ServerConfigs.DISKLESS_ALLOW_FROM_CLASSIC_ENABLE_CONFIG, true)
+                .setStaticConfig(TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG, "3")
+                .setIsElrEnabled(true)
+                .build();
+            ctx.registerBrokers(0, 1, 2);
+            ctx.unfenceBrokers(0, 1, 2);
+            Uuid fooId = ctx.createTestTopic("foo", new int[][] {new int[] {0, 1, 2}}).topicId();
+
+            // Fence broker 2 — ISR drops below minISR (3), so broker 2 goes to ELR
+            ctx.fenceBrokers(2);
+            PartitionRegistration partition = ctx.replicationControl.getPartition(fooId, 0);
+            assertTrue(partition.elr.length > 0,
+                "Expected ELR to be non-empty after fencing with minISR=3, got elr=" +
+                Arrays.toString(partition.elr));
+
+            ConfigResource resource = new ConfigResource(ConfigResource.Type.TOPIC, "foo");
+
+            Map<ConfigResource, ApiError> errors =
+                ctx.replicationControl.validateClassicToDisklessSwitchPreconditions(Set.of(resource));
+
+            assertEquals(1, errors.size());
+            ApiError error = errors.get(resource);
+            assertEquals(Errors.INVALID_CONFIG, error.error());
+            assertTrue(error.message().contains("non-empty ELR"),
+                "Expected 'non-empty ELR' in: " + error.message());
+        }
+
+        @Test
+        public void testSwitchRejectedWhenLastKnownElrIsNonEmpty() {
+            ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder()
+                .setStaticConfig(ServerConfigs.DISKLESS_ALLOW_FROM_CLASSIC_ENABLE_CONFIG, true)
+                .setStaticConfig(TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG, "3")
+                .setIsElrEnabled(true)
+                .build();
+            ctx.registerBrokers(0, 1, 2);
+            ctx.unfenceBrokers(0, 1, 2);
+            Uuid fooId = ctx.createTestTopic("foo", new int[][] {new int[] {0, 1, 2}}).topicId();
+
+            // Fence broker 2 — ISR drops below minISR (3), so broker 2 goes to ELR
+            ctx.fenceBrokers(2);
+            PartitionRegistration partition = ctx.replicationControl.getPartition(fooId, 0);
+            assertTrue(partition.elr.length > 0 || partition.lastKnownElr.length > 0,
+                "Expected ELR or lastKnownElr to be non-empty after fencing, got elr=" +
+                Arrays.toString(partition.elr) + " lastKnownElr=" + Arrays.toString(partition.lastKnownElr));
+
+            ConfigResource resource = new ConfigResource(ConfigResource.Type.TOPIC, "foo");
+
+            Map<ConfigResource, ApiError> errors =
+                ctx.replicationControl.validateClassicToDisklessSwitchPreconditions(Set.of(resource));
+
+            assertEquals(1, errors.size());
+            ApiError error = errors.get(resource);
+            assertEquals(Errors.INVALID_CONFIG, error.error());
+            assertTrue(error.message().contains("ELR") || error.message().contains("last-known ELR"),
+                "Expected 'ELR' or 'last-known ELR' in: " + error.message());
+        }
+
+        @Test
+        public void testSwitchRejectedWhenRecovering() {
+            ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder()
+                .setStaticConfig(ServerConfigs.DISKLESS_ALLOW_FROM_CLASSIC_ENABLE_CONFIG, true)
+                .setStaticConfig(TopicConfig.UNCLEAN_LEADER_ELECTION_ENABLE_CONFIG, "true")
+                .build();
+            ctx.registerBrokers(0, 1, 2);
+            ctx.unfenceBrokers(0, 1, 2);
+            Uuid fooId = ctx.createTestTopic("foo", new int[][] {new int[] {0, 1, 2}}).topicId();
+
+            // Fence brokers 1, 2 to shrink ISR to [0]
+            ctx.fenceBrokers(1, 2);
+            // Fence broker 0 to make partition leaderless
+            ctx.fenceBrokers(0, 1, 2);
+            // Unfence broker 1 to trigger unclean election (RECOVERING state)
+            ctx.unfenceBrokers(1);
+
+            PartitionRegistration partition = ctx.replicationControl.getPartition(fooId, 0);
+            assertEquals(LeaderRecoveryState.RECOVERING, partition.leaderRecoveryState);
+
+            // Disable unclean leader election so the unclean check doesn't fire first
+            ctx.replay(ctx.configurationControl.incrementalAlterConfigs(
+                Map.of(new ConfigResource(ConfigResource.Type.TOPIC, "foo"),
+                    Map.of(TopicConfig.UNCLEAN_LEADER_ELECTION_ENABLE_CONFIG,
+                        new AbstractMap.SimpleImmutableEntry<>(AlterConfigOp.OpType.SET, "false"))),
+                false).records());
+
+            ConfigResource resource = new ConfigResource(ConfigResource.Type.TOPIC, "foo");
+
+            Map<ConfigResource, ApiError> errors =
+                ctx.replicationControl.validateClassicToDisklessSwitchPreconditions(Set.of(resource));
+
+            assertEquals(1, errors.size());
+            ApiError error = errors.get(resource);
+            assertEquals(Errors.INVALID_CONFIG, error.error());
+            assertTrue(error.message().contains("recovering"),
+                "Expected 'recovering' in: " + error.message());
+        }
+
+        @Test
+        public void testMaybeTriggerUncleanElectionSkipsPendingSwitchPartition() {
+            ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder()
+                .setStaticConfig(TopicConfig.UNCLEAN_LEADER_ELECTION_ENABLE_CONFIG, "true")
+                .build();
+            ctx.registerBrokers(0, 1, 2);
+            ctx.unfenceBrokers(0, 1, 2);
+            Uuid fooId = ctx.createTestTopic("foo", new int[][] {new int[] {0, 1, 2}}).topicId();
+
+            // Shrink ISR to just [0] by fencing brokers 1 and 2, then unfence them
+            // so they are unfenced replicas (non-ISR) eligible for unclean election.
+            ctx.fenceBrokers(1, 2);
+            ctx.unfenceBrokers(1, 2);
+            PartitionRegistration partitionBefore = ctx.replicationControl.getPartition(fooId, 0);
+            assertEquals(0, partitionBefore.leader);
+            assertEquals(1, partitionBefore.isr.length, "ISR should be shrunk to just the leader");
+
+            // Mark the partition as switch pending
+            ConfigResource resource = new ConfigResource(ConfigResource.Type.TOPIC, "foo");
+            Map<ConfigResource, Map<String, Map.Entry<AlterConfigOp.OpType, String>>> disklessChanges = Map.of(
+                resource, Map.of(DISKLESS_ENABLE_CONFIG,
+                    new AbstractMap.SimpleImmutableEntry<>(AlterConfigOp.OpType.SET, "true")));
+            List<ApiMessageAndVersion> switchRecords =
+                ctx.replicationControl.markClassicToDisklessSwitchStarted(
+                    disklessChanges, Map.of(resource, ApiError.NONE));
+            ctx.replay(switchRecords);
+
+            // Fence the leader (broker 0) — partition becomes leaderless.
+            // Brokers 1 and 2 are unfenced replicas eligible for unclean election.
+            ctx.fenceBrokers(0);
+            PartitionRegistration partitionAfterFence = ctx.replicationControl.getPartition(fooId, 0);
+            assertFalse(partitionAfterFence.hasLeader(),
+                "Partition should be leaderless because the pending-switch guard " +
+                "prevented unclean election during fencing");
+
+            // Explicitly call maybeTriggerUncleanLeaderElection — should also be skipped
+            List<ApiMessageAndVersion> electionRecords = new ArrayList<>();
+            ctx.replicationControl.maybeTriggerUncleanLeaderElectionForLeaderlessPartitions(
+                electionRecords, Integer.MAX_VALUE);
+
+            assertEquals(0, electionRecords.size(),
+                "Expected no unclean election for partition with pending switch");
+        }
+
+        @Test
+        public void testBrokerFencingDoesNotTriggerUncleanElectionForPendingSwitchPartition() {
+            ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder()
+                .setStaticConfig(TopicConfig.UNCLEAN_LEADER_ELECTION_ENABLE_CONFIG, "true")
+                .build();
+            ctx.registerBrokers(0, 1, 2);
+            ctx.unfenceBrokers(0, 1, 2);
+            Uuid fooId = ctx.createTestTopic("foo", new int[][] {new int[] {0, 1, 2}}).topicId();
+
+            // Shrink ISR to just [0] by fencing brokers 1 and 2, then unfence them
+            // so they are replicas but not in ISR.
+            ctx.fenceBrokers(1, 2);
+            ctx.unfenceBrokers(1, 2);
+            PartitionRegistration partitionBefore = ctx.replicationControl.getPartition(fooId, 0);
+            assertEquals(0, partitionBefore.leader);
+            assertEquals(1, partitionBefore.isr.length, "ISR should be shrunk to just the leader");
+
+            // Mark the partition as switch pending
+            ConfigResource resource = new ConfigResource(ConfigResource.Type.TOPIC, "foo");
+            Map<ConfigResource, Map<String, Map.Entry<AlterConfigOp.OpType, String>>> disklessChanges = Map.of(
+                resource, Map.of(DISKLESS_ENABLE_CONFIG,
+                    new AbstractMap.SimpleImmutableEntry<>(AlterConfigOp.OpType.SET, "true")));
+            List<ApiMessageAndVersion> switchRecords =
+                ctx.replicationControl.markClassicToDisklessSwitchStarted(
+                    disklessChanges, Map.of(resource, ApiError.NONE));
+            ctx.replay(switchRecords);
+
+            // Fence the leader (broker 0) — brokers 1, 2 are unfenced replicas (non-ISR).
+            // With unclean enabled but pending switch, should NOT do unclean election.
+            ctx.fenceBrokers(0);
+            PartitionRegistration partition = ctx.replicationControl.getPartition(fooId, 0);
+
+            // Partition should be leaderless, not unclean-elected
+            assertFalse(partition.hasLeader(),
+                "Expected no unclean election for partition with pending switch");
+        }
+
+        @Test
+        public void testLegacyAlterConfigsRejectsImplicitSwitchWhenUnderReplicated() {
+            // Legacy AlterConfigs replaces the entire config map. If a topic has
+            // diskless.enable=false and the request omits it, the override would be deleted,
+            // switching to diskless via broker default. The precondition check must
+            // detect this implicit switch and reject it when partitions are unhealthy.
+            ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder()
+                .setStaticConfig(ServerConfigs.DISKLESS_ALLOW_FROM_CLASSIC_ENABLE_CONFIG, true)
+                .setDisklessStorageSystemEnabled(true)
+                .setDefaultDisklessEnable(true)
+                .build();
+            ctx.registerBrokers(0, 1, 2);
+            ctx.unfenceBrokers(0, 1, 2);
+            Uuid fooId = ctx.createTestTopic("foo", new int[][] {new int[] {0, 1, 2}},
+                Map.of(DISKLESS_ENABLE_CONFIG, "false"), (short) 0).topicId();
+
+            ConfigResource resource = new ConfigResource(ConfigResource.Type.TOPIC, "foo");
+            assertEquals("false", ctx.configurationControl.currentTopicConfig("foo").get(DISKLESS_ENABLE_CONFIG));
+
+            // Make the partition under-replicated
+            ctx.fenceBrokers(2);
+            PartitionRegistration partition = ctx.replicationControl.getPartition(fooId, 0);
+            assertTrue(partition.isr.length < partition.replicas.length);
+
+            // Legacy AlterConfigs with only retention.ms (omits diskless.enable).
+            // Since this would implicitly switch via broker default and the partition
+            // is under-replicated, it must be rejected.
+            ControllerResult<Map<ConfigResource, ApiError>> legacyResult =
+                ctx.configurationControl.legacyAlterConfigs(
+                    Map.of(resource, Map.of("retention.ms", "86400000")),
+                    false,
+                    r -> ctx.replicationControl.validateClassicToDisklessSwitchPreconditionForLegacy(
+                        r, Map.of(resource, Map.of("retention.ms", "86400000"))));
+
+            assertEquals(Errors.INVALID_CONFIG, legacyResult.response().get(resource).error(),
+                "Legacy AlterConfigs should reject implicit diskless switch when under-replicated");
+            assertTrue(legacyResult.response().get(resource).message().contains("under-replicated"),
+                "Expected 'under-replicated' in: " + legacyResult.response().get(resource).message());
+        }
+
+        @Test
+        public void testLegacyAlterConfigsEmitsSwitchRecordsForImplicitSwitch() {
+            // When partitions are healthy and legacy AlterConfigs implicitly enables diskless
+            // via override deletion, switch-pending records must be emitted.
+            ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder()
+                .setStaticConfig(ServerConfigs.DISKLESS_ALLOW_FROM_CLASSIC_ENABLE_CONFIG, true)
+                .setDisklessStorageSystemEnabled(true)
+                .setDefaultDisklessEnable(true)
+                .build();
+            ctx.registerBrokers(0, 1, 2);
+            ctx.unfenceBrokers(0, 1, 2);
+            ctx.createTestTopic("foo", new int[][] {new int[] {0, 1, 2}},
+                Map.of(DISKLESS_ENABLE_CONFIG, "false"), (short) 0);
+
+            ConfigResource resource = new ConfigResource(ConfigResource.Type.TOPIC, "foo");
+
+            // Legacy AlterConfigs with only retention.ms (omits diskless.enable).
+            // Partitions are healthy, so the implicit switch should succeed and produce
+            // switch-pending records.
+            Map<ConfigResource, Map<String, String>> newConfigs =
+                Map.of(resource, Map.of("retention.ms", "86400000"));
+            ControllerResult<Map<ConfigResource, ApiError>> legacyResult =
+                ctx.configurationControl.legacyAlterConfigs(newConfigs, false,
+                    r -> ctx.replicationControl.validateClassicToDisklessSwitchPreconditionForLegacy(
+                        r, newConfigs));
+            assertEquals(ApiError.NONE, legacyResult.response().get(resource));
+
+            // Call before replay (same order as QuorumController) — the override still
+            // exists in configData at this point.
+            List<ApiMessageAndVersion> switchRecords =
+                ctx.replicationControl.markClassicToDisklessSwitchStartedForLegacyAlterConfigs(
+                    newConfigs, legacyResult.response());
+            assertFalse(switchRecords.isEmpty(), "Expected switch-pending records for implicit diskless switch");
+
+            ctx.replay(legacyResult.records());
+            ctx.replay(switchRecords);
+        }
+
+        @Test
+        public void testElectLeadersRejectsUncleanElectionForPendingSwitchPartition() {
+            ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder()
+                .setStaticConfig(TopicConfig.UNCLEAN_LEADER_ELECTION_ENABLE_CONFIG, "true")
+                .build();
+            ctx.registerBrokers(0, 1, 2);
+            ctx.unfenceBrokers(0, 1, 2);
+            Uuid fooId = ctx.createTestTopic("foo", new int[][] {new int[] {0, 1, 2}}).topicId();
+
+            // Shrink ISR to just [0] by fencing brokers 1 and 2, then unfence them
+            ctx.fenceBrokers(1, 2);
+            ctx.unfenceBrokers(1, 2);
+            PartitionRegistration partitionBefore = ctx.replicationControl.getPartition(fooId, 0);
+            assertEquals(0, partitionBefore.leader);
+            assertEquals(1, partitionBefore.isr.length);
+
+            // Mark the partition as switch pending
+            ConfigResource resource = new ConfigResource(ConfigResource.Type.TOPIC, "foo");
+            Map<ConfigResource, Map<String, Map.Entry<AlterConfigOp.OpType, String>>> disklessChanges = Map.of(
+                resource, Map.of(DISKLESS_ENABLE_CONFIG,
+                    new AbstractMap.SimpleImmutableEntry<>(AlterConfigOp.OpType.SET, "true")));
+            List<ApiMessageAndVersion> switchRecords =
+                ctx.replicationControl.markClassicToDisklessSwitchStarted(
+                    disklessChanges, Map.of(resource, ApiError.NONE));
+            ctx.replay(switchRecords);
+
+            // Fence the leader to make partition leaderless
+            ctx.fenceBrokers(0);
+            PartitionRegistration partitionAfterFence = ctx.replicationControl.getPartition(fooId, 0);
+            assertFalse(partitionAfterFence.hasLeader());
+
+            // Attempt explicit unclean election via electLeaders API — should be rejected
+            ElectLeadersRequestData request = new ElectLeadersRequestData()
+                .setElectionType(ElectionType.UNCLEAN.value);
+            request.topicPartitions().add(new TopicPartitions()
+                .setTopic("foo")
+                .setPartitions(List.of(0)));
+
+            ControllerResult<ElectLeadersResponseData> result =
+                ctx.replicationControl.electLeaders(request);
+
+            assertEquals(0, result.records().size(),
+                "Expected no election records for partition with pending switch");
+
+            ReplicaElectionResult topicResult = result.response().replicaElectionResults().get(0);
+            assertEquals("foo", topicResult.topic());
+            PartitionResult partitionResult = topicResult.partitionResult().get(0);
+            assertEquals(0, partitionResult.partitionId());
+            assertEquals(Errors.INVALID_REQUEST.code(), partitionResult.errorCode());
+            assertTrue(partitionResult.errorMessage().contains("pending classic-to-diskless switch"),
+                "Expected pending switch message in: " + partitionResult.errorMessage());
+        }
+
     }
 
 }

--- a/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
@@ -192,6 +192,8 @@ public class ReplicationControlManagerTest {
             private boolean disklessRemoteStorageConsolidationEnabled = false;
             private boolean classicRemoteStorageForceEnabled = false;
             private List<String> classicRemoteStorageForceExcludeTopicRegexes = List.of();
+            private boolean disklessForceEnabled = false;
+            private List<String> disklessForceIncludeTopicRegexes = List.of();
 
             Builder setCreateTopicPolicy(CreateTopicPolicy createTopicPolicy) {
                 this.createTopicPolicy = Optional.of(createTopicPolicy);
@@ -248,6 +250,16 @@ public class ReplicationControlManagerTest {
                 return this;
             }
 
+            Builder setDisklessForceEnabled(boolean disklessForceEnabled) {
+                this.disklessForceEnabled = disklessForceEnabled;
+                return this;
+            }
+
+            Builder setDisklessForceIncludeTopicRegexes(List<String> disklessForceIncludeTopicRegexes) {
+                this.disklessForceIncludeTopicRegexes = disklessForceIncludeTopicRegexes;
+                return this;
+            }
+
             ReplicationControlTestContext build() {
                 return new ReplicationControlTestContext(metadataVersion,
                     createTopicPolicy,
@@ -259,7 +271,9 @@ public class ReplicationControlManagerTest {
                     disklessManagedReplicasEnable,
                     disklessRemoteStorageConsolidationEnabled,
                     classicRemoteStorageForceEnabled,
-                    classicRemoteStorageForceExcludeTopicRegexes);
+                    classicRemoteStorageForceExcludeTopicRegexes,
+                    disklessForceEnabled,
+                    disklessForceIncludeTopicRegexes);
             }
         }
 
@@ -290,7 +304,9 @@ public class ReplicationControlManagerTest {
             boolean disklessManagedReplicasEnable,
             boolean disklessRemoteStorageConsolidationEnabled,
             final boolean classicRemoteStorageForceEnabled,
-            final List<String> classicRemoteStorageForceExcludeTopicRegexes
+            final List<String> classicRemoteStorageForceExcludeTopicRegexes,
+            final boolean disklessForceEnabled,
+            final List<String> disklessForceIncludeTopicRegexes
         ) {
             this.time = time;
             this.featureControl = new FeatureControlManager.Builder().
@@ -340,6 +356,8 @@ public class ReplicationControlManagerTest {
                 setDisklessRemoteStorageConsolidationEnabled(disklessRemoteStorageConsolidationEnabled).
                 setClassicRemoteStorageForceEnabled(classicRemoteStorageForceEnabled).
                 setClassicRemoteStorageForceExcludeTopicRegexes(classicRemoteStorageForceExcludeTopicRegexes).
+                setDisklessForceEnabled(disklessForceEnabled).
+                setDisklessForceIncludeTopicRegexes(disklessForceIncludeTopicRegexes).
                 build();
             clusterControl.activate();
         }
@@ -3689,6 +3707,42 @@ public class ReplicationControlManagerTest {
             .filter(m -> m.message() instanceof ConfigRecord)
             .map(m -> (ConfigRecord) m.message())
             .noneMatch(r -> r.name().equals(REMOTE_LOG_STORAGE_ENABLE_CONFIG) && r.value().equals("true")));
+    }
+
+    @Test
+    void testDisklessForceInterceptorRejectsOnlyOffendingTopic() {
+        final ReplicationControlTestContext ctx = new ReplicationControlTestContext.Builder()
+            .setDisklessForceEnabled(true)
+            .setDisklessForceIncludeTopicRegexes(List.of("forced-.*"))
+            .setDisklessStorageSystemEnabled(true)
+            .build();
+        ctx.registerBrokers(0, 1, 2);
+        ctx.unfenceBrokers(0, 1, 2);
+
+        final CreateTopicsRequestData request = new CreateTopicsRequestData();
+
+        // Topic that matches the regex and explicitly sets diskless.enable=false — should be rejected
+        final CreateTopicsRequestData.CreatableTopicConfigCollection badConfigs = new CreateTopicsRequestData.CreatableTopicConfigCollection();
+        badConfigs.add(new CreateTopicsRequestData.CreatableTopicConfig()
+            .setName(DISKLESS_ENABLE_CONFIG)
+            .setValue("false"));
+        request.topics().add(new CreatableTopic()
+            .setName("forced-bad")
+            .setNumPartitions(1)
+            .setReplicationFactor((short) 1)
+            .setConfigs(badConfigs));
+
+        // Topic that does not match the regex — should succeed
+        request.topics().add(new CreatableTopic()
+            .setName("normal-topic")
+            .setNumPartitions(1)
+            .setReplicationFactor((short) 1));
+
+        final ControllerResult<CreateTopicsResponseData> result = ctx.replicationControl.createTopics(
+            anonymousContextFor(ApiKeys.CREATE_TOPICS), request, Set.of("forced-bad", "normal-topic"));
+
+        assertEquals(INVALID_REQUEST.code(), result.response().topics().find("forced-bad").errorCode());
+        assertEquals(NONE.code(), result.response().topics().find("normal-topic").errorCode());
     }
 
     @Nested

--- a/metadata/src/test/java/org/apache/kafka/metadata/PartitionRegistrationTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/PartitionRegistrationTest.java
@@ -593,4 +593,68 @@ public class PartitionRegistrationTest {
 
         assertEquals(PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING, merged.classicToDisklessStartOffset);
     }
+
+    @Test
+    public void testDefaultDisklessLeaderEpoch() {
+        PartitionRegistration registration = new PartitionRegistration.Builder().
+            setReplicas(new int[]{1, 2, 3}).setDirectories(DirectoryId.unassignedArray(3)).
+            setIsr(new int[]{1, 2, 3}).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
+            setLeaderEpoch(0).setPartitionEpoch(0).build();
+        assertEquals(PartitionRegistration.NO_DISKLESS_LEADER_EPOCH, registration.disklessLeaderEpoch);
+    }
+
+    @Test
+    public void testDisklessLeaderEpochRoundTrip() {
+        PartitionRegistration original = new PartitionRegistration.Builder().
+            setReplicas(new int[]{1, 2, 3}).setDirectories(DirectoryId.unassignedArray(3)).
+            setIsr(new int[]{1, 2, 3}).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
+            setLeaderEpoch(7).setPartitionEpoch(0).setClassicToDisklessStartOffset(42L).
+            setDisklessLeaderEpoch(7).build();
+
+        Uuid topicId = Uuid.randomUuid();
+        ApiMessageAndVersion record = original.toRecord(topicId, 0,
+            new ImageWriterOptions.Builder(MetadataVersion.latestTesting()).build());
+        PartitionRecord partitionRecord = (PartitionRecord) record.message();
+        PartitionRegistration restored = new PartitionRegistration(partitionRecord);
+
+        assertEquals(7, restored.disklessLeaderEpoch);
+        assertEquals(42L, restored.classicToDisklessStartOffset);
+        assertEquals(original, restored);
+    }
+
+    @Test
+    public void testMergeCapturesDisklessLeaderEpoch() {
+        PartitionRegistration original = new PartitionRegistration.Builder().
+            setReplicas(new int[]{1, 2, 3}).setDirectories(DirectoryId.unassignedArray(3)).
+            setIsr(new int[]{1, 2, 3}).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
+            setLeaderEpoch(5).setPartitionEpoch(0).
+            setClassicToDisklessStartOffset(PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING).build();
+
+        // Simulates the initDisklessLog commit: it carries both the seal and the captured leader epoch.
+        PartitionChangeRecord changeRecord = new PartitionChangeRecord();
+        changeRecord.unknownTaggedFields().add(
+            InitDisklessLogFields.encodeClassicToDisklessStartOffset(100L));
+        changeRecord.unknownTaggedFields().add(
+            InitDisklessLogFields.encodeDisklessLeaderEpoch(5));
+
+        PartitionRegistration merged = original.merge(changeRecord);
+        assertEquals(100L, merged.classicToDisklessStartOffset);
+        assertEquals(5, merged.disklessLeaderEpoch);
+    }
+
+    @Test
+    public void testMergePreservesDisklessLeaderEpoch() {
+        PartitionRegistration original = new PartitionRegistration.Builder().
+            setReplicas(new int[]{1, 2, 3}).setDirectories(DirectoryId.unassignedArray(3)).
+            setIsr(new int[]{1, 2, 3}).setLeader(1).setLeaderRecoveryState(LeaderRecoveryState.RECOVERED).
+            setLeaderEpoch(5).setPartitionEpoch(0).setClassicToDisklessStartOffset(100L).
+            setDisklessLeaderEpoch(5).build();
+
+        // A subsequent change record (e.g. a leader change) does not carry the diskless epoch tag.
+        PartitionRegistration merged = original.merge(new PartitionChangeRecord().
+            setLeader(2).setIsr(List.of(2, 3)));
+
+        assertEquals(5, merged.disklessLeaderEpoch);
+        assertEquals(100L, merged.classicToDisklessStartOffset);
+    }
 }

--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -1350,6 +1350,45 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
         self.logger.info("Running alter message format command...\n%s" % cmd)
         node.account.ssh(cmd)
 
+    def alter_topic_config(self, topic, config_name, config_value, node=None):
+        if node is None:
+            node = self.nodes[0]
+        self.logger.info("Altering topic %s config %s=%s", topic, config_name, config_value)
+
+        force_use_zk_connection = not self.all_nodes_configs_command_uses_bootstrap_server()
+
+        cmd = fix_opts_for_new_jvm(node)
+        cmd += "%s --entity-name %s --entity-type topics --alter --add-config %s=%s" % \
+              (self.kafka_configs_cmd_with_optional_security_settings(node, force_use_zk_connection),
+               topic, config_name, config_value)
+        self.logger.info("Running alter topic config command...\n%s" % cmd)
+        node.account.ssh(cmd)
+
+    def describe_topic_config(self, topic, node=None):
+        if node is None:
+            node = self.nodes[0]
+        self.logger.info("Describing config for topic %s", topic)
+
+        force_use_zk_connection = not self.all_nodes_configs_command_uses_bootstrap_server()
+
+        cmd = fix_opts_for_new_jvm(node)
+        cmd += "%s --entity-name %s --entity-type topics --describe" % \
+              (self.kafka_configs_cmd_with_optional_security_settings(node, force_use_zk_connection), topic)
+        self.logger.info("Running describe topic config command...\n%s" % cmd)
+        config = {}
+        in_config_block = False
+        for line in node.account.ssh_capture(cmd):
+            line = line.decode("utf-8") if isinstance(line, bytes) else line
+            stripped = line.strip()
+            if "configs for" in stripped.lower() and "are:" in stripped.lower():
+                in_config_block = True
+                continue
+            if in_config_block and stripped and "=" in stripped:
+                k, rest = stripped.split("=", 1)
+                v = rest.split(" ")[0]
+                config[k.strip()] = v.strip()
+        return config
+
     def kafka_acls_cmd_with_optional_security_settings(self, node, force_use_zk_connection, kafka_security_protocol = None, override_command_config = None):
         if self.quorum_info.using_kraft and not self.quorum_info.has_brokers:
             raise Exception("Must invoke kafka-acls against a broker, not a KRaft controller")

--- a/tests/kafkatest/services/kafka/templates/log4j.properties
+++ b/tests/kafkatest/services/kafka/templates/log4j.properties
@@ -139,3 +139,8 @@ log4j.additivity.kafka.authorizer.logger=false
 # Group Coordinator logging.
 log4j.logger.org.apache.kafka.coordinator={{ log_level|default("DEBUG") }}, kafkaInfoAppender, kafkaDebugAppender
 log4j.additivity.org.apache.kafka.coordinator=false
+
+ log4j.logger.software.amazon.awssdk=WARN, kafkaInfoAppender, kafkaDebugAppender
+ log4j.additivity.software.amazon.awssdk=false
+ log4j.logger.io.netty=WARN, kafkaInfoAppender, kafkaDebugAppender
+ log4j.additivity.io.netty=false

--- a/tests/kafkatest/services/kafka/templates/log4j2.yaml
+++ b/tests/kafkatest/services/kafka/templates/log4j2.yaml
@@ -295,3 +295,18 @@ Configuration:
         AppenderRef:
           - ref: KafkaInfoAppender
           - ref: KafkaDebugAppender
+
+      - name: software.amazon.awssdk
+        level: WARN
+        additivity: false
+        AppenderRef:
+          - ref: KafkaInfoAppender
+          - ref: KafkaDebugAppender
+
+      - name: io.netty
+        level: WARN
+        additivity: false
+        AppenderRef:
+          - ref: KafkaInfoAppender
+          - ref: KafkaDebugAppender
+

--- a/tests/kafkatest/tests/inkless/inkless_topic_switch_test.py
+++ b/tests/kafkatest/tests/inkless/inkless_topic_switch_test.py
@@ -1,0 +1,1620 @@
+# Inkless
+# Copyright (C) 2026 Aiven OY
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import uuid
+
+from ducktape.cluster.remoteaccount import RemoteCommandError
+from ducktape.mark import matrix
+from ducktape.mark.resource import cluster
+from ducktape.tests.test import Test, TestContext
+from ducktape.utils.util import wait_until
+
+from kafkatest.services.console_consumer import ConsoleConsumer
+from kafkatest.services.kafka import KafkaService, quorum
+from kafkatest.services.trogdor.degraded_network_fault_spec import DegradedNetworkFaultSpec
+from kafkatest.services.trogdor.network_partition_fault_spec import NetworkPartitionFaultSpec
+from kafkatest.services.trogdor.process_stop_fault_spec import ProcessStopFaultSpec
+from kafkatest.services.trogdor.trogdor import TrogdorService
+from kafkatest.services.verifiable_consumer import VerifiableConsumer
+from kafkatest.services.verifiable_producer import VerifiableProducer
+from kafkatest.utils import is_int_with_prefix
+
+
+def _enable_tiered_storage_classpath(kafka):
+    """Add the ``:storage`` test jar (containing ``LocalTieredStorage``)
+    to the broker classpath. ``kafka-run-class.sh`` neither scans
+    ``storage/build/libs/`` nor keeps ``*-test.jar`` files by default, so
+    we set ``INCLUDE_TEST_JARS=true`` and prepend the jar explicitly.
+
+    Patched on the instance rather than via a ``KafkaService`` subclass
+    because ducktape's ``render()`` resolves Jinja2 templates relative to
+    the class's module, which breaks for subclasses defined in test files.
+    """
+    original_start_cmd = kafka.start_cmd
+
+    def _patched_start_cmd(node):
+        kafka_home = kafka.path.home(node)
+        storage_test_libs = os.path.join(kafka_home, "storage", "build", "libs", "*-test.jar")
+        prefix = (
+            "export INCLUDE_TEST_JARS=true; "
+            "export CLASSPATH=\"$(echo %s 2>/dev/null | tr ' ' ':')${CLASSPATH:+:$CLASSPATH}\"; "
+        ) % (storage_test_libs,)
+        return prefix + original_start_cmd(node)
+
+    kafka.start_cmd = _patched_start_cmd
+
+
+class InklessClassicToDisklessSwitchTest(Test):
+    """System tests for classic-to-diskless topic switch.
+
+    Tests are organized into three categories:
+      A) Post-switch data availability 
+      B) Mid-switch fault tolerance (faults injected during switch)
+      C) Operational scenarios (concurrent switch, producer state)
+    """
+
+    SWITCH_TIMEOUT_SEC = 120
+    PRODUCE_TIMEOUT_SEC = 120
+    CONSUME_TIMEOUT_SEC = 120
+    BROKER_STARTUP_TIMEOUT_SEC = 120
+
+    def __init__(self, test_context: TestContext) -> None:
+        super(InklessClassicToDisklessSwitchTest, self).__init__(test_context=test_context)
+        self.num_brokers = 3
+        self.topic = "switch-test-topic"
+        self.num_partitions = 6
+        self.replication_factor = 3
+        self._switched_topics = set()
+
+    # -----------------------------------------------------------------------
+    # Cluster setup
+    # -----------------------------------------------------------------------
+
+    # Per-state JMX gauges that the Category B tests poll on every
+    # broker to confirm that the injected fault actually overlapped a mid-
+    # switch state (rather than landing after switch had already
+    # completed). Each entry maps a short state name to ``(count_object_name,
+    # oldest_age_ms_object_name)``: the count drives the assertion, the
+    # oldest-age gauge is reported alongside as diagnostic context (so a
+    # failure log shows e.g. ``max_count=2 max_age_ms=45123`` instead of just
+    # ``max_count=2``).
+    _IDLM_OBJ = "kafka.server:type=InitDisklessLogManager,name=%s"
+    SWITCH_STATE_GAUGES = {
+        "WaitingForReplication": (
+            _IDLM_OBJ % "WaitingForReplicationPartitions",
+            _IDLM_OBJ % "OldestWaitingForReplicationAgeMs",
+        ),
+        "SendingToController": (
+            _IDLM_OBJ % "SendingToControllerPartitions",
+            _IDLM_OBJ % "OldestSendingToControllerAgeMs",
+        ),
+        "AwaitingMetadata": (
+            _IDLM_OBJ % "AwaitingMetadataPartitions",
+            _IDLM_OBJ % "OldestAwaitingMetadataAgeMs",
+        ),
+    }
+    SEALED_LEADER_PARTITIONS_JMX_OBJECT = "kafka.server:type=ReplicaManager,name=SealedPartitionsCount"
+    INIT_DISKLESS_IN_FLIGHT_PARTITIONS_JMX_OBJECT = _IDLM_OBJ % "InFlightPartitions"
+    SWITCH_COMPLETION_JMX_OBJECT_NAMES = [
+        SEALED_LEADER_PARTITIONS_JMX_OBJECT,
+        INIT_DISKLESS_IN_FLIGHT_PARTITIONS_JMX_OBJECT,
+    ]
+    SWITCH_STATE_JMX_OBJECT_NAMES = [obj for pair in SWITCH_STATE_GAUGES.values() for obj in pair]
+    SWITCH_JMX_OBJECT_NAMES = SWITCH_COMPLETION_JMX_OBJECT_NAMES + SWITCH_STATE_JMX_OBJECT_NAMES
+    SWITCH_JMX_ATTRIBUTES = ["Value"]
+
+    def _create_kafka(self, num_nodes=None, controller_num_nodes=1,
+                      scrape_switch_state_jmx=False):
+        if num_nodes is None:
+            num_nodes = self.num_brokers
+        self._switched_topics = set()
+        jmx_object_names = self.SWITCH_JMX_OBJECT_NAMES if scrape_switch_state_jmx else \
+            self.SWITCH_COMPLETION_JMX_OBJECT_NAMES
+        self.kafka = KafkaService(
+            self.test_context,
+            num_nodes=num_nodes,
+            zk=None,
+            controller_num_nodes_override=controller_num_nodes,
+            server_prop_overrides=[
+                ["diskless.managed.rf.enable", "true"],
+            ],
+            jmx_object_names=jmx_object_names,
+            jmx_attributes=self.SWITCH_JMX_ATTRIBUTES,
+        )
+        # Switch configs (diskless.allow.from.classic.enable) require
+        # remote.log.storage.system.enable, which needs RSM class names.
+        # The NoOp classes are test-only and absent from the broker runtime
+        # classpath, but the controller never instantiates RemoteLogManager
+        # so referencing them there is safe. We must copy the list first
+        # because both KafkaService instances share the same list object.
+        controller_only_overrides = [
+            ["diskless.allow.from.classic.enable", "true"],
+            ["remote.log.storage.system.enable", "true"],
+            ["remote.log.storage.manager.class.name",
+             "org.apache.kafka.server.log.remote.storage.NoOpRemoteStorageManager"],
+            ["remote.log.metadata.manager.class.name",
+             "org.apache.kafka.server.log.remote.storage.NoOpRemoteLogMetadataManager"],
+        ]
+        if hasattr(self.kafka, 'isolated_controller_quorum') and self.kafka.isolated_controller_quorum:
+            ctrl = self.kafka.isolated_controller_quorum
+            ctrl.server_prop_overrides = list(ctrl.server_prop_overrides) + controller_only_overrides
+            # KafkaService forwards jmx_object_names/jmx_attributes to the
+            # isolated controller quorum too, but our broker-side MBeans
+            # (ReplicaManager, InitDisklessLogManager) don't exist on a
+            # controller-only node. Disable JMX scraping there so JmxTool
+            # doesn't block start_jmx_tool() waiting for MBeans that never
+            # show up.
+            ctrl.jmx_object_names = None
+            ctrl.jmx_attributes = []
+
+        security_protocol = 'PLAINTEXT'
+        self.kafka.security_protocol = security_protocol
+        self.kafka.interbroker_security_protocol = security_protocol
+        self.kafka.logs["kafka_data_1"]["collect_default"] = True
+        self.kafka.logs["kafka_data_2"]["collect_default"] = True
+        self.kafka.logs["kafka_operational_logs_debug"]["collect_default"] = True
+
+    def _create_classic_topic(self, topic=None, num_partitions=None):
+        if topic is None:
+            topic = self.topic
+        if num_partitions is None:
+            num_partitions = self.num_partitions
+        self.kafka.create_topic({
+            "topic": topic,
+            "partitions": num_partitions,
+            "replication-factor": self.replication_factor,
+            "configs": {
+                "min.insync.replicas": 2,
+                "diskless.enable": "false",
+            }
+        })
+
+    def _create_kafka_with_tiered_storage(self):
+        """Single-broker cluster with real (LocalTieredStorage) tiered storage
+        on the broker, plus the diskless-from-classic switch bridge.
+
+        Single broker keeps the test self-contained: LocalTieredStorage uses
+        a per-broker filesystem path, so multi-broker reads from remote would
+        require shared storage or sticky leadership - neither is needed to
+        exercise the classic-tiered to diskless switch path.
+        """
+        self.replication_factor = 1
+        self.num_partitions = 1
+        self._switched_topics = set()
+
+        storage_dir = os.path.join(KafkaService.PERSISTENT_ROOT, "kafka-tiered-storage")
+
+        common_overrides = [
+            ["diskless.managed.rf.enable", "true"],
+            ["remote.log.storage.system.enable", "true"],
+            ["diskless.allow.from.classic.enable", "true"],
+            ["remote.log.metadata.manager.class.name",
+             "org.apache.kafka.server.log.remote.metadata.storage.TopicBasedRemoteLogMetadataManager"],
+            ["remote.log.metadata.manager.listener.name", "PLAINTEXT"],
+            ["rlmm.config.remote.log.metadata.topic.replication.factor", "1"],
+            ["rlmm.config.remote.log.metadata.topic.num.partitions", "1"],
+            ["remote.log.manager.task.interval.ms", "1000"],
+            ["log.retention.check.interval.ms", "1000"],
+        ]
+
+        broker_overrides = list(common_overrides) + [
+            ["remote.log.storage.manager.class.name",
+             "org.apache.kafka.server.log.remote.storage.LocalTieredStorage"],
+            ["rsm.config.dir", storage_dir],
+            ["rsm.config.delete.on.close", "true"],
+        ]
+
+        # Controllers only validate the class names; using NoOp avoids needing
+        # LocalTieredStorage on the controller classpath.
+        controller_overrides = list(common_overrides) + [
+            ["remote.log.storage.manager.class.name",
+             "org.apache.kafka.server.log.remote.storage.NoOpRemoteStorageManager"],
+        ]
+
+        self.kafka = KafkaService(
+            self.test_context,
+            num_nodes=1,
+            zk=None,
+            controller_num_nodes_override=1,
+            server_prop_overrides=broker_overrides,
+            jmx_object_names=self.SWITCH_COMPLETION_JMX_OBJECT_NAMES,
+            jmx_attributes=self.SWITCH_JMX_ATTRIBUTES,
+        )
+        _enable_tiered_storage_classpath(self.kafka)
+        if hasattr(self.kafka, 'isolated_controller_quorum') and self.kafka.isolated_controller_quorum:
+            ctrl = self.kafka.isolated_controller_quorum
+            ctrl.server_prop_overrides = list(ctrl.server_prop_overrides) + controller_overrides
+            ctrl.jmx_object_names = None
+            ctrl.jmx_attributes = []
+
+        security_protocol = 'PLAINTEXT'
+        self.kafka.security_protocol = security_protocol
+        self.kafka.interbroker_security_protocol = security_protocol
+        self.kafka.logs["kafka_data_1"]["collect_default"] = True
+        self.kafka.logs["kafka_data_2"]["collect_default"] = True
+        self.kafka.logs["kafka_operational_logs_debug"]["collect_default"] = True
+
+    def _create_classic_tiered_topic(self, topic, num_partitions=1):
+        """Classic topic with tiered storage enabled and very short local
+        retention so closed segments are uploaded to remote and then
+        deleted from the local log directory.
+        ``segment.bytes`` has a hard floor of 1 MiB (LogConfig.validate),
+        so we additionally force time-based rolling via ``segment.ms`` to
+        produce closed segments quickly without needing a huge produce
+        volume.
+        """
+        self.kafka.create_topic({
+            "topic": topic,
+            "partitions": num_partitions,
+            "replication-factor": 1,
+            "configs": {
+                "remote.storage.enable": "true",
+                "min.insync.replicas": 1,
+                # 1 MiB is the enforced minimum for segment.bytes.
+                "segment.bytes": 1048576,
+                # Force a roll every 2s regardless of segment fill, so that
+                # produced records flow through closed segments quickly.
+                "segment.ms": 2000,
+                # Delete local segments ~immediately after the upload to remote.
+                "local.retention.ms": 1000,
+                # Long total retention so remote data remains during the test.
+                "retention.ms": 3600000,
+                "file.delete.delay.ms": 1000,
+            }
+        })
+
+    # -----------------------------------------------------------------------
+    # Helpers: switch
+    # -----------------------------------------------------------------------
+
+    def _switch_topic_to_diskless(self, topic=None):
+        if topic is None:
+            topic = self.topic
+        self.logger.info("Switching topic %s to diskless", topic)
+        self._switched_topics.add(topic)
+        self.kafka.alter_topic_config(topic, "diskless.enable", "true")
+
+    def _wait_for_switch_config(self, topic=None, timeout_sec=None):
+        """Wait until kafka-configs reports diskless.enable=true for the topic."""
+        if topic is None:
+            topic = self.topic
+        if timeout_sec is None:
+            timeout_sec = self.SWITCH_TIMEOUT_SEC
+
+        def check():
+            try:
+                config = self.kafka.describe_topic_config(topic)
+                return config.get("diskless.enable") == "true"
+            except Exception:
+                return False
+
+        wait_until(check, timeout_sec=timeout_sec, backoff_sec=2,
+                   err_msg="Topic %s did not become diskless within %ds" % (topic, timeout_sec))
+
+    def _wait_for_switch_complete(self, topic=None, timeout_sec=None):
+        """Wait until the classic-to-diskless init work has drained.
+
+        The topic config becomes visible before leaders finish sealing their
+        classic logs and before InitDisklessLogManager commits the diskless
+        start offsets. Poll broker-side JMX so post-switch produce/read
+        steps do not race the switch-pending state.
+        """
+        if topic is None:
+            topic = self.topic
+        if timeout_sec is None:
+            timeout_sec = self.SWITCH_TIMEOUT_SEC
+
+        self._wait_for_switch_config(topic, timeout_sec)
+        expected_sealed_leader_count = 0
+        for switched_topic in self._switched_topics:
+            description = self.kafka.describe_topic(switched_topic)
+            expected_sealed_leader_count += len(self.kafka.parse_describe_topic(description)["partitions"])
+
+        def check():
+            try:
+                self.kafka.read_jmx_output_all_nodes()
+                sealed_key = "%s:Value" % self.SEALED_LEADER_PARTITIONS_JMX_OBJECT
+                in_flight_key = "%s:Value" % self.INIT_DISKLESS_IN_FLIGHT_PARTITIONS_JMX_OBJECT
+                sealed_leader_count = 0.0
+                in_flight_init_count = 0.0
+                for time_to_stats in self.kafka.jmx_stats:
+                    if time_to_stats:
+                        latest = max(time_to_stats.keys())
+                        sealed_leader_count += time_to_stats[latest].get(sealed_key, 0)
+                        in_flight_init_count += time_to_stats[latest].get(in_flight_key, 0)
+                self.logger.info(
+                    "Switch state for %s: sealed leader partitions=%s/%s, in-flight init partitions=%s",
+                    topic,
+                    int(sealed_leader_count),
+                    int(expected_sealed_leader_count),
+                    int(in_flight_init_count)
+                )
+                return sealed_leader_count >= expected_sealed_leader_count and in_flight_init_count == 0
+            except Exception as e:
+                self.logger.debug("Failed to read switch JMX state for %s: %s", topic, e)
+                return False
+
+        wait_until(
+            check,
+            timeout_sec=timeout_sec,
+            backoff_sec=5,
+            err_msg=("Topic %s did not finish classic-to-diskless switch within %ds "
+                     "(expected at least %d sealed leader partitions and zero in-flight init partitions)" %
+                     (topic, timeout_sec, expected_sealed_leader_count))
+        )
+
+    # -----------------------------------------------------------------------
+    # Helpers: produce / consume
+    # -----------------------------------------------------------------------
+
+    def _start_producer(self, topic=None, num_nodes=1, max_messages=-1, enable_idempotence=True,
+                        throughput=10000):
+        if topic is None:
+            topic = self.topic
+        producer = VerifiableProducer(
+            context=self.test_context,
+            num_nodes=num_nodes,
+            kafka=self.kafka,
+            topic=topic,
+            max_messages=max_messages,
+            throughput=throughput,
+            message_validator=is_int_with_prefix,
+            enable_idempotence=enable_idempotence,
+            repeating_keys=max_messages if max_messages > 0 else 10000,
+        )
+        producer.start()
+        return producer
+
+    def _produce_messages(self, topic=None, num_messages=10000):
+        """Produce a fixed number of messages and wait for acks."""
+        if topic is None:
+            topic = self.topic
+        producer = self._start_producer(topic=topic, max_messages=num_messages)
+        wait_until(
+            lambda: producer.num_acked >= num_messages or producer.worker_errors,
+            timeout_sec=self.PRODUCE_TIMEOUT_SEC,
+            err_msg="Producer failed to produce %d messages in %ds" % (num_messages, self.PRODUCE_TIMEOUT_SEC)
+        )
+        assert not producer.worker_errors, "Unexpected producer errors: %s" % producer.worker_errors
+        acked = producer.num_acked
+        producer.stop()
+        producer.free()
+        return acked
+
+    def _consume_all_from_beginning(self, expected_count, topic=None, timeout_sec=None,
+                                    wait_for_completion=False):
+        """Start a fresh consumer from the beginning and collect all messages.
+
+        Returns the number of messages consumed. This is the Phase 2
+        validation that catches post-restart classic data availability bugs.
+        Set wait_for_completion when the caller needs an exact count rather
+        than stopping as soon as the expected minimum is observed.
+        """
+        if topic is None:
+            topic = self.topic
+        if timeout_sec is None:
+            timeout_sec = self.CONSUME_TIMEOUT_SEC
+
+        group_id = "fresh-%s" % str(uuid.uuid4())[:8]
+        consumer = ConsoleConsumer(
+            context=self.test_context,
+            num_nodes=1,
+            kafka=self.kafka,
+            topic=topic,
+            group_id=group_id,
+            from_beginning=True,
+            consumer_timeout_ms=30000,
+            isolation_level="read_committed",
+            print_key=True,
+        )
+        consumer.start()
+
+        consumer_seen_alive = [False]
+
+        def _check_consumed():
+            is_alive = consumer.alive(consumer.nodes[0])
+            if is_alive:
+                consumer_seen_alive[0] = True
+            if wait_for_completion:
+                has_consumed = len(consumer.messages_consumed[1]) > 0
+                return (consumer_seen_alive[0] or has_consumed) and not is_alive
+            if len(consumer.messages_consumed[1]) >= expected_count:
+                return True
+            return consumer_seen_alive[0] and not is_alive
+
+        wait_until(
+            _check_consumed,
+            timeout_sec=timeout_sec,
+            backoff_sec=2,
+            err_msg="Fresh consumer consumed only %d out of %d expected messages in %ds" %
+                    (len(consumer.messages_consumed[1]), expected_count, timeout_sec)
+        )
+
+        consumer.stop()
+        consumed = len(consumer.messages_consumed[1])
+
+        expected_relation = "==" if wait_for_completion else ">="
+        self.logger.info("Fresh consumer consumed %d messages from topic %s (expected %s %d)",
+                         consumed, topic, expected_relation, expected_count)
+        consumer.free()
+        return consumed
+
+    def _earliest_local_offset(self, topic, partition=0):
+        """Return the topic-partition's earliest-local offset via
+        kafka-get-offsets.sh --time -4 (i.e. OffsetSpec.earliestLocal()).
+
+        For a tiered topic this advances past 0 once segments have been
+        uploaded to remote and deleted from the broker's local log dir.
+        Returns -1 if the offset cannot be parsed yet."""
+        node = self.kafka.nodes[0]
+        cmd = "%s --bootstrap-server %s --topic %s --partitions %d --time -4" % (
+            self.kafka.path.script("kafka-get-offsets.sh", node),
+            self.kafka.bootstrap_servers(),
+            topic,
+            partition,
+        )
+        try:
+            output = node.account.ssh_capture(cmd, allow_fail=True)
+            for line in output:
+                line = line.decode("utf-8") if isinstance(line, bytes) else line
+                parts = line.strip().split(":")
+                if len(parts) == 3 and parts[0] == topic and parts[1] == str(partition):
+                    return int(parts[2])
+        except Exception as e:
+            self.logger.warn("Failed to read earliest-local offset for %s-%d: %s",
+                             topic, partition, str(e))
+        return -1
+
+    def _wait_for_local_log_truncation(self, topic, partition=0, timeout_sec=120):
+        """Wait until the topic's earliest-local offset advances past 0,
+        which proves that some segments have been tiered to remote AND
+        deleted locally (so reads from offset 0 must come from remote)."""
+        def check():
+            offset = self._earliest_local_offset(topic, partition)
+            self.logger.info("Topic %s-%d earliest-local offset: %d",
+                             topic, partition, offset)
+            return offset > 0
+
+        wait_until(
+            check,
+            timeout_sec=timeout_sec,
+            backoff_sec=2,
+            err_msg=("earliest-local offset for %s-%d did not advance past 0 within %ds; "
+                     "tiering or local retention is not progressing") %
+                    (topic, partition, timeout_sec)
+        )
+
+    def _wait_for_steady_production(self, producer, min_acked=5000, timeout_sec=60,
+                                    err_msg=None, worker_err_msg=None):
+        wait_until(
+            lambda: producer.num_acked >= min_acked or producer.worker_errors,
+            timeout_sec=timeout_sec,
+            err_msg=err_msg or "Producer did not reach %d acks in %ds" % (min_acked, timeout_sec)
+        )
+        if worker_err_msg is None:
+            worker_err_msg = "Unexpected producer errors: %s"
+        assert not producer.worker_errors, worker_err_msg % producer.worker_errors
+
+    # -----------------------------------------------------------------------
+    # Helpers: broker operations
+    # -----------------------------------------------------------------------
+
+    def _get_leader_node(self, topic=None, partition=0):
+        if topic is None:
+            topic = self.topic
+        leader = self.kafka.leader(topic, partition=partition)
+        return leader
+
+    def _get_follower_nodes(self, topic=None, partition=0):
+        if topic is None:
+            topic = self.topic
+        leader = self._get_leader_node(topic, partition)
+        replicas = self.kafka.replicas(topic, partition)
+        return [r for r in replicas if r != leader]
+
+    def _restart_broker(self, node, clean_shutdown=True):
+        self.logger.info("Restarting broker %s (clean=%s)", node.account.hostname, clean_shutdown)
+        self.kafka.restart_node(node, clean_shutdown=clean_shutdown, timeout_sec=self.BROKER_STARTUP_TIMEOUT_SEC)
+        self._restart_broker_jmx_tool(node)
+
+    def _stop_broker(self, node, clean_shutdown=True):
+        self.logger.info("Stopping broker %s (clean=%s)", node.account.hostname, clean_shutdown)
+        self.kafka.stop_node(node, clean_shutdown=clean_shutdown, timeout_sec=self.BROKER_STARTUP_TIMEOUT_SEC)
+        if not clean_shutdown:
+            # Unclean shutdown recovery only needs replacement leaders before the test can continue.
+            # Waiting for ISR shrinkage here adds replica.lag.time.max.ms latency and does not test
+            # the post-crash behavior any more precisely.
+            self._wait_for_all_partitions_have_leaders()
+
+    def _start_broker(self, node):
+        self.logger.info("Starting broker %s", node.account.hostname)
+        self.kafka.start_node(node, timeout_sec=self.BROKER_STARTUP_TIMEOUT_SEC)
+        self._restart_broker_jmx_tool(node)
+
+    def _restart_broker_jmx_tool(self, node):
+        """Refresh JmxTool after a broker JVM restart.
+
+        JmxMixin tracks whether it has ever started JmxTool on a node, but a
+        broker restart also kills the tool process. Reset only the JMX tool
+        state/log for this node so subsequent switch waits read live
+        post-restart samples. Before removing the old log, preserve any samples
+        not yet scraped into memory so the mid-switch assertions still see
+        states observed before the broker bounce.
+        """
+        if self.kafka.jmx_object_names is None:
+            return
+
+        idx = self.kafka.idx(node)
+        try:
+            self.kafka.read_jmx_output(idx, node)
+        except Exception as e:
+            self.logger.debug("Could not preserve pre-restart JMX samples from %s: %s",
+                              node.account.hostname, e)
+
+        node.account.kill_java_processes(
+            self.kafka.jmx_class_name(self.kafka.jmxtool_version(node)),
+            clean_shutdown=False,
+            allow_fail=True,
+        )
+        self.kafka.started[idx - 1] = False
+        node.account.ssh(
+            "rm -f -- %s %s" % (self.kafka.jmx_tool_log, self.kafka.jmx_tool_err_log),
+            allow_fail=False,
+        )
+        self.kafka.start_jmx_tool(idx, node)
+
+    def _rolling_restart(self, clean_shutdown=True):
+        self.logger.info("Performing rolling restart of all brokers")
+        for node in self.kafka.nodes:
+            self._restart_broker(node, clean_shutdown=clean_shutdown)
+            self._wait_for_all_partitions_have_leaders()
+            # Pace the next bounce on evidence that this broker is fetching again, without
+            # forcing all partitions to fully heal between every restart under degraded network.
+            self._wait_for_broker_in_isr(node, num_partitions=1)
+
+    def _wait_for_all_partitions_have_leaders(self, topic=None, num_partitions=None, timeout_sec=120):
+        if topic is None:
+            topic = self.topic
+        if num_partitions is None:
+            num_partitions = self.num_partitions
+
+        def all_partitions_have_leaders():
+            try:
+                query_node = None
+                for candidate in self.kafka.nodes:
+                    if self.kafka.pids(candidate):
+                        query_node = candidate
+                        break
+                if query_node is None:
+                    return False
+                # Query once through any live broker; per-partition calls are very slow under
+                # the network-degradation faults used by these tests.
+                describe_output = self.kafka.describe_topic(topic, node=query_node)
+                for p in range(num_partitions):
+                    line = self.kafka._describe_topic_line_for_partition(p, describe_output)
+                    if line is None:
+                        return False
+                    if int(line.split()[5]) < 0:
+                        return False
+                return True
+            except (Exception, RemoteCommandError):
+                return False
+
+        wait_until(
+            all_partitions_have_leaders,
+            timeout_sec=timeout_sec, backoff_sec=2,
+            err_msg="Not all %d partitions of %s had leaders within %ds" %
+                    (num_partitions, topic, timeout_sec)
+        )
+
+    def _wait_for_broker_in_isr(self, node, topic=None, num_partitions=None, timeout_sec=120):
+        if topic is None:
+            topic = self.topic
+        if num_partitions is None:
+            num_partitions = self.num_partitions
+        broker_idx = self.kafka.idx(node)
+
+        def broker_in_isr():
+            try:
+                query_node = None
+                for candidate in self.kafka.nodes:
+                    if self.kafka.pids(candidate):
+                        query_node = candidate
+                        break
+                if query_node is None:
+                    return False
+                for p in range(num_partitions):
+                    if broker_idx not in self.kafka.isr_idx_list(topic, partition=p, node=query_node):
+                        return False
+                return True
+            except (Exception, RemoteCommandError):
+                return False
+
+        wait_until(
+            broker_in_isr,
+            timeout_sec=timeout_sec, backoff_sec=2,
+            err_msg="Broker %d did not rejoin ISR for all %d partitions of %s within %ds" %
+                    (broker_idx, num_partitions, topic, timeout_sec)
+        )
+
+    def _wait_for_all_partitions_isr_full(self, topic=None, num_partitions=None, timeout_sec=180):
+        """Wait until every partition of the topic has a full ISR.
+
+        After a broker restart, partition leaders re-add the broker to ISR
+        independently as each one processes the next follower fetch, so the
+        per-partition timings are not identical. Tests that drive leadership
+        movement (preferred-replica election) for *all* partitions need every
+        partition's ISR healed first.
+        """
+        if topic is None:
+            topic = self.topic
+        if num_partitions is None:
+            num_partitions = self.num_partitions
+        expected_isr_size = self.replication_factor
+
+        def all_isr_full():
+            try:
+                query_node = None
+                for candidate in self.kafka.nodes:
+                    if self.kafka.pids(candidate):
+                        query_node = candidate
+                        break
+                if query_node is None:
+                    return False
+
+                # One describe call keeps this wait cheap even for 30 partitions over a slow link.
+                describe_output = self.kafka.describe_topic(topic, node=query_node)
+                for p in range(num_partitions):
+                    line = self.kafka._describe_topic_line_for_partition(p, describe_output)
+                    if line is None:
+                        return False
+                    if int(line.split()[5]) < 0:
+                        return False
+                    isr_csv = line.split()[9]
+                    isr_size = 0 if isr_csv == "Elr:" else len(isr_csv.split(","))
+                    if isr_size != expected_isr_size:
+                        return False
+                return True
+            except (Exception, RemoteCommandError):
+                return False
+
+        wait_until(
+            all_isr_full,
+            timeout_sec=timeout_sec, backoff_sec=2,
+            err_msg=("Not all %d partitions of %s reached full ISR size %d within %ds"
+                     % (num_partitions, topic, expected_isr_size, timeout_sec))
+        )
+
+    def _run_preferred_leader_election(self, topic=None):
+        """Run preferred-replica election for every partition of the topic.
+
+        With round-robin replica assignment, this redistributes leadership
+        back across all brokers (in particular, restoring leadership to a
+        recently-restarted broker for the partitions where it is the
+        preferred replica). Useful for regression tests that need a
+        previously-failed broker to actually serve consumer fetches.
+        """
+        if topic is None:
+            topic = self.topic
+        node = self.kafka.nodes[0]
+        cmd = "%s --bootstrap-server %s --election-type preferred --all-topic-partitions" % (
+            self.kafka.path.script("kafka-leader-election.sh", node),
+            self.kafka.bootstrap_servers(),
+        )
+        self.logger.info("Running preferred-leader election: %s", cmd)
+        # The tool exits non-zero if there is no election to run for some
+        # partition (e.g. already on the preferred leader); only the
+        # successful redistribution matters here.
+        node.account.ssh(cmd, allow_fail=True)
+
+    # -----------------------------------------------------------------------
+    # Helpers: Trogdor faults and mid-switch JMX assertions
+    # -----------------------------------------------------------------------
+
+    # Per-state mid-switch window used by the Category B tests. The two
+    # RPC-bounded windows are the ones the injected faults (broker restart,
+    # SIGKILL, SIGSTOP, rolling restart, network partition) most directly hit.
+    # Names are short state keys into ``SWITCH_STATE_GAUGES``.
+    DEFAULT_REQUIRED_SWITCH_STATES = (
+        "SendingToController",
+        "AwaitingMetadata",
+    )
+
+    # Two orthogonal floors, asserted together, that together establish
+    # "the fault really overlapped this switch phase". Each catches a
+    # different way the overlap could be illusory:
+    #
+    #   * ``partition_seconds`` - integral of the cluster-wide per-state
+    #     gauge over the 1 s JMX polls. Catches "fault never landed at
+    #     all" (value = 0) and "single non-zero sample" flukes (a value
+    #     of 2 requires at least two 1-partition-poll units of mass,
+    #     however distributed in time or across partitions).
+    #
+    #   * ``oldest_age_ms`` - max over brokers and polls of the
+    #     per-state oldest-age gauge. Catches sub-second state
+    #     traversals that all happened between polls: a healthy
+    #     classic->diskless transition is sub-millisecond, so a sample
+    #     showing >= 200 ms is two orders of magnitude above the
+    #     happy-path noise floor and direct evidence that the state
+    #     machine was actually blocked, not just briefly traversed.
+    #
+    # ``duration_sec`` (number of distinct 1 s polls with cluster-wide
+    # count >= 1) is computed and logged as diagnostic context but not
+    # asserted by default: with 1 s polling it is heavily quantised and
+    # nearly redundant with ``partition_seconds`` once that floor is
+    # >= 2. Tests that specifically want temporal-extent evidence can
+    # opt in via the ``min_duration_sec`` kwarg.
+    #
+    # Defaults are chosen well above the noise floor (single-sample
+    # flukes, JMX poll jitter, healthy-path transition times) and well
+    # below what every Category B fault that actually bites produces:
+    # even a vanilla broker restart with no ``tc`` shaping reliably
+    # produces partition_seconds ~20 / oldest_age_ms ~400-1000; a 30 s
+    # network partition with 6 partitions yields partition_seconds ~180
+    # / oldest_age_ms ~30000; a 2 Mbit/s + 200 ms RTT degraded network
+    # with 30 partitions yields partition_seconds in the tens /
+    # oldest_age_ms in the thousands.
+    DEFAULT_MIN_MID_SWITCH_PARTITION_SECONDS = 2
+    DEFAULT_MIN_MID_SWITCH_OLDEST_AGE_MS = 200
+
+    def _start_trogdor(self) -> None:
+        """Idempotently start a TrogdorService scoped to the Kafka brokers."""
+        if getattr(self, "trogdor", None) is None:
+            self.trogdor = TrogdorService(
+                context=self.test_context,
+                client_services=[self.kafka],
+            )
+            self.trogdor.start()
+
+    def _stop_trogdor(self) -> None:
+        if getattr(self, "trogdor", None) is not None:
+            self.trogdor.stop()
+            self.trogdor.free()
+            self.trogdor = None
+
+    def _degrade_network(self, latency_ms=200, rate_kbit=2000, duration_ms=5 * 60 * 1000,
+                         nodes=None, network_device="eth0", task_name="degrade-network"):
+        """Apply tc-based latency + rate limit to every broker NIC. Returns the
+        Trogdor task so the caller can ``.stop()`` it once switch finishes."""
+        if nodes is None:
+            nodes = list(self.kafka.nodes)
+        spec = DegradedNetworkFaultSpec(0, duration_ms)
+        for node in nodes:
+            spec.add_node_spec(
+                node.name, network_device,
+                latencyMs=latency_ms, rateLimitKbit=rate_kbit,
+            )
+        return self.trogdor.create_task(task_name, spec)
+
+    def _pause_broker_process(self, node, duration_ms, task_name="pause-broker"):
+        """SIGSTOP the broker JVM on ``node`` for ``duration_ms`` via Trogdor.
+        Returns the Trogdor task; Trogdor will SIGCONT automatically when
+        the task duration elapses or ``.stop()`` is called."""
+        spec = ProcessStopFaultSpec(
+            0, duration_ms, [node], self.kafka.java_class_name(),
+        )
+        return self.trogdor.create_task(task_name, spec)
+
+    def _wait_for_mid_switch_state(
+            self, state, min_partition_seconds=None, min_oldest_age_ms=None, timeout_sec=120) -> None:
+        """Poll historical JMX until the injected fault is observed overlapping ``state``.
+
+        This replaces fixed sleeps in network-partition tests with the same
+        evidence that the final assertions use: partition-seconds plus the
+        oldest-age gauge for the requested switch state.
+        """
+        if min_partition_seconds is None:
+            min_partition_seconds = self.DEFAULT_MIN_MID_SWITCH_PARTITION_SECONDS
+        if min_oldest_age_ms is None:
+            min_oldest_age_ms = self.DEFAULT_MIN_MID_SWITCH_OLDEST_AGE_MS
+
+        def check():
+            try:
+                self._assert_mid_switch_observed(
+                    require_states=(state,),
+                    min_partition_seconds=min_partition_seconds,
+                    min_oldest_age_ms=min_oldest_age_ms,
+                )
+                return True
+            except AssertionError as e:
+                self.logger.debug("%s switch JMX state is not ready yet: %s", state, e)
+                return False
+            except Exception as e:
+                self.logger.debug("Failed to read %s switch JMX state: %s", state, e)
+                return False
+
+        wait_until(
+            check,
+            timeout_sec=timeout_sec,
+            backoff_sec=2,
+            err_msg=("%s state did not reach partition_seconds >= %s and oldest_age_ms >= %s "
+                     "while the fault was active within %ds" %
+                     (state, min_partition_seconds, min_oldest_age_ms, timeout_sec))
+        )
+
+    def _assert_mid_switch_observed(
+            self,
+            require_states=None,
+            min_partition_seconds=None,
+            min_oldest_age_ms=None,
+            min_duration_sec=None) -> None:
+        """Assert that each state in ``require_states`` was occupied long
+        enough during the test that the injected fault must have
+        overlapped it, computed from the per-broker JmxTool logs scraped
+        when the Kafka service was started with
+        ``scrape_switch_state_jmx=True``.
+
+        Two orthogonal signals are asserted together by default (see the
+        class-level ``DEFAULT_MIN_MID_SWITCH_*`` thresholds for the
+        rationale of each floor):
+
+        - ``partition_seconds`` (mass): integral of the cluster-wide
+          per-state gauge over the 1 s polls. Catches "fault never
+          landed at all" and single non-zero-sample flukes.
+
+        - ``oldest_age_ms`` (stuck-time evidence): max over brokers and
+          polls of the per-state oldest-age gauge. Catches sub-second
+          state traversals that all happened between polls.
+
+        ``duration_sec`` (number of distinct 1 s polls with cluster-wide
+        count >= 1) is always computed and logged as diagnostic context
+        but only asserted when the caller passes ``min_duration_sec``.
+        """
+        if require_states is None:
+            require_states = self.DEFAULT_REQUIRED_SWITCH_STATES
+        if min_partition_seconds is None:
+            min_partition_seconds = self.DEFAULT_MIN_MID_SWITCH_PARTITION_SECONDS
+        if min_oldest_age_ms is None:
+            min_oldest_age_ms = self.DEFAULT_MIN_MID_SWITCH_OLDEST_AGE_MS
+
+        self.kafka.read_jmx_output_all_nodes()
+        per_node_stats = self.kafka.jmx_stats
+
+        all_times = set()
+        for ts in per_node_stats:
+            all_times.update(ts.keys())
+        if all_times:
+            start_sec = min(all_times)
+            end_sec = max(all_times)
+        else:
+            start_sec, end_sec = 0, -1
+
+        def _attr_key(obj_name):
+            return "%s:Value" % obj_name
+
+        def _cluster_sum_at(obj_name, t):
+            key = _attr_key(obj_name)
+            total = 0.0
+            for ts in per_node_stats:
+                bucket = ts.get(t)
+                if bucket is not None:
+                    total += bucket.get(key, 0)
+            return total
+
+        def _partition_seconds(obj_name):
+            total = 0.0
+            for t in range(start_sec, end_sec + 1):
+                total += _cluster_sum_at(obj_name, t)
+            return int(total)
+
+        def _duration_sec(obj_name):
+            count = 0
+            for t in range(start_sec, end_sec + 1):
+                if _cluster_sum_at(obj_name, t) >= 1:
+                    count += 1
+            return count
+
+        def _max_per_broker(obj_name):
+            # Max over (broker, time) of the gauge. Used for the oldest-age
+            # gauges, where summing across brokers (as JmxMixin does for
+            # ``maximum_jmx_value``) has no natural meaning - each
+            # partition is led by one broker, so we want the largest
+            # single sample anywhere in the cluster.
+            key = _attr_key(obj_name)
+            best = 0.0
+            for ts in per_node_stats:
+                for bucket in ts.values():
+                    v = bucket.get(key, 0)
+                    if v > best:
+                        best = v
+            return int(best)
+
+        summary_parts = []
+        for state, (count_obj, age_obj) in self.SWITCH_STATE_GAUGES.items():
+            summary_parts.append(
+                "%s: partition_seconds=%s duration_sec=%s oldest_age_ms=%s" %
+                (state,
+                 _partition_seconds(count_obj),
+                 _duration_sec(count_obj),
+                 _max_per_broker(age_obj))
+            )
+        summary = "; ".join(summary_parts)
+        self.logger.info("Mid-switch JMX summary: %s", summary)
+
+        failures = []
+        for state in require_states:
+            count_obj, age_obj = self.SWITCH_STATE_GAUGES[state]
+            partition_seconds = _partition_seconds(count_obj)
+            duration_sec = _duration_sec(count_obj)
+            oldest_age_ms = _max_per_broker(age_obj)
+
+            shortfalls = []
+            if partition_seconds < min_partition_seconds:
+                shortfalls.append("partition_seconds=%s < %s" %
+                                  (partition_seconds, min_partition_seconds))
+            if oldest_age_ms < min_oldest_age_ms:
+                shortfalls.append("oldest_age_ms=%s < %s" %
+                                  (oldest_age_ms, min_oldest_age_ms))
+            if min_duration_sec is not None and duration_sec < min_duration_sec:
+                shortfalls.append("duration_sec=%s < %s" %
+                                  (duration_sec, min_duration_sec))
+
+            if shortfalls:
+                failures.append("%s: %s" % (state, ", ".join(shortfalls)))
+
+        assert not failures, (
+            "Fault did not meaningfully overlap required switch "
+            "state(s): %s. Either the switch finished before the "
+            "fault landed, the fault did not actually degrade the state "
+            "machine, or the gauges are not being published. Full JMX "
+            "summary: %s." % ("; ".join(failures), summary)
+        )
+
+    # -----------------------------------------------------------------------
+    # Category A: Post-Switch Data Availability
+    # -----------------------------------------------------------------------
+
+    @cluster(num_nodes=5)
+    @matrix(metadata_quorum=[quorum.isolated_kraft])
+    def test_classic_data_available_after_restarts(self, metadata_quorum) -> None:
+        """After switch completes, verify classic + diskless data remains
+        readable after a single leader restart and after a full rolling restart.
+
+        The classic prefix is deliberately ~3x the diskless tail so that a
+        regression which only serves the diskless portion (or only the
+        classic portion) shows up as an obviously short consume rather than
+        a borderline count that could be mistaken for a flake."""
+        self._create_kafka()
+        self.kafka.start()
+        self._create_classic_topic()
+
+        classic_count = self._produce_messages(num_messages=15000)
+
+        self._switch_topic_to_diskless()
+        self._wait_for_switch_complete()
+
+        diskless_count = self._produce_messages(num_messages=5000)
+        total = classic_count + diskless_count
+
+        leader_node = self._get_leader_node(partition=0)
+        self._restart_broker(leader_node)
+        self._wait_for_all_partitions_isr_full()
+
+        consumed = self._consume_all_from_beginning(expected_count=total, timeout_sec=self.CONSUME_TIMEOUT_SEC,
+                                                    wait_for_completion=True)
+        assert consumed == total, "Expected exactly %d messages after restart but got %d" % (total, consumed)
+
+        self._rolling_restart()
+        self._wait_for_all_partitions_isr_full()
+
+        consumed = self._consume_all_from_beginning(expected_count=total, timeout_sec=self.CONSUME_TIMEOUT_SEC,
+                                                    wait_for_completion=True)
+        assert consumed == total, "Expected exactly %d messages after rolling restart but got %d" % (total, consumed)
+
+    @cluster(num_nodes=5)
+    @matrix(metadata_quorum=[quorum.isolated_kraft])
+    def test_classic_data_available_after_leader_failures(self, metadata_quorum) -> None:
+        """After switch, verify classic + diskless data remains readable
+        while the old leader is down and after an unclean broker restart."""
+        self._create_kafka()
+        self.kafka.start()
+        self._create_classic_topic()
+
+        classic_count = self._produce_messages(num_messages=10000)
+
+        self._switch_topic_to_diskless()
+        self._wait_for_switch_complete()
+
+        diskless_count = self._produce_messages(num_messages=5000)
+        total = classic_count + diskless_count
+
+        leader_node = self._get_leader_node(partition=0)
+        self._stop_broker(leader_node, clean_shutdown=True)
+        self._wait_for_all_partitions_have_leaders()
+
+        consumed = self._consume_all_from_beginning(expected_count=total, timeout_sec=self.CONSUME_TIMEOUT_SEC,
+                                                    wait_for_completion=True)
+
+        self._start_broker(leader_node)
+
+        assert consumed == total, "Classic data unavailable after leader change: expected exactly %d but got %d" % (total, consumed)
+
+        self._wait_for_all_partitions_isr_full()
+        leader_node = self._get_leader_node(partition=0)
+        self._stop_broker(leader_node, clean_shutdown=False)
+
+        self._start_broker(leader_node)
+        self._wait_for_all_partitions_isr_full()
+
+        consumed = self._consume_all_from_beginning(expected_count=total, timeout_sec=self.CONSUME_TIMEOUT_SEC,
+                                                    wait_for_completion=True)
+
+        assert consumed == total, "Classic data lost after unclean shutdown: expected exactly %d but got %d" % (total, consumed)
+
+    # -----------------------------------------------------------------------
+    # Category B: Mid-Switch Fault Tolerance
+    # -----------------------------------------------------------------------
+
+    @cluster(num_nodes=7)
+    @matrix(metadata_quorum=[quorum.isolated_kraft])
+    def test_switch_succeeds_with_degraded_network(self, metadata_quorum) -> None:
+        """Switch a classic topic to diskless under continuous load.
+        Verify no data loss."""
+        self.num_partitions = 30
+        self._create_kafka(scrape_switch_state_jmx=True)
+        self.kafka.start()
+        self._create_classic_topic()
+
+        self._start_trogdor()
+        degrade = self._degrade_network()
+
+        producer = self._start_producer(max_messages=-1)
+        consumer = VerifiableConsumer(
+            context=self.test_context,
+            num_nodes=1,
+            kafka=self.kafka,
+            topic=self.topic,
+            group_id="continuous-%s" % str(uuid.uuid4())[:8],
+            enable_autocommit=True,
+        )
+        consumer.start()
+
+        self._wait_for_steady_production(producer, min_acked=5000)
+
+        self._switch_topic_to_diskless()
+        self._wait_for_switch_complete()
+
+        post_switch_target = producer.num_acked + 5000
+        self._wait_for_steady_production(
+            producer,
+            min_acked=post_switch_target,
+            timeout_sec=180,
+            err_msg="Producer did not reach %d acks within 180s after switch" % post_switch_target,
+            worker_err_msg="Producer errors after switch under degraded network: %s",
+        )
+
+        producer.stop()
+        total_produced = producer.num_acked
+        producer.free()
+
+        wait_until(
+            lambda: consumer.total_consumed() >= total_produced or consumer.worker_errors,
+            timeout_sec=self.CONSUME_TIMEOUT_SEC,
+            err_msg="Consumer consumed only %d out of %d produced" % (consumer.total_consumed(), total_produced)
+        )
+        assert not consumer.worker_errors, "Consumer errors: %s" % consumer.worker_errors
+        consumer.stop()
+        total_consumed = consumer.total_consumed()
+        consumer.free()
+
+        self._assert_mid_switch_observed()
+
+        degrade.stop()
+        degrade.wait_for_done(timeout_sec=60)
+        self._stop_trogdor()
+
+        assert total_consumed >= total_produced, \
+            "Data loss: produced %d but consumed only %d" % (total_produced, total_consumed)
+
+    @cluster(num_nodes=6)
+    @matrix(metadata_quorum=[quorum.isolated_kraft])
+    def test_switch_leader_restart(self, metadata_quorum) -> None:
+        """Restart the leader broker during switch. Verify switch
+        completes and all data is readable via fresh consumer.
+
+        Runs under a degraded broker network (200 ms latency, 2 Mbit/s) and
+        with 30 partitions so the restart reliably overlaps a partition still
+        in SendingToController or AwaitingMetadata; the JMX assertion at the
+        end fails the test if that overlap never happened."""
+        self.num_partitions = 30
+        self._create_kafka(scrape_switch_state_jmx=True)
+        self.kafka.start()
+        self._create_classic_topic()
+
+        self._start_trogdor()
+        degrade = self._degrade_network()
+
+        producer = self._start_producer(max_messages=-1)
+        self._wait_for_steady_production(producer, min_acked=5000)
+
+        self._switch_topic_to_diskless()
+
+        leader_node = self._get_leader_node(partition=0)
+        self._restart_broker(leader_node)
+
+        self._wait_for_switch_complete()
+        self._wait_for_steady_production(producer, min_acked=producer.num_acked + 5000, timeout_sec=180)
+
+        producer.stop()
+        total_produced = producer.num_acked
+        producer.free()
+
+        self._assert_mid_switch_observed()
+
+        degrade.stop()
+        degrade.wait_for_done(timeout_sec=60)
+        self._stop_trogdor()
+
+        consumed = self._consume_all_from_beginning(expected_count=total_produced,
+                                                    timeout_sec=self.CONSUME_TIMEOUT_SEC,
+                                                    wait_for_completion=True)
+        assert consumed == total_produced, \
+            "Unexpected message count after leader restart during switch: expected exactly %d but got %d" % (total_produced, consumed)
+
+    @cluster(num_nodes=6)
+    @matrix(
+        metadata_quorum=[quorum.isolated_kraft],
+        leader_failure_mode=["sigkill", "sigstop"],
+    )
+    def test_switch_leader_crash(self, metadata_quorum, leader_failure_mode) -> None:
+        """Take down the leader during switch via either SIGKILL or SIGSTOP
+        and verify switch completes plus all data is recoverable.
+
+        ``sigkill`` exercises hard-loss-of-in-memory-state recovery: the broker
+        is killed, restarted, and must rebuild its InitDisklessLogManager state
+        from disk and incoming metadata.
+
+        ``sigstop`` (Trogdor ProcessStopFaultSpec) freezes the broker process
+        while keeping in-memory state intact: the controller and other brokers
+        observe it as unresponsive, leadership/switch progress on partitions
+        led by it must continue, and after SIGCONT the broker should rejoin and
+        catch up without re-issuing duplicate InitDisklessLog requests."""
+        self.num_partitions = 30
+        self._create_kafka(scrape_switch_state_jmx=True)
+        self.kafka.start()
+        self._create_classic_topic()
+
+        self._start_trogdor()
+        degrade = self._degrade_network()
+
+        producer = self._start_producer(max_messages=-1)
+        self._wait_for_steady_production(producer, min_acked=5000)
+
+        self._switch_topic_to_diskless()
+
+        leader_node = self._get_leader_node(partition=0)
+        pause_duration_ms = 30_000
+        if leader_failure_mode == "sigkill":
+            self._stop_broker(leader_node, clean_shutdown=False)
+            self._start_broker(leader_node)
+        elif leader_failure_mode == "sigstop":
+            pause = self._pause_broker_process(leader_node, duration_ms=pause_duration_ms)
+            pause.wait_for_done(timeout_sec=pause_duration_ms // 1000 + 60)
+        else:
+            raise AssertionError("Unknown leader_failure_mode: %s" % leader_failure_mode)
+
+        self._wait_for_switch_complete()
+
+        self._wait_for_steady_production(
+            producer,
+            min_acked=producer.num_acked + 5000,
+            timeout_sec=240,
+            err_msg="Producer did not recover after leader %s" % leader_failure_mode,
+            worker_err_msg="Producer errors after leader %s during switch: %%s" % leader_failure_mode,
+        )
+        producer.stop()
+        total_produced = producer.num_acked
+        producer.free()
+
+        self._assert_mid_switch_observed()
+
+        degrade.stop()
+        degrade.wait_for_done(timeout_sec=60)
+        self._stop_trogdor()
+
+        consumed = self._consume_all_from_beginning(expected_count=total_produced,
+                                                    timeout_sec=self.CONSUME_TIMEOUT_SEC,
+                                                    wait_for_completion=True)
+        assert consumed == total_produced, \
+            "Unexpected message count after leader %s during switch: expected exactly %d but got %d" % \
+            (leader_failure_mode, total_produced, consumed)
+
+    @cluster(num_nodes=6)
+    @matrix(metadata_quorum=[quorum.isolated_kraft])
+    def test_switch_follower_crash_with_lagged_hw(self, metadata_quorum) -> None:
+        """SIGKILL a follower mid-switch while the leader's HW still lags
+        its LEO, then verify a fresh consumer reads every produced record
+        even after leadership moves back to the restarted broker.
+        """
+        self.num_partitions = 30
+        self._create_kafka(scrape_switch_state_jmx=True)
+        self.kafka.start()
+        self._create_classic_topic()
+
+        self._start_trogdor()
+        degrade = self._degrade_network()
+
+        producer = self._start_producer(max_messages=-1)
+        self._wait_for_steady_production(producer, min_acked=5000)
+
+        self._switch_topic_to_diskless()
+
+        target_follower = self._get_follower_nodes(partition=0)[0]
+        self.logger.info("Killing follower %s mid-switch", target_follower.account.hostname)
+        self._stop_broker(target_follower, clean_shutdown=False)
+        self._start_broker(target_follower)
+
+        self._wait_for_switch_complete()
+
+        self._wait_for_steady_production(
+            producer,
+            min_acked=producer.num_acked + 5000,
+            timeout_sec=240,
+            err_msg="Producer did not recover after follower SIGKILL",
+            worker_err_msg="Producer errors after follower SIGKILL during switch: %s",
+        )
+        producer.stop()
+        total_produced = producer.num_acked
+        producer.free()
+
+        self._assert_mid_switch_observed()
+
+        degrade.stop()
+        degrade.wait_for_done(timeout_sec=60)
+        self._stop_trogdor()
+
+        # Heal ISR on every partition so preferred-replica election can
+        # actually move leadership (a replica out of ISR cannot take over).
+        self._wait_for_all_partitions_isr_full()
+
+        # Force the previously-killed broker back into a leader role for
+        # the partitions where it is the preferred replica. Its local log
+        # contains the pre-crash classic data with a possibly-stale HW;
+        # only the fixed code path arms a replica fetcher to advance that
+        # HW to the seal so reads below the seal are not clamped.
+        self._run_preferred_leader_election()
+
+        consumed = self._consume_all_from_beginning(expected_count=total_produced,
+                                                    timeout_sec=self.CONSUME_TIMEOUT_SEC,
+                                                    wait_for_completion=True)
+        assert consumed == total_produced, \
+            "Unexpected message count after follower SIGKILL during switch: expected exactly %d but got %d" % \
+            (total_produced, consumed)
+
+    @cluster(num_nodes=6)
+    @matrix(metadata_quorum=[quorum.isolated_kraft])
+    def test_switch_rolling_restart(self, metadata_quorum) -> None:
+        """Rolling restart all brokers during switch. Verify switch
+        completes and data is fully readable.
+
+        With a degraded broker network and 30 partitions, every broker bounce
+        in the rolling sequence lands while at least one other broker still
+        has partitions mid-switch. The JMX assertion at the end fails the
+        test if no partition was ever observed in the RPC-bounded states."""
+        self.num_partitions = 30
+        self._create_kafka(scrape_switch_state_jmx=True)
+        self.kafka.start()
+        self._create_classic_topic()
+
+        self._start_trogdor()
+        degrade = self._degrade_network()
+
+        # Lower throughput than the default 10k/s: under the degraded network
+        # (200ms latency, 2 Mbps cap) the cluster can only drain ~4.5k/s, so a
+        # higher target makes the producer accumulator grow unbounded across
+        # the rolling restart and OOMs the VerifiableProducer JVM.
+        producer = self._start_producer(max_messages=-1, throughput=3000)
+        self._wait_for_steady_production(producer, min_acked=5000)
+
+        self._switch_topic_to_diskless()
+
+        self._rolling_restart()
+
+        # After the final bounce, wait for cluster-wide ISR recovery before
+        # using switch-complete JMX. This avoids racing leaders that still
+        # cannot finish init work because their replicas have not caught up.
+        self._wait_for_all_partitions_isr_full(timeout_sec=240)
+        self._wait_for_switch_complete()
+
+        self._wait_for_steady_production(
+            producer,
+            min_acked=producer.num_acked + 5000,
+            timeout_sec=240,
+            err_msg="Producer did not recover after rolling restart",
+            worker_err_msg="Producer errors after rolling restart during switch: %s",
+        )
+        producer.stop()
+        total_produced = producer.num_acked
+        producer.free()
+
+        self._assert_mid_switch_observed()
+
+        degrade.stop()
+        degrade.wait_for_done(timeout_sec=60)
+        self._stop_trogdor()
+
+        consumed = self._consume_all_from_beginning(expected_count=total_produced,
+                                                    timeout_sec=self.CONSUME_TIMEOUT_SEC,
+                                                    wait_for_completion=True)
+        assert consumed == total_produced, \
+            "Unexpected message count after rolling restart during switch: expected exactly %d but got %d" % (total_produced, consumed)
+
+    @cluster(num_nodes=6)
+    @matrix(metadata_quorum=[quorum.isolated_kraft])
+    def test_switch_follower_network_partition(self, metadata_quorum) -> None:
+        """Isolate a follower via Trogdor network partition during switch.
+        Verify ISR shrinks, switch completes, ISR re-expands, no data loss.
+
+        Switch is triggered while the partitioned follower is still
+        listed in ISR: it cannot fetch while isolated, so HW cannot advance
+        to LEO. Partitions therefore park in WaitingForReplication until
+        ISR shrinks (after replica.lag.time.max.ms, ~30 s) and the network
+        heals. The downstream states (SendingToController, AwaitingMetadata)
+        are subsecond once unblocked and frequently fall between 1 s JMX
+        polls, so we only assert the WaitingForReplication overlap here -
+        same rationale as ``test_switch_leader_network_partition``.
+
+        Note: triggering switch *after* waiting for ISR to shrink would
+        defeat the purpose of the fault - once the slow follower is out of
+        ISR, HW advances freely among the remaining replicas and
+        WaitingForReplication is traversed sub-millisecond."""
+        self._create_kafka(scrape_switch_state_jmx=True)
+        self.kafka.start()
+        self._create_classic_topic()
+
+        self._start_trogdor()
+
+        producer = self._start_producer(max_messages=-1)
+        self._wait_for_steady_production(producer, min_acked=5000)
+
+        follower_nodes = self._get_follower_nodes(partition=0)
+        follower = follower_nodes[0]
+
+        partition_spec = NetworkPartitionFaultSpec(
+            0, 5 * 60 * 1000,
+            [[follower], [n for n in self.kafka.nodes if n != follower]]
+        )
+        fault = self.trogdor.create_task("follower_partition", partition_spec)
+
+        self._switch_topic_to_diskless()
+
+        # The partition fault should block switch in WaitingForReplication;
+        # waiting on that JMX state is more precise than sleeping for ISR lag.
+        self._wait_for_mid_switch_state("WaitingForReplication", timeout_sec=120)
+
+        fault.stop()
+        fault.wait_for_done(timeout_sec=120)
+
+        self._wait_for_all_partitions_isr_full(num_partitions=1, timeout_sec=120)
+        self._wait_for_switch_complete()
+
+        self._wait_for_steady_production(
+            producer,
+            min_acked=producer.num_acked + 3000,
+            timeout_sec=120,
+            err_msg="Producer did not recover after follower partition",
+            worker_err_msg="Producer errors after follower partition during switch: %s",
+        )
+
+        producer.stop()
+        total_produced = producer.num_acked
+        producer.free()
+
+        self._assert_mid_switch_observed(require_states=("WaitingForReplication",))
+        self._stop_trogdor()
+
+        consumed = self._consume_all_from_beginning(expected_count=total_produced,
+                                                    timeout_sec=self.CONSUME_TIMEOUT_SEC,
+                                                    wait_for_completion=True)
+        assert consumed == total_produced, \
+            "Unexpected message count with follower partition during switch: expected exactly %d but got %d" % (total_produced, consumed)
+
+    @cluster(num_nodes=6)
+    @matrix(metadata_quorum=[quorum.isolated_kraft])
+    def test_switch_leader_network_partition(self, metadata_quorum) -> None:
+        """Isolate the leader via Trogdor network partition during switch.
+        Verify new leader elected, switch completes, ISR heals, no data loss.
+
+        The new leader picks up switch once it is elected. It can reach
+        the controller (only the old leader is isolated), but the old leader
+        is still listed in ISR and cannot catch up while partitioned, so HW
+        cannot advance to LEO. Partitions therefore park in
+        WaitingForReplication until ISR shrinks (after
+        replica.lag.time.max.ms, ~30 s) and the network heals. The downstream
+        states (SendingToController, AwaitingMetadata) are subsecond once
+        unblocked and frequently fall between 1 s JMX polls, so we only
+        assert the WaitingForReplication overlap here."""
+        self._create_kafka(scrape_switch_state_jmx=True)
+        self.kafka.start()
+        self._create_classic_topic()
+
+        self._start_trogdor()
+
+        producer = self._start_producer(max_messages=-1)
+        self._wait_for_steady_production(producer, min_acked=5000)
+
+        leader_node = self._get_leader_node(partition=0)
+        non_leader_nodes = [n for n in self.kafka.nodes if n != leader_node]
+
+        partition_spec = NetworkPartitionFaultSpec(
+            0, 5 * 60 * 1000,
+            [[leader_node], non_leader_nodes]
+        )
+        fault = self.trogdor.create_task("leader_partition", partition_spec)
+
+        self._switch_topic_to_diskless()
+
+        # The partition fault should block switch in WaitingForReplication;
+        # waiting on that JMX state is more precise than sleeping for ISR lag.
+        self._wait_for_mid_switch_state("WaitingForReplication", timeout_sec=120)
+
+        fault.stop()
+        fault.wait_for_done(timeout_sec=120)
+
+        self._wait_for_all_partitions_isr_full(num_partitions=1, timeout_sec=180)
+        self._wait_for_switch_complete()
+
+        self._wait_for_steady_production(
+            producer,
+            min_acked=producer.num_acked + 3000,
+            timeout_sec=120,
+            err_msg="Producer did not recover after leader partition",
+            worker_err_msg="Producer errors after leader partition during switch: %s",
+        )
+        producer.stop()
+        total_produced = producer.num_acked
+        producer.free()
+
+        self._assert_mid_switch_observed(require_states=("WaitingForReplication",))
+        self._stop_trogdor()
+
+        consumed = self._consume_all_from_beginning(expected_count=total_produced,
+                                                    timeout_sec=self.CONSUME_TIMEOUT_SEC,
+                                                    wait_for_completion=True)
+        assert consumed == total_produced, \
+            "Unexpected message count with leader partition during switch: expected exactly %d but got %d" % (total_produced, consumed)
+
+    # -----------------------------------------------------------------------
+    # Category C: Operational Scenarios
+    # -----------------------------------------------------------------------
+
+    @cluster(num_nodes=5)
+    @matrix(metadata_quorum=[quorum.isolated_kraft])
+    def test_switch_concurrent_topics(self, metadata_quorum) -> None:
+        """Switch 3 classic topics simultaneously. Verify all switch
+        successfully with no data loss."""
+        self._create_kafka()
+        self.kafka.start()
+
+        topics = ["concurrent-topic-%d" % i for i in range(3)]
+        produced_counts = {}
+
+        for topic in topics:
+            self._create_classic_topic(topic=topic, num_partitions=4)
+            produced_counts[topic] = self._produce_messages(topic=topic, num_messages=5000)
+
+        for topic in topics:
+            self._switch_topic_to_diskless(topic=topic)
+
+        for topic in topics:
+            self._wait_for_switch_complete(topic=topic)
+
+        for topic in topics:
+            post_count = self._produce_messages(topic=topic, num_messages=2000)
+            produced_counts[topic] += post_count
+
+        for topic in topics:
+            consumed = self._consume_all_from_beginning(
+                topic=topic,
+                expected_count=produced_counts[topic],
+                timeout_sec=self.CONSUME_TIMEOUT_SEC,
+                wait_for_completion=True
+            )
+            assert consumed == produced_counts[topic], \
+                "Unexpected message count on topic %s: expected exactly %d but got %d" % \
+                (topic, produced_counts[topic], consumed)
+
+    @cluster(num_nodes=3)
+    @matrix(metadata_quorum=[quorum.isolated_kraft])
+    def test_classic_tiered_to_diskless_switch(self, metadata_quorum) -> None:
+        """Switch a classic topic with real (LocalTieredStorage) tiered
+        storage to diskless, then read across all three layers.
+
+        Sequence:
+          1. Create a classic topic with ``remote.storage.enable=true``,
+             small ``segment.bytes``, and short ``local.retention.ms``.
+             Produce a first batch large enough to roll several segments.
+                                                          state: [empty]
+          2. Wait until the topic's earliest-local offset advances past 0,
+             confirming closed segments were uploaded to remote and then
+             deleted from local disk.
+                                                          state: [remote]
+          3. Produce a second batch. The active segment is never eligible
+             for upload, so the most recent records are local-only at this
+             instant.
+                                                          state: [remote][local]
+          4. Switch the topic to diskless and produce a third batch which
+             is written via the diskless write path.
+                                                          state: [remote][local][diskless]
+          5. A fresh consumer reads from offset 0 and must see every record,
+             crossing the remote->local boundary, the classic->diskless
+             boundary, and any internal classic-segment seam.
+        """
+        topic = "tiered-switch-topic"
+
+        self._create_kafka_with_tiered_storage()
+        self.kafka.start()
+        self._create_classic_tiered_topic(topic=topic)
+
+        remote_count = self._produce_messages(topic=topic, num_messages=8000)
+        self._wait_for_local_log_truncation(topic=topic)
+
+        local_count = self._produce_messages(topic=topic, num_messages=2000)
+
+        self._switch_topic_to_diskless(topic=topic)
+        self._wait_for_switch_complete(topic=topic)
+
+        diskless_count = self._produce_messages(topic=topic, num_messages=1000)
+
+        total = remote_count + local_count + diskless_count
+
+        consumed = self._consume_all_from_beginning(
+            topic=topic,
+            expected_count=total,
+            timeout_sec=self.CONSUME_TIMEOUT_SEC,
+            wait_for_completion=True,
+        )
+        assert consumed == total, \
+            "Cross-tier consumption (remote/local/diskless) failed: expected exactly %d but got %d" % \
+            (total, consumed)
+
+    @cluster(num_nodes=5)
+    @matrix(metadata_quorum=[quorum.isolated_kraft])
+    def test_switch_idempotent_producer_state(self, metadata_quorum) -> None:
+        """Verify idempotent producer state is preserved across the
+        switch boundary. The same producer continues producing after
+        switch without OutOfOrderSequence errors or duplicates."""
+        self._create_kafka()
+        self.kafka.start()
+        self._create_classic_topic()
+
+        producer = self._start_producer(max_messages=50000, enable_idempotence=True)
+        self._wait_for_steady_production(producer, min_acked=10000)
+
+        pre_switch_acked = producer.num_acked
+
+        self._switch_topic_to_diskless()
+        self._wait_for_switch_complete()
+
+        self._wait_for_steady_production(
+            producer,
+            min_acked=pre_switch_acked + 15000,
+            timeout_sec=self.PRODUCE_TIMEOUT_SEC,
+            err_msg="Idempotent producer stalled after switch at %d acks" % producer.num_acked,
+            worker_err_msg="Idempotent producer errors after switch (possible OutOfOrderSequence): %s",
+        )
+
+        producer.stop()
+        total_produced = producer.num_acked
+        producer.free()
+
+        consumed = self._consume_all_from_beginning(expected_count=total_produced,
+                                                    timeout_sec=self.CONSUME_TIMEOUT_SEC,
+                                                    wait_for_completion=True)
+        assert consumed == total_produced, \
+            "Unexpected message count with idempotent producer: expected exactly %d but got %d" % \
+            (total_produced, consumed)

--- a/tests/kafkatest/version.py
+++ b/tests/kafkatest/version.py
@@ -100,6 +100,15 @@ class KafkaVersion(LooseVersion):
     def supports_feature_command(self):
         return self >= V_3_8_0
 
+    def supports_command_config(self):
+        return self >= V_4_2_0
+
+    def supports_formatter_property(self):
+        return self >= V_4_2_0
+
+    def supports_command_property(self):
+        return self >= V_4_2_0
+
 def get_version(node=None):
     """Return the version attached to the given node.
     Default to DEV_BRANCH if node or node.version is undefined (aka None)
@@ -226,3 +235,7 @@ LATEST_4_0 = V_4_0_0
 # 4.1.x version
 V_4_1_0 = KafkaVersion("4.1.0")
 LATEST_4_1 = V_4_1_0
+
+# 4.2.x version
+V_4_2_0 = KafkaVersion("4.2.0")
+LATEST_4_2 = V_4_2_0


### PR DESCRIPTION
This cherry picks all latest commits from `main`, starting at https://github.com/aiven/inkless/commit/07e43ec131cc7aa63486e52594b2c1594f72647f into `inkless-4.1` branch.
