### PR TITLE
feat(inkless:tools): add operator tooling for topic type switch [KC-97]

### DIFF
--- a/bin/kafka-topic-switch.sh
+++ b/bin/kafka-topic-switch.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+exec $(dirname $0)/kafka-run-class.sh org.apache.kafka.tools.TopicSwitchCommand "$@"

--- a/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
@@ -332,6 +332,29 @@ public interface Admin extends AutoCloseable {
     DescribeTopicsResult describeTopics(TopicCollection topics, DescribeTopicsOptions options);
 
     /**
+     * Describe topic partitions in the cluster, returning raw response data including unknown tagged fields.
+     * This is a convenience method for {@link #describeTopicPartitions(Collection, DescribeTopicsOptions)}
+     * with default options.
+     *
+     * @param topics The topics to describe.
+     * @return The DescribeTopicPartitionsResult containing raw response data.
+     */
+    default DescribeTopicPartitionsResult describeTopicPartitions(Collection<String> topics) {
+        return describeTopicPartitions(topics, new DescribeTopicsOptions());
+    }
+
+    /**
+     * Describe topic partitions in the cluster, returning raw response data including unknown tagged fields.
+     * This is useful for accessing Inkless-specific metadata (classicToDisklessStartOffset, disklessLeaderEpoch,
+     * producerStates) that are encoded as tagged fields on the DescribeTopicPartitions response.
+     *
+     * @param topics  The topics to describe.
+     * @param options The options to use when describing the topics.
+     * @return The DescribeTopicPartitionsResult containing raw response data.
+     */
+    DescribeTopicPartitionsResult describeTopicPartitions(Collection<String> topics, DescribeTopicsOptions options);
+
+    /**
      * Get information about the nodes in the cluster, using the default options.
      * <p>
      * This is a convenience method for {@link #describeCluster(DescribeClusterOptions)} with default options.

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeTopicPartitionsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeTopicPartitionsResult.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.message.DescribeTopicPartitionsResponseData;
+
+/**
+ * Raw protocol result for {@link Admin#describeTopicPartitions(java.util.Collection, DescribeTopicsOptions)}.
+ * This exposes the raw protocol response data directly rather than a typed model.
+ * The returned data is mutable and may contain embedded errors that callers must inspect.
+ */
+public class DescribeTopicPartitionsResult {
+
+    private final KafkaFuture<DescribeTopicPartitionsResponseData> future;
+
+    public DescribeTopicPartitionsResult(KafkaFuture<DescribeTopicPartitionsResponseData> future) {
+        this.future = future;
+    }
+
+    /**
+     * Returns the raw {@link DescribeTopicPartitionsResponseData} accumulated across all pagination rounds.
+     * Topic-level and partition-level errors are checked during accumulation and will cause the future
+     * to complete exceptionally. The returned data is mutable.
+     */
+    public KafkaFuture<DescribeTopicPartitionsResponseData> rawResponse() {
+        return future;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ForwardingAdmin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ForwardingAdmin.java
@@ -79,6 +79,11 @@ public class ForwardingAdmin implements Admin {
     }
 
     @Override
+    public DescribeTopicPartitionsResult describeTopicPartitions(Collection<String> topics, DescribeTopicsOptions options) {
+        return delegate.describeTopicPartitions(topics, options);
+    }
+
+    @Override
     public DescribeClusterResult describeCluster(DescribeClusterOptions options) {
         return delegate.describeCluster(options);
     }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -2454,6 +2454,84 @@ public class KafkaAdminClient extends AdminClient {
     }
 
     @Override
+    public DescribeTopicPartitionsResult describeTopicPartitions(Collection<String> topics, DescribeTopicsOptions options) {
+        if (topics.isEmpty()) {
+            throw new IllegalArgumentException("topics must not be empty");
+        }
+        final KafkaFutureImpl<DescribeTopicPartitionsResponseData> future = new KafkaFutureImpl<>();
+        final DescribeTopicPartitionsResponseData accumulated = new DescribeTopicPartitionsResponseData();
+        final long now = time.milliseconds();
+        final List<String> topicNamesList = new ArrayList<>(topics);
+        topicNamesList.sort(String::compareTo);
+
+        runnable.call(new Call("describeTopicPartitions", calcDeadlineMs(now, options.timeoutMs()),
+            new LeastLoadedNodeProvider()) {
+            DescribeTopicPartitionsResponseData.Cursor cursor = null;
+
+            @Override
+            DescribeTopicPartitionsRequest.Builder createRequest(int timeoutMs) {
+                DescribeTopicPartitionsRequestData request = new DescribeTopicPartitionsRequestData()
+                    .setTopics(topicNamesList.stream()
+                        .map(name -> new TopicRequest().setName(name))
+                        .collect(Collectors.toList()))
+                    .setResponsePartitionLimit(options.partitionSizeLimitPerResponse());
+                if (cursor != null) {
+                    request.setCursor(new DescribeTopicPartitionsRequestData.Cursor()
+                        .setTopicName(cursor.topicName())
+                        .setPartitionIndex(cursor.partitionIndex()));
+                }
+                return new DescribeTopicPartitionsRequest.Builder(request);
+            }
+
+            @Override
+            void handleResponse(AbstractResponse abstractResponse) {
+                DescribeTopicPartitionsResponse response = (DescribeTopicPartitionsResponse) abstractResponse;
+                DescribeTopicPartitionsResponseData data = response.data();
+
+                for (DescribeTopicPartitionsResponseTopic topic : data.topics()) {
+                    Errors error = Errors.forCode(topic.errorCode());
+                    if (error != Errors.NONE) {
+                        future.completeExceptionally(error.exception());
+                        return;
+                    }
+                    for (DescribeTopicPartitionsResponsePartition partition : topic.partitions()) {
+                        Errors partitionError = Errors.forCode(partition.errorCode());
+                        if (partitionError != Errors.NONE) {
+                            future.completeExceptionally(partitionError.exception());
+                            return;
+                        }
+                    }
+                    DescribeTopicPartitionsResponseTopic existing = accumulated.topics().find(topic.name());
+                    if (existing != null) {
+                        if (!existing.topicId().equals(topic.topicId())) {
+                            future.completeExceptionally(new UnknownTopicOrPartitionException(
+                                "Topic " + topic.name() + " changed while fetching paginated response"));
+                            return;
+                        }
+                        existing.partitions().addAll(topic.partitions());
+                    } else {
+                        accumulated.topics().add(topic.duplicate());
+                    }
+                }
+
+                cursor = data.nextCursor();
+                if (cursor != null) {
+                    runnable.call(this, time.milliseconds());
+                } else {
+                    future.complete(accumulated);
+                }
+            }
+
+            @Override
+            void handleFailure(Throwable throwable) {
+                future.completeExceptionally(throwable);
+            }
+        }, now);
+
+        return new DescribeTopicPartitionsResult(future);
+    }
+
+    @Override
     public DescribeClusterResult describeCluster(DescribeClusterOptions options) {
         final KafkaFutureImpl<Collection<Node>> describeClusterFuture = new KafkaFutureImpl<>();
         final KafkaFutureImpl<Node> controllerFuture = new KafkaFutureImpl<>();

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -1795,6 +1795,85 @@ public class KafkaAdminClientTest {
     }
 
     @Test
+    public void testDescribeTopicPartitionsRawResponse() throws ExecutionException, InterruptedException {
+        try (AdminClientUnitTestEnv env = mockClientEnv()) {
+            env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
+            String topicName = "test-topic";
+            Uuid topicId = Uuid.randomUuid();
+
+            DescribeTopicPartitionsResponseData responseData = new DescribeTopicPartitionsResponseData();
+            addPartitionToDescribeTopicPartitionsResponse(responseData, topicName, topicId, asList(0, 1));
+            env.kafkaClient().prepareResponse(new DescribeTopicPartitionsResponse(responseData));
+
+            DescribeTopicPartitionsResult result = env.adminClient().describeTopicPartitions(
+                singletonList(topicName), new DescribeTopicsOptions());
+            DescribeTopicPartitionsResponseData data = result.rawResponse().get();
+
+            assertEquals(1, data.topics().size());
+            DescribeTopicPartitionsResponseTopic topic = data.topics().find(topicName);
+            assertEquals(topicName, topic.name());
+            assertEquals(topicId, topic.topicId());
+            assertEquals(2, topic.partitions().size());
+            assertEquals(0, topic.partitions().get(0).partitionIndex());
+            assertEquals(1, topic.partitions().get(1).partitionIndex());
+        }
+    }
+
+    @Test
+    public void testDescribeTopicPartitionsEmptyTopicsThrows() {
+        try (AdminClientUnitTestEnv env = mockClientEnv()) {
+            assertThrows(IllegalArgumentException.class,
+                () -> env.adminClient().describeTopicPartitions(List.of(), new DescribeTopicsOptions()));
+        }
+    }
+
+    @Test
+    public void testDescribeTopicPartitionsTopicIdChangedDuringPagination() {
+        try (AdminClientUnitTestEnv env = mockClientEnv()) {
+            env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
+            String topicName = "test-topic";
+            Uuid originalId = Uuid.randomUuid();
+            Uuid newId = Uuid.randomUuid();
+
+            DescribeTopicPartitionsResponseData firstPage = new DescribeTopicPartitionsResponseData();
+            addPartitionToDescribeTopicPartitionsResponse(firstPage, topicName, originalId, singletonList(0));
+            firstPage.setNextCursor(new DescribeTopicPartitionsResponseData.Cursor()
+                .setTopicName(topicName)
+                .setPartitionIndex(1));
+            env.kafkaClient().prepareResponse(new DescribeTopicPartitionsResponse(firstPage));
+
+            DescribeTopicPartitionsResponseData secondPage = new DescribeTopicPartitionsResponseData();
+            addPartitionToDescribeTopicPartitionsResponse(secondPage, topicName, newId, singletonList(1));
+            env.kafkaClient().prepareResponse(new DescribeTopicPartitionsResponse(secondPage));
+
+            DescribeTopicPartitionsResult result = env.adminClient().describeTopicPartitions(
+                singletonList(topicName), new DescribeTopicsOptions());
+
+            TestUtils.assertFutureThrows(UnknownTopicOrPartitionException.class, result.rawResponse());
+        }
+    }
+
+    @Test
+    public void testDescribeTopicPartitionsTopicError() {
+        try (AdminClientUnitTestEnv env = mockClientEnv()) {
+            env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
+            String topicName = "unauthorized-topic";
+
+            DescribeTopicPartitionsResponseData responseData = new DescribeTopicPartitionsResponseData();
+            responseData.topics().add(new DescribeTopicPartitionsResponseTopic()
+                .setErrorCode(Errors.TOPIC_AUTHORIZATION_FAILED.code())
+                .setTopicId(Uuid.ZERO_UUID)
+                .setName(topicName));
+            env.kafkaClient().prepareResponse(new DescribeTopicPartitionsResponse(responseData));
+
+            DescribeTopicPartitionsResult result = env.adminClient().describeTopicPartitions(
+                singletonList(topicName), new DescribeTopicsOptions());
+
+            TestUtils.assertFutureThrows(TopicAuthorizationException.class, result.rawResponse());
+        }
+    }
+
+    @Test
     public void testAdminClientApisAuthenticationFailure() {
         Cluster cluster = mockBootstrapCluster();
         try (final AdminClientUnitTestEnv env = new AdminClientUnitTestEnv(Time.SYSTEM, cluster,

--- a/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
@@ -1260,6 +1260,11 @@ public class MockAdminClient extends AdminClient {
     }
 
     @Override
+    public DescribeTopicPartitionsResult describeTopicPartitions(Collection<String> topics, DescribeTopicsOptions options) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
     public DescribeMetadataQuorumResult describeMetadataQuorum(DescribeMetadataQuorumOptions options) {
         throw new UnsupportedOperationException("Not implemented yet");
     }

--- a/core/src/main/scala/kafka/server/metadata/KRaftMetadataCache.scala
+++ b/core/src/main/scala/kafka/server/metadata/KRaftMetadataCache.scala
@@ -29,7 +29,7 @@ import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.requests.MetadataResponse
 import org.apache.kafka.image.MetadataImage
-import org.apache.kafka.metadata.{BrokerRegistration, LeaderAndIsr, MetadataCache, PartitionRegistration, Replicas}
+import org.apache.kafka.metadata.{BrokerRegistration, InitDisklessLogFields, LeaderAndIsr, MetadataCache, PartitionRegistration, Replicas}
 import org.apache.kafka.server.common.{FinalizedFeatures, KRaftVersion, MetadataVersion}
 
 import java.util
@@ -174,9 +174,9 @@ class KRaftMetadataCache(
               val filteredIsr = maybeFilterAliveReplicas(image, partition.isr, listenerName, filterUnavailableEndpoints = false)
               val offlineReplicas = getOfflineReplicas(image, partition, listenerName)
               val maybeLeader = getAliveEndpoint(image, partition.leader, listenerName)
-              maybeLeader match {
+              val responsePartition = maybeLeader match {
                 case None =>
-                  result.append(new DescribeTopicPartitionsResponsePartition()
+                  new DescribeTopicPartitionsResponsePartition()
                     .setPartitionIndex(partitionId)
                     .setLeaderId(MetadataResponse.NO_LEADER_ID)
                     .setLeaderEpoch(partition.leaderEpoch)
@@ -184,9 +184,9 @@ class KRaftMetadataCache(
                     .setIsrNodes(filteredIsr)
                     .setOfflineReplicas(offlineReplicas)
                     .setEligibleLeaderReplicas(Replicas.toList(partition.elr))
-                    .setLastKnownElr(Replicas.toList(partition.lastKnownElr)))
+                    .setLastKnownElr(Replicas.toList(partition.lastKnownElr))
                 case Some(leader) =>
-                  result.append(new DescribeTopicPartitionsResponsePartition()
+                  new DescribeTopicPartitionsResponsePartition()
                     .setPartitionIndex(partitionId)
                     .setLeaderId(leader.id())
                     .setLeaderEpoch(partition.leaderEpoch)
@@ -194,8 +194,21 @@ class KRaftMetadataCache(
                     .setIsrNodes(filteredIsr)
                     .setOfflineReplicas(offlineReplicas)
                     .setEligibleLeaderReplicas(Replicas.toList(partition.elr))
-                    .setLastKnownElr(Replicas.toList(partition.lastKnownElr)))
+                    .setLastKnownElr(Replicas.toList(partition.lastKnownElr))
               }
+              if (partition.classicToDisklessStartOffset != PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET) {
+                responsePartition.unknownTaggedFields().add(
+                  InitDisklessLogFields.encodeClassicToDisklessStartOffset(partition.classicToDisklessStartOffset))
+                if (!partition.disklessProducerStates.isEmpty) {
+                  responsePartition.unknownTaggedFields().add(
+                    InitDisklessLogFields.encodeProducerStates(partition.disklessProducerStates))
+                }
+              }
+              if (partition.disklessLeaderEpoch != PartitionRegistration.NO_DISKLESS_LEADER_EPOCH) {
+                responsePartition.unknownTaggedFields().add(
+                  InitDisklessLogFields.encodeDisklessLeaderEpoch(partition.disklessLeaderEpoch))
+              }
+              result.append(responsePartition)
             }
             case _ => warn(s"The partition $partitionId does not exist for $topicName")
           }

--- a/core/src/test/java/kafka/server/handlers/DescribeTopicPartitionsRequestHandlerTest.java
+++ b/core/src/test/java/kafka/server/handlers/DescribeTopicPartitionsRequestHandlerTest.java
@@ -31,6 +31,7 @@ import org.apache.kafka.common.internals.Plugin;
 import org.apache.kafka.common.memory.MemoryPool;
 import org.apache.kafka.common.message.DescribeTopicPartitionsRequestData;
 import org.apache.kafka.common.message.DescribeTopicPartitionsResponseData;
+import org.apache.kafka.common.message.DescribeTopicPartitionsResponseData.DescribeTopicPartitionsResponsePartition;
 import org.apache.kafka.common.message.DescribeTopicPartitionsResponseData.DescribeTopicPartitionsResponseTopic;
 import org.apache.kafka.common.metadata.PartitionRecord;
 import org.apache.kafka.common.metadata.RegisterBrokerRecord;
@@ -57,6 +58,8 @@ import org.apache.kafka.image.ClusterImage;
 import org.apache.kafka.image.MetadataDelta;
 import org.apache.kafka.image.MetadataImage;
 import org.apache.kafka.image.MetadataProvenance;
+import org.apache.kafka.metadata.InitDisklessLogFields;
+import org.apache.kafka.metadata.InitDisklessLogFields.ProducerStateEntry;
 import org.apache.kafka.metadata.LeaderRecoveryState;
 import org.apache.kafka.network.SocketServerConfigs;
 import org.apache.kafka.network.metrics.RequestChannelMetrics;
@@ -476,6 +479,113 @@ class DescribeTopicPartitionsRequestHandlerTest {
         } catch (Exception e) {
             assertInstanceOf(InvalidRequestException.class, e, e.getMessage());
         }
+    }
+
+    @Test
+    void testDescribeTopicPartitionsResponseIncludesDisklessFields() {
+        Authorizer authorizer = mock(Authorizer.class);
+        Plugin<Authorizer> authorizerPlugin = Plugin.wrapInstance(authorizer, null, "authorizer.class.name");
+        String topicName = "diskless-topic";
+
+        Action expectedAction = new Action(AclOperation.DESCRIBE, new ResourcePattern(ResourceType.TOPIC, topicName, PatternType.LITERAL), 1, true, true);
+        when(authorizer.authorize(any(RequestContext.class), argThat(t -> t.contains(expectedAction))))
+            .thenAnswer(invocation -> {
+                List<Action> actions = invocation.getArgument(1);
+                return actions.stream().map(action -> AuthorizationResult.ALLOWED).toList();
+            });
+
+        Uuid topicId = Uuid.randomUuid();
+
+        BrokerEndpointCollection collection = new BrokerEndpointCollection();
+        collection.add(brokerEndpoint);
+
+        PartitionRecord switchedPartition = new PartitionRecord()
+            .setTopicId(topicId)
+            .setPartitionId(0)
+            .setReplicas(List.of(0))
+            .setLeader(0)
+            .setIsr(List.of(0))
+            .setLeaderEpoch(5)
+            .setPartitionEpoch(1)
+            .setLeaderRecoveryState(LeaderRecoveryState.RECOVERED.value());
+        switchedPartition.unknownTaggedFields().add(
+            InitDisklessLogFields.encodeClassicToDisklessStartOffset(42L));
+        switchedPartition.unknownTaggedFields().add(
+            InitDisklessLogFields.encodeDisklessLeaderEpoch(7));
+        switchedPartition.unknownTaggedFields().add(
+            InitDisklessLogFields.encodeProducerStates(List.of(
+                new ProducerStateEntry(1001L, (short) 2, 0, 5, 40L, 1700000000000L)
+            )));
+
+        PartitionRecord classicPartition = new PartitionRecord()
+            .setTopicId(topicId)
+            .setPartitionId(1)
+            .setReplicas(List.of(0))
+            .setLeader(0)
+            .setIsr(List.of(0))
+            .setLeaderEpoch(3)
+            .setPartitionEpoch(1)
+            .setLeaderRecoveryState(LeaderRecoveryState.RECOVERED.value());
+
+        List<ApiMessage> records = List.of(
+            new RegisterBrokerRecord()
+                .setBrokerId(brokerId)
+                .setBrokerEpoch(0)
+                .setIncarnationId(Uuid.randomUuid())
+                .setEndPoints(collection)
+                .setRack(rack)
+                .setFenced(false),
+            new TopicRecord().setName(topicName).setTopicId(topicId),
+            switchedPartition,
+            classicPartition
+        );
+
+        KRaftMetadataCache metadataCache = new KRaftMetadataCache(0, () -> KRaftVersion.KRAFT_VERSION_1);
+        updateKraftMetadataCache(metadataCache, records);
+        DescribeTopicPartitionsRequestHandler handler =
+            new DescribeTopicPartitionsRequestHandler(metadataCache, new AuthHelper(scala.Option.apply(authorizerPlugin)), createKafkaDefaultConfig());
+
+        DescribeTopicPartitionsRequest describeRequest = new DescribeTopicPartitionsRequest(
+            new DescribeTopicPartitionsRequestData()
+                .setTopics(List.of(new DescribeTopicPartitionsRequestData.TopicRequest().setName(topicName)))
+        );
+
+        RequestChannel.Request request;
+        try {
+            request = buildRequest(describeRequest, plaintextListener);
+        } catch (Exception e) {
+            fail(e.getMessage());
+            return;
+        }
+
+        DescribeTopicPartitionsResponseData response = handler.handleDescribeTopicPartitionsRequest(request);
+        List<DescribeTopicPartitionsResponseTopic> topics = response.topics().valuesList();
+        assertEquals(1, topics.size());
+
+        DescribeTopicPartitionsResponseTopic topicData = topics.get(0);
+        assertEquals(topicName, topicData.name());
+        assertEquals(2, topicData.partitions().size());
+
+        // Partition 0 (switched to diskless): has diskless tagged fields
+        DescribeTopicPartitionsResponsePartition p0 = topicData.partitions().get(0);
+        assertEquals(0, p0.partitionIndex());
+        assertEquals(42L, InitDisklessLogFields.decodeClassicToDisklessStartOffset(p0.unknownTaggedFields()));
+        assertEquals(7, InitDisklessLogFields.decodeDisklessLeaderEpoch(p0.unknownTaggedFields()));
+        List<ProducerStateEntry> producerStates = InitDisklessLogFields.decodeProducerStates(p0.unknownTaggedFields());
+        assertEquals(1, producerStates.size());
+        assertEquals(1001L, producerStates.get(0).producerId());
+        assertEquals((short) 2, producerStates.get(0).producerEpoch());
+        assertEquals(0, producerStates.get(0).baseSequence());
+        assertEquals(5, producerStates.get(0).lastSequence());
+        assertEquals(40L, producerStates.get(0).assignedOffset());
+        assertEquals(1700000000000L, producerStates.get(0).batchMaxTimestamp());
+
+        // Partition 1 (classic): no diskless tagged fields
+        DescribeTopicPartitionsResponsePartition p1 = topicData.partitions().get(1);
+        assertEquals(1, p1.partitionIndex());
+        assertEquals(-1L, InitDisklessLogFields.decodeClassicToDisklessStartOffset(p1.unknownTaggedFields()));
+        assertEquals(-1, InitDisklessLogFields.decodeDisklessLeaderEpoch(p1.unknownTaggedFields()));
+        assertEquals(List.of(), InitDisklessLogFields.decodeProducerStates(p1.unknownTaggedFields()));
     }
 
     void updateKraftMetadataCache(KRaftMetadataCache kRaftMetadataCache, List<ApiMessage> records) {

--- a/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/TestingMetricsInterceptingAdminClient.java
+++ b/streams/integration-tests/src/test/java/org/apache/kafka/streams/integration/TestingMetricsInterceptingAdminClient.java
@@ -95,6 +95,7 @@ import org.apache.kafka.clients.admin.DescribeShareGroupsOptions;
 import org.apache.kafka.clients.admin.DescribeShareGroupsResult;
 import org.apache.kafka.clients.admin.DescribeStreamsGroupsOptions;
 import org.apache.kafka.clients.admin.DescribeStreamsGroupsResult;
+import org.apache.kafka.clients.admin.DescribeTopicPartitionsResult;
 import org.apache.kafka.clients.admin.DescribeTopicsOptions;
 import org.apache.kafka.clients.admin.DescribeTopicsResult;
 import org.apache.kafka.clients.admin.DescribeTransactionsOptions;
@@ -396,6 +397,11 @@ public class TestingMetricsInterceptingAdminClient extends AdminClient {
     @Override
     public UpdateFeaturesResult updateFeatures(final Map<String, FeatureUpdate> featureUpdates, final UpdateFeaturesOptions options) {
         return adminDelegate.updateFeatures(featureUpdates, options);
+    }
+
+    @Override
+    public DescribeTopicPartitionsResult describeTopicPartitions(final Collection<String> topics, final DescribeTopicsOptions options) {
+        return adminDelegate.describeTopicPartitions(topics, options);
     }
 
     @Override

--- a/tools/src/main/java/org/apache/kafka/tools/TopicSwitchCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/TopicSwitchCommand.java
@@ -17,15 +17,33 @@
 
 package org.apache.kafka.tools;
 
-import org.apache.kafka.clients.admin.*;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.DescribeTopicPartitionsResult;
+import org.apache.kafka.clients.admin.DescribeTopicsOptions;
+import org.apache.kafka.clients.admin.ListOffsetsResult;
+import org.apache.kafka.clients.admin.OffsetSpec;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.message.DescribeTopicPartitionsResponseData;
+import org.apache.kafka.common.message.DescribeTopicPartitionsResponseData.DescribeTopicPartitionsResponsePartition;
+import org.apache.kafka.common.message.DescribeTopicPartitionsResponseData.DescribeTopicPartitionsResponseTopic;
 import org.apache.kafka.common.utils.Exit;
 import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.metadata.InitDisklessLogFields;
+import org.apache.kafka.metadata.InitDisklessLogFields.ProducerStateEntry;
+import org.apache.kafka.metadata.PartitionRegistration;
 import org.apache.kafka.server.util.CommandLineUtils;
 
 import net.sourceforge.argparse4j.ArgumentParsers;
-import net.sourceforge.argparse4j.inf.*;
+import net.sourceforge.argparse4j.inf.ArgumentParser;
+import net.sourceforge.argparse4j.inf.MutuallyExclusiveGroup;
+import net.sourceforge.argparse4j.inf.Namespace;
+import net.sourceforge.argparse4j.inf.Subparser;
+import net.sourceforge.argparse4j.inf.Subparsers;
 
+import java.io.PrintStream;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 
@@ -62,6 +80,10 @@ public abstract class TopicSwitchCommand {
 
         switch (command) {
             case "state":
+                try (Admin adminClient = Admin.create(properties)) {
+                    stateCommand(System.out, adminClient, topic);
+                }
+                break;
             case "seal":
             case "repair":
                 throw new RuntimeException("Command \"" + command + "\" not implemented");
@@ -97,6 +119,7 @@ public abstract class TopicSwitchCommand {
                     .help("Config properties file for the Admin client.");
             subparser.addArgument("--topic", "-t")
                     .action(store())
+                    .required(true)
                     .help("Topic name for the specified topic.");
         }
 
@@ -105,5 +128,89 @@ public abstract class TopicSwitchCommand {
                 .help("Whether to only perform validation when adjusting the seal offset.");
 
         return parser;
+    }
+
+    static void stateCommand(PrintStream stream, Admin adminClient, String topic) throws Exception {
+        DescribeTopicPartitionsResult describeResult = adminClient.describeTopicPartitions(
+            List.of(topic), new DescribeTopicsOptions());
+        DescribeTopicPartitionsResponseData responseData = describeResult.rawResponse().get();
+
+        DescribeTopicPartitionsResponseTopic topicData = responseData.topics().find(topic);
+        if (topicData == null) {
+            throw new RuntimeException("Topic not found: " + topic);
+        }
+        if (topicData.errorCode() != 0) {
+            throw new RuntimeException("Error describing topic " + topic + ": error code " + topicData.errorCode());
+        }
+
+        List<DescribeTopicPartitionsResponsePartition> partitions = topicData.partitions();
+
+        Map<TopicPartition, OffsetSpec> latestOffsets = new HashMap<>();
+        Map<TopicPartition, OffsetSpec> earliestOffsets = new HashMap<>();
+        for (DescribeTopicPartitionsResponsePartition partition : partitions) {
+            TopicPartition tp = new TopicPartition(topic, partition.partitionIndex());
+            latestOffsets.put(tp, OffsetSpec.latest());
+            earliestOffsets.put(tp, OffsetSpec.earliest());
+        }
+
+        Map<TopicPartition, ListOffsetsResult.ListOffsetsResultInfo> latest =
+            adminClient.listOffsets(latestOffsets).all().get();
+        Map<TopicPartition, ListOffsetsResult.ListOffsetsResultInfo> earliest =
+            adminClient.listOffsets(earliestOffsets).all().get();
+
+        for (DescribeTopicPartitionsResponsePartition partition : partitions) {
+            int partitionIndex = partition.partitionIndex();
+            TopicPartition tp = new TopicPartition(topic, partitionIndex);
+
+            long classicToDisklessStartOffset = InitDisklessLogFields.decodeClassicToDisklessStartOffset(
+                partition.unknownTaggedFields());
+            int disklessLeaderEpoch = InitDisklessLogFields.decodeDisklessLeaderEpoch(
+                partition.unknownTaggedFields());
+            List<ProducerStateEntry> producerStates = InitDisklessLogFields.decodeProducerStates(
+                partition.unknownTaggedFields());
+
+            ListOffsetsResult.ListOffsetsResultInfo latestInfo = latest.get(tp);
+            ListOffsetsResult.ListOffsetsResultInfo earliestInfo = earliest.get(tp);
+
+            stream.printf("Partition %d:%n", partitionIndex);
+            stream.printf("  leader=%d epoch=%d isr=%s%n",
+                partition.leaderId(), partition.leaderEpoch(), partition.isrNodes());
+            stream.printf("  classicToDisklessStartOffset=%s%n",
+                formatStartOffset(classicToDisklessStartOffset));
+            stream.printf("  disklessLeaderEpoch=%s%n",
+                formatDisklessLeaderEpoch(disklessLeaderEpoch));
+            stream.printf("  logStartOffset=%d logEndOffset=%d%n",
+                earliestInfo != null ? earliestInfo.offset() : -1,
+                latestInfo != null ? latestInfo.offset() : -1);
+
+            if (!producerStates.isEmpty()) {
+                stream.printf("  producerStates (%d):%n", producerStates.size());
+                for (ProducerStateEntry entry : producerStates) {
+                    stream.printf("    producerId=%d epoch=%d seq=%d..%d offset=%d timestamp=%d%n",
+                        entry.producerId(), entry.producerEpoch(),
+                        entry.baseSequence(), entry.lastSequence(),
+                        entry.assignedOffset(), entry.batchMaxTimestamp());
+                }
+            }
+            stream.println();
+        }
+    }
+
+    private static String formatStartOffset(long offset) {
+        if (offset == PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET) {
+            return "-1 (not switched)";
+        } else if (offset == PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING) {
+            return "-2 (switch pending)";
+        } else {
+            return String.valueOf(offset);
+        }
+    }
+
+    private static String formatDisklessLeaderEpoch(int epoch) {
+        if (epoch == PartitionRegistration.NO_DISKLESS_LEADER_EPOCH) {
+            return "-1 (none)";
+        } else {
+            return String.valueOf(epoch);
+        }
     }
 }

--- a/tools/src/main/java/org/apache/kafka/tools/TopicSwitchCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/TopicSwitchCommand.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.tools;
+
+import org.apache.kafka.clients.admin.*;
+import org.apache.kafka.common.utils.Exit;
+import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.server.util.CommandLineUtils;
+
+import net.sourceforge.argparse4j.ArgumentParsers;
+import net.sourceforge.argparse4j.inf.*;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Properties;
+
+import static net.sourceforge.argparse4j.impl.Arguments.store;
+import static net.sourceforge.argparse4j.impl.Arguments.storeTrue;
+
+public abstract class TopicSwitchCommand {
+    public static void main(String... args) {
+        Exit.exit(mainNoExit(args));
+    }
+
+    private static int mainNoExit(String... args) {
+        try {
+            execute(args);
+            return 0;
+        } catch (Throwable e) {
+            System.err.println(e.getMessage());
+            System.err.println(Utils.stackTrace(e));
+            return 1;
+        }
+    }
+
+    static void execute(String... args) throws Exception {
+        ArgumentParser parser = argumentParser();
+        Namespace namespace = parser.parseArgsOrFail(args);
+        String command = namespace.getString("command");
+        String commandConfigFile = namespace.getString("command_config");
+        String topic =  namespace.getString("topic");
+
+        Properties properties = (commandConfigFile != null) ? Utils.loadProps(commandConfigFile) : new Properties();
+        CommandLineUtils.initializeBootstrapProperties(properties,
+                Optional.ofNullable(namespace.getString("bootstrap_server")),
+                Optional.ofNullable(namespace.getString("bootstrap_controller")));
+
+        switch (command) {
+            case "state":
+            case "seal":
+            case "repair":
+                throw new RuntimeException("Command \"" + command + "\" not implemented");
+            default:
+                throw new RuntimeException("Unknown command " + command);
+        }
+    }
+
+    private static ArgumentParser argumentParser() {
+        ArgumentParser parser = ArgumentParsers
+                .newArgumentParser("kafka-topic-switch")
+                .defaultHelp(true)
+                .description("The Kafka topic switch tool.");
+        Subparsers commandParsers = parser.addSubparsers().dest("command");
+
+        Subparser stateParser = commandParsers.addParser("state")
+                .help("Print the switch state for each partition of a specified topic.");
+        Subparser sealParser = commandParsers.addParser("seal")
+                .help("Override the topic seal offset. Use --dry-run to perform validation only.");
+        Subparser repairParser = commandParsers.addParser("repair")
+                .help("Repair the control-plane diskless log entry.");
+
+        for (Subparser subparser : List.of(stateParser, sealParser, repairParser)) {
+            MutuallyExclusiveGroup connectionOptions = subparser.addMutuallyExclusiveGroup().required(true);
+            connectionOptions.addArgument("--bootstrap-server", "-b")
+                    .action(store())
+                    .help("A list of host/port pairs to use for establishing the connection to the Kafka cluster.");
+            connectionOptions.addArgument("--bootstrap-controller", "-C")
+                    .action(store())
+                    .help("A list of host/port pairs to use for establishing the connection to the KRaft controllers.");
+            subparser.addArgument("--command-config", "-c")
+                    .action(store())
+                    .help("Config properties file for the Admin client.");
+            subparser.addArgument("--topic", "-t")
+                    .action(store())
+                    .help("Topic name for the specified topic.");
+        }
+
+        sealParser.addArgument("--dry-run", "-d")
+                .action(storeTrue())
+                .help("Whether to only perform validation when adjusting the seal offset.");
+
+        return parser;
+    }
+}

--- a/tools/src/test/java/org/apache/kafka/tools/TopicSwitchCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/TopicSwitchCommandTest.java
@@ -1,0 +1,234 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.tools;
+
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.DescribeTopicPartitionsResult;
+import org.apache.kafka.clients.admin.DescribeTopicsOptions;
+import org.apache.kafka.clients.admin.ListOffsetsResult;
+import org.apache.kafka.clients.admin.OffsetSpec;
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.message.DescribeTopicPartitionsResponseData;
+import org.apache.kafka.common.message.DescribeTopicPartitionsResponseData.DescribeTopicPartitionsResponsePartition;
+import org.apache.kafka.common.message.DescribeTopicPartitionsResponseData.DescribeTopicPartitionsResponseTopic;
+import org.apache.kafka.metadata.InitDisklessLogFields;
+import org.apache.kafka.metadata.InitDisklessLogFields.ProducerStateEntry;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class TopicSwitchCommandTest {
+
+    private static final String TOPIC = "test-topic";
+
+    @Mock
+    private Admin adminClient;
+
+    @Test
+    public void testStateCommandFullySwitched() throws Exception {
+        DescribeTopicPartitionsResponseData responseData = buildResponseData(
+            List.of(buildPartition(0, 1, 5, 100L, 7), buildPartition(1, 2, 6, 200L, 8))
+        );
+        mockAdminCalls(responseData, Map.of(
+            new TopicPartition(TOPIC, 0), new ListOffsetsResult.ListOffsetsResultInfo(150, -1, java.util.Optional.empty()),
+            new TopicPartition(TOPIC, 1), new ListOffsetsResult.ListOffsetsResultInfo(250, -1, java.util.Optional.empty())
+        ), Map.of(
+            new TopicPartition(TOPIC, 0), new ListOffsetsResult.ListOffsetsResultInfo(0, -1, java.util.Optional.empty()),
+            new TopicPartition(TOPIC, 1), new ListOffsetsResult.ListOffsetsResultInfo(10, -1, java.util.Optional.empty())
+        ));
+
+        String output = runStateCommand();
+        assertTrue(output.contains("Partition 0:"));
+        assertTrue(output.contains("leader=1 epoch=5"));
+        assertTrue(output.contains("classicToDisklessStartOffset=100"));
+        assertTrue(output.contains("disklessLeaderEpoch=7"));
+        assertTrue(output.contains("logStartOffset=0 logEndOffset=150"));
+
+        assertTrue(output.contains("Partition 1:"));
+        assertTrue(output.contains("leader=2 epoch=6"));
+        assertTrue(output.contains("classicToDisklessStartOffset=200"));
+        assertTrue(output.contains("disklessLeaderEpoch=8"));
+        assertTrue(output.contains("logStartOffset=10 logEndOffset=250"));
+    }
+
+    @Test
+    public void testStateCommandNotSwitched() throws Exception {
+        DescribeTopicPartitionsResponseData responseData = buildResponseData(
+            List.of(buildPartition(0, 1, 3, -1L, -1))
+        );
+        mockAdminCalls(responseData, Map.of(
+            new TopicPartition(TOPIC, 0), new ListOffsetsResult.ListOffsetsResultInfo(50, -1, java.util.Optional.empty())
+        ), Map.of(
+            new TopicPartition(TOPIC, 0), new ListOffsetsResult.ListOffsetsResultInfo(0, -1, java.util.Optional.empty())
+        ));
+
+        String output = runStateCommand();
+        assertTrue(output.contains("classicToDisklessStartOffset=-1 (not switched)"));
+        assertTrue(output.contains("disklessLeaderEpoch=-1 (none)"));
+    }
+
+    @Test
+    public void testStateCommandSwitchPending() throws Exception {
+        DescribeTopicPartitionsResponseData responseData = buildResponseData(
+            List.of(buildPartition(0, 1, 4, -2L, -1))
+        );
+        mockAdminCalls(responseData, Map.of(
+            new TopicPartition(TOPIC, 0), new ListOffsetsResult.ListOffsetsResultInfo(75, -1, java.util.Optional.empty())
+        ), Map.of(
+            new TopicPartition(TOPIC, 0), new ListOffsetsResult.ListOffsetsResultInfo(0, -1, java.util.Optional.empty())
+        ));
+
+        String output = runStateCommand();
+
+        assertTrue(output.contains("classicToDisklessStartOffset=-2 (switch pending)"));
+    }
+
+    @Test
+    public void testStateCommandWithProducerStates() throws Exception {
+        List<ProducerStateEntry> producerStates = List.of(
+            new ProducerStateEntry(1001L, (short) 5, 0, 10, 99L, 1700000000000L),
+            new ProducerStateEntry(2002L, (short) 3, 5, 15, 150L, 1700000001000L)
+        );
+
+        DescribeTopicPartitionsResponsePartition partition = buildPartition(0, 1, 10, 500L, 12);
+        partition.unknownTaggedFields().add(InitDisklessLogFields.encodeProducerStates(producerStates));
+
+        DescribeTopicPartitionsResponseData responseData = buildResponseData(List.of(partition));
+        mockAdminCalls(responseData, Map.of(
+            new TopicPartition(TOPIC, 0), new ListOffsetsResult.ListOffsetsResultInfo(600, -1, java.util.Optional.empty())
+        ), Map.of(
+            new TopicPartition(TOPIC, 0), new ListOffsetsResult.ListOffsetsResultInfo(0, -1, java.util.Optional.empty())
+        ));
+
+        String output = runStateCommand();
+        assertTrue(output.contains("producerStates (2):"));
+        assertTrue(output.contains("producerId=1001 epoch=5 seq=0..10 offset=99 timestamp=1700000000000"));
+        assertTrue(output.contains("producerId=2002 epoch=3 seq=5..15 offset=150 timestamp=1700000001000"));
+    }
+
+    @Test
+    public void testStateCommandTopicNotFound() {
+        DescribeTopicPartitionsResponseData responseData = new DescribeTopicPartitionsResponseData();
+
+        DescribeTopicPartitionsResult describeResult = new DescribeTopicPartitionsResult(
+            KafkaFuture.completedFuture(responseData));
+        when(adminClient.describeTopicPartitions(ArgumentMatchers.any(), any(DescribeTopicsOptions.class)))
+            .thenReturn(describeResult);
+
+        PrintStream stream = new PrintStream(new ByteArrayOutputStream());
+        RuntimeException ex = assertThrows(RuntimeException.class,
+            () -> TopicSwitchCommand.stateCommand(stream, adminClient, TOPIC));
+        assertTrue(ex.getMessage().contains("Topic not found"));
+    }
+
+    @Test
+    public void testStateCommandMixedPartitions() throws Exception {
+        DescribeTopicPartitionsResponseData responseData = buildResponseData(
+            List.of(buildPartition(0, 1, 5, 100L, 7), buildPartition(1, 2, 6, -1L, -1))
+        );
+        mockAdminCalls(responseData, Map.of(
+            new TopicPartition(TOPIC, 0), new ListOffsetsResult.ListOffsetsResultInfo(150, -1, java.util.Optional.empty()),
+            new TopicPartition(TOPIC, 1), new ListOffsetsResult.ListOffsetsResultInfo(50, -1, java.util.Optional.empty())
+        ), Map.of(
+            new TopicPartition(TOPIC, 0), new ListOffsetsResult.ListOffsetsResultInfo(0, -1, java.util.Optional.empty()),
+            new TopicPartition(TOPIC, 1), new ListOffsetsResult.ListOffsetsResultInfo(0, -1, java.util.Optional.empty())
+        ));
+
+        String output = runStateCommand();
+        assertTrue(output.contains("classicToDisklessStartOffset=100"));
+        assertTrue(output.contains("classicToDisklessStartOffset=-1 (not switched)"));
+    }
+
+    private String runStateCommand() throws Exception {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        PrintStream stream = new PrintStream(out, false, StandardCharsets.UTF_8);
+        TopicSwitchCommand.stateCommand(stream, adminClient, TOPIC);
+        return out.toString(StandardCharsets.UTF_8);
+    }
+
+    private DescribeTopicPartitionsResponseData buildResponseData(List<DescribeTopicPartitionsResponsePartition> partitions) {
+        DescribeTopicPartitionsResponseData responseData = new DescribeTopicPartitionsResponseData();
+        DescribeTopicPartitionsResponseTopic topicData = new DescribeTopicPartitionsResponseTopic()
+            .setName(TOPIC)
+            .setErrorCode((short) 0);
+        topicData.partitions().addAll(partitions);
+        responseData.topics().add(topicData);
+        return responseData;
+    }
+
+    private DescribeTopicPartitionsResponsePartition buildPartition(
+            int partitionIndex, int leaderId, int leaderEpoch,
+            long classicToDisklessStartOffset, int disklessLeaderEpoch) {
+        DescribeTopicPartitionsResponsePartition partition = new DescribeTopicPartitionsResponsePartition()
+            .setPartitionIndex(partitionIndex)
+            .setLeaderId(leaderId)
+            .setLeaderEpoch(leaderEpoch)
+            .setReplicaNodes(List.of(leaderId))
+            .setIsrNodes(List.of(leaderId));
+
+        if (classicToDisklessStartOffset >= 0 || classicToDisklessStartOffset == -2) {
+            partition.unknownTaggedFields().add(
+                InitDisklessLogFields.encodeClassicToDisklessStartOffset(classicToDisklessStartOffset));
+        }
+        if (disklessLeaderEpoch >= 0) {
+            partition.unknownTaggedFields().add(
+                InitDisklessLogFields.encodeDisklessLeaderEpoch(disklessLeaderEpoch));
+        }
+
+        return partition;
+    }
+
+    private void mockAdminCalls(
+            DescribeTopicPartitionsResponseData responseData,
+            Map<TopicPartition, ListOffsetsResult.ListOffsetsResultInfo> latestOffsets,
+            Map<TopicPartition, ListOffsetsResult.ListOffsetsResultInfo> earliestOffsets) {
+        DescribeTopicPartitionsResult describeResult = new DescribeTopicPartitionsResult(
+            KafkaFuture.completedFuture(responseData));
+        when(adminClient.describeTopicPartitions(ArgumentMatchers.any(), any(DescribeTopicsOptions.class)))
+            .thenReturn(describeResult);
+
+        when(adminClient.listOffsets(anyMap()))
+            .thenAnswer(invocation -> {
+                Map<TopicPartition, OffsetSpec> request = invocation.getArgument(0);
+                boolean isLatest = request.values().stream().anyMatch(s -> s instanceof OffsetSpec.LatestSpec);
+                Map<TopicPartition, ListOffsetsResult.ListOffsetsResultInfo> results = isLatest ? latestOffsets : earliestOffsets;
+
+                Map<TopicPartition, KafkaFuture<ListOffsetsResult.ListOffsetsResultInfo>> futures = new java.util.HashMap<>();
+                for (Map.Entry<TopicPartition, ListOffsetsResult.ListOffsetsResultInfo> entry : results.entrySet()) {
+                    futures.put(entry.getKey(), KafkaFuture.completedFuture(entry.getValue()));
+                }
+                return new ListOffsetsResult(futures);
+            });
+    }
+}


### PR DESCRIPTION
This change introduces the necessary scaffolding for topic type switch operator tooling, as well as the first or three commands that will be available via `bin/kafka-topic-switch.sh`. We implement the `state` command, which outputs per-partition switch state, offsets, and producer state. Furthermore, a new admin method `describeTopicPartitions` is added to expose unknown tagged fields, which contains the switch state.