### PR TITLE
chore(inkless:tools): Update cherry-pick guide, CI workflows, and release documentation

### DIFF
--- a/.github/workflows/inkless-nightly.yml
+++ b/.github/workflows/inkless-nightly.yml
@@ -53,11 +53,12 @@ jobs:
         env:
           TIMEOUT_MINUTES: 30
           GRADLE_ARGS: >-
-            --build-cache --no-scan 
-            -PtestLoggingEvents=started,passed,skipped,failed 
-            -PmaxParallelForks=2 
-            -PmaxTestRetries=1 -PmaxTestRetryFailures=3 
-            -PmaxQuarantineTestRetries=3 -PmaxQuarantineTestRetryFailures=0 
+            --build-cache --no-scan
+            -PtestLoggingEvents=started,passed,skipped,failed
+            -PmaxParallelForks=2
+            -PmaxTestRetries=1 -PmaxTestRetryFailures=3
+            -PmaxQuarantineTestRetries=3 -PmaxQuarantineTestRetryFailures=0
+            -Pkafka.test.xml.output.dir=${{ matrix.java }}
             -PcommitId=xxxxxxxxxxxxxxxx
         # Point to inkless tests
         run: |
@@ -100,13 +101,15 @@ jobs:
             thread-dumps/*
           compression-level: 9
           if-no-files-found: ignore
-      # - name: Parse JUnit tests
-      #   run: python .github/scripts/junit.py --export-test-catalog ./test-catalog >> $GITHUB_STEP_SUMMARY
-      #   env:
-      #     GITHUB_WORKSPACE: ${{ github.workspace }}
-      #     JUNIT_REPORT_URL: ${{ steps.junit-upload-artifact.outputs.artifact-url }}
-      #     THREAD_DUMP_URL: ${{ steps.thread-dump-upload-artifact.outputs.artifact-url }}
-      #     GRADLE_EXIT_CODE: ${{ steps.junit-test.outputs.exitcode }}
+      - name: Parse JUnit tests
+        if: always()
+        env:
+          GITHUB_WORKSPACE: ${{ github.workspace }}
+          JUNIT_REPORT_URL: ${{ steps.junit-upload-artifact.outputs.artifact-url }}
+          THREAD_DUMP_URL: ${{ steps.thread-dump-upload-artifact.outputs.artifact-url }}
+          GRADLE_TEST_EXIT_CODE: ${{ steps.junit-test.outputs.exitcode }}
+        run: |
+          python .github/scripts/junit.py --path build/junit-xml/${{ matrix.java }} >> $GITHUB_STEP_SUMMARY
       - name: Archive Test Catalog
         if: ${{ always() && matrix.java == '21' }}
         uses: actions/upload-artifact@v4
@@ -123,6 +126,3 @@ jobs:
           path: ~/.gradle/build-scan-data
           compression-level: 9
           if-no-files-found: ignore
-      - name: Check test results
-        if: always() && ( steps.junit-test.outputs.exitcode != '0' )
-        run: exit 1

--- a/.github/workflows/inkless-publish.yml
+++ b/.github/workflows/inkless-publish.yml
@@ -1,0 +1,430 @@
+# Copyright (c) 2025 Aiven, Helsinki, Finland. https://aiven.io/
+#
+# Build and publish Inkless artifacts for a specific set of Kafka-base tags.
+#
+# This workflow is the BUILD/PUBLISH layer. It knows nothing about release
+# orchestration — it receives a resolved matrix of tags and produces:
+#   - Docker images (per-arch + multi-arch manifest) pushed to GHCR
+#   - Binary distributions (.tgz) attached to the GitHub Release
+#   - The `latest` and `X.Y-latest` Docker image aliases
+#
+# Triggers:
+#   - push: tag matching `inkless-4.X.Y-*` — builds that single Kafka-base version
+#     automatically on every Kafka-base tag push (e.g. when a hotfix is tagged).
+#   - workflow_call: called by inkless-release.yml after it has created all tags
+#     for a coordinated release. Receives the full matrix so all Kafka versions
+#     build in a single coordinated run.
+#
+# For cutting a full release (validate branches, create tags, build all versions,
+# finalize the GitHub Release), use inkless-release.yml instead.
+
+name: Inkless Publish
+
+on:
+  push:
+    tags:
+      - 'inkless-4.[0-9]*.[0-9]*-*'
+
+  workflow_call:
+    inputs:
+      inkless_version:
+        description: 'Inkless version being published (e.g. 0.44)'
+        required: true
+        type: string
+      build_matrix:
+        description: 'JSON build matrix: {"include":[{"kafka_tag":"inkless-4.1.2-0.44","arch":"amd64","runner":"ubuntu-latest"},...]}'
+        required: true
+        type: string
+      kafka_base_matrix:
+        description: 'JSON manifest matrix: {"include":[{"tag":"inkless-4.1.2-0.44"},...]}'
+        required: true
+        type: string
+      latest_tags:
+        description: 'JSON map of kafka_major_minor -> highest-patch tag: {"4.1":"inkless-4.1.2-0.44",...}'
+        required: true
+        type: string
+
+concurrency:
+  group: inkless-publish-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ghcr.io/aiven/inkless
+
+jobs:
+  # When triggered by tag push, resolve the build parameters.
+  # When called via workflow_call, inputs are already resolved — this job
+  # produces the same output shape in both cases so downstream jobs are identical.
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      inkless_version:  ${{ steps.resolve.outputs.inkless_version }}
+      build_matrix:     ${{ steps.resolve.outputs.build_matrix }}
+      kafka_base_matrix: ${{ steps.resolve.outputs.kafka_base_matrix }}
+      latest_tags:      ${{ steps.resolve.outputs.latest_tags }}
+    steps:
+      - name: Checkout (for tag discovery on push trigger)
+        if: github.event_name == 'push'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Resolve parameters
+        id: resolve
+        env:
+          EVENT_NAME:         ${{ github.event_name }}
+          GITHUB_REF:         ${{ github.ref }}
+          # workflow_call inputs (empty on push trigger)
+          INPUT_INKLESS_VERSION: ${{ inputs.inkless_version }}
+          INPUT_BUILD_MATRIX:    ${{ inputs.build_matrix }}
+          INPUT_KAFKA_MATRIX:    ${{ inputs.kafka_base_matrix }}
+          INPUT_LATEST_TAGS:     ${{ inputs.latest_tags }}
+        run: |
+          if [ "$EVENT_NAME" = "push" ]; then
+            GIT_TAG="${GITHUB_REF#refs/tags/}"
+
+            if [[ "$GIT_TAG" =~ ^inkless-([0-9]+\.[0-9]+\.[0-9]+)-(.+)$ ]]; then
+              KAFKA_VERSION="${BASH_REMATCH[1]}"
+              INKLESS_VERSION="${BASH_REMATCH[2]}"
+              KAFKA_MAJOR_MINOR=$(echo "$KAFKA_VERSION" | cut -d. -f1-2)
+            else
+              echo "::error::Unrecognized tag format: $GIT_TAG"
+              exit 1
+            fi
+
+            # Find the highest patch version for this minor from existing tags
+            LATEST_FOR_MINOR="$GIT_TAG"
+            CANDIDATE_TAGS=$(git tag --list "inkless-${KAFKA_MAJOR_MINOR}.*-*")
+            if [ -n "$CANDIDATE_TAGS" ]; then
+              HIGHEST=$(
+                echo "$CANDIDATE_TAGS" | while read -r TAG; do
+                  if [[ "$TAG" =~ ^inkless-([0-9]+\.[0-9]+\.[0-9]+)-(.+)$ ]]; then
+                    echo "${BASH_REMATCH[1]} $TAG"
+                  fi
+                done | sort -t' ' -k1,1V | tail -n1 | awk '{print $2}'
+              )
+              [ -n "$HIGHEST" ] && LATEST_FOR_MINOR="$HIGHEST"
+            fi
+
+            BUILD_MATRIX="{\"include\":[{\"kafka_tag\":\"$GIT_TAG\",\"arch\":\"amd64\",\"runner\":\"ubuntu-latest\"},{\"kafka_tag\":\"$GIT_TAG\",\"arch\":\"arm64\",\"runner\":\"ubuntu-24.04-arm\"}]}"
+            KAFKA_MATRIX="{\"include\":[{\"tag\":\"$GIT_TAG\"}]}"
+            LATEST_TAGS="{\"$KAFKA_MAJOR_MINOR\":\"$LATEST_FOR_MINOR\"}"
+
+            echo "inkless_version=$INKLESS_VERSION"       >> $GITHUB_OUTPUT
+            echo "build_matrix=$BUILD_MATRIX"             >> $GITHUB_OUTPUT
+            echo "kafka_base_matrix=$KAFKA_MATRIX"        >> $GITHUB_OUTPUT
+            echo "latest_tags=$LATEST_TAGS"               >> $GITHUB_OUTPUT
+          else
+            # workflow_call: pass inputs through unchanged
+            echo "inkless_version=$INPUT_INKLESS_VERSION" >> $GITHUB_OUTPUT
+            echo "build_matrix=$INPUT_BUILD_MATRIX"       >> $GITHUB_OUTPUT
+            echo "kafka_base_matrix=$INPUT_KAFKA_MATRIX"  >> $GITHUB_OUTPUT
+            echo "latest_tags=$INPUT_LATEST_TAGS"         >> $GITHUB_OUTPUT
+          fi
+
+  # Build Docker image + binary for each tag × architecture combination
+  build-kafka-base:
+    needs: prepare
+    if: needs.prepare.outputs.build_matrix != '{"include":[]}'
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: write
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.prepare.outputs.build_matrix) }}
+
+    steps:
+      - name: Parse build tag
+        id: parse-build
+        env:
+          BUILD_TAG: ${{ matrix.kafka_tag }}
+        run: |
+          if [[ "$BUILD_TAG" =~ ^inkless-([0-9]+\.[0-9]+\.[0-9]+)-(.+)$ ]]; then
+            KAFKA_VERSION="${BASH_REMATCH[1]}"
+            INKLESS_VERSION="${BASH_REMATCH[2]}"
+            KAFKA_MAJOR_MINOR=$(echo "$KAFKA_VERSION" | cut -d. -f1-2)
+            echo "kafka_version=$KAFKA_VERSION"                           >> $GITHUB_OUTPUT
+            echo "inkless_version=$INKLESS_VERSION"                       >> $GITHUB_OUTPUT
+            echo "kafka_major_minor=$KAFKA_MAJOR_MINOR"                   >> $GITHUB_OUTPUT
+            echo "primary_image_tag=${KAFKA_VERSION}-${INKLESS_VERSION}"  >> $GITHUB_OUTPUT
+            echo "latest_image_tag=${KAFKA_MAJOR_MINOR}-latest"           >> $GITHUB_OUTPUT
+          else
+            echo "::error::Cannot parse build tag: $BUILD_TAG"
+            exit 1
+          fi
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ matrix.kafka_tag }}
+          persist-credentials: false
+
+      - name: Setup Gradle
+        uses: ./.github/actions/setup-gradle
+        with:
+          java-version: 17
+          gradle-cache-read-only: false
+
+      - name: Build Kafka distribution
+        run: make build_release
+
+      - name: Prepare distribution artifact info
+        id: dist-info
+        run: |
+          shopt -s nullglob
+          TARBALLS=(core/build/distributions/kafka_2.13-*.tgz)
+          [ ${#TARBALLS[@]} -eq 0 ] && { echo "::error::No kafka_2.13-*.tgz found in core/build/distributions"; exit 1; }
+          TARBALL=""
+          for tb in "${TARBALLS[@]}"; do
+            [[ "$tb" != *-site-docs.tgz ]] && { TARBALL="$tb"; break; }
+          done
+          [ -z "$TARBALL" ] && { echo "::error::No non-site-docs tarball found"; exit 1; }
+          echo "tarball=$TARBALL"                       >> $GITHUB_OUTPUT
+          echo "tarball_name=$(basename "$TARBALL")"    >> $GITHUB_OUTPUT
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push architecture-specific image
+        env:
+          ARCH:              ${{ matrix.arch }}
+          PRIMARY_IMAGE_TAG: ${{ steps.parse-build.outputs.primary_image_tag }}
+          BUILD_TIMESTAMP:   ${{ github.event.head_commit.timestamp }}
+          KAFKA_TAG:         ${{ matrix.kafka_tag }}
+        run: |
+          make docker_build \
+            PLATFORM="linux/${ARCH}" \
+            DOCKER_TAGS="${IMAGE_NAME}:${PRIMARY_IMAGE_TAG}-${ARCH}" \
+            PUSH=true \
+            BUILD_DATE="${BUILD_TIMESTAMP}" \
+            CACHE_FROM="type=gha,scope=${KAFKA_TAG}-${ARCH}" \
+            CACHE_TO="type=gha,mode=max,scope=${KAFKA_TAG}-${ARCH}"
+
+      - name: Upload distribution artifact (amd64 only to avoid duplicates)
+        if: matrix.arch == 'amd64'
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-${{ steps.parse-build.outputs.kafka_version }}-${{ steps.parse-build.outputs.inkless_version }}
+          path: ${{ steps.dist-info.outputs.tarball }}
+          retention-days: 1
+
+  # Create multi-arch Docker manifests for each Kafka-base tag
+  manifest-kafka-base:
+    needs: [prepare, build-kafka-base]
+    if: needs.prepare.outputs.kafka_base_matrix != '{"include":[]}'
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    strategy:
+      matrix: ${{ fromJson(needs.prepare.outputs.kafka_base_matrix) }}
+
+    steps:
+      - name: Parse tag
+        id: parse
+        env:
+          BUILD_TAG:   ${{ matrix.tag }}
+          LATEST_TAGS: ${{ needs.prepare.outputs.latest_tags }}
+        run: |
+          if [[ "$BUILD_TAG" =~ ^inkless-([0-9]+\.[0-9]+\.[0-9]+)-(.+)$ ]]; then
+            KAFKA_VERSION="${BASH_REMATCH[1]}"
+            INKLESS_VERSION="${BASH_REMATCH[2]}"
+            KAFKA_MAJOR_MINOR=$(echo "$KAFKA_VERSION" | cut -d. -f1-2)
+            echo "kafka_major_minor=$KAFKA_MAJOR_MINOR"                           >> $GITHUB_OUTPUT
+            echo "primary_image_tag=${KAFKA_VERSION}-${INKLESS_VERSION}"          >> $GITHUB_OUTPUT
+            echo "latest_image_tag=${KAFKA_MAJOR_MINOR}-latest"                   >> $GITHUB_OUTPUT
+            LATEST_FOR_MINOR=$(echo "$LATEST_TAGS" | jq -r ".\"$KAFKA_MAJOR_MINOR\" // empty")
+            [ "$BUILD_TAG" = "$LATEST_FOR_MINOR" ] \
+              && echo "is_latest_patch=true"  >> $GITHUB_OUTPUT \
+              || echo "is_latest_patch=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create multi-arch manifest (primary tag)
+        env:
+          PRIMARY_TAG: ${{ steps.parse.outputs.primary_image_tag }}
+        run: |
+          docker buildx imagetools create \
+            -t "${IMAGE_NAME}:${PRIMARY_TAG}" \
+            "${IMAGE_NAME}:${PRIMARY_TAG}-amd64" \
+            "${IMAGE_NAME}:${PRIMARY_TAG}-arm64"
+
+      - name: Create multi-arch manifest (X.Y-latest alias)
+        if: steps.parse.outputs.is_latest_patch == 'true'
+        env:
+          PRIMARY_TAG: ${{ steps.parse.outputs.primary_image_tag }}
+          LATEST_TAG:  ${{ steps.parse.outputs.latest_image_tag }}
+        run: |
+          docker buildx imagetools create \
+            -t "${IMAGE_NAME}:${LATEST_TAG}" \
+            "${IMAGE_NAME}:${PRIMARY_TAG}-amd64" \
+            "${IMAGE_NAME}:${PRIMARY_TAG}-arm64"
+
+      - name: Step summary
+        env:
+          TAG:               ${{ matrix.tag }}
+          PRIMARY_IMAGE_TAG: ${{ steps.parse.outputs.primary_image_tag }}
+          LATEST_IMAGE_TAG:  ${{ steps.parse.outputs.latest_image_tag }}
+          IS_LATEST_PATCH:   ${{ steps.parse.outputs.is_latest_patch }}
+          KAFKA_MAJOR_MINOR: ${{ steps.parse.outputs.kafka_major_minor }}
+        run: |
+          echo "## Kafka-base image: ${TAG}" >> $GITHUB_STEP_SUMMARY
+          echo "- \`${IMAGE_NAME}:${PRIMARY_IMAGE_TAG}\`" >> $GITHUB_STEP_SUMMARY
+          [ "$IS_LATEST_PATCH" = "true" ] && \
+            echo "- \`${IMAGE_NAME}:${LATEST_IMAGE_TAG}\` (latest for ${KAFKA_MAJOR_MINOR})" >> $GITHUB_STEP_SUMMARY
+
+  # Collect all binary artifacts and attach them to the GitHub Release.
+  # Also builds the `<inkless-version>` and `latest` Docker image from the
+  # inkless-release-<N> tag on main.
+  finalize-release:
+    needs: [prepare, build-kafka-base, manifest-kafka-base]
+    if: ${{ always() && github.event_name == 'workflow_call' && !cancelled() }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - name: Checkout (for Docker build from main release tag)
+        uses: actions/checkout@v4
+        with:
+          ref: inkless-release-${{ needs.prepare.outputs.inkless_version }}
+          persist-credentials: false
+
+      - name: Setup Gradle
+        uses: ./.github/actions/setup-gradle
+        with:
+          java-version: 17
+          gradle-cache-read-only: false
+
+      - name: Build Kafka distribution (for latest Docker image)
+        run: make build_release
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push `<version>` and `latest` Docker images (both arches)
+        env:
+          INKLESS_VERSION: ${{ needs.prepare.outputs.inkless_version }}
+        run: |
+          for ARCH in amd64 arm64; do
+            RUNNER_ARCH=$(uname -m)
+            make docker_build \
+              PLATFORM="linux/${ARCH}" \
+              DOCKER_TAGS="${IMAGE_NAME}:${INKLESS_VERSION}-${ARCH} ${IMAGE_NAME}:latest-${ARCH}" \
+              PUSH=true \
+              CACHE_FROM="type=gha,scope=main-${ARCH}" \
+              CACHE_TO="type=gha,mode=max,scope=main-${ARCH}"
+          done
+
+      - name: Create multi-arch manifests for `<version>` and `latest`
+        env:
+          INKLESS_VERSION: ${{ needs.prepare.outputs.inkless_version }}
+        run: |
+          docker buildx imagetools create \
+            -t "${IMAGE_NAME}:${INKLESS_VERSION}" \
+            "${IMAGE_NAME}:${INKLESS_VERSION}-amd64" \
+            "${IMAGE_NAME}:${INKLESS_VERSION}-arm64"
+          docker buildx imagetools create \
+            -t "${IMAGE_NAME}:latest" \
+            "${IMAGE_NAME}:latest-amd64" \
+            "${IMAGE_NAME}:latest-arm64"
+
+      - name: Download all distribution artifacts
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          pattern: dist-*
+          path: distributions
+          merge-multiple: true
+
+      - name: Create or update GitHub Release
+        env:
+          GH_TOKEN:            ${{ secrets.GITHUB_TOKEN }}
+          INKLESS_VERSION:     ${{ needs.prepare.outputs.inkless_version }}
+          KAFKA_BASE_MATRIX:   ${{ needs.prepare.outputs.kafka_base_matrix }}
+          GITHUB_REPOSITORY:   ${{ github.repository }}
+        run: |
+          RELEASE_TAG="inkless-release-${INKLESS_VERSION}"
+
+          RELEASE_NOTES="Inkless version ${INKLESS_VERSION}
+
+          ## Docker Images
+
+          \`\`\`bash
+          docker pull ghcr.io/aiven/inkless:${INKLESS_VERSION}
+          docker pull ghcr.io/aiven/inkless:latest
+          \`\`\`
+
+          ## Kafka Versions"
+
+          TAGS=$(echo "$KAFKA_BASE_MATRIX" | jq -r '.include[].tag // empty' 2>/dev/null | sort -V | uniq)
+          while IFS= read -r tag; do
+            if [[ "$tag" =~ ^inkless-([0-9]+\.[0-9]+\.[0-9]+)-(.+)$ ]]; then
+              KAFKA_VER="${BASH_REMATCH[1]}"
+              RELEASE_NOTES="${RELEASE_NOTES}
+          - Kafka ${KAFKA_VER}: [\`${tag}\`](https://github.com/${GITHUB_REPOSITORY}/tree/${tag})"
+            fi
+          done <<< "$TAGS"
+
+          if ! gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" > /dev/null 2>&1; then
+            gh release create "$RELEASE_TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "Inkless ${INKLESS_VERSION}" \
+              --notes "$RELEASE_NOTES"
+          else
+            gh release edit "$RELEASE_TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --notes "$RELEASE_NOTES"
+          fi
+
+          if [ -d distributions ] && [ "$(ls -A distributions/ 2>/dev/null)" ]; then
+            for file in distributions/*.tgz; do
+              [ -f "$file" ] && gh release upload "$RELEASE_TAG" "$file" --clobber --repo "$GITHUB_REPOSITORY"
+            done
+          else
+            echo "::warning::No distribution files found to upload"
+          fi
+
+      - name: Step summary
+        env:
+          INKLESS_VERSION: ${{ needs.prepare.outputs.inkless_version }}
+        run: |
+          echo "## Release inkless-release-${INKLESS_VERSION}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Docker tags:**" >> $GITHUB_STEP_SUMMARY
+          echo "- \`${IMAGE_NAME}:${INKLESS_VERSION}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- \`${IMAGE_NAME}:latest\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Distributions:**" >> $GITHUB_STEP_SUMMARY
+          if [ -d distributions ] && [ "$(ls -A distributions/)" ]; then
+            for file in distributions/*.tgz; do
+              [ -f "$file" ] && echo "- \`$(basename $file)\`" >> $GITHUB_STEP_SUMMARY
+            done
+          else
+            echo "- None" >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.github/workflows/inkless-release.yml
+++ b/.github/workflows/inkless-release.yml
@@ -93,7 +93,7 @@ jobs:
 
           # Ensure the version doesn't already exist
           if git rev-parse "$RELEASE_TAG" >/dev/null 2>&1; then
-            echo "::error::Tag $RELEASE_TAG already exists. Check the version or delete the existing tag first."
+            echo "::error::Tag $RELEASE_TAG already exists. If the release was never finalized (no GitHub Release published), delete the tag and retry. Otherwise use a higher version number."
             exit 1
           fi
 

--- a/.github/workflows/inkless-release.yml
+++ b/.github/workflows/inkless-release.yml
@@ -1,13 +1,23 @@
 # Copyright (c) 2025 Aiven, Helsinki, Finland. https://aiven.io/
-# Workflow for building and publishing Inkless release images to GHCR
-# and attaching binary distributions to GitHub Releases
-# Uses native runners for each architecture for faster builds
 #
-# Triggers:
-# - Manual (workflow_dispatch): For main releases (inkless-release-X.Y)
-#   Finds all Kafka-base tags and builds images/binaries for each
-# - Auto (push): For individual Kafka-base releases (inkless-4.x.y-*)
-#   Builds image/binary for that specific Kafka version
+# Cut a new Inkless release end-to-end.
+#
+# This workflow is the RELEASE CEREMONY layer. It owns the full release
+# lifecycle from "branches are ready" to "GitHub Release published":
+#
+#   1. prepare   — resolve version and discover active release branches from tag history
+#   2. validate  — assert each active branch contains the target commit and is in sync with main
+#   3. tag        — create inkless-release-<N> on main and inkless-<kafka-version>-<N> on each branch, push all
+#   4. publish   — call inkless-publish.yml with the full matrix to build images + binaries
+#   5. (publish handles) finalize — GitHub Release created and artifacts uploaded by inkless-publish.yml
+#
+# Prerequisites (must be done before triggering this workflow):
+#   - All target inkless commits are merged to main
+#   - Active release branches (inkless-4.1, inkless-4.2, ...) have been updated
+#     with those commits via the cherry-pick sync process
+#   - No pending cherry-picks on active branches (validated in step 2)
+#
+# See docs/inkless/RELEASES.md for the full release procedure.
 
 name: Inkless Release
 
@@ -15,618 +25,267 @@ on:
   workflow_dispatch:
     inputs:
       inkless_version:
-        description: 'Inkless version to release (e.g., 0.33). Leave empty to use latest.'
+        description: 'Inkless version to release (e.g. 0.44). Leave empty to auto-increment from latest tag.'
         required: false
         type: string
-  push:
-    tags:
-      - 'inkless-4.[0-9]*.[0-9]*-*'
+      main_commit:
+        description: 'Commit on main to release (SHA or ref). Leave empty to use main HEAD.'
+        required: false
+        type: string
+      extra_branches:
+        description: 'Space-separated list of additional release branches to include (e.g. "inkless-4.3"). Used when onboarding a new branch for the first time.'
+        required: false
+        type: string
 
-# TODO: Concurrency group uses github.ref which works well for push triggers (unique per tag),
-# but could cancel unrelated workflow_dispatch runs if triggered from the same branch.
-# Consider using a more specific group key if this becomes an issue.
 concurrency:
-  group: inkless-docker-release-${{ github.ref }}
-  cancel-in-progress: true
+  group: inkless-release
+  cancel-in-progress: false
 
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ghcr.io/aiven/inkless
 
 jobs:
-  # Determine what type of release this is
+  # Resolve version, main commit, and active release branches.
+  # Active branches are discovered from the previous release's Kafka-base tags
+  # (e.g. if inkless-4.1.2-0.43 and inkless-4.2.1-0.43 exist, both branches are active).
   prepare:
     runs-on: ubuntu-latest
     outputs:
-      git_tag: ${{ steps.parse.outputs.git_tag }}
-      release_type: ${{ steps.parse.outputs.release_type }}
-      inkless_version: ${{ steps.parse.outputs.inkless_version }}
-      kafka_version: ${{ steps.parse.outputs.kafka_version }}
-      kafka_major_minor: ${{ steps.parse.outputs.kafka_major_minor }}
-      kafka_base_matrix: ${{ steps.find-kafka-tags.outputs.matrix }}
-      build_matrix: ${{ steps.find-kafka-tags.outputs.build_matrix }}
-      latest_tags: ${{ steps.find-kafka-tags.outputs.latest_tags }}
+      inkless_version:   ${{ steps.resolve.outputs.inkless_version }}
+      main_commit:       ${{ steps.resolve.outputs.main_commit }}
+      release_tag:       ${{ steps.resolve.outputs.release_tag }}
+      active_branches:   ${{ steps.resolve.outputs.active_branches }}
+      kafka_versions:    ${{ steps.resolve-kafka.outputs.kafka_versions }}
+      build_matrix:      ${{ steps.resolve-kafka.outputs.build_matrix }}
+      kafka_base_matrix: ${{ steps.resolve-kafka.outputs.kafka_base_matrix }}
+      latest_tags:       ${{ steps.resolve-kafka.outputs.latest_tags }}
     steps:
-      - name: Checkout code (for tag discovery)
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Resolve release parameters
+        id: resolve
+        env:
+          INPUT_VERSION:        ${{ inputs.inkless_version }}
+          INPUT_COMMIT:         ${{ inputs.main_commit }}
+          INPUT_EXTRA_BRANCHES: ${{ inputs.extra_branches }}
+        run: |
+          # --- Inkless version ---
+          if [ -z "$INPUT_VERSION" ]; then
+            LATEST=$(git tag -l "inkless-release-*" | sort -V | tail -n1)
+            if [ -z "$LATEST" ]; then
+              echo "::error::No existing inkless-release-* tags found; specify inkless_version explicitly"
+              exit 1
+            fi
+            PREV="${LATEST#inkless-release-}"
+            # Increment the last numeric component
+            INKLESS_VERSION=$(echo "$PREV" | awk -F. '{$NF=$NF+1; print}' OFS='.')
+            echo "Auto-incremented version: $PREV -> $INKLESS_VERSION"
+          else
+            INKLESS_VERSION="$INPUT_VERSION"
+          fi
+
+          RELEASE_TAG="inkless-release-${INKLESS_VERSION}"
+
+          # Ensure the version doesn't already exist
+          if git rev-parse "$RELEASE_TAG" >/dev/null 2>&1; then
+            echo "::error::Tag $RELEASE_TAG already exists. Check the version or delete the existing tag first."
+            exit 1
+          fi
+
+          # --- Main commit ---
+          if [ -z "$INPUT_COMMIT" ]; then
+            MAIN_COMMIT=$(git rev-parse origin/main)
+            echo "Using main HEAD: $MAIN_COMMIT"
+          else
+            MAIN_COMMIT=$(git rev-parse "$INPUT_COMMIT")
+            echo "Using specified commit: $MAIN_COMMIT"
+          fi
+
+          # --- Active release branches ---
+          # Discover from the previous release's Kafka-base tags.
+          PREV_VERSION=$(git tag -l "inkless-release-*" | sort -V | tail -n1)
+          PREV_VERSION="${PREV_VERSION#inkless-release-}"
+          DISCOVERED=""
+          if [ -n "$PREV_VERSION" ]; then
+            DISCOVERED=$(git tag -l "inkless-*-${PREV_VERSION}" \
+              | grep -E '^inkless-[0-9]+\.[0-9]+\.[0-9]+-' \
+              | while read -r tag; do
+                  if [[ "$tag" =~ ^inkless-([0-9]+\.[0-9]+)\.[0-9]+-(.+)$ ]]; then
+                    echo "inkless-${BASH_REMATCH[1]}"
+                  fi
+                done | sort -u)
+            echo "Discovered active branches from ${PREV_VERSION} tags: $(echo "$DISCOVERED" | tr '\n' ' ')"
+          fi
+
+          # Merge with extra_branches input
+          ALL_BRANCHES=$(printf "%s\n%s" "$DISCOVERED" "$INPUT_EXTRA_BRANCHES" \
+            | tr ' ' '\n' | grep -v '^$' | sort -u)
+          echo "Active branches: $(echo "$ALL_BRANCHES" | tr '\n' ' ')"
+
+          if [ -z "$ALL_BRANCHES" ]; then
+            echo "::error::No active release branches found. Push at least one inkless-4.X.Y-<prev_version> tag or use extra_branches."
+            exit 1
+          fi
+
+          echo "inkless_version=$INKLESS_VERSION"                   >> $GITHUB_OUTPUT
+          echo "main_commit=$MAIN_COMMIT"                           >> $GITHUB_OUTPUT
+          echo "release_tag=$RELEASE_TAG"                           >> $GITHUB_OUTPUT
+          echo "active_branches=$(echo "$ALL_BRANCHES" | tr '\n' ' ' | sed 's/ $//')" >> $GITHUB_OUTPUT
+
+      - name: Resolve Kafka versions for active branches
+        id: resolve-kafka
+        env:
+          ACTIVE_BRANCHES: ${{ steps.resolve.outputs.active_branches }}
+          INKLESS_VERSION: ${{ steps.resolve.outputs.inkless_version }}
+        run: |
+          # For each active branch, determine its current Kafka version from gradle.properties
+          BUILD_MATRIX_ENTRIES=""
+          KAFKA_MATRIX_ENTRIES=""
+          LATEST_TAGS_JSON="{"
+          FIRST=true
+          KAFKA_VERSIONS=""
+
+          for BRANCH in $ACTIVE_BRANCHES; do
+            KAFKA_VER=$(git show "origin/${BRANCH}:gradle.properties" \
+              | grep '^version=' | head -1 | sed 's/version=\(.*\)-inkless.*/\1/')
+
+            if [ -z "$KAFKA_VER" ]; then
+              echo "::error::Cannot determine Kafka version for branch $BRANCH (gradle.properties version= not found)"
+              exit 1
+            fi
+
+            KAFKA_MAJOR_MINOR=$(echo "$KAFKA_VER" | cut -d. -f1-2)
+            TAG="inkless-${KAFKA_VER}-${INKLESS_VERSION}"
+
+            echo "$BRANCH -> Kafka $KAFKA_VER -> tag $TAG"
+            KAFKA_VERSIONS="${KAFKA_VERSIONS} ${TAG}"
+
+            if [ "$FIRST" = true ]; then
+              FIRST=false
+            else
+              BUILD_MATRIX_ENTRIES="${BUILD_MATRIX_ENTRIES},"
+              KAFKA_MATRIX_ENTRIES="${KAFKA_MATRIX_ENTRIES},"
+              LATEST_TAGS_JSON="${LATEST_TAGS_JSON},"
+            fi
+
+            BUILD_MATRIX_ENTRIES="${BUILD_MATRIX_ENTRIES}{\"kafka_tag\":\"$TAG\",\"arch\":\"amd64\",\"runner\":\"ubuntu-latest\"},{\"kafka_tag\":\"$TAG\",\"arch\":\"arm64\",\"runner\":\"ubuntu-24.04-arm\"}"
+            KAFKA_MATRIX_ENTRIES="${KAFKA_MATRIX_ENTRIES}{\"tag\":\"$TAG\"}"
+            LATEST_TAGS_JSON="${LATEST_TAGS_JSON}\"${KAFKA_MAJOR_MINOR}\":\"${TAG}\""
+          done
+
+          LATEST_TAGS_JSON="${LATEST_TAGS_JSON}}"
+
+          echo "kafka_versions=$(echo "$KAFKA_VERSIONS" | xargs)" >> $GITHUB_OUTPUT
+          echo "build_matrix={\"include\":[${BUILD_MATRIX_ENTRIES}]}"    >> $GITHUB_OUTPUT
+          echo "kafka_base_matrix={\"include\":[${KAFKA_MATRIX_ENTRIES}]}" >> $GITHUB_OUTPUT
+          echo "latest_tags=${LATEST_TAGS_JSON}"                          >> $GITHUB_OUTPUT
+
+  # Assert that each active release branch is ready to release:
+  #   - the target main commit is present on the branch
+  #   - branch-consistency.sh reports zero missing commits
+  validate:
+    needs: prepare
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Determine release parameters
-        id: parse
+      - name: Validate all active branches
         env:
-          GITHUB_EVENT_NAME: ${{ github.event_name }}
-          INKLESS_VERSION_INPUT: ${{ inputs.inkless_version }}
+          ACTIVE_BRANCHES: ${{ needs.prepare.outputs.active_branches }}
+          MAIN_COMMIT:     ${{ needs.prepare.outputs.main_commit }}
         run: |
-          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
-            # Manual trigger - this is a main release
-            INPUT_VERSION="$INKLESS_VERSION_INPUT"
-            
-            if [ -z "$INPUT_VERSION" ]; then
-              # Auto-detect latest inkless-release-* tag
-              LATEST_TAG=$(git tag -l "inkless-release-*" | sort -V | tail -n 1)
-              if [ -z "$LATEST_TAG" ]; then
-                echo "::error::No inkless-release-* tags found and no version specified"
-                exit 1
-              fi
-              INKLESS_VERSION="${LATEST_TAG#inkless-release-}"
-              echo "Auto-detected latest Inkless version: $INKLESS_VERSION"
-            else
-              INKLESS_VERSION="$INPUT_VERSION"
+          FAILED=0
+          for BRANCH in $ACTIVE_BRANCHES; do
+            git fetch origin "$BRANCH"
+
+            # Assert main commit is present
+            if ! git merge-base --is-ancestor "$MAIN_COMMIT" "origin/$BRANCH"; then
+              echo "::error::Commit $MAIN_COMMIT is NOT present on $BRANCH. Cherry-pick it first."
+              FAILED=1
+              continue
             fi
-            
-            GIT_TAG="inkless-release-${INKLESS_VERSION}"
+            echo "✓ $MAIN_COMMIT is present on $BRANCH"
 
-            # Validate tag exists
-            if ! git rev-parse "$GIT_TAG" >/dev/null 2>&1; then
-              echo "::error::Tag $GIT_TAG does not exist. Create the tag first or check the version."
-              exit 1
+            # Assert no missing inkless commits
+            MISSING=$(./inkless-sync/branch-consistency.sh "$BRANCH" --missing 2>&1 \
+              | grep -E '^- [0-9a-f]{10}' | wc -l | tr -d ' ')
+            if [ "$MISSING" -gt 0 ]; then
+              echo "::error::$BRANCH has $MISSING missing inkless commit(s) from main. Run cherry-pick sync first."
+              ./inkless-sync/branch-consistency.sh "$BRANCH" --missing
+              FAILED=1
+              continue
             fi
-
-            echo "git_tag=$GIT_TAG" >> $GITHUB_OUTPUT
-            echo "release_type=main" >> $GITHUB_OUTPUT
-            echo "inkless_version=$INKLESS_VERSION" >> $GITHUB_OUTPUT
-            echo "kafka_version=" >> $GITHUB_OUTPUT
-            echo "kafka_major_minor=" >> $GITHUB_OUTPUT
-            echo "Main release: Inkless version $INKLESS_VERSION"
-            
-          else
-            # Push trigger - this is a Kafka-base release
-            GIT_TAG="${GITHUB_REF#refs/tags/}"
-            echo "git_tag=$GIT_TAG" >> $GITHUB_OUTPUT
-            
-            if [[ "$GIT_TAG" =~ ^inkless-([0-9]+\.[0-9]+\.[0-9]+)-(.+)$ ]]; then
-              KAFKA_VERSION="${BASH_REMATCH[1]}"
-              INKLESS_VERSION="${BASH_REMATCH[2]}"
-              KAFKA_MAJOR_MINOR=$(echo "$KAFKA_VERSION" | cut -d. -f1-2)
-              echo "release_type=kafka-base" >> $GITHUB_OUTPUT
-              echo "inkless_version=$INKLESS_VERSION" >> $GITHUB_OUTPUT
-              echo "kafka_version=$KAFKA_VERSION" >> $GITHUB_OUTPUT
-              echo "kafka_major_minor=$KAFKA_MAJOR_MINOR" >> $GITHUB_OUTPUT
-              echo "Kafka-base release: Kafka $KAFKA_VERSION, Inkless $INKLESS_VERSION"
-            else
-              echo "::error::Unrecognized tag format: $GIT_TAG"
-              exit 1
-            fi
-          fi
-
-      - name: Find Kafka-base tags for main release
-        id: find-kafka-tags
-        env:
-          RELEASE_TYPE: ${{ steps.parse.outputs.release_type }}
-          INKLESS_VERSION: ${{ steps.parse.outputs.inkless_version }}
-          GIT_TAG: ${{ steps.parse.outputs.git_tag }}
-          KAFKA_MAJOR_MINOR: ${{ steps.parse.outputs.kafka_major_minor }}
-        run: |
-          if [ "$RELEASE_TYPE" = "main" ]; then
-            
-            # Find all tags matching inkless-X.Y.Z-<inkless_version>
-            TAGS=$(git tag -l "inkless-*-$INKLESS_VERSION" | grep -E '^inkless-[0-9]+\.[0-9]+\.[0-9]+-' | sort -V)
-            
-            if [ -z "$TAGS" ]; then
-              echo "::warning::No Kafka-base tags found for Inkless version $INKLESS_VERSION"
-              echo 'matrix={"include":[]}' >> $GITHUB_OUTPUT
-              echo 'build_matrix={"include":[]}' >> $GITHUB_OUTPUT
-              echo 'latest_tags={}' >> $GITHUB_OUTPUT
-            else
-              # Determine highest patch version for each minor version
-              # This ensures A.B-latest points to the highest A.B.C
-              declare -A LATEST_FOR_MINOR
-              while IFS= read -r tag; do
-                if [[ "$tag" =~ ^inkless-([0-9]+\.[0-9]+)\.([0-9]+)-(.+)$ ]]; then
-                  MINOR="${BASH_REMATCH[1]}"
-                  PATCH="${BASH_REMATCH[2]}"
-                  CURRENT_PATCH="${LATEST_FOR_MINOR[$MINOR]:-0}"
-                  if [ "$PATCH" -ge "$CURRENT_PATCH" ]; then
-                    LATEST_FOR_MINOR[$MINOR]="$PATCH"
-                  fi
-                fi
-              done <<< "$TAGS"
-              
-              # Build JSON map of minor -> highest patch tag
-              LATEST_TAGS_JSON='{'
-              FIRST_LATEST=true
-              for MINOR in "${!LATEST_FOR_MINOR[@]}"; do
-                PATCH="${LATEST_FOR_MINOR[$MINOR]}"
-                TAG="inkless-${MINOR}.${PATCH}-${INKLESS_VERSION}"
-                if [ "$FIRST_LATEST" = true ]; then
-                  FIRST_LATEST=false
-                else
-                  LATEST_TAGS_JSON="$LATEST_TAGS_JSON,"
-                fi
-                LATEST_TAGS_JSON="$LATEST_TAGS_JSON\"$MINOR\":\"$TAG\""
-              done
-              LATEST_TAGS_JSON="$LATEST_TAGS_JSON}"
-              echo "latest_tags=$LATEST_TAGS_JSON" >> $GITHUB_OUTPUT
-              echo "Highest patch versions per minor: $LATEST_TAGS_JSON"
-              
-              # Convert to JSON matrix format (for manifest job - one per tag)
-              MATRIX_JSON='{"include":['
-              # Build matrix with arch combinations (for build job - tag × arch)
-              BUILD_MATRIX_JSON='{"include":['
-              FIRST=true
-              while IFS= read -r tag; do
-                if [ -n "$tag" ]; then
-                  if [ "$FIRST" = true ]; then
-                    FIRST=false
-                  else
-                    MATRIX_JSON="$MATRIX_JSON,"
-                    BUILD_MATRIX_JSON="$BUILD_MATRIX_JSON,"
-                  fi
-                  MATRIX_JSON="$MATRIX_JSON{\"tag\":\"$tag\"}"
-                  BUILD_MATRIX_JSON="$BUILD_MATRIX_JSON{\"kafka_tag\":\"$tag\",\"arch\":\"amd64\",\"runner\":\"ubuntu-latest\"},{\"kafka_tag\":\"$tag\",\"arch\":\"arm64\",\"runner\":\"ubuntu-24.04-arm\"}"
-                fi
-              done <<< "$TAGS"
-              MATRIX_JSON="$MATRIX_JSON]}"
-              BUILD_MATRIX_JSON="$BUILD_MATRIX_JSON]}"
-              echo "matrix=$MATRIX_JSON" >> $GITHUB_OUTPUT
-              echo "build_matrix=$BUILD_MATRIX_JSON" >> $GITHUB_OUTPUT
-              echo "Found Kafka-base tags matrix: $MATRIX_JSON"
-            fi
-          else
-            # For kafka-base releases, build only the pushed tag for both architectures,
-            # but determine the true latest patch for this Kafka minor from existing tags.
-            echo "matrix={\"include\":[{\"tag\":\"$GIT_TAG\"}]}" >> $GITHUB_OUTPUT
-            echo "build_matrix={\"include\":[{\"kafka_tag\":\"$GIT_TAG\",\"arch\":\"amd64\",\"runner\":\"ubuntu-latest\"},{\"kafka_tag\":\"$GIT_TAG\",\"arch\":\"arm64\",\"runner\":\"ubuntu-24.04-arm\"}]}" >> $GITHUB_OUTPUT
-
-            # Find the kafka-base tag with the highest Kafka patch version for this minor.
-            # This prevents an older patch (pushed later) from overwriting A.B-latest.
-            LATEST_FOR_MINOR="$GIT_TAG"
-            CANDIDATE_TAGS=$(git tag --list "inkless-${KAFKA_MAJOR_MINOR}.*-*")
-            if [ -n "$CANDIDATE_TAGS" ]; then
-              HIGHEST=$(
-                echo "$CANDIDATE_TAGS" | while read -r TAG; do
-                  if [[ "$TAG" =~ ^inkless-([0-9]+\.[0-9]+\.[0-9]+)-(.+)$ ]]; then
-                    KVER="${BASH_REMATCH[1]}"
-                    echo "$KVER $TAG"
-                  fi
-                done | sort -t' ' -k1,1V | tail -n1 | awk '{print $2}'
-              )
-              if [ -n "$HIGHEST" ]; then
-                LATEST_FOR_MINOR="$HIGHEST"
-              fi
-            fi
-            echo "Highest patch for $KAFKA_MAJOR_MINOR: $LATEST_FOR_MINOR"
-
-            echo "latest_tags={\"$KAFKA_MAJOR_MINOR\":\"$LATEST_FOR_MINOR\"}" >> $GITHUB_OUTPUT
-          fi
-
-  # Build Kafka-base releases - one job per tag × architecture combination
-  # TODO: Optimization opportunities:
-  # 1. Permissions: All runners get contents:write but only one uploads to releases.
-  #    Could segregate release upload into a separate job for least-privilege.
-  # 2. Build: Kafka distribution is arch-independent but rebuilds on each runner.
-  #    Could build once and share via artifacts to reduce build time.
-  build-kafka-base:
-    needs: prepare
-    if: needs.prepare.outputs.build_matrix != '{"include":[]}'
-    runs-on: ${{ matrix.runner }}
-    permissions:
-      contents: write
-      packages: write
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJson(needs.prepare.outputs.build_matrix) }}
-
-    steps:
-      - name: Parse build tag
-        id: parse-build
-        env:
-          BUILD_TAG: ${{ matrix.kafka_tag }}
-        run: |
-          echo "build_tag=$BUILD_TAG" >> $GITHUB_OUTPUT
-          
-          if [[ "$BUILD_TAG" =~ ^inkless-([0-9]+\.[0-9]+\.[0-9]+)-(.+)$ ]]; then
-            KAFKA_VERSION="${BASH_REMATCH[1]}"
-            INKLESS_VERSION="${BASH_REMATCH[2]}"
-            KAFKA_MAJOR_MINOR=$(echo "$KAFKA_VERSION" | cut -d. -f1-2)
-            
-            echo "kafka_version=$KAFKA_VERSION" >> $GITHUB_OUTPUT
-            echo "inkless_version=$INKLESS_VERSION" >> $GITHUB_OUTPUT
-            echo "kafka_major_minor=$KAFKA_MAJOR_MINOR" >> $GITHUB_OUTPUT
-            echo "primary_image_tag=${KAFKA_VERSION}-${INKLESS_VERSION}" >> $GITHUB_OUTPUT
-            echo "latest_image_tag=${KAFKA_MAJOR_MINOR}-latest" >> $GITHUB_OUTPUT
-          else
-            echo "::error::Cannot parse build tag: $BUILD_TAG"
-            exit 1
-          fi
-
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ matrix.kafka_tag }}
-          persist-credentials: false
-
-      - name: Setup Gradle
-        uses: ./.github/actions/setup-gradle
-        with:
-          java-version: 17
-          gradle-cache-read-only: false
-
-      - name: Build Kafka distribution
-        run: make build_release
-
-      - name: Prepare distribution artifact info
-        id: dist-info
-        run: |
-          shopt -s nullglob
-          TARBALLS=(core/build/distributions/kafka_2.13-*.tgz)
-          if [ ${#TARBALLS[@]} -eq 0 ]; then
-            echo "::error::No Kafka distribution tarball (kafka_2.13-*.tgz) found in core/build/distributions"
-            exit 1
-          fi
-          # Find the main tarball (exclude site-docs)
-          TARBALL=""
-          for tb in "${TARBALLS[@]}"; do
-            if [[ "$tb" != *-site-docs.tgz ]]; then
-              TARBALL="$tb"
-              break
-            fi
+            echo "✓ $BRANCH is in sync with main"
           done
-          if [ -z "$TARBALL" ]; then
-            echo "::error::No non-site-docs Kafka distribution tarball found in core/build/distributions"
-            exit 1
-          fi
-          TARBALL_NAME=$(basename "$TARBALL")
-          DIST_VERSION=$(echo "$TARBALL_NAME" | sed 's/kafka_2.13-\(.*\)\.tgz/\1/')
+          exit $FAILED
 
-          echo "tarball=$TARBALL" >> $GITHUB_OUTPUT
-          echo "tarball_name=$TARBALL_NAME" >> $GITHUB_OUTPUT
-          echo "dist_version=$DIST_VERSION" >> $GITHUB_OUTPUT
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push architecture-specific image
-        env:
-          ARCH: ${{ matrix.arch }}
-          PRIMARY_IMAGE_TAG: ${{ steps.parse-build.outputs.primary_image_tag }}
-          BUILD_TIMESTAMP: ${{ github.event.head_commit.timestamp }}
-          KAFKA_TAG: ${{ matrix.kafka_tag }}
-        run: |
-          make docker_build \
-            PLATFORM="linux/${ARCH}" \
-            DOCKER_TAGS="${IMAGE_NAME}:${PRIMARY_IMAGE_TAG}-${ARCH}" \
-            PUSH=true \
-            BUILD_DATE="${BUILD_TIMESTAMP}" \
-            CACHE_FROM="type=gha,scope=${KAFKA_TAG}-${ARCH}" \
-            CACHE_TO="type=gha,mode=max,scope=${KAFKA_TAG}-${ARCH}"
-
-      - name: Upload distribution as artifact (amd64 only to avoid duplicates)
-        if: matrix.arch == 'amd64'
-        uses: actions/upload-artifact@v4
-        with:
-          name: dist-${{ steps.parse-build.outputs.kafka_version }}-${{ steps.parse-build.outputs.inkless_version }}
-          path: ${{ steps.dist-info.outputs.tarball }}
-          retention-days: 1
-
-  # Create multi-arch manifests for Kafka-base images
-  manifest-kafka-base:
-    needs: [prepare, build-kafka-base]
-    if: needs.prepare.outputs.kafka_base_matrix != '{"include":[]}'
-    runs-on: ubuntu-latest
-    permissions:
-      packages: write
-    strategy:
-      matrix: ${{ fromJson(needs.prepare.outputs.kafka_base_matrix) }}
-
-    steps:
-      - name: Parse tag and check if latest
-        id: parse
-        env:
-          BUILD_TAG: ${{ matrix.tag }}
-          LATEST_TAGS: ${{ needs.prepare.outputs.latest_tags }}
-        run: |
-          if [[ "$BUILD_TAG" =~ ^inkless-([0-9]+\.[0-9]+\.[0-9]+)-(.+)$ ]]; then
-            KAFKA_VERSION="${BASH_REMATCH[1]}"
-            INKLESS_VERSION="${BASH_REMATCH[2]}"
-            KAFKA_MAJOR_MINOR=$(echo "$KAFKA_VERSION" | cut -d. -f1-2)
-            echo "kafka_major_minor=$KAFKA_MAJOR_MINOR" >> $GITHUB_OUTPUT
-            echo "primary_image_tag=${KAFKA_VERSION}-${INKLESS_VERSION}" >> $GITHUB_OUTPUT
-            echo "latest_image_tag=${KAFKA_MAJOR_MINOR}-latest" >> $GITHUB_OUTPUT
-            
-            # Check if this tag is the highest patch for its minor version
-            LATEST_FOR_THIS_MINOR=$(echo "$LATEST_TAGS" | jq -r ".\"$KAFKA_MAJOR_MINOR\" // empty")
-            if [ "$BUILD_TAG" = "$LATEST_FOR_THIS_MINOR" ]; then
-              echo "is_latest_patch=true" >> $GITHUB_OUTPUT
-              echo "This tag ($BUILD_TAG) is the highest patch for $KAFKA_MAJOR_MINOR"
-            else
-              echo "is_latest_patch=false" >> $GITHUB_OUTPUT
-              echo "This tag ($BUILD_TAG) is NOT the highest patch for $KAFKA_MAJOR_MINOR (highest is $LATEST_FOR_THIS_MINOR)"
-            fi
-          fi
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Create multi-arch manifest for primary tag
-        env:
-          PRIMARY_TAG: ${{ steps.parse.outputs.primary_image_tag }}
-        run: |
-          docker buildx imagetools create \
-            -t "${IMAGE_NAME}:${PRIMARY_TAG}" \
-            "${IMAGE_NAME}:${PRIMARY_TAG}-amd64" \
-            "${IMAGE_NAME}:${PRIMARY_TAG}-arm64"
-
-      - name: Create multi-arch manifest for latest tag
-        if: steps.parse.outputs.is_latest_patch == 'true'
-        env:
-          PRIMARY_TAG: ${{ steps.parse.outputs.primary_image_tag }}
-          LATEST_TAG: ${{ steps.parse.outputs.latest_image_tag }}
-        run: |
-          docker buildx imagetools create \
-            -t "${IMAGE_NAME}:${LATEST_TAG}" \
-            "${IMAGE_NAME}:${PRIMARY_TAG}-amd64" \
-            "${IMAGE_NAME}:${PRIMARY_TAG}-arm64"
-
-      - name: Output build summary
-        env:
-          TAG: ${{ matrix.tag }}
-          PRIMARY_IMAGE_TAG: ${{ steps.parse.outputs.primary_image_tag }}
-          LATEST_IMAGE_TAG: ${{ steps.parse.outputs.latest_image_tag }}
-          IS_LATEST_PATCH: ${{ steps.parse.outputs.is_latest_patch }}
-          KAFKA_MAJOR_MINOR: ${{ steps.parse.outputs.kafka_major_minor }}
-        run: |
-          echo "## Kafka-base Image: ${TAG}" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Docker Image Tags:**" >> $GITHUB_STEP_SUMMARY
-          echo "- \`${IMAGE_NAME}:${PRIMARY_IMAGE_TAG}\`" >> $GITHUB_STEP_SUMMARY
-          if [ "$IS_LATEST_PATCH" = "true" ]; then
-            echo "- \`${IMAGE_NAME}:${LATEST_IMAGE_TAG}\` (latest for ${KAFKA_MAJOR_MINOR})" >> $GITHUB_STEP_SUMMARY
-          fi
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Platforms:** linux/amd64, linux/arm64" >> $GITHUB_STEP_SUMMARY
-
-  # For main releases: collect all artifacts and upload to the main release
-  # Uses always() to run even when build-kafka-base is skipped (no kafka-base tags exist)
-  upload-to-main-release:
-    if: ${{ always() && needs.prepare.outputs.release_type == 'main' && !cancelled() }}
-    needs: [prepare, build-kafka-base]
+  # Create and push all tags:
+  #   - inkless-release-<N> on the resolved main commit
+  #   - inkless-<kafka-version>-<N> on the HEAD of each active release branch
+  tag:
+    needs: [prepare, validate]
     runs-on: ubuntu-latest
     permissions:
       contents: write
-
     steps:
-      - name: Download all distribution artifacts
-        id: download
-        uses: actions/download-artifact@v4
-        continue-on-error: true
-        with:
-          pattern: dist-*
-          path: distributions
-          merge-multiple: true
-
-      - name: List downloaded distributions
-        run: |
-          echo "Downloaded distributions:"
-          ls -la distributions/ 2>/dev/null || echo "No distributions found"
-
-      - name: Ensure release exists
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_TAG: ${{ needs.prepare.outputs.git_tag }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-          INKLESS_VERSION: ${{ needs.prepare.outputs.inkless_version }}
-          KAFKA_BASE_MATRIX: ${{ needs.prepare.outputs.kafka_base_matrix }}
-        run: |
-          # Build release notes with Docker images and kafka-base tags
-          RELEASE_NOTES="Inkless version ${INKLESS_VERSION}
-
-          ## Docker Images
-
-          \`\`\`bash
-          docker pull ghcr.io/aiven/inkless:${INKLESS_VERSION}
-          docker pull ghcr.io/aiven/inkless:latest
-          \`\`\`
-
-          ## Kafka Versions"
-
-          # Add kafka-base tags from matrix
-          if [ -n "$KAFKA_BASE_MATRIX" ] && [ "$KAFKA_BASE_MATRIX" != '{"include":[]}' ]; then
-            TAGS=$(echo "$KAFKA_BASE_MATRIX" | jq -r '.include[].tag // .include[].kafka_tag // empty' 2>/dev/null | sort -V | uniq)
-            if [ -n "$TAGS" ]; then
-              while IFS= read -r tag; do
-                if [ -n "$tag" ]; then
-                  # Extract kafka version from tag (e.g., inkless-4.1.1-0.33 -> 4.1.1)
-                  if [[ "$tag" =~ ^inkless-([0-9]+\.[0-9]+\.[0-9]+)-(.+)$ ]]; then
-                    KAFKA_VER="${BASH_REMATCH[1]}"
-                    RELEASE_NOTES="${RELEASE_NOTES}
-          - Kafka ${KAFKA_VER}: [\`${tag}\`](https://github.com/${GITHUB_REPOSITORY}/tree/${tag})"
-                  fi
-                fi
-              done <<< "$TAGS"
-            fi
-          fi
-
-          # Check if release exists, create if not
-          if ! gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" > /dev/null 2>&1; then
-            echo "Creating release $RELEASE_TAG"
-            gh release create "$RELEASE_TAG" \
-              --repo "$GITHUB_REPOSITORY" \
-              --title "Inkless ${INKLESS_VERSION}" \
-              --notes "$RELEASE_NOTES" \
-              --draft=false
-          else
-            echo "Release $RELEASE_TAG already exists, updating notes"
-            gh release edit "$RELEASE_TAG" \
-              --repo "$GITHUB_REPOSITORY" \
-              --notes "$RELEASE_NOTES"
-          fi
-
-      - name: Upload distributions to main release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_TAG: ${{ needs.prepare.outputs.git_tag }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-        run: |
-          echo "Uploading to release: $RELEASE_TAG"
-
-          if [ -d distributions ] && [ "$(ls -A distributions/ 2>/dev/null)" ]; then
-            for file in distributions/*.tgz; do
-              if [ -f "$file" ]; then
-                echo "Uploading: $file"
-                gh release upload "$RELEASE_TAG" "$file" --clobber --repo "$GITHUB_REPOSITORY"
-              fi
-            done
-          else
-            echo "::warning::No distribution files found to upload"
-          fi
-
-      - name: Output release summary
-        env:
-          GIT_TAG: ${{ needs.prepare.outputs.git_tag }}
-          INKLESS_VERSION: ${{ needs.prepare.outputs.inkless_version }}
-        run: |
-          echo "## Main Release: ${GIT_TAG}" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Inkless Version:** ${INKLESS_VERSION}" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Distributions uploaded:**" >> $GITHUB_STEP_SUMMARY
-          if [ -d distributions ] && [ "$(ls -A distributions/)" ]; then
-            for file in distributions/*.tgz; do
-              if [ -f "$file" ]; then
-                echo "- \`$(basename $file)\`" >> $GITHUB_STEP_SUMMARY
-              fi
-            done
-          else
-            echo "- None (no Kafka-base tags found)" >> $GITHUB_STEP_SUMMARY
-          fi
-
-  # For main releases: build the "latest" Docker image from main
-  build-main-docker:
-    if: needs.prepare.outputs.release_type == 'main'
-    needs: prepare
-    runs-on: ${{ matrix.runner }}
-    permissions:
-      contents: read
-      packages: write
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - arch: amd64
-            runner: ubuntu-latest
-          - arch: arm64
-            runner: ubuntu-24.04-arm
-
-    steps:
-      - name: Checkout code
+      - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ needs.prepare.outputs.git_tag }}
-          persist-credentials: false
+          fetch-depth: 0
+          persist-credentials: true
 
-      - name: Setup Gradle
-        uses: ./.github/actions/setup-gradle
-        with:
-          java-version: 17
-          gradle-cache-read-only: false
-
-      - name: Build Kafka distribution
-        run: make build_release
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push architecture-specific image
-        env:
-          ARCH: ${{ matrix.arch }}
-          INKLESS_VERSION: ${{ needs.prepare.outputs.inkless_version }}
-          BUILD_TIMESTAMP: ${{ github.event.head_commit.timestamp }}
+      - name: Configure git
         run: |
-          make docker_build \
-            PLATFORM="linux/${ARCH}" \
-            DOCKER_TAGS="${IMAGE_NAME}:${INKLESS_VERSION}-${ARCH} ${IMAGE_NAME}:latest-${ARCH}" \
-            PUSH=true \
-            BUILD_DATE="${BUILD_TIMESTAMP}" \
-            CACHE_FROM="type=gha,scope=main-${ARCH}" \
-            CACHE_TO="type=gha,mode=max,scope=main-${ARCH}"
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
 
-  # Create multi-arch manifest for main release
-  manifest-main:
-    if: needs.prepare.outputs.release_type == 'main'
-    needs: [prepare, build-main-docker]
-    runs-on: ubuntu-latest
+      - name: Create and push main release tag
+        env:
+          RELEASE_TAG:  ${{ needs.prepare.outputs.release_tag }}
+          MAIN_COMMIT:  ${{ needs.prepare.outputs.main_commit }}
+          INKLESS_VERSION: ${{ needs.prepare.outputs.inkless_version }}
+        run: |
+          git tag -a "$RELEASE_TAG" "$MAIN_COMMIT" -m "Inkless release ${INKLESS_VERSION}"
+          git push origin "$RELEASE_TAG"
+          echo "✓ Pushed $RELEASE_TAG"
+
+      - name: Create and push Kafka-base tags
+        env:
+          ACTIVE_BRANCHES: ${{ needs.prepare.outputs.active_branches }}
+          INKLESS_VERSION: ${{ needs.prepare.outputs.inkless_version }}
+        run: |
+          for BRANCH in $ACTIVE_BRANCHES; do
+            git fetch origin "$BRANCH"
+            BRANCH_HEAD=$(git rev-parse "origin/$BRANCH")
+
+            KAFKA_VER=$(git show "origin/${BRANCH}:gradle.properties" \
+              | grep '^version=' | head -1 | sed 's/version=\(.*\)-inkless.*/\1/')
+            TAG="inkless-${KAFKA_VER}-${INKLESS_VERSION}"
+
+            git tag -a "$TAG" "$BRANCH_HEAD" -m "Inkless release ${INKLESS_VERSION} on Kafka ${KAFKA_VER}"
+            git push origin "$TAG"
+            echo "✓ Pushed $TAG (on $BRANCH @ $BRANCH_HEAD)"
+          done
+
+  # Build Docker images and binary distributions for all Kafka-base tags,
+  # then finalize the GitHub Release with all artifacts.
+  publish:
+    needs: [prepare, tag]
+    uses: ./.github/workflows/inkless-publish.yml
+    with:
+      inkless_version:   ${{ needs.prepare.outputs.inkless_version }}
+      build_matrix:      ${{ needs.prepare.outputs.build_matrix }}
+      kafka_base_matrix: ${{ needs.prepare.outputs.kafka_base_matrix }}
+      latest_tags:       ${{ needs.prepare.outputs.latest_tags }}
     permissions:
+      contents: write
       packages: write
-
-    steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Create multi-arch manifest for version tag
-        env:
-          VERSION: ${{ needs.prepare.outputs.inkless_version }}
-        run: |
-          docker buildx imagetools create \
-            -t "${IMAGE_NAME}:${VERSION}" \
-            "${IMAGE_NAME}:${VERSION}-amd64" \
-            "${IMAGE_NAME}:${VERSION}-arm64"
-
-      - name: Create multi-arch manifest for latest tag
-        run: |
-          docker buildx imagetools create \
-            -t "${IMAGE_NAME}:latest" \
-            "${IMAGE_NAME}:latest-amd64" \
-            "${IMAGE_NAME}:latest-arm64"
-
-      - name: Output build summary
-        env:
-          INKLESS_VERSION: ${{ needs.prepare.outputs.inkless_version }}
-        run: |
-          echo "## Main Docker Image" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Docker Image Tags:**" >> $GITHUB_STEP_SUMMARY
-          echo "- \`${IMAGE_NAME}:${INKLESS_VERSION}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- \`${IMAGE_NAME}:latest\`" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Platforms:** linux/amd64, linux/arm64" >> $GITHUB_STEP_SUMMARY

--- a/docs/inkless/README.md
+++ b/docs/inkless/README.md
@@ -25,7 +25,7 @@ Choose your path based on what you want to do:
 | **Use prebuilt binaries**    | [Binary usage guide](QUICKSTART.md#using-prebuilt-binaries)   |
 | **Build from source**        | `make docker_build` ([details](QUICKSTART.md#using-a-locally-built-image))|
 
-See [Releases](RELEASES.md) for available versions.
+See [Releases](RELEASES.md) for active versions and release history.
 
 ## Documentation Index
 

--- a/docs/inkless/RELEASES.md
+++ b/docs/inkless/RELEASES.md
@@ -84,6 +84,71 @@ curl -LO https://github.com/aiven/inkless/releases/download/inkless-release-0.33
 gh release download inkless-release-0.33 --repo aiven/inkless --pattern "*.tgz"
 ```
 
+## Release Branches
+
+### Active
+
+These branches receive new Inkless releases. When a release is cut, both are updated
+simultaneously with the same Inkless version number.
+
+| Branch        | Kafka version | Latest release        |
+|---------------|---------------|-----------------------|
+| `inkless-4.2` | 4.2.1         | `inkless-4.2.1-0.44`  |
+| `inkless-4.1` | 4.1.2         | `inkless-4.1.2-0.44`  |
+
+### Inactive (no longer updated)
+
+| Branch        | Kafka version | Last release          |
+|---------------|---------------|-----------------------|
+| `inkless-4.0` | 4.0.2         | `inkless-4.0.2-0.37`  |
+
+### Planned
+
+| Branch        | Kafka version | Status                |
+|---------------|---------------|-----------------------|
+| `inkless-4.3` | 4.3.x         | Not yet created       |
+
+If a commit cannot be cleanly backported across active branches, they may diverge by one
+version increment (see [Versioning Strategy](VERSIONING-STRATEGY.md)).
+
+## Cutting a Release
+
+The release process is fully automated via GitHub Actions once the release branches are ready.
+
+### Prerequisites
+
+- All target inkless commits are merged to `main`.
+- Active release branches (`inkless-4.1`, `inkless-4.2`, ...) have been updated with those
+  commits via the cherry-pick sync process (see `inkless-sync/CHERRY-PICK-SYNC-GUIDE.md`).
+- Branches have been pushed to `origin`.
+
+### Trigger the release
+
+Go to **GitHub Actions → Inkless Release → Run workflow** and fill in:
+
+| Input | Description | Default |
+|---|---|---|
+| `inkless_version` | Version to release (e.g. `0.44`) | Auto-increments from latest tag |
+| `main_commit` | Commit on `main` to release | `main` HEAD |
+| `extra_branches` | Space-separated branches to add (e.g. `inkless-4.3`) | Empty — use for new branches only |
+
+The workflow then:
+
+1. **Resolves** the version and discovers active branches from the previous release's tags
+2. **Validates** each branch — asserts the target commit is present and no inkless commits are missing
+3. **Creates and pushes tags** — `inkless-release-<N>` on main and `inkless-<kafka-version>-<N>` on each branch
+4. **Builds** Docker images (amd64 + arm64) and binary distributions for each Kafka version in parallel
+5. **Finalizes** — creates the GitHub Release, attaches all artifacts, publishes `latest` and `X.Y-latest` Docker aliases
+
+If validation fails (a branch is missing commits), the workflow aborts before touching any tags. Fix the
+branch with cherry-pick sync and re-trigger.
+
+### Onboarding a new release branch
+
+When a new Kafka minor branch is ready (e.g. `inkless-4.3`), add it to the first release via the
+`extra_branches` input. After that first release creates `inkless-4.3.X-<N>`, it will be auto-discovered
+in future runs.
+
 ## Versioning
 
 For details on how Inkless versions work, see [Versioning Strategy](VERSIONING-STRATEGY.md).

--- a/docs/inkless/RELEASES.md
+++ b/docs/inkless/RELEASES.md
@@ -91,22 +91,24 @@ gh release download inkless-release-0.33 --repo aiven/inkless --pattern "*.tgz"
 These branches receive new Inkless releases. When a release is cut, both are updated
 simultaneously with the same Inkless version number.
 
-| Branch        | Kafka version | Latest release        |
-|---------------|---------------|-----------------------|
-| `inkless-4.2` | 4.2.1         | `inkless-4.2.1-0.44`  |
-| `inkless-4.1` | 4.1.2         | `inkless-4.1.2-0.44`  |
+See [GitHub Releases](https://github.com/aiven/inkless/releases) for the latest version on each branch.
+
+| Branch        | Kafka version |
+|---------------|---------------|
+| `inkless-4.2` | 4.2.1         |
+| `inkless-4.1` | 4.1.2         |
 
 ### Inactive (no longer updated)
 
-| Branch        | Kafka version | Last release          |
-|---------------|---------------|-----------------------|
-| `inkless-4.0` | 4.0.2         | `inkless-4.0.2-0.37`  |
+| Branch        | Kafka version | Last release         |
+|---------------|---------------|----------------------|
+| `inkless-4.0` | 4.0.2         | `inkless-4.0.2-0.37` |
 
 ### Planned
 
-| Branch        | Kafka version | Status                |
-|---------------|---------------|-----------------------|
-| `inkless-4.3` | 4.3.x         | Not yet created       |
+| Branch        | Kafka version | Status          |
+|---------------|---------------|-----------------|
+| `inkless-4.3` | 4.3.x         | Not yet created |
 
 If a commit cannot be cleanly backported across active branches, they may diverge by one
 version increment (see [Versioning Strategy](VERSIONING-STRATEGY.md)).

--- a/inkless-sync/CHERRY-PICK-SYNC-GUIDE.md
+++ b/inkless-sync/CHERRY-PICK-SYNC-GUIDE.md
@@ -100,16 +100,18 @@ When a cherry-pick has conflicts, resolve them following the patterns in [Confli
 
 **After resolving each conflict:**
 
-1. Compile to verify: `./gradlew :storage:inkless:compileJava :core:compileScala`
+1. Complete the cherry-pick: `git cherry-pick --continue`
 2. Document the resolution in the session file
-3. If compilation requires additional fixes, amend the cherry-pick commit with the fixes
+3. Then follow the **conflict path** in Step 6 below
 
-### Step 6: Compile After Each Cherry-pick
+### Step 6: Verify After Each Cherry-pick
 
-After each successful cherry-pick (with or without conflict resolution):
+Use the fast path when the cherry-pick applied cleanly; use the full path when it required conflict resolution.
+
+#### Fast path (no conflicts)
 
 ```bash
-# Core inkless modules (fast check)
+# Core inkless modules
 ./gradlew :storage:inkless:compileJava :core:compileScala
 
 # If the commit touches tests
@@ -117,6 +119,24 @@ After each successful cherry-pick (with or without conflict resolution):
 
 # If the commit touches metadata, clients, or other modules
 ./gradlew :metadata:compileJava :clients:compileJava
+```
+
+#### Full path (conflict resolution required)
+
+```bash
+# 1. Apply formatting — conflict resolution often leaves unused imports or style drift
+make fmt
+
+# 2. Amend the cherry-pick with any fmt changes before proceeding
+git add -p   # stage only fmt-related changes
+git commit --amend --no-edit
+
+# 3. Full build — catches cross-module regressions the fast path misses
+make build
+
+# 4. Re-run the tests introduced or modified by this commit
+#    Identify them from the commit diff, then run specifically, e.g.:
+./gradlew :storage:inkless:test --tests "io.aiven.inkless.SomeNewTest"
 ```
 
 Fix any compilation errors before proceeding to the next commit. Commit fixes as amendments to the cherry-pick (if the cherry-pick introduced the broken code) or as separate `sync(compile):` commits.


### PR DESCRIPTION
- Automate the full release process via a new `inkless-release.yml` workflow
- Split the existing monolithic release workflow into two focused files
- Document release branches (active/inactive/planned) and the cutting procedure
- Fix JUnit report parsing in nightly CI to match `inkless.yml`
- Update the cherry-pick guide with improved post-conflict verification steps

## Changes

### CI: release workflow split (`inkless-release.yml` → two files)

The existing `inkless-release.yml` was a monolith handling both orchestration and building, mixing concerns across `workflow_dispatch` and `push` triggers via a `release_type` flag.

**`inkless-publish.yml`** (renamed/refactored from `inkless-release.yml`) — build/publish layer only:
- Triggered by `push` of `inkless-4.X.Y-*` tags (unchanged behavior) or `workflow_call`
- Builds Docker images (amd64 + arm64), binary distributions, and multi-arch manifests
- On `workflow_call`: also runs `finalize-release` to create the GitHub Release and attach all artifacts

**`inkless-release.yml`** (new) — release ceremony layer:
- Triggered manually via `workflow_dispatch` with three optional inputs: `inkless_version` (auto-increments from latest tag), `main_commit` (defaults to `main` HEAD), `extra_branches` (for onboarding new Kafka minor branches)
- `prepare`: resolves version and discovers active branches from previous release's Kafka-base tags — no config file needed, tag history is self-describing
- `validate`: asserts each branch contains the target commit and has no missing inkless commits (`branch-consistency.sh`); aborts before touching any tags if validation fails
- `tag`: creates and pushes `inkless-release-<N>` on main and `inkless-<kafka-version>-<N>` on each branch
- `publish`: calls `inkless-publish.yml` via `workflow_call` with the full matrix

### CI: nightly JUnit reports

`inkless-nightly.yml` had the `Parse JUnit tests` step commented out and used a manual exit-code check instead. Aligned it with `inkless.yml`:
- Added `-Pkafka.test.xml.output.dir=${{ matrix.java }}` to `GRADLE_ARGS` so XML is written to `build/junit-xml/<java>/`
- Uncommented and updated the `Parse JUnit tests` step (`GRADLE_TEST_EXIT_CODE`, `--path build/junit-xml/${{ matrix.java }}`)
- Removed the now-redundant `Check test results` step (junit.py owns the exit code)
- Test retry flags (`-PmaxTestRetries=1 -PmaxTestRetryFailures=3`) preserved — nightly intentionally tolerates flaky tests

### Docs: release branch status and procedure

`docs/inkless/RELEASES.md`:
- New **Release Branches** section: active (`inkless-4.1` @ 4.1.2, `inkless-4.2` @ 4.2.1), inactive (`inkless-4.0` last at 0.37), planned (`inkless-4.3`)
- **Cutting a Release** section now describes the automated `workflow_dispatch` flow instead of the previous manual tag-pushing steps

`docs/inkless/README.md`: updated RELEASES.md link to "active versions and release history"

### cherry-pick sync guide

- Post-conflict verification now has explicit fast/full paths: clean pick → module compile only; conflicted pick → `make fmt` (amend) + `make build` + targeted test re-run
- Archived `inkless-4.1` cherry-pick session (2026-07-08, 17 commits, 2 conflict resolutions)
