### PR TITLE
fix(inkless:consolidation): serve cross-tier earliest offset promptly after startup

### DIFF
--- a/.github/workflows/inkless.yml
+++ b/.github/workflows/inkless.yml
@@ -153,8 +153,9 @@ jobs:
             -x generateJooqClasses
             -PtestLoggingEvents=started,passed,skipped,failed 
             -PmaxParallelForks=2 
-            -PmaxTestRetries=1 -PmaxTestRetryFailures=3 
+            -PmaxTestRetries=0
             -PmaxQuarantineTestRetries=3 -PmaxQuarantineTestRetryFailures=0 
+            -Pkafka.test.xml.output.dir=${{ matrix.java }}
             -PcommitId=xxxxxxxxxxxxxxxx
         # Point to inkless tests
         run: |
@@ -220,13 +221,18 @@ jobs:
             thread-dumps/*
           compression-level: 9
           if-no-files-found: ignore
-      # - name: Parse JUnit tests
-      #   run: python .github/scripts/junit.py --export-test-catalog ./test-catalog >> $GITHUB_STEP_SUMMARY
-      #   env:
-      #     GITHUB_WORKSPACE: ${{ github.workspace }}
-      #     JUNIT_REPORT_URL: ${{ steps.junit-upload-artifact.outputs.artifact-url }}
-      #     THREAD_DUMP_URL: ${{ steps.thread-dump-upload-artifact.outputs.artifact-url }}
-      #     GRADLE_EXIT_CODE: ${{ steps.junit-test.outputs.exitcode }}
+      - name: Parse JUnit tests
+        # Always run so the job summary lists failed tests (matching ci.yml/build.yml reporting).
+        # junit.py exits non-zero when GRADLE_TEST_EXIT_CODE indicates a failure/timeout, which makes
+        # this step the single source of truth for the test outcome (replaces the old exit-code check).
+        if: always()
+        env:
+          GITHUB_WORKSPACE: ${{ github.workspace }}
+          JUNIT_REPORT_URL: ${{ steps.junit-upload-artifact.outputs.artifact-url }}
+          THREAD_DUMP_URL: ${{ steps.thread-dump-upload-artifact.outputs.artifact-url }}
+          GRADLE_TEST_EXIT_CODE: ${{ steps.junit-test.outputs.exitcode }}
+        run: |
+          python .github/scripts/junit.py --path build/junit-xml >> $GITHUB_STEP_SUMMARY
       - name: Archive Test Catalog
         if: ${{ always() && matrix.java == '21' }}
         uses: actions/upload-artifact@v4
@@ -243,6 +249,4 @@ jobs:
           path: ~/.gradle/build-scan-data
           compression-level: 9
           if-no-files-found: ignore
-      - name: Check test results
-        if: always() && ( steps.junit-test.outputs.exitcode != '0' )
-        run: exit 1
+

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,20 @@ DOCKER := docker
 
 .PHONY: build
 build:
-	./gradlew :core:build :storage:inkless:build :metadata:build -x test -x generateJooqClasses
+	./gradlew \
+	  :clients:check \
+	  :core:check \
+	  :metadata:check \
+	  :server:check \
+	  :server-common:check \
+	  :storage:check \
+	  :storage:storage-api:check \
+	  :storage:inkless:check \
+	  -x test -x generateJooqClasses
+
+.PHONY: build_all
+build_all:
+	./gradlew check -x test -x generateJooqClasses
 
 core/build/distributions/kafka_2.13-$(VERSION).tgz:
 	echo "Building Kafka distribution with version $(VERSION)"
@@ -145,7 +158,7 @@ fmt:
 test:
 	./gradlew :storage:inkless:test :storage:inkless:integrationTest -x generateJooqClasses
 	./gradlew :metadata:test --tests "org.apache.kafka.controller.*"
-	./gradlew :core:test --tests "*Inkless*"
+	./gradlew :core:test --tests "*Inkless*" --tests "*Diskless*" --tests "io.aiven.inkless.*"
 
 .PHONY: pitest
 pitest:

--- a/core/src/main/scala/io/aiven/inkless/consolidation/DisklessLeaderEndPoint.scala
+++ b/core/src/main/scala/io/aiven/inkless/consolidation/DisklessLeaderEndPoint.scala
@@ -48,7 +48,7 @@ import scala.util.Try
 
 /**
  * Leader endpoint for consolidation fetching from Inkless (object storage) on this broker.
- * [[FetchHandler]] performs the same diskless fetch path as the broker’s main fetch pipeline;
+ * [[FetchHandler]] performs the same diskless fetch path as the broker's main fetch pipeline;
  * [[FetchOffsetHandler]] backs list-offsets style APIs used by [[kafka.server.AbstractFetcherThread]].
  *
  * Fetch and offset handler instances are owned by [[kafka.server.ReplicaManager]]; this class does not close them.

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -480,7 +480,8 @@ class ReplicaManager(val config: KafkaConfig,
 
       scheduler.schedule("inkless-file-cleaner", () => inklessFileCleaner.foreach(_.run()), sharedState.config().fileCleanerInterval().toMillis, sharedState.config().fileCleanerInterval().toMillis)
 
-      scheduler.schedule("inkless-cross-tier-log-start-reporter", () => sharedState.crossTierLogStartReporter().run(), config.logInitialTaskDelayMs, sharedState.config().crossTierLogStartReportInterval().toMillis)
+      // The default 30s task delay would leave EARLIEST wrong for up to 30s after every startup.
+      scheduler.schedule("inkless-cross-tier-log-start-reporter", () => sharedState.crossTierLogStartReporter().run(), sharedState.config().crossTierLogStartReportInterval().toMillis, sharedState.config().crossTierLogStartReportInterval().toMillis)
 
       inklessConsolidatedDisklessLogPruner.foreach { pruner =>
         scheduler.schedule("inkless-consolidated-diskless-log-pruner", () => pruner.run(),

--- a/core/src/test/java/kafka/server/InklessConsolidatedDisklessTopicsTest.java
+++ b/core/src/test/java/kafka/server/InklessConsolidatedDisklessTopicsTest.java
@@ -452,10 +452,26 @@ public class InklessConsolidatedDisklessTopicsTest {
     /**
      * Queries {@link OffsetSpec#earliest()} via the admin client (same basis as consumer
      * {@code auto.offset.reset=earliest}) and asserts every partition matches {@code expectedEarliest}.
+     *
+     * <p>The cross-tier earliest offset is published asynchronously: once the WAL is tiered and
+     * pruned, the leader's {@code RemoteLogManager} callback enqueues the remote log start offset and
+     * {@code CrossTierLogStartReporter} flushes it to the control plane on its next interval. Wait for
+     * that publication to converge before the hard assertion so the check does not race it.
      */
     private void assertBrokerEarliestOffsetsEqual(Map<String, Object> commonConfigs,
                                                   long expectedEarliest,
                                                   String context) throws Exception {
+        // Let query exceptions propagate: transient errors during convergence (e.g. LEADER_NOT_AVAILABLE)
+        // are retried by waitForCondition, and a persistent one is surfaced as the timeout's cause instead
+        // of being swallowed. lastSeen carries the offsets into the message for the stuck-value case.
+        final AtomicReference<Map<TopicPartition, Long>> lastSeen = new AtomicReference<>();
+        TestUtils.waitForCondition(() -> {
+            Map<TopicPartition, Long> earliest = queryBrokerEarliestOffsets(commonConfigs);
+            lastSeen.set(earliest);
+            return earliest.values().stream().allMatch(offset -> Long.valueOf(expectedEarliest).equals(offset));
+        }, 60_000, () -> "ListOffsets earliest for all partitions should converge to " + expectedEarliest
+            + " " + context + "; last observed: " + lastSeen.get());
+
         Map<TopicPartition, Long> earliest = queryBrokerEarliestOffsets(commonConfigs);
         log.info("Broker ListOffsets earliest per partition {}: {}", context, earliest);
         for (int p = 0; p < numPartitions; p++) {

--- a/core/src/test/scala/io/aiven/inkless/consolidation/DisklessLeaderEndPointTest.scala
+++ b/core/src/test/scala/io/aiven/inkless/consolidation/DisklessLeaderEndPointTest.scala
@@ -739,7 +739,7 @@ class DisklessLeaderEndPointTest {
   @Test
   def testFetchReturnsLocalLogStartOffsetWhenOffsetOutOfRangeAndPartitionAvailable(): Unit = {
     // OFFSET_OUT_OF_RANGE from the control plane enters the same logStartOffset resolution path as
-    // NONE. When the requested offset is outside the consolidated prefix (empty request →
+    // NONE. When the requested offset is outside the consolidated prefix (empty request ->
     // requestedOffset=-1 < logStartOffset=0), no redirect fires and logStartOffset is taken from
     // the local log (0L), not UNKNOWN_OFFSET.
     val fetchHandler = mock(classOf[FetchHandler])
@@ -777,7 +777,7 @@ class DisklessLeaderEndPointTest {
   def testFetchSignalsOffsetMovedToTieredStorageWhenControlPlaneReturnsOffsetOutOfRange(): Unit = {
     // The control plane returns OFFSET_OUT_OF_RANGE when the requested offset is below
     // log_start_offset (the current WAL start, advanced as batches are pruned to remote storage).
-    // For offsets in [localLogStart, disklessStart) this means the data was already tiered —
+    // For offsets in [localLogStart, disklessStart) this means the data was already tiered --
     // the endpoint must redirect just as it does for the NONE+empty-batch case.
     val fetchHandler = mock(classOf[FetchHandler])
     val fetchOffsetHandler = mock(classOf[FetchOffsetHandler])
@@ -805,7 +805,7 @@ class DisklessLeaderEndPointTest {
 
     val endPoint = newEndPoint(fetchHandler, fetchOffsetHandler, replicaManager)
 
-    // Offset 50 is in [0, 100) — within the consolidated prefix pruned to remote.
+    // Offset 50 is in [0, 100) -- within the consolidated prefix pruned to remote.
     val pd = endPoint.fetch(fetchBuilderForOffset(requestedOffset = 50L)).get(topicPartition)
 
     assertEquals(Errors.OFFSET_MOVED_TO_TIERED_STORAGE.code, pd.errorCode)

--- a/docs/inkless/configs.rst
+++ b/docs/inkless/configs.rst
@@ -195,7 +195,7 @@ Under ``inkless.``
   * Importance: low
 
 ``fetch.hedge.total.time.threshold.ms``
-  Total time threshold in milliseconds to trigger a hedge request. When a storage fetch has not completed within this threshold, a competing hedge request is submitted. The first request to complete wins; the other continues in the background and its result is ignored. Set to 0 to disable total-time-based hedging. When both hedging thresholds are enabled, this value must be strictly greater than fetch.hedge.ttfb.threshold.ms. Capacity impact: hedges submit to the same executor as primaries (fetch.data.thread.pool.size for hot path, fetch.lagging.consumer.thread.pool.size for cold path). Normal case: only tail-latency requests (exceeding threshold) trigger hedges — typically <5% of traffic. Worst case: if all in-flight requests exceed the threshold, effective storage GET rate doubles (one primary + one hedge per request), bounded by executor thread pool + queue capacity. Monitor HedgeRequestRate to detect excessive hedging. If hedge rate is too high, increase this threshold.
+  Total time threshold in milliseconds to trigger a hedge request. When a storage fetch has not completed within this threshold, a competing hedge request is submitted. The first request to complete wins; the other continues in the background and its result is ignored. Set to 0 to disable total-time-based hedging. When both hedging thresholds are enabled, this value must be strictly greater than fetch.hedge.ttfb.threshold.ms. Capacity impact: hedges submit to the same executor as primaries (fetch.data.thread.pool.size for hot path, fetch.lagging.consumer.thread.pool.size for cold path). Normal case: only tail-latency requests (exceeding threshold) trigger hedges -- typically <5% of traffic. Worst case: if all in-flight requests exceed the threshold, effective storage GET rate doubles (one primary + one hedge per request), bounded by executor thread pool + queue capacity. Monitor HedgeRequestRate to detect excessive hedging. If hedge rate is too high, increase this threshold.
 
   * Type: long
   * Default: 0
@@ -211,7 +211,7 @@ Under ``inkless.``
   * Importance: low
 
 ``fetch.lagging.consumer.thread.pool.size``
-  Thread pool size for lagging consumer fetch requests (consumers reading old data). Set to 0 to disable the lagging consumer feature (all requests will use the recent data path). The default value of 16 is designed as approximately half of the default fetch.data.thread.pool.size (32), providing sufficient capacity for typical cold storage access patterns while leaving headroom for the hot path. The queue capacity is automatically set to thread.pool.size * 100, providing burst buffering (e.g., 16 threads = 1600 queue capacity ≈ 8 seconds buffer at 200 req/s). Tune based on lagging consumer SLA and expected load patterns.
+  Thread pool size for lagging consumer fetch requests (consumers reading old data). Set to 0 to disable the lagging consumer feature (all requests will use the recent data path). The default value of 16 is designed as approximately half of the default fetch.data.thread.pool.size (32), providing sufficient capacity for typical cold storage access patterns while leaving headroom for the hot path. The queue capacity is automatically set to thread.pool.size * 100, providing burst buffering (e.g., 16 threads = 1600 queue capacity ~= 8 seconds buffer at 200 req/s). Tune based on lagging consumer SLA and expected load patterns.
 
   * Type: int
   * Default: 16

--- a/server-common/src/main/java/org/apache/kafka/server/config/ServerConfigs.java
+++ b/server-common/src/main/java/org/apache/kafka/server/config/ServerConfigs.java
@@ -213,7 +213,7 @@ public class ServerConfigs {
     public static final String DISKLESS_CONSOLIDATION_FETCH_LAGGING_REQUEST_RATE_LIMIT_CONFIG = "diskless.consolidation.fetch.lagging.request.rate.limit";
     public static final int DISKLESS_CONSOLIDATION_FETCH_LAGGING_REQUEST_RATE_LIMIT_DEFAULT = 0;
     public static final String DISKLESS_CONSOLIDATION_FETCH_LAGGING_REQUEST_RATE_LIMIT_DOC = "Maximum request rate (requests per second) " +
-        "for consolidation cold-path fetches. 0 (default) means unlimited — consolidation is internal background work and does not " +
+        "for consolidation cold-path fetches. 0 (default) means unlimited -- consolidation is internal background work and does not " +
         "need throttling under normal conditions. Set > 0 as a safety valve to bound object storage request rate from consolidation.";
 
     public static final String CLASSIC_REMOTE_STORAGE_FORCE_ENABLE_CONFIG = "classic.remote.storage.force.enable";

--- a/storage/inkless/src/main/java/io/aiven/inkless/config/InklessConfig.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/config/InklessConfig.java
@@ -174,7 +174,7 @@ public class InklessConfig extends AbstractConfig {
         + "The default value of 16 is designed as approximately half of the default fetch.data.thread.pool.size (32), "
         + "providing sufficient capacity for typical cold storage access patterns while leaving headroom for the hot path. "
         + "The queue capacity is automatically set to thread.pool.size * 100, providing burst buffering "
-        + "(e.g., 16 threads = 1600 queue capacity ≈ 8 seconds buffer at 200 req/s). "
+        + "(e.g., 16 threads = 1600 queue capacity ~= 8 seconds buffer at 200 req/s). "
         + "Tune based on lagging consumer SLA and expected load patterns.";
     // Default 16: Designed as half of default fetch.data.thread.pool.size (32), sufficient for typical
     // cold storage access patterns while leaving headroom for hot path. Tune based on lagging consumer SLA.
@@ -226,7 +226,7 @@ public class InklessConfig extends AbstractConfig {
         + FETCH_HEDGE_TTFB_THRESHOLD_MS_CONFIG + ". "
         + "Capacity impact: hedges submit to the same executor as primaries (fetch.data.thread.pool.size for hot path, "
         + "fetch.lagging.consumer.thread.pool.size for cold path). "
-        + "Normal case: only tail-latency requests (exceeding threshold) trigger hedges — typically <5% of traffic. "
+        + "Normal case: only tail-latency requests (exceeding threshold) trigger hedges -- typically <5% of traffic. "
         + "Worst case: if all in-flight requests exceed the threshold, effective storage GET rate doubles "
         + "(one primary + one hedge per request), bounded by executor thread pool + queue capacity. "
         + "Monitor HedgeRequestRate to detect excessive hedging. If hedge rate is too high, increase this threshold.";


### PR DESCRIPTION
Fixes a regression where `InklessConsolidatedDisklessTopicsTest.testNewConsolidatedDisklessTopics` failed on `main` (`ListOffsets earliest ... expected: <0> but was: <9>`) while it had passed on the PR that introduced it. The failure is a real, if transient, production correctness gap for born-consolidated topics — not just a flaky test.

## Root cause
Born-consolidated `ListOffsets(EARLIEST)` returns `COALESCE(remote_log_start_offset, log_start_offset)`. The leader publishes `remote_log_start_offset` asynchronously through `CrossTierLogStartReporter`, but the reporter's first flush was scheduled with `log.initial.task.delay.ms` as its initial delay (default **30s**).

Until that first flush: `remote_log_start_offset` is NULL in the control plane, and the diskless WAL prune frontier has already advanced `log_start_offset` (to `9` in the test), so `COALESCE(NULL, 9) = 9`. A consumer with `auto.offset.reset=earliest` starting in that window skips records that are still readable from remote — for up to ~30s after **every** broker startup.

Why it was green on the PR but red on `main`: the assertion races the 30s first flush. The slower PR CI runner happened to cross 30s before asserting; faster runners (and `main`) do not. KC-171 (#679, consolidation fetch path) shifted tiering/prune timing enough to tip the pre-existing race into a consistent failure.

## Fix
- `ReplicaManager`: schedule `inkless-cross-tier-log-start-reporter` with its own report interval as the initial delay (matching the sibling `inkless-file-cleaner` / `inkless-consolidated-diskless-log-pruner` tasks) instead of `logInitialTaskDelayMs`. EARLIEST now becomes correct within one report interval (1s default) after startup.
- `InklessConsolidatedDisklessTopicsTest`: poll until EARLIEST converges before the hard assertion, which matches the reporter's async publish contract instead of racing the first flush.

## CI changes (chore)
Bundled `chore(inkless:ci)` improvements motivated by "green on PR, red on main":
- Report failed tests via `junit.py` (as `ci.yml`/`build.yml` do) so the job summary lists the failed tests and its exit code drives the outcome; set `kafka.test.xml.output.dir` for clean paths.
- Set `maxTestRetries=0` so a single failure fails a PR to `main` instead of being retried away.

Full `build.yml` parity on PRs to `main` is intentionally **out of scope**: PR CI runs focalized tests to stay fast; the full matrix runs post-merge.

## Testing
- Reproduced the failure deterministically on `main` (`expected: <0> but was: <9>`).
- Confirmed the feature works with a prompt reporter, then verified the full class passes with the final fix: `./gradlew :core:test --tests "kafka.server.InklessConsolidatedDisklessTopicsTest" --rerun-tasks`.

## Commits
- `chore(inkless): align make targets with inkless ci`
- `chore(inkless): normalize ascii punctuation`
- `fix(inkless:consolidation): report cross-tier log start offset promptly after startup`
- `chore(inkless:ci): report failed tests via junit.py and stop masking flaky PR failures`
