### PR TITLE
fix: allow diskless+remote.storage on creation when allow-switch flag is on

### DIFF
--- a/core/src/test/scala/unit/kafka/log/LogConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogConfigTest.scala
@@ -605,6 +605,44 @@ class LogConfigTest {
   }
 
   @Test
+  def testAllowFromClassicAllowsDisklessAndRemoteStorageAtCreation(): Unit = {
+    val kafkaConfig = KafkaConfig.fromProps(TestUtils.createDummyBrokerConfig())
+    val noExisting: util.Map[String, String] = util.Map.of()
+    val mutualExclusionError = "It is not valid to set a value for both diskless.enable and remote.storage.enable unless it's for diskless switch or consolidation."
+
+    // Allowed: diskless.enable=true and remote.storage.enable=true at creation with only allowFromClassic (no consolidation)
+    assertValid(noExisting, topicProps(
+      TopicConfig.DISKLESS_ENABLE_CONFIG -> "true",
+      TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG -> "true"),
+      kafkaConfig,
+      disklessAllowFromClassic = true, remoteStorageConsolidationEnabled = false)
+
+    // NOT allowed when both diskless=true and remote.storage=false (not a valid consolidation mode)
+    assertInvalid(noExisting, topicProps(
+      TopicConfig.DISKLESS_ENABLE_CONFIG -> "true",
+      TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG -> "false"),
+      mutualExclusionError,
+      kafkaConfig,
+      disklessAllowFromClassic = true, remoteStorageConsolidationEnabled = false)
+
+    // NOT allowed when diskless=false and remote.storage=true
+    assertInvalid(noExisting, topicProps(
+      TopicConfig.DISKLESS_ENABLE_CONFIG -> "false",
+      TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG -> "true"),
+      mutualExclusionError,
+      kafkaConfig,
+      disklessAllowFromClassic = true, remoteStorageConsolidationEnabled = false)
+
+    // NOT allowed when both flags are off
+    assertInvalid(noExisting, topicProps(
+      TopicConfig.DISKLESS_ENABLE_CONFIG -> "true",
+      TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG -> "true"),
+      mutualExclusionError,
+      kafkaConfig,
+      disklessAllowFromClassic = false, remoteStorageConsolidationEnabled = false)
+  }
+
+  @Test
   def testRemoteStorageConsolidationAtUpdate(): Unit = {
     val kafkaConfig = KafkaConfig.fromProps(TestUtils.createDummyBrokerConfig())
     val mutualExclusionError = "It is not valid to set a value for both diskless.enable and remote.storage.enable unless it's for diskless switch or consolidation."

--- a/storage/src/main/java/org/apache/kafka/storage/internals/log/LogConfig.java
+++ b/storage/src/main/java/org/apache/kafka/storage/internals/log/LogConfig.java
@@ -548,7 +548,9 @@ public class LogConfig extends AbstractConfig {
         }
 
         public boolean isDisklessConsolidationModeOnCreation() {
-            return isRemoteStorageConsolidationEnabled && isCreation() && isDisklessEnabled() && isRemoteStorageEnabled();
+            return (isRemoteStorageConsolidationEnabled || isDisklessAllowFromClassicEnabled)
+                && isCreation()
+                && isDisklessEnabled() && isRemoteStorageEnabled();
         }
 
         public boolean isValidConsolidationModeTransitionOnUpdate() {
@@ -655,7 +657,7 @@ public class LogConfig extends AbstractConfig {
         // by checking that diskless is (or will be) enabled and remote storage was and remains enabled.
         final boolean isSwitchedFromClassicWithRemoteStorage = logConfigHelper.isSwitchedFromClassicWithRemoteStorage();
         // Exception 2: when we're at creation we allow both properties to be set to true if remote storage
-        // consolidation is also enabled.
+        // consolidation OR allow-switch flag is enabled (tiered-storage-unification).
         final boolean isDisklessConsolidationOnCreation = logConfigHelper.isDisklessConsolidationModeOnCreation();
         // Exception 3: if remote log storage consolidation is enabled, and we're on an update, we allow
         // - diskless to stay enabled and remote storage to stay enabled (steady state)


### PR DESCRIPTION
Extend isDisklessConsolidationModeOnCreation() to permit topic creation with both diskless=on and remote.storage=on when either the consolidation flag OR the allow-from-classic flag is enabled. This matches the tiered storage unification semantics where allow-switch + ts-consolidation are equivalent.