### PR TITLE
fix(inkless:ci): fix RequestQuotaTest and make CI test failures visible

### DIFF
--- a/.github/workflows/inkless-nightly.yml
+++ b/.github/workflows/inkless-nightly.yml
@@ -65,13 +65,16 @@ jobs:
           set +e
           ./.github/scripts/thread-dump.sh &
           # inkless tests
-          timeout ${TIMEOUT_MINUTES}m \
+          # Wrap the whole chain in a single timeout so a hang in any suite is
+          # killed and yields exit 124, which triggers the thread-dump upload.
+          timeout ${TIMEOUT_MINUTES}m bash -c '
           ./gradlew ${GRADLE_ARGS} :storage:inkless:test :storage:inkless:integrationTest && \
           ./gradlew ${GRADLE_ARGS} :metadata:test --tests "org.apache.kafka.controller.*" && \
           ./gradlew ${GRADLE_ARGS} :core:test --tests "*Inkless*" --tests "*Diskless*" && \
           ./gradlew ${GRADLE_ARGS} :core:test --tests "kafka.server.*" && \
           ./gradlew ${GRADLE_ARGS} :core:test --tests "kafka.api.*" && \
           ./gradlew ${GRADLE_ARGS} :core:test --tests "kafka.log.*"
+          '
           exitcode="$?"
           echo "exitcode=$exitcode" >> $GITHUB_OUTPUT
       - name: Archive JUnit HTML reports

--- a/.github/workflows/inkless-nightly.yml
+++ b/.github/workflows/inkless-nightly.yml
@@ -109,7 +109,7 @@ jobs:
           THREAD_DUMP_URL: ${{ steps.thread-dump-upload-artifact.outputs.artifact-url }}
           GRADLE_TEST_EXIT_CODE: ${{ steps.junit-test.outputs.exitcode }}
         run: |
-          python .github/scripts/junit.py --path build/junit-xml/${{ matrix.java }} >> $GITHUB_STEP_SUMMARY
+          python .github/scripts/junit.py --path build/junit-xml >> $GITHUB_STEP_SUMMARY
       - name: Archive Test Catalog
         if: ${{ always() && matrix.java == '21' }}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/inkless.yml
+++ b/.github/workflows/inkless.yml
@@ -153,24 +153,28 @@ jobs:
             -x generateJooqClasses
             -PtestLoggingEvents=started,passed,skipped,failed 
             -PmaxParallelForks=2 
-            -PmaxTestRetries=0
             -PmaxQuarantineTestRetries=3 -PmaxQuarantineTestRetryFailures=0 
             -Pkafka.test.xml.output.dir=${{ matrix.java }}
             -PcommitId=xxxxxxxxxxxxxxxx
+          # Inkless-owned tests run without retries so we catch our own flakiness.
+          INKLESS_RETRY_ARGS: -PmaxTestRetries=0
+          # Kafka-owned tests are retried to tolerate known upstream flakiness.
+          KAFKA_RETRY_ARGS: -PmaxTestRetries=1 -PmaxTestRetryFailures=3
         # Point to inkless tests
         run: |
           set +e
           ./.github/scripts/thread-dump.sh &
-          # inkless tests
+          # Inkless-owned tests (no retries)
           timeout ${TIMEOUT_MINUTES}m \
-          ./gradlew ${GRADLE_ARGS} :storage:inkless:test :storage:inkless:integrationTest && \
-          ./gradlew ${GRADLE_ARGS} :metadata:test \
+          ./gradlew ${GRADLE_ARGS} ${INKLESS_RETRY_ARGS} :storage:inkless:test :storage:inkless:integrationTest && \
+          ./gradlew ${GRADLE_ARGS} ${INKLESS_RETRY_ARGS} :core:test \
+            --tests "*Inkless*" --tests "*Diskless*" \
+            --tests "io.aiven.inkless.*" && \
+          ./gradlew ${GRADLE_ARGS} ${KAFKA_RETRY_ARGS} :metadata:test \
             --tests "org.apache.kafka.controller.*" \
             --tests "org.apache.kafka.metadata.PartitionRegistrationTest" \
             --tests "org.apache.kafka.image.TopicsImageTest" && \
-          ./gradlew ${GRADLE_ARGS} :core:test \
-            --tests "*Inkless*" --tests "*Diskless*" \
-            --tests "io.aiven.inkless.*" \
+          ./gradlew ${GRADLE_ARGS} ${KAFKA_RETRY_ARGS} :core:test \
             --tests "kafka.log.LogConfigTest" \
             --tests "kafka.server.KafkaConfigTest" \
             --tests "kafka.server.ReplicaManagerTest" \
@@ -183,14 +187,15 @@ jobs:
             --tests "kafka.server.metadata.BrokerMetadataPublisherTest" \
             --tests "kafka.server.ControllerApisTest" \
             --tests "kafka.server.ControllerConfigurationValidatorTest" \
-            --tests "kafka.server.DelayedFetchTest" && \
-          ./gradlew ${GRADLE_ARGS} :clients:test \
+            --tests "kafka.server.DelayedFetchTest" \
+            --tests "kafka.server.RequestQuotaTest" && \
+          ./gradlew ${GRADLE_ARGS} ${KAFKA_RETRY_ARGS} :clients:test \
             --tests "org.apache.kafka.common.requests.RequestResponseTest" \
             --tests "org.apache.kafka.common.utils.FlattenedIteratorTest" && \
-          ./gradlew ${GRADLE_ARGS} :storage:test \
+          ./gradlew ${GRADLE_ARGS} ${KAFKA_RETRY_ARGS} :storage:test \
             --tests "org.apache.kafka.storage.log.metrics.BrokerTopicMetricsTest" \
             --tests "org.apache.kafka.storage.log.metrics.BrokerTopicStatsTest" && \
-          ./gradlew ${GRADLE_ARGS} :server:test \
+          ./gradlew ${GRADLE_ARGS} ${KAFKA_RETRY_ARGS} :server:test \
             --tests "org.apache.kafka.network.RequestConvertToJsonTest"
           exitcode="$?"
           echo "exitcode=$exitcode" >> $GITHUB_OUTPUT

--- a/.github/workflows/inkless.yml
+++ b/.github/workflows/inkless.yml
@@ -164,8 +164,10 @@ jobs:
         run: |
           set +e
           ./.github/scripts/thread-dump.sh &
+          # Wrap the whole chain in a single timeout so a hang in any suite is
+          # killed and yields exit 124, which triggers the thread-dump upload.
+          timeout ${TIMEOUT_MINUTES}m bash -c '
           # Inkless-owned tests (no retries)
-          timeout ${TIMEOUT_MINUTES}m \
           ./gradlew ${GRADLE_ARGS} ${INKLESS_RETRY_ARGS} :storage:inkless:test :storage:inkless:integrationTest && \
           ./gradlew ${GRADLE_ARGS} ${INKLESS_RETRY_ARGS} :core:test \
             --tests "*Inkless*" --tests "*Diskless*" \
@@ -197,6 +199,7 @@ jobs:
             --tests "org.apache.kafka.storage.log.metrics.BrokerTopicStatsTest" && \
           ./gradlew ${GRADLE_ARGS} ${KAFKA_RETRY_ARGS} :server:test \
             --tests "org.apache.kafka.network.RequestConvertToJsonTest"
+          '
           exitcode="$?"
           echo "exitcode=$exitcode" >> $GITHUB_OUTPUT
       - name: Archive JUnit HTML reports

--- a/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
+++ b/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
@@ -760,6 +760,9 @@ class RequestQuotaTest extends BaseRequestTest {
         case ApiKeys.DELETE_SHARE_GROUP_OFFSETS =>
           new DeleteShareGroupOffsetsRequest.Builder(new DeleteShareGroupOffsetsRequestData())
 
+        case ApiKeys.ALTER_DISKLESS_SWITCH =>
+          new AlterDisklessSwitchRequest.Builder(new AlterDisklessSwitchRequestData())
+
         case _ =>
           throw new IllegalArgumentException("Unsupported API key " + apiKey)
     }


### PR DESCRIPTION
Main CI was red with a misleading `Found 0 JUnit results` / `0 PASSED, 0 FAILED` summary despite tests actually failing.

Root cause: `:core:test` had 3 real failures in `RequestQuotaTest`, all `IllegalArgumentException: Unsupported API key ALTER_DISKLESS_SWITCH` — the test builds a request for every `ApiKeys.brokerApis` entry, but `requestBuilder` had no case for the inkless-added key (#678). The "0 tests" summary was a second bug: the nightly parse step pointed `junit.py` at `build/junit-xml/<java>`, but reports are written to `build/junit-xml/<module>/<java>`, so the glob matched nothing.

## Changes

- `fix(inkless:test)`: add the `ALTER_DISKLESS_SWITCH` case to `RequestQuotaTest.requestBuilder`.
- `fix(inkless:ci)`: point the nightly parse step at `build/junit-xml` so failures are actually reported (matches `inkless.yml`).
- `fix(inkless:ci)`: split `inkless.yml` retries by ownership — Kafka-owned suites retried (`maxTestRetries=1`), inkless-owned tests unretried so our own flakiness stays visible. Also adds `kafka.server.RequestQuotaTest` to per-PR CI so future inkless ApiKeys are guarded there, not just nightly.
- `fix(inkless:ci)`: wrap the whole test chain in a single `timeout ... bash -c` in both workflows. Previously only the first gradle call was budgeted, so a hang in a later suite ran untimed and never emitted exit `124` (which gates the thread-dump upload).

## Testing

- `./gradlew :core:test --tests kafka.server.RequestQuotaTest` — passes.
- Both workflow YAMLs validated.
