### PR TITLE
fix(inkless:switch): Fix stale HW on switched leader promotion

### DIFF
--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -3299,22 +3299,68 @@ class ReplicaManager(val config: KafkaConfig,
   }
 
   /**
-   * Reconciles a partition whose classic-to-diskless seal was *just committed* in this delta
-   * (previous seal < 0, now >= 0); other transitions are left untouched. Records beyond the seal
-   * are uncommitted (the diskless log continues from the seal), so:
-   *  - LEO > seal: truncate down to the seal (a follower/deposed leader that held un-replicated
-   *    records past a seal a different broker committed at a lower HW);
-   *  - LEO < seal and leader: fence offline. Unreachable on the clean path (the driving leader
-   *    seals at its own HW == LEO; a cleanly-elected leader comes from the ISR with LEO >= seal),
-   *    so it implies a corrupt classic prefix -- don't serve an incomplete prefix below the seal.
+   * Reconcile a leader whose classic-to-diskless seal has already been committed.
    *
-   * Must run after makeLeader/makeFollower (so the log exists) and before any catch-up or
-   * consolidation fetcher starts (so they initialize from the reconciled LEO).
+   * A committed seal is the first diskless offset and the classic prefix [0, seal) must be fully
+   * present on any cleanly-elected leader. Once sealed, the local classic log cannot advance HW
+   * naturally, so a leader promoted with a stale checkpointed HW must restore HW to the seal.
+   *
+   *  - LEO > seal: truncate down to the seal. Records at or above the seal are uncommitted classic
+   *    tail; diskless owns that range.
+   *  - LEO == seal and HW < seal: advance HW to the seal so consumers can cross into diskless.
+   *  - LEO < seal: fence offline. The classic prefix is incomplete, so serving it would hide a
+   *    hole in acknowledged data.
+   *
+   * Must run after makeLeader (so the log exists) and before any consolidation fetcher starts.
    */
-  private def maybeTruncateNewlySwitchedPartition(tp: TopicPartition,
-                                                  topicId: Uuid,
-                                                  newRegistration: PartitionRegistration,
-                                                  delta: TopicsDelta): Unit = {
+  private def maybeReconcileSwitchedLeader(tp: TopicPartition,
+                                           topicId: Uuid,
+                                           newRegistration: PartitionRegistration): Unit = {
+    val seal = newRegistration.classicToDisklessStartOffset
+    if (seal < 0) return
+
+    onlinePartition(tp).foreach { partition =>
+      try {
+        val log = partition.localLogOrException
+        if (log.logEndOffset > seal) {
+          stateChangeLogger.info(s"Truncating switched partition $tp from LEO ${log.logEndOffset} " +
+            s"to classic-to-diskless start offset $seal")
+          // Seal is the classicToDisklessStartOffset, the first offset owned by diskless storage.
+          // truncateTo(seal) removes all entries with offset >= seal, leaving LEO = seal.
+          // The last classic record is at offset seal - 1.
+          partition.truncateTo(seal, isFuture = false)
+        }
+        if (partition.isLeader) {
+          if (log.logEndOffset >= seal && log.highWatermark < seal) {
+            log.maybeUpdateHighWatermark(seal)
+            stateChangeLogger.info(s"Stale high watermark detected: advanced high watermark to seal offset $seal for " +
+              s"switched leader partition $tp")
+          } else if (log.logEndOffset < seal) {
+            // This is unreachable in normal operation
+            stateChangeLogger.error(s"Leader partition $tp has LEO ${log.logEndOffset} below " +
+              s"classic-to-diskless start offset $seal; cannot catch up from another replica. " +
+              s"Marking the partition offline as its local log is corrupt below the committed seal.")
+            markPartitionOffline(tp)
+          }
+        }
+      } catch {
+        case e: KafkaStorageException =>
+          stateChangeLogger.error(s"Unable to reconcile switched partition $tp " +
+            s"with topic ID $topicId due to a storage error ${e.getMessage}", e)
+          markPartitionOffline(tp)
+      }
+    }
+  }
+
+  /**
+   * Followers truncate only when the seal is committed in the current metadata delta. A switched
+   * follower may later grow past the seal as part of normal consolidation/catch-up flows; unlike a
+   * promoted leader, a follower should not be re-truncated on every unrelated metadata change.
+   */
+  private def maybeTruncateNewlySwitchedFollower(tp: TopicPartition,
+                                                 topicId: Uuid,
+                                                 newRegistration: PartitionRegistration,
+                                                 delta: TopicsDelta): Unit = {
     val seal = newRegistration.classicToDisklessStartOffset
     if (seal < 0) return
 
@@ -3328,22 +3374,13 @@ class ReplicaManager(val config: KafkaConfig,
       try {
         val log = partition.localLogOrException
         if (log.logEndOffset > seal) {
-          stateChangeLogger.info(s"Truncating switched partition $tp from LEO ${log.logEndOffset} " +
+          stateChangeLogger.info(s"Truncating switched follower partition $tp from LEO ${log.logEndOffset} " +
             s"to classic-to-diskless start offset $seal")
-          // Seal is the classicToDisklessStartOffset, the first offset owned by diskless storage.
-          // truncateTo(seal) removes all entries with offset >= seal, leaving LEO = seal.
-          // The last classic record is at offset seal - 1.
           partition.truncateTo(seal, isFuture = false)
-        } else if (log.logEndOffset < seal && partition.isLeader) {
-          // This is unreachable in normal operation
-          stateChangeLogger.error(s"Leader partition $tp has LEO ${log.logEndOffset} below " +
-            s"classic-to-diskless start offset $seal; cannot catch up from another replica. " +
-            s"Marking the partition offline as its local log is corrupt below the committed seal.")
-          markPartitionOffline(tp)
         }
       } catch {
         case e: KafkaStorageException =>
-          stateChangeLogger.error(s"Unable to reconcile switched partition $tp " +
+          stateChangeLogger.error(s"Unable to reconcile switched follower partition $tp " +
             s"with topic ID $topicId due to a storage error ${e.getMessage}", e)
           markPartitionOffline(tp)
       }
@@ -3526,16 +3563,6 @@ class ReplicaManager(val config: KafkaConfig,
             // local log; seal() here just marks the partition sealed for the HW restore below.
             partition.makeLeader(info.partition, isNew, offsetCheckpoints, Some(info.topicId), partitionAssignedDirectoryId)
             partition.seal()
-            // makeLeader reloads HW from the on-disk checkpoint, which may be stale
-            // (unclean shutdown, or checkpoint interval hadn't fired). Since the
-            // partition is sealed, no produces or follower fetches can ever advance
-            // HW naturally — restore it to the seal offset so consumers can read.
-            val sealOffset = _inklessMetadataView.getClassicToDisklessStartOffset(tp)
-            if (sealOffset >= 0 && partition.localLogOrException.highWatermark < sealOffset) {
-              partition.localLogOrException.maybeUpdateHighWatermark(sealOffset)
-              stateChangeLogger.info(s"Advanced high watermark to seal offset $sealOffset for " +
-                s"switched leader partition $tp after restart")
-            }
             changedPartitions.add(partition)
           } catch {
             case e: KafkaStorageException =>
@@ -3547,13 +3574,11 @@ class ReplicaManager(val config: KafkaConfig,
       }
     }
 
-    // Truncate any partition whose seal was just committed in this delta and whose local log still
-    // runs past it (uncommitted records beyond the committed seal). This must happen after
-    // makeLeader (so the log exists) and before the consolidation fetchers below start, so
-    // consolidation initializes against the truncated LEO. For the broker that drove the switch
-    // this is a no-op (it seals at its own HW == LEO); it is kept here as defense.
+    // Reconcile switched leaders after makeLeader so promoted leaders with stale checkpointed HW
+    // are immediately readable up to the seal, and corrupt/incomplete prefixes are fenced before
+    // serving reads.
     localLeaders.foreachEntry { (tp, info) =>
-      maybeTruncateNewlySwitchedPartition(tp, info.topicId, info.partition, delta)
+      maybeReconcileSwitchedLeader(tp, info.topicId, info.partition)
     }
 
     if (consolidatingDisklessPartitionsToStartFetching.nonEmpty) {
@@ -3683,7 +3708,7 @@ class ReplicaManager(val config: KafkaConfig,
     // truncated LEO. The fetch decisions above key off the high watermark (which never exceeds
     // the seal), so truncating here does not change which partitions need a catch-up fetcher.
     localFollowers.foreachEntry { (tp, info) =>
-      maybeTruncateNewlySwitchedPartition(tp, info.topicId, info.partition, delta)
+      maybeTruncateNewlySwitchedFollower(tp, info.topicId, info.partition, delta)
     }
 
     if (partitionsToStartFetching.nonEmpty) {

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -3320,34 +3320,39 @@ class ReplicaManager(val config: KafkaConfig,
     if (seal < 0) return
 
     onlinePartition(tp).foreach { partition =>
-      try {
-        val log = partition.localLogOrException
-        if (log.logEndOffset > seal) {
-          stateChangeLogger.info(s"Truncating switched partition $tp from LEO ${log.logEndOffset} " +
-            s"to classic-to-diskless start offset $seal")
-          // Seal is the classicToDisklessStartOffset, the first offset owned by diskless storage.
-          // truncateTo(seal) removes all entries with offset >= seal, leaving LEO = seal.
-          // The last classic record is at offset seal - 1.
-          partition.truncateTo(seal, isFuture = false)
-        }
-        if (partition.isLeader) {
-          if (log.logEndOffset >= seal && log.highWatermark < seal) {
-            log.maybeUpdateHighWatermark(seal)
-            stateChangeLogger.info(s"Stale high watermark detected: advanced high watermark to seal offset $seal for " +
-              s"switched leader partition $tp")
-          } else if (log.logEndOffset < seal) {
-            // This is unreachable in normal operation
-            stateChangeLogger.error(s"Leader partition $tp has LEO ${log.logEndOffset} below " +
-              s"classic-to-diskless start offset $seal; cannot catch up from another replica. " +
-              s"Marking the partition offline as its local log is corrupt below the committed seal.")
-            markPartitionOffline(tp)
+      partition.log match {
+        case Some(log) =>
+          try {
+            if (log.logEndOffset > seal) {
+              stateChangeLogger.info(s"Truncating switched partition $tp from LEO ${log.logEndOffset} " +
+                s"to classic-to-diskless start offset $seal")
+              // Seal is the classicToDisklessStartOffset, the first offset owned by diskless storage.
+              // truncateTo(seal) removes all entries with offset >= seal, leaving LEO = seal.
+              // The last classic record is at offset seal - 1.
+              partition.truncateTo(seal, isFuture = false)
+            }
+            if (partition.isLeader) {
+              if (log.logEndOffset >= seal && log.highWatermark < seal) {
+                log.maybeUpdateHighWatermark(seal)
+                stateChangeLogger.info(s"Stale high watermark detected: advanced high watermark to seal offset $seal for " +
+                  s"switched leader partition $tp")
+              } else if (log.logEndOffset < seal) {
+                // This is unreachable in normal operation
+                stateChangeLogger.error(s"Leader partition $tp has LEO ${log.logEndOffset} below " +
+                  s"classic-to-diskless start offset $seal; cannot catch up from another replica. " +
+                  s"Marking the partition offline as its local log is corrupt below the committed seal.")
+                markPartitionOffline(tp)
+              }
+            }
+          } catch {
+            case e: KafkaStorageException =>
+              stateChangeLogger.error(s"Unable to reconcile switched partition $tp " +
+                s"with topic ID $topicId due to a storage error ${e.getMessage}", e)
+              markPartitionOffline(tp)
           }
-        }
-      } catch {
-        case e: KafkaStorageException =>
-          stateChangeLogger.error(s"Unable to reconcile switched partition $tp " +
-            s"with topic ID $topicId due to a storage error ${e.getMessage}", e)
-          markPartitionOffline(tp)
+        case None =>
+          stateChangeLogger.warn(s"Skipping switched partition reconciliation for $tp " +
+            s"with topic ID $topicId because the local log is not available")
       }
     }
   }
@@ -3371,18 +3376,23 @@ class ReplicaManager(val config: KafkaConfig,
     if (!sealJustCommitted) return
 
     onlinePartition(tp).foreach { partition =>
-      try {
-        val log = partition.localLogOrException
-        if (log.logEndOffset > seal) {
-          stateChangeLogger.info(s"Truncating switched follower partition $tp from LEO ${log.logEndOffset} " +
-            s"to classic-to-diskless start offset $seal")
-          partition.truncateTo(seal, isFuture = false)
-        }
-      } catch {
-        case e: KafkaStorageException =>
-          stateChangeLogger.error(s"Unable to reconcile switched follower partition $tp " +
-            s"with topic ID $topicId due to a storage error ${e.getMessage}", e)
-          markPartitionOffline(tp)
+      partition.log match {
+        case Some(log) =>
+          try {
+            if (log.logEndOffset > seal) {
+              stateChangeLogger.info(s"Truncating switched follower partition $tp from LEO ${log.logEndOffset} " +
+                s"to classic-to-diskless start offset $seal")
+              partition.truncateTo(seal, isFuture = false)
+            }
+          } catch {
+            case e: KafkaStorageException =>
+              stateChangeLogger.error(s"Unable to reconcile switched follower partition $tp " +
+                s"with topic ID $topicId due to a storage error ${e.getMessage}", e)
+              markPartitionOffline(tp)
+          }
+        case None =>
+          stateChangeLogger.warn(s"Skipping switched follower partition reconciliation for $tp " +
+            s"with topic ID $topicId because the local log is not available")
       }
     }
   }

--- a/core/src/test/scala/unit/kafka/server/DisklessSwitchInvariantsTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DisklessSwitchInvariantsTest.scala
@@ -29,6 +29,7 @@ import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.record.{MemoryRecords, SimpleRecord}
 import org.apache.kafka.common.utils.Time
 import org.apache.kafka.image._
+import org.apache.kafka.metadata.{InitDisklessLogFields, PartitionRegistration}
 import org.apache.kafka.server.common.{KRaftVersion, MetadataVersion}
 import org.apache.kafka.server.config.ServerConfigs
 import org.apache.kafka.server.PartitionFetchState
@@ -84,18 +85,21 @@ class DisklessSwitchInvariantsTest {
 
   // --- Invariant: Sealed leader HW >= seal offset ---
 
-  @ParameterizedTest(name = "leader checkpoint hw={0}, seal={1}")
+  @ParameterizedTest(name = "leader checkpoint hw={0}, seal={1}, leo={2}")
   @MethodSource(Array("sealedLeaderScenarios"))
-  def testSealedLeaderHwInvariant(checkpointHw: Long, sealOffset: Long, expectedHw: Long): Unit = {
+  def testSealedLeaderHwInvariant(
+      checkpointHw: Long,
+      sealOffset: Long,
+      localLeo: Long,
+      expectedHw: Long,
+      expectedLeo: Long): Unit = {
     val topicName = "switched-topic"
     val topicId = Uuid.randomUuid()
     val tp = new TopicPartition(topicName, 0)
-    // For committed seals, LEO == seal (fully replicated). For pending/none, use a fixed LEO.
-    val leo = if (sealOffset >= 0) sealOffset else 10L
 
     replicaManager = createReplicaManager(List(topicName))
     val log = replicaManager.logManager.getOrCreateLog(tp, isNew = true, topicId = Optional.of(topicId))
-    populateLocalLogAtLeoAndCheckpointedHwm(replicaManager, tp, log, leo, checkpointHw)
+    populateLocalLogAtLeoAndCheckpointedHwm(replicaManager, tp, log, localLeo, checkpointHw)
 
     when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(tp))
       .thenReturn(sealOffset)
@@ -110,6 +114,8 @@ class DisklessSwitchInvariantsTest {
     assertEquals(expectedHw, partition.localLogOrException.highWatermark,
       s"Sealed leader invariant: HW must be >= sealOffset ($sealOffset) " +
       s"regardless of checkpoint state ($checkpointHw)")
+    assertEquals(expectedLeo, partition.localLogOrException.logEndOffset,
+      s"Sealed leader invariant: LEO must be reconciled to expected offset $expectedLeo")
   }
 
   // --- Invariant: Sealed follower with HW < seal triggers catch-up fetcher ---
@@ -156,7 +162,7 @@ class DisklessSwitchInvariantsTest {
   private def leaderDelta(topicName: String, topicId: Uuid): TopicsDelta = {
     val delta = new TopicsDelta(TopicsImage.EMPTY)
     delta.replay(new TopicRecord().setName(topicName).setTopicId(topicId))
-    delta.replay(new PartitionRecord()
+    val partitionRecord = new PartitionRecord()
       .setPartitionId(0)
       .setTopicId(topicId)
       .setReplicas(util.Arrays.asList(brokerId, brokerId + 1))
@@ -164,14 +170,15 @@ class DisklessSwitchInvariantsTest {
       .setLeader(brokerId)
       .setLeaderEpoch(0)
       .setPartitionEpoch(0)
-    )
+    addClassicToDisklessStartOffsetIfPresent(topicName, partitionRecord)
+    delta.replay(partitionRecord)
     delta
   }
 
   private def followerDelta(topicName: String, topicId: Uuid, leaderId: Int): TopicsDelta = {
     val delta = new TopicsDelta(TopicsImage.EMPTY)
     delta.replay(new TopicRecord().setName(topicName).setTopicId(topicId))
-    delta.replay(new PartitionRecord()
+    val partitionRecord = new PartitionRecord()
       .setPartitionId(0)
       .setTopicId(topicId)
       .setReplicas(util.Arrays.asList(brokerId, leaderId))
@@ -179,8 +186,18 @@ class DisklessSwitchInvariantsTest {
       .setLeader(leaderId)
       .setLeaderEpoch(0)
       .setPartitionEpoch(0)
-    )
+    addClassicToDisklessStartOffsetIfPresent(topicName, partitionRecord)
+    delta.replay(partitionRecord)
     delta
+  }
+
+  private def addClassicToDisklessStartOffsetIfPresent(topicName: String, partitionRecord: PartitionRecord): Unit = {
+    val sealOffset = replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(
+      new TopicPartition(topicName, partitionRecord.partitionId()))
+    if (sealOffset != PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET) {
+      partitionRecord.unknownTaggedFields().add(
+        InitDisklessLogFields.encodeClassicToDisklessStartOffset(sealOffset))
+    }
   }
 
   private def populateLocalLogAtLeoAndCheckpointedHwm(
@@ -263,28 +280,30 @@ object DisklessSwitchInvariantsTest {
   import org.apache.kafka.metadata.PartitionRegistration._
 
   def sealedLeaderScenarios(): java.util.stream.Stream[Arguments] = {
-    // (checkpointHw, sealOffset, expectedHwAfterApplyDelta)
+    // (checkpointHw, sealOffset, localLeo, expectedHwAfterApplyDelta, expectedLeoAfterApplyDelta)
     // Committed seal (>= 0): HW is always advanced to sealOffset regardless of checkpoint.
     // The post-restart path (getOrCreatePartition + makeLeader) creates a new Partition object
     // that re-initializes HW from the checkpoint via LazyOffsetCheckpoints. However, since the
     // log already exists, LogManager returns it without re-reading the checkpoint. The seal
     // offset advancement in applyLocalLeadersDelta (sealOffset >= 0 && HW < sealOffset guard)
-    // compensates by forcing HW = sealOffset.
+    // compensates by forcing HW = sealOffset, even when an uncommitted tail must first be
+    // truncated from LEO > seal to LEO == seal.
     java.util.stream.Stream.of(
-      Arguments.of(0L: java.lang.Long,  10L: java.lang.Long, 10L: java.lang.Long),  // unclean shutdown
-      Arguments.of(5L: java.lang.Long,  10L: java.lang.Long, 10L: java.lang.Long),  // partial flush
-      Arguments.of(10L: java.lang.Long, 10L: java.lang.Long, 10L: java.lang.Long),  // clean shutdown
+      Arguments.of(0L: java.lang.Long,  10L: java.lang.Long, 10L: java.lang.Long, 10L: java.lang.Long, 10L: java.lang.Long),  // unclean shutdown
+      Arguments.of(5L: java.lang.Long,  10L: java.lang.Long, 10L: java.lang.Long, 10L: java.lang.Long, 10L: java.lang.Long),  // partial flush
+      Arguments.of(5L: java.lang.Long,  10L: java.lang.Long, 13L: java.lang.Long, 10L: java.lang.Long, 10L: java.lang.Long),  // stale HW with uncommitted tail
+      Arguments.of(10L: java.lang.Long, 10L: java.lang.Long, 10L: java.lang.Long, 10L: java.lang.Long, 10L: java.lang.Long),  // clean shutdown
       // Pending seal (-2): partition is sealed. The HW is NOT advanced because the seal
       // offset is not yet committed. The post-restart path does not restore HW from
       // checkpoint for pending seals — the pending fetcher (follower side) will eventually
       // propagate the correct HW when the seal commits.
-      Arguments.of(0L: java.lang.Long,  CLASSIC_TO_DISKLESS_SWITCH_PENDING: java.lang.Long, 0L: java.lang.Long),
-      Arguments.of(5L: java.lang.Long,  CLASSIC_TO_DISKLESS_SWITCH_PENDING: java.lang.Long, 0L: java.lang.Long),
+      Arguments.of(0L: java.lang.Long,  CLASSIC_TO_DISKLESS_SWITCH_PENDING: java.lang.Long, 10L: java.lang.Long, 0L: java.lang.Long, 10L: java.lang.Long),
+      Arguments.of(5L: java.lang.Long,  CLASSIC_TO_DISKLESS_SWITCH_PENDING: java.lang.Long, 10L: java.lang.Long, 0L: java.lang.Long, 10L: java.lang.Long),
       // No switch (-1): not realistic today but documents defensive behavior of the
       // post-restart path which seals unconditionally. Relevant if diskless topics
       // eventually use local logs as a read cache.
-      Arguments.of(0L: java.lang.Long,  NO_CLASSIC_TO_DISKLESS_START_OFFSET: java.lang.Long, 0L: java.lang.Long),
-      Arguments.of(5L: java.lang.Long,  NO_CLASSIC_TO_DISKLESS_START_OFFSET: java.lang.Long, 0L: java.lang.Long),
+      Arguments.of(0L: java.lang.Long,  NO_CLASSIC_TO_DISKLESS_START_OFFSET: java.lang.Long, 10L: java.lang.Long, 0L: java.lang.Long, 10L: java.lang.Long),
+      Arguments.of(5L: java.lang.Long,  NO_CLASSIC_TO_DISKLESS_START_OFFSET: java.lang.Long, 10L: java.lang.Long, 0L: java.lang.Long, 10L: java.lang.Long),
     )
   }
 

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerInklessTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerInklessTest.scala
@@ -5202,7 +5202,7 @@ class ReplicaManagerInklessTest {
       // Apply a delta that makes this broker the leader (post-restart path).
       val delta = new TopicsDelta(TopicsImage.EMPTY)
       delta.replay(new TopicRecord().setName(topicName).setTopicId(topicId))
-      delta.replay(new PartitionRecord()
+      val partitionRecord = new PartitionRecord()
         .setPartitionId(0)
         .setTopicId(topicId)
         .setReplicas(util.Arrays.asList(brokerId, brokerId + 1))
@@ -5210,7 +5210,9 @@ class ReplicaManagerInklessTest {
         .setLeader(brokerId)
         .setLeaderEpoch(0)
         .setPartitionEpoch(0)
-      )
+      partitionRecord.unknownTaggedFields().add(
+        InitDisklessLogFields.encodeClassicToDisklessStartOffset(10L))
+      delta.replay(partitionRecord)
       replicaManager.applyDelta(delta, imageFromTopics(delta.apply()))
 
       val partition = replicaManager.getPartition(tp)
@@ -5243,7 +5245,7 @@ class ReplicaManagerInklessTest {
 
       val delta = new TopicsDelta(TopicsImage.EMPTY)
       delta.replay(new TopicRecord().setName(topicName).setTopicId(topicId))
-      delta.replay(new PartitionRecord()
+      val partitionRecord = new PartitionRecord()
         .setPartitionId(0)
         .setTopicId(topicId)
         .setReplicas(util.Arrays.asList(brokerId, brokerId + 1))
@@ -5251,7 +5253,9 @@ class ReplicaManagerInklessTest {
         .setLeader(brokerId)
         .setLeaderEpoch(0)
         .setPartitionEpoch(0)
-      )
+      partitionRecord.unknownTaggedFields().add(
+        InitDisklessLogFields.encodeClassicToDisklessStartOffset(10L))
+      delta.replay(partitionRecord)
       replicaManager.applyDelta(delta, imageFromTopics(delta.apply()))
 
       val partition = replicaManager.getPartition(tp)
@@ -5409,10 +5413,16 @@ class ReplicaManagerInklessTest {
   }
 
   // Build a follower delta where `brokerId` is a follower of `leaderId` for the given topic.
-  private def disklessFollowerDelta(topicName: String, topicId: Uuid, brokerId: Int, leaderId: Int): TopicsDelta = {
+  private def disklessFollowerDelta(
+    topicName: String,
+    topicId: Uuid,
+    brokerId: Int,
+    leaderId: Int,
+    classicToDisklessStartOffset: Long = PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET
+  ): TopicsDelta = {
     val delta = new TopicsDelta(TopicsImage.EMPTY)
     delta.replay(new TopicRecord().setName(topicName).setTopicId(topicId))
-    delta.replay(new PartitionRecord()
+    val partitionRecord = new PartitionRecord()
       .setPartitionId(0)
       .setTopicId(topicId)
       .setReplicas(util.Arrays.asList(brokerId, leaderId))
@@ -5420,7 +5430,23 @@ class ReplicaManagerInklessTest {
       .setLeader(leaderId)
       .setLeaderEpoch(0)
       .setPartitionEpoch(0)
-    )
+    if (classicToDisklessStartOffset != PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET) {
+      partitionRecord.unknownTaggedFields().add(
+        InitDisklessLogFields.encodeClassicToDisklessStartOffset(classicToDisklessStartOffset))
+    }
+    delta.replay(partitionRecord)
+    delta
+  }
+
+  private def promoteFollowerToLeaderDelta(topicsImage: TopicsImage,
+                                           topicId: Uuid,
+                                           partitionId: Int,
+                                           brokerId: Int): TopicsDelta = {
+    val delta = new TopicsDelta(topicsImage)
+    delta.replay(new PartitionChangeRecord()
+      .setTopicId(topicId)
+      .setPartitionId(partitionId)
+      .setLeader(brokerId))
     delta
   }
 
@@ -5517,6 +5543,157 @@ class ReplicaManagerInklessTest {
 
       // Nothing to catch up — no fetcher should be added for this partition.
       verify(mockFetcherManager, never()).addFetcherForPartitions(any())
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
+  def testApplyDeltaRestoresStaleHwmWhenSwitchedFollowerBecomesLeader(): Unit = {
+    val topicName = "switched-topic"
+    val topicId = Uuid.randomUuid()
+    val tp = new TopicPartition(topicName, 0)
+    val brokerId = 1
+    val leaderId = 2
+    val sealOffset = 10L
+
+    val mockFetcherManager = mock(classOf[ReplicaFetcherManager])
+    when(mockFetcherManager.removeFetcherForPartitions(any())).thenReturn(Map.empty[TopicPartition, PartitionFetchState])
+
+    val replicaManager = spy(createReplicaManager(
+      List(topicName),
+      mockReplicaFetcherManager = Some(mockFetcherManager),
+      initDisklessLogManager = Some(mock(classOf[InitDisklessLogManager]))
+    ))
+    try {
+      val log = replicaManager.logManager.getOrCreateLog(tp, isNew = true, topicId = Optional.of(topicId))
+      populateLocalLogAtLeoAndCheckpointedHwm(replicaManager, tp, log, leo = sealOffset, hw = 5L)
+      when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(tp)).thenReturn(sealOffset)
+
+      val followerDelta = disklessFollowerDelta(
+        topicName,
+        topicId,
+        brokerId,
+        leaderId,
+        classicToDisklessStartOffset = sealOffset
+      )
+      val followerImage = imageFromTopics(followerDelta.apply())
+      replicaManager.applyDelta(followerDelta, followerImage)
+
+      assertFalse(replicaManager.getPartition(tp).asInstanceOf[HostedPartition.Online].partition.isLeader)
+      assertEquals(5L, replicaManager.localLogOrException(tp).highWatermark)
+
+      val leaderDelta = promoteFollowerToLeaderDelta(
+        followerImage.topics(),
+        topicId,
+        tp.partition(),
+        brokerId
+      )
+      replicaManager.applyDelta(leaderDelta, imageFromTopics(leaderDelta.apply()))
+
+      val promotedPartition = replicaManager.getPartition(tp).asInstanceOf[HostedPartition.Online].partition
+      assertTrue(promotedPartition.isLeader)
+      assertTrue(promotedPartition.isSealed)
+      assertEquals(sealOffset, promotedPartition.localLogOrException.highWatermark,
+        "Promoted switched leader must restore stale HW to the committed seal")
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
+  def testApplyDeltaTruncatesSwitchedFollowerTailWhenBecomingLeader(): Unit = {
+    val topicName = "switched-topic"
+    val topicId = Uuid.randomUuid()
+    val tp = new TopicPartition(topicName, 0)
+    val brokerId = 1
+    val leaderId = 2
+    val sealOffset = 10L
+
+    val mockFetcherManager = mock(classOf[ReplicaFetcherManager])
+    when(mockFetcherManager.removeFetcherForPartitions(any())).thenReturn(Map.empty[TopicPartition, PartitionFetchState])
+
+    val replicaManager = spy(createReplicaManager(
+      List(topicName),
+      mockReplicaFetcherManager = Some(mockFetcherManager),
+      initDisklessLogManager = Some(mock(classOf[InitDisklessLogManager]))
+    ))
+    try {
+      val log = replicaManager.logManager.getOrCreateLog(tp, isNew = true, topicId = Optional.of(topicId))
+      populateLocalLogAtLeoAndCheckpointedHwm(replicaManager, tp, log, leo = 13L, hw = sealOffset)
+      when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(tp)).thenReturn(sealOffset)
+
+      val followerDelta = disklessFollowerDelta(
+        topicName,
+        topicId,
+        brokerId,
+        leaderId,
+        classicToDisklessStartOffset = sealOffset
+      )
+      val followerImage = imageFromTopics(followerDelta.apply())
+      replicaManager.applyDelta(followerDelta, followerImage)
+      assertEquals(13L, replicaManager.localLogOrException(tp).logEndOffset)
+
+      val leaderDelta = promoteFollowerToLeaderDelta(
+        followerImage.topics(),
+        topicId,
+        tp.partition(),
+        brokerId
+      )
+      replicaManager.applyDelta(leaderDelta, imageFromTopics(leaderDelta.apply()))
+
+      val promotedPartition = replicaManager.getPartition(tp).asInstanceOf[HostedPartition.Online].partition
+      assertTrue(promotedPartition.isLeader)
+      assertEquals(sealOffset, promotedPartition.localLogOrException.logEndOffset,
+        "Promoted switched leader must drop uncommitted classic records at or beyond the seal")
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
+  def testApplyDeltaFencesSwitchedFollowerBelowSealWhenBecomingLeader(): Unit = {
+    val topicName = "switched-topic"
+    val topicId = Uuid.randomUuid()
+    val tp = new TopicPartition(topicName, 0)
+    val brokerId = 1
+    val leaderId = 2
+    val sealOffset = 10L
+
+    val mockFetcherManager = mock(classOf[ReplicaFetcherManager])
+    when(mockFetcherManager.removeFetcherForPartitions(any())).thenReturn(Map.empty[TopicPartition, PartitionFetchState])
+
+    val replicaManager = spy(createReplicaManager(
+      List(topicName),
+      mockReplicaFetcherManager = Some(mockFetcherManager),
+      initDisklessLogManager = Some(mock(classOf[InitDisklessLogManager]))
+    ))
+    try {
+      val log = replicaManager.logManager.getOrCreateLog(tp, isNew = true, topicId = Optional.of(topicId))
+      populateLocalLogAtLeoAndCheckpointedHwm(replicaManager, tp, log, leo = 5L, hw = 5L)
+      when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(tp)).thenReturn(sealOffset)
+
+      val followerDelta = disklessFollowerDelta(
+        topicName,
+        topicId,
+        brokerId,
+        leaderId,
+        classicToDisklessStartOffset = sealOffset
+      )
+      val followerImage = imageFromTopics(followerDelta.apply())
+      replicaManager.applyDelta(followerDelta, followerImage)
+
+      val leaderDelta = promoteFollowerToLeaderDelta(
+        followerImage.topics(),
+        topicId,
+        tp.partition(),
+        brokerId
+      )
+      replicaManager.applyDelta(leaderDelta, imageFromTopics(leaderDelta.apply()))
+
+      val partition = replicaManager.getPartition(tp)
+      assertTrue(partition.isInstanceOf[HostedPartition.Offline],
+        s"Promoted leader below the committed seal must be fenced offline, but was $partition")
     } finally {
       replicaManager.shutdown(checkpointHW = false)
     }
@@ -6526,7 +6703,7 @@ class ReplicaManagerInklessTest {
 
   @Test
   def testApplyDeltaFencesLeaderWithLocalLogBelowCommittedSeal(): Unit = {
-    // Corruption-detection branch of maybeTruncateNewlySwitchedPartition: the switch is committed
+    // Corruption-detection branch of maybeReconcileSwitchedLeader: the switch is committed
     // (PENDING -> seal) while this broker is the leader, but the local log ends below the seal.
     // This is unreachable in normal operation (unclean leader election is not supported by the
     // diskless switch). Reaching here therefore means the leader's classic prefix has a hole in
@@ -6544,7 +6721,7 @@ class ReplicaManagerInklessTest {
 
     // disklessManagedReplicasEnabled and a present InitDisklessLogManager are both required so the
     // active classic-to-diskless switch branch runs for the leader (it bails out early otherwise),
-    // letting the seal-commit delta reach maybeTruncateNewlySwitchedPartition. The seal is committed
+    // letting the seal-commit delta reach maybeReconcileSwitchedLeader. The seal is committed
     // (>= 0, not PENDING), so the manager is never actually invoked here and a mock suffices.
     val replicaManager = spy(createReplicaManager(
       Seq(topicName),

--- a/tests/kafkatest/tests/inkless/inkless_topic_switch_test.py
+++ b/tests/kafkatest/tests/inkless/inkless_topic_switch_test.py
@@ -181,20 +181,27 @@ class InklessClassicToDisklessSwitchTest(Test):
         self.kafka.logs["kafka_data_2"]["collect_default"] = True
         self.kafka.logs["kafka_operational_logs_debug"]["collect_default"] = True
 
-    def _create_classic_topic(self, topic=None, num_partitions=None):
+    def _create_classic_topic(self, topic=None, num_partitions=None,
+                              replica_assignment=None, configs=None):
         if topic is None:
             topic = self.topic
         if num_partitions is None:
             num_partitions = self.num_partitions
-        self.kafka.create_topic({
+        topic_cfg = {
             "topic": topic,
-            "partitions": num_partitions,
-            "replication-factor": self.replication_factor,
             "configs": {
                 "min.insync.replicas": 2,
                 "diskless.enable": "false",
             }
-        })
+        }
+        if replica_assignment is None:
+            topic_cfg["partitions"] = num_partitions
+            topic_cfg["replication-factor"] = self.replication_factor
+        else:
+            topic_cfg["replica-assignment"] = replica_assignment
+        if configs:
+            topic_cfg["configs"].update(configs)
+        self.kafka.create_topic(topic_cfg)
 
     def _create_kafka_with_tiered_storage(self):
         """Single-broker cluster with real (LocalTieredStorage) tiered storage
@@ -576,6 +583,100 @@ class InklessClassicToDisklessSwitchTest(Test):
         replicas = self.kafka.replicas(topic, partition)
         return [r for r in replicas if r != leader]
 
+    def _wait_for_partition_leader(self, expected_node, topic=None, partition=0, timeout_sec=120):
+        if topic is None:
+            topic = self.topic
+        expected_broker_id = self.kafka.idx(expected_node)
+
+        def leader_is_expected():
+            try:
+                return self.kafka.idx(self._get_leader_node(topic, partition)) == expected_broker_id
+            except (Exception, RemoteCommandError):
+                return False
+
+        wait_until(
+            leader_is_expected,
+            timeout_sec=timeout_sec,
+            backoff_sec=2,
+            err_msg="Partition %s-%d did not move to expected leader broker %d within %ds" %
+                    (topic, partition, expected_broker_id, timeout_sec)
+        )
+
+    def _partition_log_dir(self, node, topic=None, partition=0):
+        if topic is None:
+            topic = self.topic
+        partition_dir = "%s-%d" % (topic, partition)
+        cmd = "for d in %s-*; do if [ -d \"$d/%s\" ]; then echo \"$d\"; fi; done" % (
+            KafkaService.DATA_LOG_DIR_PREFIX,
+            partition_dir,
+        )
+        log_dirs = []
+        for line in node.account.ssh_capture(cmd, allow_fail=True):
+            line = line.decode("utf-8") if isinstance(line, bytes) else line
+            stripped = line.strip()
+            if stripped:
+                log_dirs.append(stripped)
+        assert len(log_dirs) == 1, \
+            "Expected exactly one log dir for %s on %s, found %s" % \
+            (partition_dir, node.account.hostname, log_dirs)
+        return log_dirs[0]
+
+    def _set_replication_checkpoint_offset(self, node, topic=None, partition=0, offset=0):
+        """Rewrite the replica HW checkpoint for one topic-partition on a stopped broker.
+
+        This is only for fault injection: it creates a replica that has the full
+        local log on disk but reloads with a stale cached high-watermark.
+        """
+        if topic is None:
+            topic = self.topic
+        checkpoint = os.path.join(
+            self._partition_log_dir(node, topic, partition),
+            "replication-offset-checkpoint",
+        )
+
+        raw_checkpoint = ""
+        for line in node.account.ssh_capture("cat %s" % checkpoint):
+            line = line.decode("utf-8") if isinstance(line, bytes) else line
+            raw_checkpoint += line
+
+        lines = [line.strip() for line in raw_checkpoint.splitlines() if line.strip()]
+        assert len(lines) >= 2, "Malformed checkpoint %s on %s: %r" % \
+            (checkpoint, node.account.hostname, raw_checkpoint)
+
+        version = lines[0]
+        expected_entries = int(lines[1])
+        entry_lines = lines[2:]
+        assert expected_entries == len(entry_lines), \
+            "Malformed checkpoint %s on %s: expected %d entries but found %d" % \
+            (checkpoint, node.account.hostname, expected_entries, len(entry_lines))
+
+        entries = []
+        updated = False
+        for entry_line in entry_lines:
+            parts = entry_line.split()
+            assert len(parts) == 3, "Malformed checkpoint entry in %s: %r" % \
+                (checkpoint, entry_line)
+            entry_topic, entry_partition, entry_offset = parts
+            entry_partition = int(entry_partition)
+            if entry_topic == topic and entry_partition == partition:
+                entry_offset = offset
+                updated = True
+            else:
+                entry_offset = int(entry_offset)
+            entries.append((entry_topic, entry_partition, entry_offset))
+
+        if not updated:
+            entries.append((topic, partition, offset))
+
+        rewritten_checkpoint = "%s\n%d\n%s\n" % (
+            version,
+            len(entries),
+            "\n".join("%s %d %d" % entry for entry in entries),
+        )
+        self.logger.info("Setting %s-%d replication checkpoint on %s to %d",
+                         topic, partition, node.account.hostname, offset)
+        node.account.create_file(checkpoint, rewritten_checkpoint)
+
     def _restart_broker(self, node, clean_shutdown=True):
         self.logger.info("Restarting broker %s (clean=%s)", node.account.hostname, clean_shutdown)
         self.kafka.restart_node(node, clean_shutdown=clean_shutdown, timeout_sec=self.BROKER_STARTUP_TIMEOUT_SEC)
@@ -769,6 +870,19 @@ class InklessClassicToDisklessSwitchTest(Test):
         # The tool exits non-zero if there is no election to run for some
         # partition (e.g. already on the preferred leader); only the
         # successful redistribution matters here.
+        node.account.ssh(cmd, allow_fail=True)
+
+    def _run_unclean_leader_election(self, topic=None, partition=0):
+        if topic is None:
+            topic = self.topic
+        node = self.kafka.nodes[0]
+        cmd = "%s --bootstrap-server %s --election-type unclean --topic %s --partition %d" % (
+            self.kafka.path.script("kafka-leader-election.sh", node),
+            self.kafka.bootstrap_servers(),
+            topic,
+            partition,
+        )
+        self.logger.info("Running unclean leader election: %s", cmd)
         node.account.ssh(cmd, allow_fail=True)
 
     # -----------------------------------------------------------------------
@@ -1156,6 +1270,128 @@ class InklessClassicToDisklessSwitchTest(Test):
                                                     wait_for_completion=True)
 
         assert consumed == total, "Classic data lost after unclean shutdown: expected exactly %d but got %d" % (total, consumed)
+
+    @cluster(num_nodes=5)
+    @matrix(metadata_quorum=[quorum.isolated_kraft])
+    def test_switched_leader_promotion_restores_stale_hw(self, metadata_quorum) -> None:
+        """Promote an already-switched replica whose local HW is stale.
+
+        The CI failure this guards against is not missing log data: the promoted
+        replica has the whole classic prefix up to the committed seal, but its
+        cached high-watermark is below the seal. Without the leader-promotion
+        reconcile, consumers are clamped at that stale HW and never reach the
+        diskless tail. This test injects that state directly by rewriting the
+        preferred replica's HW checkpoint while it is stopped, then promoting it
+        after it has come back as an existing follower partition.
+        """
+        self.num_partitions = 1
+        self._create_kafka()
+        self.kafka.start()
+
+        stale_preferred = self.kafka.nodes[0]
+        switch_leader = self.kafka.nodes[1]
+        other_replica = self.kafka.nodes[2]
+        replica_assignment = "%d:%d:%d" % (
+            self.kafka.idx(stale_preferred),
+            self.kafka.idx(switch_leader),
+            self.kafka.idx(other_replica),
+        )
+        self._create_classic_topic(
+            num_partitions=1,
+            replica_assignment=replica_assignment,
+        )
+
+        # The preferred replica starts as leader. Move leadership away before
+        # producing/switching so it is a follower with a complete classic prefix.
+        self._wait_for_partition_leader(stale_preferred, partition=0)
+        self._stop_broker(stale_preferred, clean_shutdown=True)
+        self._wait_for_partition_leader(switch_leader, partition=0)
+        self._start_broker(stale_preferred)
+        self._wait_for_all_partitions_isr_full(num_partitions=1)
+        self._wait_for_partition_leader(switch_leader, partition=0)
+
+        classic_count = self._produce_messages(num_messages=5000)
+
+        self._switch_topic_to_diskless()
+        self._wait_for_switch_complete()
+
+        diskless_count = self._produce_messages(num_messages=1000)
+        total = classic_count + diskless_count
+
+        stale_hw = classic_count // 2
+        assert stale_hw > 0 and stale_hw < classic_count
+
+        # Enable unclean election only after the switch has committed. The
+        # switch precondition rejects topics with unclean election enabled, but
+        # the forced promotion below needs it to elect the isolated replica.
+        self.kafka.alter_topic_config(
+            self.topic,
+            "unclean.leader.election.enable",
+            "true",
+        )
+
+        # Restart the preferred follower with a stale HW checkpoint. Keep it
+        # partitioned from the current ISR so its follower fetcher cannot heal
+        # the HW before we promote it.
+        self._stop_broker(stale_preferred, clean_shutdown=True)
+        self._set_replication_checkpoint_offset(
+            stale_preferred,
+            partition=0,
+            offset=stale_hw,
+        )
+
+        self._start_trogdor()
+        partition_fault = None
+        try:
+            partition_spec = NetworkPartitionFaultSpec(
+                0,
+                5 * 60 * 1000,
+                [[stale_preferred], [switch_leader, other_replica]],
+            )
+            partition_fault = self.trogdor.create_task(
+                "isolate-stale-hw-preferred",
+                partition_spec,
+            )
+            wait_until(
+                lambda: partition_fault.running(),
+                timeout_sec=30,
+                backoff_sec=1,
+                err_msg="Network partition fault did not start before stale broker restart",
+            )
+
+            self._start_broker(stale_preferred)
+
+            # Take down the in-sync replicas so the isolated preferred replica
+            # is the only live replica and the unclean election picks it. This
+            # is deliberately a harness shortcut; the data-loss concern is
+            # avoided because the edited replica's LEO is the committed seal.
+            self.logger.info("Stopping ISR brokers %s and %s to force stale-HW leader promotion",
+                             switch_leader.account.hostname, other_replica.account.hostname)
+            self.kafka.stop_node(switch_leader, clean_shutdown=False,
+                                 timeout_sec=self.BROKER_STARTUP_TIMEOUT_SEC)
+            self.kafka.stop_node(other_replica, clean_shutdown=False,
+                                 timeout_sec=self.BROKER_STARTUP_TIMEOUT_SEC)
+            self._run_unclean_leader_election(partition=0)
+            self._wait_for_partition_leader(stale_preferred, partition=0)
+
+            partition_fault.stop()
+            partition_fault.wait_for_done(timeout_sec=60)
+            partition_fault = None
+        finally:
+            if partition_fault is not None:
+                partition_fault.stop()
+                partition_fault.wait_for_done(timeout_sec=60)
+            self._stop_trogdor()
+
+        consumed = self._consume_all_from_beginning(
+            expected_count=total,
+            timeout_sec=self.CONSUME_TIMEOUT_SEC,
+            wait_for_completion=True,
+        )
+        assert consumed == total, \
+            ("Stale-HW switched leader served only %d of %d records "
+             "(classic=%d, diskless=%d, injected stale HW=%d)") % \
+            (consumed, total, classic_count, diskless_count, stale_hw)
 
     # -----------------------------------------------------------------------
     # Category B: Mid-Switch Fault Tolerance


### PR DESCRIPTION
Reconcile already-switched leaders after makeLeader so a promoted replica with a stale checkpointed HW advances to the committed seal. Truncate any local classic tail above the seal, and fence leaders whose local LEO is below the seal to avoid serving an incomplete prefix. Keep follower truncation limited to the seal-commit delta. Add a deterministic system test for the stale-HW promotion regression.
