### PR TITLE
fix(inkless:consolidation): start consolidation when remote storage is enabled on a diskless topic

### DIFF
--- a/core/src/main/scala/kafka/server/ConfigHandler.scala
+++ b/core/src/main/scala/kafka/server/ConfigHandler.scala
@@ -83,6 +83,17 @@ class TopicConfigHandler(private val replicaManager: ReplicaManager,
         rlm.onLeadershipChange((leaderPartitions.toSet: Set[TopicPartitionLog]).asJava, (followerPartitions.toSet: Set[TopicPartitionLog]).asJava, topicIds))
     }
 
+    // Start consolidation on a classic -> consolidated switch. remote.storage.enable=true arrives as a
+    // config-only delta after the seal, with no partition/leader change, so applyLocalLeadersDelta never
+    // starts the consolidation fetcher. Kick it off here for the topic's online partitions; the reconciler
+    // skips any not yet at the seal (they resume via the classic fetcher's hand-off) and is a no-op for
+    // non-consolidating topics.
+    if (isRemoteLogEnabled && !wasRemoteLogEnabled &&
+        replicaManager.inklessMetadataView().isDisklessTopic(topic)) {
+      val consolidatingPartitions = (leaderPartitions ++ followerPartitions).map(_.topicPartition).toSet
+      replicaManager.startConsolidationFetchersForCaughtUpClassicPartitions(consolidatingPartitions)
+    }
+
     // When copy disabled, we should stop leaderCopyRLMTask, but keep expirationTask
     if (isRemoteLogEnabled && !wasCopyDisabled && isCopyDisabled) {
       replicaManager.remoteLogManager.foreach(rlm => {

--- a/core/src/test/scala/unit/kafka/server/DynamicConfigChangeTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DynamicConfigChangeTest.scala
@@ -536,6 +536,10 @@ class DynamicConfigChangeUnitTest {
     when(replicaManager.remoteLogManager).thenReturn(Some(rlm))
     when(replicaManager.metadataCache).thenReturn(metadataCache)
     when(metadataCache.getTopicId(topic)).thenReturn(topicUuid)
+    // Classic-tiered topic: the consolidation hook must not fire for a non-diskless topic.
+    val inklessMetadataView = mock(classOf[kafka.server.metadata.InklessMetadataView])
+    when(inklessMetadataView.isDisklessTopic(topic)).thenReturn(false)
+    when(replicaManager.inklessMetadataView()).thenReturn(inklessMetadataView)
 
     val tp0 = new TopicPartition(topic, 0)
     val log0: UnifiedLog = mock(classOf[UnifiedLog])
@@ -564,6 +568,87 @@ class DynamicConfigChangeUnitTest {
     configHandler.maybeUpdateRemoteLogComponents(topic, Seq(log0, log1), isRemoteLogEnabledBeforeUpdate, false)
     assertEquals(Collections.singleton(partition0), leaderPartitionsArg.getValue)
     assertEquals(Collections.singleton(partition1), followerPartitionsArg.getValue)
+    verify(replicaManager, never()).startConsolidationFetchersForCaughtUpClassicPartitions(any())
+  }
+
+  @Test
+  def testEnableRemoteLogStorageOnDisklessTopicStartsConsolidation(): Unit = {
+    // A classic -> consolidated switch flips diskless.enable=true (sealing the classic log) and
+    // remote.storage.enable=true in separate controller deltas, with remote storage landing after
+    // the seal as a config-only change. This hook starts consolidation when remote storage flips on
+    // for a (now consolidating) diskless topic, since the leader-delta path no longer re-runs.
+    val topic = "diskless-topic"
+    val topicUuid = Uuid.randomUuid()
+    val rlm: RemoteLogManager = mock(classOf[RemoteLogManager])
+    val replicaManager: ReplicaManager = mock(classOf[ReplicaManager])
+    val metadataCache = mock(classOf[MetadataCache])
+    when(replicaManager.remoteLogManager).thenReturn(Some(rlm))
+    when(replicaManager.metadataCache).thenReturn(metadataCache)
+    when(metadataCache.getTopicId(topic)).thenReturn(topicUuid)
+    val inklessMetadataView = mock(classOf[kafka.server.metadata.InklessMetadataView])
+    when(inklessMetadataView.isDisklessTopic(topic)).thenReturn(true)
+    when(replicaManager.inklessMetadataView()).thenReturn(inklessMetadataView)
+
+    val tp0 = new TopicPartition(topic, 0)
+    val log0: UnifiedLog = mock(classOf[UnifiedLog])
+    val partition0: Partition = mock(classOf[Partition])
+    when(log0.topicPartition).thenReturn(tp0)
+    when(log0.remoteLogEnabled()).thenReturn(true)
+    when(partition0.isLeader).thenReturn(true)
+    when(partition0.topicPartition).thenReturn(tp0)
+    when(replicaManager.onlinePartition(tp0)).thenReturn(Some(partition0))
+    when(log0.config).thenReturn(new LogConfig(Collections.emptyMap()))
+
+    val tp1 = new TopicPartition(topic, 1)
+    val log1: UnifiedLog = mock(classOf[UnifiedLog])
+    val partition1: Partition = mock(classOf[Partition])
+    when(log1.topicPartition).thenReturn(tp1)
+    when(log1.remoteLogEnabled()).thenReturn(true)
+    when(partition1.isLeader).thenReturn(false)
+    when(partition1.topicPartition).thenReturn(tp1)
+    when(replicaManager.onlinePartition(tp1)).thenReturn(Some(partition1))
+    when(log1.config).thenReturn(new LogConfig(Collections.emptyMap()))
+
+    doNothing().when(rlm).onLeadershipChange(any(), any(), any())
+
+    val consolidatingArg: ArgumentCaptor[Set[TopicPartition]] = ArgumentCaptor.forClass(classOf[Set[TopicPartition]])
+    doNothing().when(replicaManager).startConsolidationFetchersForCaughtUpClassicPartitions(consolidatingArg.capture())
+
+    val isRemoteLogEnabledBeforeUpdate = false
+    val configHandler: TopicConfigHandler = new TopicConfigHandler(replicaManager, null, null)
+    configHandler.maybeUpdateRemoteLogComponents(topic, Seq(log0, log1), isRemoteLogEnabledBeforeUpdate, false)
+
+    // Both the leader and the follower partition are handed to the reconciler, which decides per
+    // partition whether they are ready to consolidate (at/above the seal) or must keep replicating.
+    assertEquals(Set(tp0, tp1), consolidatingArg.getValue)
+  }
+
+  @Test
+  def testEnableRemoteLogStorageOnAlreadyEnabledDisklessTopicDoesNotStartConsolidation(): Unit = {
+    // Remote storage was already on (e.g. the leader-delta path already started consolidation at the
+    // seal commit, or this is an unrelated config edit): the false->true transition guard must keep
+    // this from redundantly kicking off consolidation again.
+    val topic = "diskless-topic"
+    val rlm: RemoteLogManager = mock(classOf[RemoteLogManager])
+    val replicaManager: ReplicaManager = mock(classOf[ReplicaManager])
+    when(replicaManager.remoteLogManager).thenReturn(Some(rlm))
+    val inklessMetadataView = mock(classOf[kafka.server.metadata.InklessMetadataView])
+    when(inklessMetadataView.isDisklessTopic(topic)).thenReturn(true)
+    when(replicaManager.inklessMetadataView()).thenReturn(inklessMetadataView)
+
+    val tp0 = new TopicPartition(topic, 0)
+    val log0: UnifiedLog = mock(classOf[UnifiedLog])
+    val partition0: Partition = mock(classOf[Partition])
+    when(log0.topicPartition).thenReturn(tp0)
+    when(log0.remoteLogEnabled()).thenReturn(true)
+    when(partition0.isLeader).thenReturn(true)
+    when(replicaManager.onlinePartition(tp0)).thenReturn(Some(partition0))
+    when(log0.config).thenReturn(new LogConfig(Collections.emptyMap()))
+
+    val isRemoteLogEnabledBeforeUpdate = true
+    val configHandler: TopicConfigHandler = new TopicConfigHandler(replicaManager, null, null)
+    configHandler.maybeUpdateRemoteLogComponents(topic, Seq(log0), isRemoteLogEnabledBeforeUpdate, false)
+    verify(replicaManager, never()).startConsolidationFetchersForCaughtUpClassicPartitions(any())
   }
 
   @Test


### PR DESCRIPTION
The controller applies a classic-to-consolidated switch as separate metadata deltas: remote.storage.enable=true arrives as a config-only delta with no leader or partition change, so the leader-delta path never starts the consolidation fetcher. TopicConfigHandler now kicks off consolidation for the topic's online partitions when remote storage flips from false to true on a diskless topic; the reconciler skips any partitions that are not ready yet and it is a no-op for non-consolidating topics.

Note: this hook resolves partitions from logManager.logsByTopic(topic), so it only fires for a topic that still has a local log when remote storage flips on -- i.e. a topic switched from classic, whose classic prefix is still local. A born-diskless topic left untiered before consolidation was enabled has no local log, so this path does not cover that untiered-diskless -> consolidated upgrade.