### PR TITLE
feat(inkless): resolve client AZ from listener map in metadata transformer

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -125,7 +125,7 @@ class KafkaApis(val requestChannel: RequestChannel,
   val describeTopicPartitionsRequestHandler = new DescribeTopicPartitionsRequestHandler(
     metadataCache, authHelper, config)
 
-  val inklessTopicMetadataTransformer = inklessSharedState.map(s => new InklessTopicMetadataTransformer(s.metadata()))
+  val inklessTopicMetadataTransformer = inklessSharedState.map(s => new InklessTopicMetadataTransformer(s.metadata(), s.config().clientAzListenerMap()))
 
   def close(): Unit = {
     aclApis.close()

--- a/core/src/test/java/kafka/server/InklessManagedReplicasClusterTest.java
+++ b/core/src/test/java/kafka/server/InklessManagedReplicasClusterTest.java
@@ -50,6 +50,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.junit.jupiter.Container;
@@ -135,6 +137,8 @@ public class InklessManagedReplicasClusterTest {
             .setConfigProp(ServerConfigs.DISKLESS_STORAGE_SYSTEM_ENABLE_CONFIG, "true")
             // Enable managed replicas with RF=2 (one replica per AZ)
             .setConfigProp(ServerConfigs.DISKLESS_MANAGED_REPLICAS_ENABLE_CONFIG, "true")
+            // Map the default test-kit broker listener (EXTERNAL) to az1 for listener-based AZ inference
+            .setConfigProp(InklessConfig.PREFIX + InklessConfig.CLIENT_AZ_LISTENER_MAP_CONFIG, "EXTERNAL=az1")
             .setConfigProp(ReplicationConfigs.DEFAULT_REPLICATION_FACTOR_CONFIG, "2")
             // PG control plane config
             .setConfigProp(InklessConfig.PREFIX + InklessConfig.CONTROL_PLANE_CLASS_CONFIG, PostgresControlPlane.class.getName())
@@ -237,8 +241,12 @@ public class InklessManagedReplicasClusterTest {
         consumeWithAssign(clientConfigs, partitions, numRecords);
     }
 
-    @Test
-    public void produceAndConsumeWithClientAZ() throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "diskless_az=az1",             // explicit AZ marker in client.id
+        "connector-producer-orders-0"  // no marker - AZ inferred from the EXTERNAL listener (mapped to az1)
+    })
+    public void produceAndConsumeWithClientAZ(final String clientId) throws Exception {
         Map<String, Object> clientConfigs = new HashMap<>();
         clientConfigs.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers());
         clientConfigs.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
@@ -246,8 +254,7 @@ public class InklessManagedReplicasClusterTest {
         clientConfigs.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
         clientConfigs.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
         clientConfigs.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, AutoOffsetResetStrategy.EARLIEST.name());
-        // Set client AZ via client.id prefix
-        clientConfigs.put(CommonClientConfigs.CLIENT_ID_CONFIG, "diskless_az=az1");
+        clientConfigs.put(CommonClientConfigs.CLIENT_ID_CONFIG, clientId);
 
         String topicName = "az-aware-topic";
         int numRecords = 50;
@@ -271,9 +278,10 @@ public class InklessManagedReplicasClusterTest {
             assertEquals(Set.of(0, 1), replicaIds,
                 "Replicas should include one broker from each rack");
 
-            // Verify AZ-aware routing: client hints az1, so transformer should select node 0 (az1) as leader
+            // Whether AZ comes from the client.id marker or is inferred from the EXTERNAL
+            // listener (mapped to az1), the transformer should select node 0 (az1) as leader.
             assertEquals(0, partition.leader().id(),
-                "Leader should be the az1 broker (node 0) for a client with diskless_az=az1");
+                "Leader should be the az1 broker (node 0) for client.id=" + clientId);
         }
 
         // Produce and consume records with AZ-aware client

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -18,6 +18,7 @@
 package kafka.server
 
 import io.aiven.inkless.common.SharedState
+import io.aiven.inkless.config.InklessConfig
 import io.aiven.inkless.control_plane.MetadataView
 import kafka.cluster.Partition
 import kafka.coordinator.transaction.{InitProducerIdResult, TransactionCoordinator}
@@ -3640,6 +3641,7 @@ class KafkaApisTest extends Logging {
     when(metadataView.isDisklessTopic(ArgumentMatchers.eq(inklessTopic))).thenReturn(true)
     val sharedState = mock(classOf[SharedState])
     when(sharedState.metadata()).thenReturn(metadataView)
+    when(sharedState.config()).thenReturn(new InklessConfig(util.Map.of[String, AnyRef]()))
     sharedState
   }
 

--- a/storage/inkless/src/main/java/io/aiven/inkless/metadata/InklessTopicMetadataTransformer.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/metadata/InklessTopicMetadataTransformer.java
@@ -52,10 +52,16 @@ import io.aiven.inkless.control_plane.MetadataView;
  */
 public class InklessTopicMetadataTransformer implements Closeable {
     private final MetadataView metadataView;
+    private final Map<String, String> clientAzListenerMap;
     private final ClientAzAwarenessMetrics metrics;
 
-    public InklessTopicMetadataTransformer(final MetadataView metadataView) {
+    public InklessTopicMetadataTransformer(
+        final MetadataView metadataView,
+        final Map<String, String> clientAzListenerMap
+    ) {
         this.metadataView = Objects.requireNonNull(metadataView, "metadataView cannot be null");
+        this.clientAzListenerMap =
+            Objects.requireNonNull(clientAzListenerMap, "clientAzListenerMap cannot be null");
         metrics = new ClientAzAwarenessMetrics();
     }
 
@@ -71,7 +77,7 @@ public class InklessTopicMetadataTransformer implements Closeable {
     ) {
         Objects.requireNonNull(topicMetadata, "topicMetadata cannot be null");
 
-        final String clientAZ = normalizeAZ(ClientAZExtractor.getClientAZ(clientId));
+        final String clientAZ = resolveClientAZ(listenerName, clientId);
 
         // Lazy-init: computed on first diskless topic, reused across all topics in the response.
         AliveBrokerSnapshot snapshot = null;
@@ -119,7 +125,7 @@ public class InklessTopicMetadataTransformer implements Closeable {
     ) {
         Objects.requireNonNull(responseData, "responseData cannot be null");
 
-        final String clientAZ = normalizeAZ(ClientAZExtractor.getClientAZ(clientId));
+        final String clientAZ = resolveClientAZ(listenerName, clientId);
 
         // Lazy-init: computed on first diskless topic, reused across all topics in the response.
         AliveBrokerSnapshot snapshot = null;
@@ -410,6 +416,24 @@ public class InklessTopicMetadataTransformer implements Closeable {
 
     private static String normalizeAZ(final String az) {
         return (az == null || az.isBlank()) ? null : az;
+    }
+
+    /**
+     * Resolve the client AZ using based on client ID or listener name.
+     */
+    private String resolveClientAZ(final ListenerName listenerName, final String clientId) {
+        final String explicitAZ = normalizeAZ(ClientAZExtractor.getClientAZ(clientId));
+        if (explicitAZ != null) {
+            return explicitAZ;
+        }
+        if (listenerName != null) {
+            // Config keys are normalized upper-case; ListenerName.value() is already normalized.
+            final String az = clientAzListenerMap.get(listenerName.value());
+            if (az != null) {
+                return az;
+            }
+        }
+        return null;
     }
 
     /**

--- a/storage/inkless/src/test/java/io/aiven/inkless/metadata/InklessTopicMetadataTransformerTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/metadata/InklessTopicMetadataTransformerTest.java
@@ -44,6 +44,7 @@ import org.mockito.quality.Strictness;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Supplier;
 
 import io.aiven.inkless.control_plane.MetadataView;
@@ -51,6 +52,7 @@ import io.aiven.inkless.control_plane.MetadataView;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 
@@ -62,17 +64,21 @@ class InklessTopicMetadataTransformerTest {
     static final String TOPIC_CLASSIC = "classic-topic";
     static final Uuid TOPIC_CLASSIC_ID = new Uuid(456, 456);
     static final ListenerName LISTENER_NAME = ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT);
+    static final Map<String, String> NO_AZ_LISTENER_MAP = Map.of();
 
     @Mock
     MetadataView metadataView;
 
     @Test
     void nulls() {
-        assertThatThrownBy(() -> new InklessTopicMetadataTransformer(null))
+        assertThatThrownBy(() -> new InklessTopicMetadataTransformer(null, NO_AZ_LISTENER_MAP))
             .isInstanceOf(NullPointerException.class)
             .hasMessage("metadataView cannot be null");
+        assertThatThrownBy(() -> new InklessTopicMetadataTransformer(metadataView, null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessage("clientAzListenerMap cannot be null");
 
-        final var transformer = new InklessTopicMetadataTransformer(metadataView);
+        final var transformer = new InklessTopicMetadataTransformer(metadataView, NO_AZ_LISTENER_MAP);
         assertThatThrownBy(() -> transformer.transformClusterMetadata(LISTENER_NAME, "x", null))
             .isInstanceOf(NullPointerException.class)
             .hasMessage("topicMetadata cannot be null");
@@ -87,7 +93,7 @@ class InklessTopicMetadataTransformerTest {
         @NullSource
         @ValueSource(strings = {"diskless_az=az1", "x=y", ""})
         void clusterMetadata(final String clientId) {
-            final var transformer = new InklessTopicMetadataTransformer(metadataView);
+            final var transformer = new InklessTopicMetadataTransformer(metadataView, NO_AZ_LISTENER_MAP);
 
             final List<MetadataResponseTopic> topicMetadata = List.of();
             transformer.transformClusterMetadata(LISTENER_NAME, clientId, topicMetadata);
@@ -98,7 +104,7 @@ class InklessTopicMetadataTransformerTest {
         @NullSource
         @ValueSource(strings = {"diskless_az=az1", "x=y", ""})
         void describeTopicResponse(final String clientId) {
-            final var transformer = new InklessTopicMetadataTransformer(metadataView);
+            final var transformer = new InklessTopicMetadataTransformer(metadataView, NO_AZ_LISTENER_MAP);
 
             final DescribeTopicPartitionsResponseData describeResponse = new DescribeTopicPartitionsResponseData();
             transformer.transformDescribeTopicResponse(LISTENER_NAME, clientId, describeResponse);
@@ -179,7 +185,7 @@ class InklessTopicMetadataTransformerTest {
                 inklessTopicMetadata.get(),
                 classicTopicMetadata.get()
             );
-            final var transformer = new InklessTopicMetadataTransformer(metadataView);
+            final var transformer = new InklessTopicMetadataTransformer(metadataView, NO_AZ_LISTENER_MAP);
 
             transformer.transformClusterMetadata(LISTENER_NAME, "diskless_az=" + clientAZ, topicMetadata);
 
@@ -267,7 +273,7 @@ class InklessTopicMetadataTransformerTest {
                         inklessTopicMetadata.get(),
                         classicTopicMetadata.get()
                     ).iterator()));
-            final var transformer = new InklessTopicMetadataTransformer(metadataView);
+            final var transformer = new InklessTopicMetadataTransformer(metadataView, NO_AZ_LISTENER_MAP);
 
             transformer.transformDescribeTopicResponse(LISTENER_NAME, "diskless_az=" + clientAZ, describeResponse);
 
@@ -283,6 +289,98 @@ class InklessTopicMetadataTransformerTest {
             transformer.transformDescribeTopicResponse(LISTENER_NAME, "diskless_az=" + clientAZ, describeResponse);
             assertThat(describeResponse.topics().find(TOPIC_DISKLESS)).isEqualTo(expectedInklessTopicMetadata);
             assertThat(describeResponse.topics().find(TOPIC_CLASSIC)).isEqualTo(classicTopicMetadata.get());
+        }
+    }
+
+    @Nested
+    class ListenerBasedAzResolution {
+        static final ListenerName AZ0_LISTENER =
+            ListenerName.normalised("SASL_SSL_AZ0");
+        static final ListenerName AZ1_LISTENER =
+            ListenerName.normalised("SASL_SSL_AZ1");
+        static final Map<String, String> LISTENER_MAP =
+            Map.of(AZ0_LISTENER.value(), "az0", AZ1_LISTENER.value(), "az1");
+        static final List<Node> AZ_AWARE_NODES = List.of(
+            new Node(0, "host", 9092, "az0"),
+            new Node(2, "host", 9094, "az0"),
+            new Node(1, "host", 9093, "az1"),
+            new Node(3, "host", 9095, "az1")
+        );
+
+        @BeforeEach
+        void setup() {
+            when(metadataView.isDisklessTopic(eq(TOPIC_DISKLESS))).thenReturn(true);
+            // lenient: listenerNotInMapFallsBackToNonAzAware stubs a different listener and
+            // doesn't use this one, which would otherwise trip STRICT_STUBS.
+            lenient().when(metadataView.getAliveBrokerNodes(AZ0_LISTENER)).thenReturn(AZ_AWARE_NODES);
+            lenient().when(metadataView.getAliveBrokerNodes(AZ1_LISTENER)).thenReturn(AZ_AWARE_NODES);
+        }
+
+        private MetadataResponseTopic disklessTopic() {
+            return new MetadataResponseTopic()
+                .setName(TOPIC_DISKLESS)
+                .setErrorCode((short) 0)
+                .setTopicId(TOPIC_DISKLESS_ID)
+                .setPartitions(List.of(
+                    new MetadataResponsePartition()
+                        .setPartitionIndex(0)
+                        .setErrorCode((short) 0)
+                        .setLeaderId(-1)
+                        .setReplicaNodes(List.of(1))  // RF=1 (unmanaged)
+                        .setIsrNodes(List.of(1))
+                        .setOfflineReplicas(Collections.emptyList())
+                        .setLeaderEpoch(0)
+                ));
+        }
+
+        @ParameterizedTest
+        @CsvSource(nullValues = "NULL", value = {
+            // clientId, listener, expectedLeaderId
+            "connector-producer-orders-0,SASL_SSL_AZ0,0",  // no marker -> inferred from listener -> az0
+            "connector-producer-orders-0,SASL_SSL_AZ1,1",  // no marker -> inferred from listener -> az1
+            "NULL,SASL_SSL_AZ0,0",                         // null client.id -> inferred from listener -> az0
+            "NULL,SASL_SSL_AZ1,1",                         // null client.id -> inferred from listener -> az1
+            "diskless_az=az0,SASL_SSL_AZ1,0",              // explicit client ID marker -> overrides listener map -> az0
+            "diskless_az=az1,SASL_SSL_AZ0,1",              // explicit client ID marker -> overrides listener map -> az1
+        })
+        void resolvesAzWithClientIdPrecedenceOverListenerMap(final String clientId, final ListenerName listenerName, final int expectedLeaderId) {
+            final var transformer = new InklessTopicMetadataTransformer(metadataView, LISTENER_MAP);
+            final List<MetadataResponseTopic> topicMetadata = List.of(disklessTopic());
+
+            transformer.transformClusterMetadata(listenerName, clientId, topicMetadata);
+
+            assertThat(topicMetadata.get(0).partitions().get(0).leaderId()).isEqualTo(expectedLeaderId);
+        }
+
+        @Test
+        void listenerNotInMapFallsBackToNonAzAware() {
+            final ListenerName otherListener = ListenerName.normalised("SASL_SSL_OTHER");
+            when(metadataView.getAliveBrokerNodes(otherListener)).thenReturn(AZ_AWARE_NODES);
+            final var transformer = new InklessTopicMetadataTransformer(metadataView, LISTENER_MAP);
+            final List<MetadataResponseTopic> topicMetadata = List.of(disklessTopic());
+
+            // No marker, listener not in map -> clientAZ null -> legacy picks from ALL brokers.
+            // Expected leader = hash(TOPIC_DISKLESS_ID-0) % 4 over sorted [0,1,2,3] = 0
+            // (matches the existing az_unknown expectation for partition 0, expectedLeaderId1=0,
+            // in the InklessAndClassicTopics CSV source above).
+            transformer.transformClusterMetadata(otherListener, "no-marker", topicMetadata);
+
+            assertThat(topicMetadata.get(0).partitions().get(0).leaderId()).isEqualTo(0);
+        }
+
+        @Test
+        void listenerMatchIsCaseInsensitive() {
+            // Config value normalized upper-case; a lowercase-declared alias still matches
+            // because ListenerName.value() upper-cases the request listener too.
+            final Map<String, String> lowercaseConfiguredMap =
+                Map.of(ListenerName.normalised("sasl_ssl_az0").value(), "az0");
+            final var transformer =
+                new InklessTopicMetadataTransformer(metadataView, lowercaseConfiguredMap);
+            final List<MetadataResponseTopic> topicMetadata = List.of(disklessTopic());
+
+            transformer.transformClusterMetadata(AZ0_LISTENER, null, topicMetadata);
+
+            assertThat(topicMetadata.get(0).partitions().get(0).leaderId()).isEqualTo(0);
         }
     }
 
@@ -316,7 +414,7 @@ class InklessTopicMetadataTransformerTest {
                     ));
 
             final List<MetadataResponseTopic> topicMetadata = List.of(inklessTopicMetadata.get());
-            final var transformer = new InklessTopicMetadataTransformer(metadataView);
+            final var transformer = new InklessTopicMetadataTransformer(metadataView, NO_AZ_LISTENER_MAP);
 
             transformer.transformClusterMetadata(LISTENER_NAME, "diskless_az=az0", topicMetadata);
             final var expectedInklessTopicMetadata = inklessTopicMetadata.get();
@@ -351,7 +449,7 @@ class InklessTopicMetadataTransformerTest {
                             ))
                     ).iterator()));
 
-            final var transformer = new InklessTopicMetadataTransformer(metadataView);
+            final var transformer = new InklessTopicMetadataTransformer(metadataView, NO_AZ_LISTENER_MAP);
 
             final DescribeTopicPartitionsResponseData describeResponse = describeResponseSupplier.get();
             transformer.transformDescribeTopicResponse(LISTENER_NAME, "diskless_az=az0", describeResponse);
@@ -396,7 +494,7 @@ class InklessTopicMetadataTransformerTest {
                     ));
 
             final List<MetadataResponseTopic> topicMetadata = List.of(inklessTopicMetadata.get());
-            final var transformer = new InklessTopicMetadataTransformer(metadataView);
+            final var transformer = new InklessTopicMetadataTransformer(metadataView, NO_AZ_LISTENER_MAP);
 
             transformer.transformClusterMetadata(LISTENER_NAME, null, topicMetadata);
             final var expectedInklessTopicMetadata = inklessTopicMetadata.get();
@@ -431,7 +529,7 @@ class InklessTopicMetadataTransformerTest {
                             ))
                     ).iterator()));
 
-            final var transformer = new InklessTopicMetadataTransformer(metadataView);
+            final var transformer = new InklessTopicMetadataTransformer(metadataView, NO_AZ_LISTENER_MAP);
             final DescribeTopicPartitionsResponseData describeResponse = describeResponseSupplier.get();
 
             transformer.transformDescribeTopicResponse(LISTENER_NAME, null, describeResponse);
@@ -498,7 +596,7 @@ class InklessTopicMetadataTransformerTest {
                     ))
             );
 
-            final var transformer = new InklessTopicMetadataTransformer(metadataView);
+            final var transformer = new InklessTopicMetadataTransformer(metadataView, NO_AZ_LISTENER_MAP);
             transformer.transformClusterMetadata(LISTENER_NAME, "diskless_az=az0", topicMetadata);
 
             final var partition = topicMetadata.get(0).partitions().get(0);
@@ -532,7 +630,7 @@ class InklessTopicMetadataTransformerTest {
                     ))
             );
 
-            final var transformer = new InklessTopicMetadataTransformer(metadataView);
+            final var transformer = new InklessTopicMetadataTransformer(metadataView, NO_AZ_LISTENER_MAP);
             transformer.transformClusterMetadata(LISTENER_NAME, "diskless_az=az0", topicMetadata);
 
             final var partition = topicMetadata.get(0).partitions().get(0);
@@ -570,7 +668,7 @@ class InklessTopicMetadataTransformerTest {
                     ))
             );
 
-            final var transformer = new InklessTopicMetadataTransformer(metadataView);
+            final var transformer = new InklessTopicMetadataTransformer(metadataView, NO_AZ_LISTENER_MAP);
             transformer.transformClusterMetadata(LISTENER_NAME, "diskless_az=az0", topicMetadata);
 
             final var partition = topicMetadata.get(0).partitions().get(0);
@@ -604,7 +702,7 @@ class InklessTopicMetadataTransformerTest {
                     ))
             );
 
-            final var transformer = new InklessTopicMetadataTransformer(metadataView);
+            final var transformer = new InklessTopicMetadataTransformer(metadataView, NO_AZ_LISTENER_MAP);
             transformer.transformClusterMetadata(LISTENER_NAME, "diskless_az=az0", topicMetadata);
 
             final var partition = topicMetadata.get(0).partitions().get(0);
@@ -639,7 +737,7 @@ class InklessTopicMetadataTransformerTest {
                         ))
                 ).iterator()));
 
-            final var transformer = new InklessTopicMetadataTransformer(metadataView);
+            final var transformer = new InklessTopicMetadataTransformer(metadataView, NO_AZ_LISTENER_MAP);
             transformer.transformDescribeTopicResponse(LISTENER_NAME, "diskless_az=az0", describeResponse);
 
             final var partition = describeResponse.topics().find(TOPIC_DISKLESS).partitions().get(0);
@@ -674,7 +772,7 @@ class InklessTopicMetadataTransformerTest {
                         ))
                 ).iterator()));
 
-            final var transformer = new InklessTopicMetadataTransformer(metadataView);
+            final var transformer = new InklessTopicMetadataTransformer(metadataView, NO_AZ_LISTENER_MAP);
             transformer.transformDescribeTopicResponse(LISTENER_NAME, "diskless_az=az0", describeResponse);
 
             final var partition = describeResponse.topics().find(TOPIC_DISKLESS).partitions().get(0);
@@ -724,7 +822,7 @@ class InklessTopicMetadataTransformerTest {
                     ))
             );
 
-            final var transformer = new InklessTopicMetadataTransformer(metadataView);
+            final var transformer = new InklessTopicMetadataTransformer(metadataView, NO_AZ_LISTENER_MAP);
             transformer.transformClusterMetadata(LISTENER_NAME, "diskless_az=az0", topicMetadata);
 
             final var partition = topicMetadata.get(0).partitions().get(0);
@@ -756,7 +854,7 @@ class InklessTopicMetadataTransformerTest {
                     ))
             );
 
-            final var transformer = new InklessTopicMetadataTransformer(metadataView);
+            final var transformer = new InklessTopicMetadataTransformer(metadataView, NO_AZ_LISTENER_MAP);
             transformer.transformClusterMetadata(LISTENER_NAME, "diskless_az=az0", topicMetadata);
 
             final var partition = topicMetadata.get(0).partitions().get(0);
@@ -793,7 +891,7 @@ class InklessTopicMetadataTransformerTest {
                     ))
             );
 
-            final var transformer = new InklessTopicMetadataTransformer(metadataView);
+            final var transformer = new InklessTopicMetadataTransformer(metadataView, NO_AZ_LISTENER_MAP);
             transformer.transformClusterMetadata(LISTENER_NAME, "diskless_az=az0", topicMetadata);
 
             final var partition = topicMetadata.get(0).partitions().get(0);
@@ -832,7 +930,7 @@ class InklessTopicMetadataTransformerTest {
                     ))
             );
 
-            final var transformer = new InklessTopicMetadataTransformer(metadataView);
+            final var transformer = new InklessTopicMetadataTransformer(metadataView, NO_AZ_LISTENER_MAP);
             transformer.transformClusterMetadata(LISTENER_NAME, "diskless_az=az0", topicMetadata);
 
             final var partition = topicMetadata.get(0).partitions().get(0);
@@ -868,7 +966,7 @@ class InklessTopicMetadataTransformerTest {
                         ))
                 ).iterator()));
 
-            final var transformer = new InklessTopicMetadataTransformer(metadataView);
+            final var transformer = new InklessTopicMetadataTransformer(metadataView, NO_AZ_LISTENER_MAP);
             transformer.transformDescribeTopicResponse(LISTENER_NAME, "diskless_az=az0", describeResponse);
 
             final var partition = describeResponse.topics().find(TOPIC_DISKLESS).partitions().get(0);
@@ -903,7 +1001,7 @@ class InklessTopicMetadataTransformerTest {
                         ))
                 ).iterator()));
 
-            final var transformer = new InklessTopicMetadataTransformer(metadataView);
+            final var transformer = new InklessTopicMetadataTransformer(metadataView, NO_AZ_LISTENER_MAP);
             transformer.transformDescribeTopicResponse(LISTENER_NAME, "diskless_az=az0", describeResponse);
 
             final var partition = describeResponse.topics().find(TOPIC_DISKLESS).partitions().get(0);
@@ -943,7 +1041,7 @@ class InklessTopicMetadataTransformerTest {
                         ))
                 ).iterator()));
 
-            final var transformer = new InklessTopicMetadataTransformer(metadataView);
+            final var transformer = new InklessTopicMetadataTransformer(metadataView, NO_AZ_LISTENER_MAP);
             transformer.transformDescribeTopicResponse(LISTENER_NAME, "diskless_az=az0", describeResponse);
 
             final var partition = describeResponse.topics().find(TOPIC_DISKLESS).partitions().get(0);
@@ -974,7 +1072,7 @@ class InklessTopicMetadataTransformerTest {
                     ))
             );
 
-            final var transformer = new InklessTopicMetadataTransformer(metadataView);
+            final var transformer = new InklessTopicMetadataTransformer(metadataView, NO_AZ_LISTENER_MAP);
             transformer.transformClusterMetadata(LISTENER_NAME, "diskless_az=az0", topicMetadata);
 
             final var partition = topicMetadata.get(0).partitions().get(0);
@@ -1000,7 +1098,7 @@ class InklessTopicMetadataTransformerTest {
                         ))
                 ).iterator()));
 
-            final var transformer = new InklessTopicMetadataTransformer(metadataView);
+            final var transformer = new InklessTopicMetadataTransformer(metadataView, NO_AZ_LISTENER_MAP);
             transformer.transformDescribeTopicResponse(LISTENER_NAME, "diskless_az=az0", describeResponse);
 
             final var partition = describeResponse.topics().find(TOPIC_DISKLESS).partitions().get(0);


### PR DESCRIPTION
> [!NOTE]
> This was created on top https://github.com/aiven/inkless/pull/683 so the base branch isn't `main` yet. It will be updated once the other PR is merged.

This adds support for producers to be rack-aware without having to change their client IDs.

We are still keeping compatibility with `client.id=my-app,diskless_az=<AZ>` and it takes precedence over the
listener option.

For the listener option, all brokers will keep a config mapping LISTENER_NAME=AZ, then clients connect to the exact listener based on the AZ they want.
When handling the metadata request, the listener used for the request is mapped back to the AZ associated to that listener and a leader in that AZ is returned.

[KC-258]

[KC-258]: https://aiven.atlassian.net/browse/KC-258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ