### PR TITLE
feat(inkless): add inkless.client.az.listener.map config

### DIFF
--- a/docs/inkless/configs.rst
+++ b/docs/inkless/configs.rst
@@ -39,6 +39,13 @@ Under ``inkless.``
   * Default: io.aiven.inkless.storage_backend.in_memory.InMemoryStorage
   * Importance: high
 
+``client.az.listener.map``
+  Cluster-wide mapping from AZ-specific listener aliases to physical availability zone (rack) IDs, used for listener-based AZ routing of diskless topic metadata. Format is a comma-separated list of LISTENER=az pairs, for example SASL_SSL_US_EAST_1_AZ_1=use1-az1,SASL_SSL_US_EAST_1_AZ_2=use1-az2. Every broker should use the same mapping. Listener names are matched case-insensitively (normalized to upper case). Defaults to empty (feature disabled).
+
+  * Type: list
+  * Default: ""
+  * Importance: medium
+
 ``control.plane.batch.coalescing.enabled``
   When true, contiguous same-partition batch runs within a single commit are collapsed into a single row in the batches table via commit_file_v2, reducing control-plane metadata growth for low-throughput producers. Set to true only after all brokers in the cluster have been upgraded to a version that supports reading coalesced rows. Defaults to false for safe rolling upgrades.
 

--- a/storage/inkless/src/main/java/io/aiven/inkless/config/InklessConfig.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/config/InklessConfig.java
@@ -21,9 +21,13 @@ import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.network.ListenerName;
 
 import java.lang.reflect.InvocationTargetException;
 import java.time.Duration;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import io.aiven.inkless.common.config.validators.Subclass;
@@ -230,6 +234,14 @@ public class InklessConfig extends AbstractConfig {
         + "reading coalesced rows. "
         + "Defaults to false for safe rolling upgrades.";
     private static final boolean BATCH_COALESCING_ENABLED_DEFAULT = false;
+
+    public static final String CLIENT_AZ_LISTENER_MAP_CONFIG = "client.az.listener.map";
+    private static final String CLIENT_AZ_LISTENER_MAP_DOC = "Cluster-wide mapping from AZ-specific listener aliases to physical "
+        + "availability zone (rack) IDs, used for listener-based AZ routing of diskless topic metadata. "
+        + "Format is a comma-separated list of LISTENER=az pairs, for example "
+        + "SASL_SSL_US_EAST_1_AZ_1=use1-az1,SASL_SSL_US_EAST_1_AZ_2=use1-az2. "
+        + "Every broker should use the same mapping. Listener names are matched case-insensitively "
+        + "(normalized to upper case). Defaults to empty (feature disabled).";
 
     public static ConfigDef configDef() {
         final ConfigDef configDef = new ConfigDef();
@@ -485,7 +497,45 @@ public class InklessConfig extends AbstractConfig {
             BATCH_COALESCING_ENABLED_DOC
         );
 
+        configDef.define(
+            CLIENT_AZ_LISTENER_MAP_CONFIG,
+            ConfigDef.Type.LIST,
+            Collections.emptyList(),
+            ConfigDef.Importance.MEDIUM,
+            CLIENT_AZ_LISTENER_MAP_DOC
+        );
+
         return configDef;
+    }
+
+    private static Map<String, String> parseClientAzListenerMap(final List<String> entries) {
+        final Map<String, String> result = new LinkedHashMap<>();
+        for (final String entry : entries) {
+            final int sep = entry.indexOf('=');
+            if (sep < 0) {
+                throw new ConfigException(
+                    CLIENT_AZ_LISTENER_MAP_CONFIG, entry,
+                    "Entry is missing the '=' separator between listener name and AZ.");
+            }
+            final String listener = entry.substring(0, sep).trim();
+            final String az = entry.substring(sep + 1).trim();
+            if (listener.isEmpty()) {
+                throw new ConfigException(
+                    CLIENT_AZ_LISTENER_MAP_CONFIG, entry, "Listener name must not be empty.");
+            }
+            if (az.isEmpty()) {
+                throw new ConfigException(
+                    CLIENT_AZ_LISTENER_MAP_CONFIG, entry, "AZ must not be empty.");
+            }
+            final String normalizedListener = ListenerName.normalised(listener).value();
+            if (result.containsKey(normalizedListener)) {
+                throw new ConfigException(
+                    CLIENT_AZ_LISTENER_MAP_CONFIG, entry,
+                    "Duplicate listener name '" + normalizedListener + "' (matching is case-insensitive).");
+            }
+            result.put(normalizedListener, az);
+        }
+        return result;
     }
 
     public InklessConfig(final AbstractConfig config) {
@@ -572,6 +622,13 @@ public class InklessConfig extends AbstractConfig {
                     + FETCH_HEDGE_TTFB_THRESHOLD_MS_CONFIG + " (" + hedgeTtfbMs + "ms) when both are enabled."
             );
         }
+
+        // Parse the AZ listener map to trigger strict validation at startup.
+        // The parsed result is discarded here; the accessor re-parses on demand.
+        @SuppressWarnings("unchecked")
+        final List<String> azListenerEntries =
+            (List<String>) parsedProps.get(CLIENT_AZ_LISTENER_MAP_CONFIG);
+        parseClientAzListenerMap(azListenerEntries);
 
         return configDef;
     }
@@ -721,5 +778,10 @@ public class InklessConfig extends AbstractConfig {
 
     public long cacheMaxBytes() {
         return getLong(CONSUME_CACHE_MAX_BYTES_CONFIG);
+    }
+
+    public Map<String, String> clientAzListenerMap() {
+        return Collections.unmodifiableMap(
+            parseClientAzListenerMap(getList(CLIENT_AZ_LISTENER_MAP_CONFIG)));
     }
 }

--- a/storage/inkless/src/test/java/io/aiven/inkless/config/InklessConfigTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/config/InklessConfigTest.java
@@ -665,4 +665,71 @@ class InklessConfigTest {
         assertThat(config.fetchLaggingConsumerRequestRateLimit()).isEqualTo(300);
         assertThat(config.maxBatchesPerEnforcementRequest()).isEqualTo(10);
     }
+
+    @Test
+    void clientAzListenerMapParsesEntries() {
+        final Map<String, String> configs = new HashMap<>();
+        configs.put("inkless.client.az.listener.map",
+            "SASL_SSL_EU_WEST_1_AZ_1=euw1-az1,SASL_SSL_EU_WEST_1_AZ_2=euw1-az2");
+        final InklessConfig config = new InklessConfig(new AbstractConfig(new ConfigDef(), configs));
+        assertThat(config.clientAzListenerMap()).isEqualTo(Map.of(
+            "SASL_SSL_EU_WEST_1_AZ_1", "euw1-az1",
+            "SASL_SSL_EU_WEST_1_AZ_2", "euw1-az2"
+        ));
+    }
+
+    @Test
+    void clientAzListenerMapNormalizesListenerToUpperCase() {
+        final Map<String, String> configs = new HashMap<>();
+        configs.put("inkless.client.az.listener.map", "sasl_ssl_us_east_1_az_1=use1-az1");
+        final InklessConfig config = new InklessConfig(new AbstractConfig(new ConfigDef(), configs));
+        assertThat(config.clientAzListenerMap()).isEqualTo(Map.of("SASL_SSL_US_EAST_1_AZ_1", "use1-az1"));
+    }
+
+    @Test
+    void clientAzListenerMapDefaultsToEmpty() {
+        final InklessConfig config = new InklessConfig(new AbstractConfig(new ConfigDef(), new HashMap<>()));
+        assertThat(config.clientAzListenerMap()).isEmpty();
+    }
+
+    private InklessConfig configWithAzMap(final String value) {
+        final Map<String, String> configs = new HashMap<>();
+        configs.put("inkless.client.az.listener.map", value);
+        return new InklessConfig(new AbstractConfig(new ConfigDef(), configs));
+    }
+
+    @Test
+    void clientAzListenerMapRejectsMissingSeparator() {
+        assertThatThrownBy(() -> configWithAzMap("SASL_SSL_AZ1"))
+            .isInstanceOf(ConfigException.class)
+            .hasMessageContaining("missing the '=' separator");
+    }
+
+    @Test
+    void clientAzListenerMapRejectsEmptyListener() {
+        assertThatThrownBy(() -> configWithAzMap("=euw1-az1"))
+            .isInstanceOf(ConfigException.class)
+            .hasMessageContaining("Listener name must not be empty");
+    }
+
+    @Test
+    void clientAzListenerMapRejectsEmptyAz() {
+        assertThatThrownBy(() -> configWithAzMap("SASL_SSL_AZ1="))
+            .isInstanceOf(ConfigException.class)
+            .hasMessageContaining("AZ must not be empty");
+    }
+
+    @Test
+    void clientAzListenerMapRejectsDuplicateListener() {
+        assertThatThrownBy(() -> configWithAzMap("SASL_SSL_AZ1=euw1-az1,SASL_SSL_AZ1=euw1-az2"))
+            .isInstanceOf(ConfigException.class)
+            .hasMessageContaining("Duplicate listener name");
+    }
+
+    @Test
+    void clientAzListenerMapRejectsCaseInsensitiveDuplicateListener() {
+        assertThatThrownBy(() -> configWithAzMap("SASL_SSL_AZ1=euw1-az1,sasl_ssl_az1=euw1-az2"))
+            .isInstanceOf(ConfigException.class)
+            .hasMessageContaining("Duplicate listener name");
+    }
 }


### PR DESCRIPTION
This adds a new Inkless config `inkless.client.az.listener.map` that will be used to map listeners to specific AZs so that clients can connect to a broker that is in the same AZ.

