### PR TITLE
Backport to 4.1: KAFKA-19354: KRaft observer should send fetch to best node

### DIFF
--- a/raft/src/main/java/org/apache/kafka/raft/FollowerState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/FollowerState.java
@@ -131,12 +131,18 @@ public class FollowerState implements EpochState {
         return fetchTimer.isExpired();
     }
 
+    /**
+     * Reset the fetch timeout after successful fetch from leader.
+     */
     public void resetFetchTimeoutForSuccessfulFetch(long currentTimeMs) {
-        fetchTimer.update(currentTimeMs);
-        fetchTimer.reset(fetchTimeoutMs);
+        overrideFetchTimeout(currentTimeMs, fetchTimeoutMs);
         hasFetchedFromLeader = true;
     }
 
+    /**
+     * Override the fetch timeout to a specific value. This is useful for short-circuiting followers' timeouts after
+     * they receive end quorum requests
+     */
     public void overrideFetchTimeout(long currentTimeMs, long timeoutMs) {
         fetchTimer.update(currentTimeMs);
         fetchTimer.reset(timeoutMs);

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -2570,7 +2570,7 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
                 transitionToUnattached(epoch, OptionalInt.empty());
             }
         } else if (
-                leaderId.isPresent() &&
+            leaderId.isPresent() &&
                 (!quorum.hasLeader() || leaderEndpoints.size() > quorum.leaderEndpoints().size())
         ) {
             // The request or response indicates the leader of the current epoch
@@ -3277,11 +3277,7 @@ public final class KafkaRaftClient<T> implements RaftClient<T> {
     }
 
     private long pollFollowerAsObserver(FollowerState state, long currentTimeMs) {
-        if (state.hasFetchTimeoutExpired(currentTimeMs)) {
-            return maybeSendFetchToAnyBootstrap(currentTimeMs);
-        } else {
-            return maybeSendFetchToBestNode(state, currentTimeMs);
-        }
+        return maybeSendFetchToBestNode(state, currentTimeMs);
     }
 
     private long maybeSendFetchToBestNode(FollowerState state, long currentTimeMs) {


### PR DESCRIPTION
Bug: https://issues.apache.org/jira/browse/KAFKA-19354
Original fix: https://github.com/apache/kafka/commit/7339d65b27fd5c1aa5ba239faf193ee0ff55f06d

Observers may get stuck fetching from bootstrap servers even on discovery of a leader from a fetch response.

Observers currently fetch from bootstrap servers once their fetch timeout expires, and even on rediscovery of the leader (e.g. observer receives fetch response indicating location of leader), observers will not  attempt to resume fetching from the leader.

This change simplifies observer polling logic to just rely on maybeSendFetchToBestNode which takes care of the logic of selecting either the leader or bootstrap servers  as the destination based on timeouts and backoffs.