### PR TITLE
feat(inkless:consolidation): [KC-298] add JMX metrics for the cross-tier log start offset

### DIFF
--- a/docs/inkless/metrics.rst
+++ b/docs/inkless/metrics.rst
@@ -235,6 +235,21 @@ RetentionEnforcementTotalTime             Total time spent on a retention enforc
 ========================================  =================================================================
 
 
+CrossTierLogStartReporter metrics
+==================================
+
+io.aiven.inkless.delete:type=CrossTierLogStartReporter
+------------------------------------------------------
+
+===================  ================================================================================================
+Attribute name       Description                                                                                     
+===================  ================================================================================================
+PartitionsReported   Total number of partition cross-tier log start offsets accepted by the control plane            
+PendingPartitions    Current number of partitions with a buffered cross-tier log start offset awaiting the next flush
+ReportErrors         Total number of errors while reporting cross-tier log start offsets to the control plane        
+===================  ================================================================================================
+
+
 ClientAzAwareness metrics
 ==================================
 
@@ -259,38 +274,40 @@ PostgresControlPlane metrics
 io.aiven.inkless.control_plane.postgres:type=PostgresControlPlane
 -----------------------------------------------------------------
 
-=============================  ==================================================================
-Attribute name                 Description                                                       
-=============================  ==================================================================
-CommitFileQueryRate            Total number of CommitFile queries executed                       
-CommitFileQueryTime            Time spent executing the CommitFile query in milliseconds         
-DeleteRecordsQueryRate         Total number of DeleteRecords queries executed                    
-DeleteRecordsQueryTime         Time spent executing the DeleteRecords query in milliseconds      
-EnforceRetentionQueryRate      Total number of EnforceRetention queries executed                 
-EnforceRetentionQueryTime      Time spent executing the EnforceRetention query in milliseconds   
-FilesDeleteQueryRate           Total number of FilesDelete queries executed                      
-FilesDeleteQueryTime           Time spent executing the FilesDelete query in milliseconds        
-FindBatchesQueryRate           Total number of FindBatches queries executed                      
-FindBatchesQueryTime           Time spent executing the FindBatches query in milliseconds        
-GetFilesToDeleteQueryRate      Total number of GetFilesToDelete queries executed                 
-GetFilesToDeleteQueryTime      Time spent executing the GetFilesToDelete query in milliseconds   
-GetLogInfoQueryRate            Total number of GetLogInfo queries executed                       
-GetLogInfoQueryTime            Time spent executing the GetLogInfo query in milliseconds         
-GetLogsQueryRate               Total number of GetLogs queries executed                          
-GetLogsQueryTime               Time spent executing the GetLogs query in milliseconds            
-GetProducerStateQueryRate      Total number of GetProducerState queries executed                 
-GetProducerStateQueryTime      Time spent executing the GetProducerState query in milliseconds   
-InitDisklessLogQueryRate       Total number of InitDisklessLog queries executed                  
-InitDisklessLogQueryTime       Time spent executing the InitDisklessLog query in milliseconds    
-ListOffsetsQueryRate           Total number of ListOffsets queries executed                      
-ListOffsetsQueryTime           Time spent executing the ListOffsets query in milliseconds        
-SafeDeleteFileCheckQueryRate   Total number of SafeDeleteFileCheck queries executed              
-SafeDeleteFileCheckQueryTime   Time spent executing the SafeDeleteFileCheck query in milliseconds
-TopicCreateQueryRate           Total number of TopicCreate queries executed                      
-TopicCreateQueryTime           Time spent executing the TopicCreate query in milliseconds        
-TopicDeleteQueryRate           Total number of TopicDelete queries executed                      
-TopicDeleteQueryTime           Time spent executing the TopicDelete query in milliseconds        
-=============================  ==================================================================
+==================================  =======================================================================
+Attribute name                      Description                                                            
+==================================  =======================================================================
+AdvanceCrossTierLogStartQueryRate   Total number of AdvanceCrossTierLogStart queries executed              
+AdvanceCrossTierLogStartQueryTime   Time spent executing the AdvanceCrossTierLogStart query in milliseconds
+CommitFileQueryRate                 Total number of CommitFile queries executed                            
+CommitFileQueryTime                 Time spent executing the CommitFile query in milliseconds              
+DeleteRecordsQueryRate              Total number of DeleteRecords queries executed                         
+DeleteRecordsQueryTime              Time spent executing the DeleteRecords query in milliseconds           
+EnforceRetentionQueryRate           Total number of EnforceRetention queries executed                      
+EnforceRetentionQueryTime           Time spent executing the EnforceRetention query in milliseconds        
+FilesDeleteQueryRate                Total number of FilesDelete queries executed                           
+FilesDeleteQueryTime                Time spent executing the FilesDelete query in milliseconds             
+FindBatchesQueryRate                Total number of FindBatches queries executed                           
+FindBatchesQueryTime                Time spent executing the FindBatches query in milliseconds             
+GetFilesToDeleteQueryRate           Total number of GetFilesToDelete queries executed                      
+GetFilesToDeleteQueryTime           Time spent executing the GetFilesToDelete query in milliseconds        
+GetLogInfoQueryRate                 Total number of GetLogInfo queries executed                            
+GetLogInfoQueryTime                 Time spent executing the GetLogInfo query in milliseconds              
+GetLogsQueryRate                    Total number of GetLogs queries executed                               
+GetLogsQueryTime                    Time spent executing the GetLogs query in milliseconds                 
+GetProducerStateQueryRate           Total number of GetProducerState queries executed                      
+GetProducerStateQueryTime           Time spent executing the GetProducerState query in milliseconds        
+InitDisklessLogQueryRate            Total number of InitDisklessLog queries executed                       
+InitDisklessLogQueryTime            Time spent executing the InitDisklessLog query in milliseconds         
+ListOffsetsQueryRate                Total number of ListOffsets queries executed                           
+ListOffsetsQueryTime                Time spent executing the ListOffsets query in milliseconds             
+SafeDeleteFileCheckQueryRate        Total number of SafeDeleteFileCheck queries executed                   
+SafeDeleteFileCheckQueryTime        Time spent executing the SafeDeleteFileCheck query in milliseconds     
+TopicCreateQueryRate                Total number of TopicCreate queries executed                           
+TopicCreateQueryTime                Time spent executing the TopicCreate query in milliseconds             
+TopicDeleteQueryRate                Total number of TopicDelete queries executed                           
+TopicDeleteQueryTime                Time spent executing the TopicDelete query in milliseconds             
+==================================  =======================================================================
 
 
 PostgresConnectionPool metrics
@@ -330,6 +347,21 @@ CacheInvalidations     Total number of cache entry invalidations
 CacheMisses            Total number of batch coordinate cache misses                                   
 CacheSize              Current number of entries in the batch coordinate cache                         
 =====================  ================================================================================
+
+
+CrossTierLogStartCache metrics
+==================================
+
+io.aiven.inkless.cache:type=CrossTierLogStartCache
+--------------------------------------------------
+
+===============  ========================================================================================
+Attribute name   Description                                                                             
+===============  ========================================================================================
+CacheHits        Total number of cross-tier log start cache hits served without a control-plane call     
+CacheMisses      Total number of cross-tier log start cache misses that fell through to the control plane
+CacheSize        Current number of partitions cached for the cross-tier log start offset                 
+===============  ========================================================================================
 
 
 CaffeineCache metrics

--- a/storage/inkless/src/main/java/io/aiven/inkless/cache/CaffeineCrossTierLogStartCache.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/cache/CaffeineCrossTierLogStartCache.java
@@ -33,6 +33,7 @@ import java.time.Duration;
 public class CaffeineCrossTierLogStartCache implements CrossTierLogStartCache {
 
     private final Cache<TopicIdPartition, Long> cache;
+    private final CrossTierLogStartCacheMetrics metrics;
 
     public CaffeineCrossTierLogStartCache(final Duration ttl) {
         this(ttl, Ticker.systemTicker());
@@ -47,11 +48,18 @@ public class CaffeineCrossTierLogStartCache implements CrossTierLogStartCache {
             .expireAfterWrite(ttl)
             .ticker(ticker)
             .build();
+        this.metrics = new CrossTierLogStartCacheMetrics(cache::estimatedSize);
     }
 
     @Override
     public Long get(final TopicIdPartition topicIdPartition) {
-        return cache.getIfPresent(topicIdPartition);
+        final Long offset = cache.getIfPresent(topicIdPartition);
+        if (offset == null) {
+            metrics.recordCacheMiss();
+        } else {
+            metrics.recordCacheHit();
+        }
+        return offset;
     }
 
     @Override
@@ -66,5 +74,6 @@ public class CaffeineCrossTierLogStartCache implements CrossTierLogStartCache {
     public void close() throws IOException {
         cache.invalidateAll();
         cache.cleanUp();
+        metrics.close();
     }
 }

--- a/storage/inkless/src/main/java/io/aiven/inkless/cache/CrossTierLogStartCacheMetrics.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/cache/CrossTierLogStartCacheMetrics.java
@@ -1,0 +1,83 @@
+/*
+ * Inkless
+ * Copyright (C) 2024 - 2026 Aiven OY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.aiven.inkless.cache;
+
+import org.apache.kafka.common.MetricNameTemplate;
+import org.apache.kafka.server.metrics.KafkaMetricsGroup;
+
+import java.io.Closeable;
+import java.util.List;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.function.Supplier;
+
+/**
+ * JMX metrics for the read-through {@link CrossTierLogStartCache}. A hit is served entirely from the
+ * cache without a control-plane {@code listOffsets} call; a miss falls through to the control plane
+ * and (on success) populates the cache.
+ */
+public final class CrossTierLogStartCacheMetrics implements Closeable {
+    private static final String GROUP = CrossTierLogStartCache.class.getSimpleName();
+
+    static final String CACHE_HITS = "CacheHits";
+    private static final String CACHE_HITS_DOC =
+        "Total number of cross-tier log start cache hits served without a control-plane call";
+    static final String CACHE_MISSES = "CacheMisses";
+    private static final String CACHE_MISSES_DOC =
+        "Total number of cross-tier log start cache misses that fell through to the control plane";
+    static final String CACHE_SIZE = "CacheSize";
+    private static final String CACHE_SIZE_DOC =
+        "Current number of partitions cached for the cross-tier log start offset";
+
+    /**
+     * This method returns a list of all the metric name templates for the CrossTierLogStartCacheMetrics class.
+     * This is used for documentation purposes only.
+     */
+    public static List<MetricNameTemplate> all() {
+        return List.of(
+            new MetricNameTemplate(CACHE_HITS, GROUP, CACHE_HITS_DOC),
+            new MetricNameTemplate(CACHE_MISSES, GROUP, CACHE_MISSES_DOC),
+            new MetricNameTemplate(CACHE_SIZE, GROUP, CACHE_SIZE_DOC)
+        );
+    }
+
+    private final KafkaMetricsGroup metricsGroup = new KafkaMetricsGroup(
+        CrossTierLogStartCache.class.getPackageName(), CrossTierLogStartCache.class.getSimpleName());
+    private final LongAdder cacheHits = new LongAdder();
+    private final LongAdder cacheMisses = new LongAdder();
+
+    public CrossTierLogStartCacheMetrics(final Supplier<Long> sizeSupplier) {
+        metricsGroup.newGauge(CACHE_HITS, cacheHits::intValue);
+        metricsGroup.newGauge(CACHE_MISSES, cacheMisses::intValue);
+        metricsGroup.newGauge(CACHE_SIZE, () -> sizeSupplier.get().intValue());
+    }
+
+    public void recordCacheHit() {
+        cacheHits.increment();
+    }
+
+    public void recordCacheMiss() {
+        cacheMisses.increment();
+    }
+
+    @Override
+    public void close() {
+        metricsGroup.removeMetric(CACHE_HITS);
+        metricsGroup.removeMetric(CACHE_MISSES);
+        metricsGroup.removeMetric(CACHE_SIZE);
+    }
+}

--- a/storage/inkless/src/main/java/io/aiven/inkless/common/SharedState.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/common/SharedState.java
@@ -216,6 +216,7 @@ public final class SharedState implements Closeable {
         Utils.closeQuietly(storageMetrics, "storageMetrics");
         Utils.closeQuietly(batchCoordinateCache, "batchCoordinateCache");
         Utils.closeQuietly(crossTierLogStartCache, "crossTierLogStartCache");
+        Utils.closeQuietly(crossTierLogStartReporter, "crossTierLogStartReporter");
         Utils.closeQuietly(cache, "objectCache");
     }
 

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/PostgresControlPlane.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/PostgresControlPlane.java
@@ -229,7 +229,7 @@ public class PostgresControlPlane extends AbstractControlPlane {
     public List<AdvanceCrossTierLogStartOffsetResponse> advanceCrossTierLogStartOffset(final List<AdvanceCrossTierLogStartOffsetRequest> requests) {
         try {
             final AdvanceCrossTierLogStartOffsetJob job = new AdvanceCrossTierLogStartOffsetJob(
-                time, writeJooqCtx, requests, duration -> { });
+                time, writeJooqCtx, requests, pgMetrics::onAdvanceCrossTierLogStartCompleted);
             return job.call();
         } catch (final Exception e) {
             throw new ControlPlaneException("Failed to advance cross-tier log start offset", e);

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/PostgresControlPlaneMetrics.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/PostgresControlPlaneMetrics.java
@@ -38,7 +38,8 @@ public class PostgresControlPlaneMetrics implements Closeable {
         "TopicCreate", "TopicDelete", "FilesDelete", "ListOffsets",
         "DeleteRecords", "EnforceRetention", "GetFilesToDelete",
         "SafeDeleteFileCheck",
-        "GetLogInfo", "InitDisklessLog", "GetProducerState"
+        "GetLogInfo", "InitDisklessLog", "GetProducerState",
+        "AdvanceCrossTierLogStart"
     );
 
     /**
@@ -75,6 +76,7 @@ public class PostgresControlPlaneMetrics implements Closeable {
     private final QueryMetrics initDisklessLogMetrics = new QueryMetrics("InitDisklessLog");
     private final QueryMetrics getProducerStateMetrics = new QueryMetrics("GetProducerState");
     private final QueryMetrics pruneDisklessLogsMetrics = new QueryMetrics("PruneDisklessLogs");
+    private final QueryMetrics advanceCrossTierLogStartMetrics = new QueryMetrics("AdvanceCrossTierLogStart");
 
     public PostgresControlPlaneMetrics(Time time) {
         this.time = Objects.requireNonNull(time, "time cannot be null");
@@ -140,6 +142,10 @@ public class PostgresControlPlaneMetrics implements Closeable {
         pruneDisklessLogsMetrics.record(duration);
     }
 
+    public void onAdvanceCrossTierLogStartCompleted(Long duration) {
+        advanceCrossTierLogStartMetrics.record(duration);
+    }
+
     @Override
     public void close() {
         findBatchesMetrics.remove();
@@ -157,6 +163,7 @@ public class PostgresControlPlaneMetrics implements Closeable {
         initDisklessLogMetrics.remove();
         getProducerStateMetrics.remove();
         pruneDisklessLogsMetrics.remove();
+        advanceCrossTierLogStartMetrics.remove();
     }
 
     private class QueryMetrics {

--- a/storage/inkless/src/main/java/io/aiven/inkless/delete/CrossTierLogStartReporter.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/delete/CrossTierLogStartReporter.java
@@ -27,6 +27,7 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.Closeable;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -54,7 +55,7 @@ import io.aiven.inkless.control_plane.MetadataView;
  * partitions into a single control-plane call. Only strictly-advancing values are reported, since
  * remote retention is monotonic and the control plane stores the value forward-only.
  */
-public class CrossTierLogStartReporter implements Runnable {
+public class CrossTierLogStartReporter implements Runnable, Closeable {
     private static final Logger LOGGER = LoggerFactory.getLogger(CrossTierLogStartReporter.class);
 
     // Bounds for the lastReported dedup cache. It is a soft optimization, not a source of truth:
@@ -67,6 +68,7 @@ public class CrossTierLogStartReporter implements Runnable {
     private final MetadataView metadataView;
     private final ControlPlane controlPlane;
     private final CrossTierLogStartCache crossTierLogStartCache;
+    private final CrossTierLogStartReporterMetrics metrics;
 
     // Pending updates not yet flushed to the control plane (per partition, highest reported offset).
     private final ConcurrentHashMap<TopicIdPartition, Long> pending = new ConcurrentHashMap<>();
@@ -83,6 +85,7 @@ public class CrossTierLogStartReporter implements Runnable {
         this.metadataView = Objects.requireNonNull(metadataView, "metadataView cannot be null");
         this.controlPlane = Objects.requireNonNull(controlPlane, "controlPlane cannot be null");
         this.crossTierLogStartCache = Objects.requireNonNull(crossTierLogStartCache, "crossTierLogStartCache cannot be null");
+        this.metrics = new CrossTierLogStartReporterMetrics(pending::size);
     }
 
     /**
@@ -159,6 +162,7 @@ public class CrossTierLogStartReporter implements Runnable {
             for (int i = 0; i < requests.size(); i++) {
                 pending.merge(partitions.get(i), requests.get(i).remoteLogStartOffset(), Math::max);
             }
+            metrics.recordReportError();
             throw e;
         }
 
@@ -171,6 +175,7 @@ public class CrossTierLogStartReporter implements Runnable {
                     lastReported.asMap().merge(tidp, stored, Math::max);
                     // Write-through: keep the leader's local read path from re-querying the control plane.
                     crossTierLogStartCache.put(tidp, stored);
+                    metrics.recordPartitionReported();
                     LOGGER.trace("Reported cross-tier log start offset for {}: stored={}", tidp, stored);
                 }
                 case UNKNOWN_TOPIC_OR_PARTITION -> {
@@ -178,8 +183,10 @@ public class CrossTierLogStartReporter implements Runnable {
                     lastReported.invalidate(tidp);
                     LOGGER.debug("Cross-tier log start offset report for {} returned unknown topic or partition", tidp);
                 }
-                default ->
+                default -> {
+                    metrics.recordReportError();
                     LOGGER.error("Cross-tier log start offset report for {} returned error: {}", tidp, response.errors());
+                }
             }
         }
     }
@@ -187,5 +194,11 @@ public class CrossTierLogStartReporter implements Runnable {
     // Visible for testing.
     Map<TopicIdPartition, Long> pendingView() {
         return Map.copyOf(pending);
+    }
+
+    @Override
+    public void close() {
+        // Scheduling and lifecycle are owned externally; only the JMX metrics are owned here.
+        metrics.close();
     }
 }

--- a/storage/inkless/src/main/java/io/aiven/inkless/delete/CrossTierLogStartReporterMetrics.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/delete/CrossTierLogStartReporterMetrics.java
@@ -1,0 +1,82 @@
+/*
+ * Inkless
+ * Copyright (C) 2024 - 2026 Aiven OY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.aiven.inkless.delete;
+
+import org.apache.kafka.common.MetricNameTemplate;
+import org.apache.kafka.server.metrics.KafkaMetricsGroup;
+
+import java.io.Closeable;
+import java.util.List;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.function.Supplier;
+
+/**
+ * JMX metrics for the write path that pushes the leader's cross-tier (remote) log start offset to
+ * the control plane (see {@link CrossTierLogStartReporter}).
+ */
+public final class CrossTierLogStartReporterMetrics implements Closeable {
+    private static final String GROUP = CrossTierLogStartReporter.class.getSimpleName();
+
+    static final String PARTITIONS_REPORTED = "PartitionsReported";
+    private static final String PARTITIONS_REPORTED_DOC =
+        "Total number of partition cross-tier log start offsets accepted by the control plane";
+    static final String REPORT_ERRORS = "ReportErrors";
+    private static final String REPORT_ERRORS_DOC =
+        "Total number of errors while reporting cross-tier log start offsets to the control plane";
+    static final String PENDING_PARTITIONS = "PendingPartitions";
+    private static final String PENDING_PARTITIONS_DOC =
+        "Current number of partitions with a buffered cross-tier log start offset awaiting the next flush";
+
+    /**
+     * This method returns a list of all the metric name templates for the CrossTierLogStartReporterMetrics class.
+     * This is used for documentation purposes only.
+     */
+    public static List<MetricNameTemplate> all() {
+        return List.of(
+            new MetricNameTemplate(PARTITIONS_REPORTED, GROUP, PARTITIONS_REPORTED_DOC),
+            new MetricNameTemplate(REPORT_ERRORS, GROUP, REPORT_ERRORS_DOC),
+            new MetricNameTemplate(PENDING_PARTITIONS, GROUP, PENDING_PARTITIONS_DOC)
+        );
+    }
+
+    private final KafkaMetricsGroup metricsGroup = new KafkaMetricsGroup(
+        CrossTierLogStartReporter.class.getPackageName(), CrossTierLogStartReporter.class.getSimpleName());
+    private final LongAdder partitionsReported = new LongAdder();
+    private final LongAdder reportErrors = new LongAdder();
+
+    public CrossTierLogStartReporterMetrics(final Supplier<Integer> pendingSupplier) {
+        metricsGroup.newGauge(PARTITIONS_REPORTED, partitionsReported::intValue);
+        metricsGroup.newGauge(REPORT_ERRORS, reportErrors::intValue);
+        metricsGroup.newGauge(PENDING_PARTITIONS, pendingSupplier::get);
+    }
+
+    public void recordPartitionReported() {
+        partitionsReported.increment();
+    }
+
+    public void recordReportError() {
+        reportErrors.increment();
+    }
+
+    @Override
+    public void close() {
+        metricsGroup.removeMetric(PARTITIONS_REPORTED);
+        metricsGroup.removeMetric(REPORT_ERRORS);
+        metricsGroup.removeMetric(PENDING_PARTITIONS);
+    }
+}

--- a/storage/inkless/src/main/java/io/aiven/inkless/doc/MetricsDocs.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/doc/MetricsDocs.java
@@ -29,12 +29,14 @@ import java.util.TreeMap;
 
 import io.aiven.inkless.cache.BatchCoordinateCacheMetrics;
 import io.aiven.inkless.cache.CaffeineCacheMetricsRegistry;
+import io.aiven.inkless.cache.CrossTierLogStartCacheMetrics;
 import io.aiven.inkless.common.SharedState;
 import io.aiven.inkless.common.metrics.ThreadPoolMonitorMetricsRegistry;
 import io.aiven.inkless.consume.InklessFetchMetrics;
 import io.aiven.inkless.consume.InklessFetchOffsetMetrics;
 import io.aiven.inkless.control_plane.postgres.PostgresConnectionPoolMetrics;
 import io.aiven.inkless.control_plane.postgres.PostgresControlPlaneMetrics;
+import io.aiven.inkless.delete.CrossTierLogStartReporterMetrics;
 import io.aiven.inkless.delete.FileCleanerMetrics;
 import io.aiven.inkless.delete.RetentionEnforcerMetrics;
 import io.aiven.inkless.metadata.ClientAzAwarenessMetrics;
@@ -92,6 +94,10 @@ public class MetricsDocs {
         out.println();
         out.println(toRstTable("io.aiven.inkless.delete", RetentionEnforcerMetrics.all()));
 
+        printHeading("CrossTierLogStartReporter metrics");
+        out.println();
+        out.println(toRstTable("io.aiven.inkless.delete", CrossTierLogStartReporterMetrics.all()));
+
         // Metadata metrics
         printHeading("ClientAzAwareness metrics");
         out.println();
@@ -110,6 +116,10 @@ public class MetricsDocs {
         printHeading("BatchCoordinateCache metrics");
         out.println();
         out.println(toRstTable("io.aiven.inkless.cache", BatchCoordinateCacheMetrics.all()));
+
+        printHeading("CrossTierLogStartCache metrics");
+        out.println();
+        out.println(toRstTable("io.aiven.inkless.cache", CrossTierLogStartCacheMetrics.all()));
 
         // Caffeine cache metrics
         printHeading("CaffeineCache metrics");


### PR DESCRIPTION


Expose observability for the cross-tier log start offset path introduced in the preceding commits.

- Control plane: add the AdvanceCrossTierLogStart query rate/time metric to PostgresControlPlaneMetrics.
- Write path: add CrossTierLogStartReporter metrics (PartitionsReported, ReportErrors, PendingPartitions).
- Cache: add CrossTierLogStartCache metrics (CacheHits, CacheMisses, CacheSize).
- Register the new metric groups in MetricsDocs and regenerate metrics.rst.
