### PR TITLE
test(inkless): extract shared TopicConfigTestUtils from duplicated test helpers

### DIFF
--- a/core/src/test/java/kafka/server/DisklessAndRemoteStorageConfigsTest.java
+++ b/core/src/test/java/kafka/server/DisklessAndRemoteStorageConfigsTest.java
@@ -23,7 +23,6 @@ import org.apache.kafka.clients.admin.AlterConfigOp;
 import org.apache.kafka.clients.admin.ConfigEntry;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.common.config.ConfigResource;
-import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.apache.kafka.common.test.KafkaClusterTestKit;
 import org.apache.kafka.common.test.TestKitNodes;
 import org.apache.kafka.coordinator.group.GroupCoordinatorConfig;
@@ -42,9 +41,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 import io.aiven.inkless.config.InklessConfig;
 import io.aiven.inkless.control_plane.postgres.PostgresControlPlane;
@@ -277,7 +274,7 @@ public class DisklessAndRemoteStorageConfigsTest {
                                                String expectedDiskless,
                                                String expectedRemoteStorage) throws Exception {
         assertTrue(createTopic(admin, topic, configs).isEmpty());
-        var topicConfig = getTopicConfig(admin, topic);
+        var topicConfig = TopicConfigTestUtils.getTopicConfig(admin, topic);
         assertEquals(expectedDiskless, topicConfig.get(DISKLESS_ENABLE_CONFIG));
         assertEquals(expectedRemoteStorage, topicConfig.get(REMOTE_LOG_STORAGE_ENABLE_CONFIG));
     }
@@ -331,10 +328,8 @@ public class DisklessAndRemoteStorageConfigsTest {
                 assertTrue(incrementalAlterTopicConfig(admin, "classic-to-diskless", Map.of(
                     DISKLESS_ENABLE_CONFIG, "true")).isEmpty(),
                     "classic-to-diskless switch should succeed and auto-enable remote storage");
-                var classicConfig = getTopicConfig(admin, "classic-to-diskless");
-                assertEquals("true", classicConfig.get(DISKLESS_ENABLE_CONFIG));
-                assertEquals("true", classicConfig.get(REMOTE_LOG_STORAGE_ENABLE_CONFIG),
-                    "remote.storage.enable must be auto-enabled atomically on the switch");
+                TopicConfigTestUtils.waitForTopicConfigValue(admin, "classic-to-diskless", DISKLESS_ENABLE_CONFIG, "true");
+                TopicConfigTestUtils.waitForTopicConfigValue(admin, "classic-to-diskless", REMOTE_LOG_STORAGE_ENABLE_CONFIG, "true");
 
                 // Scenario 4b: classic-to-diskless switch setting both flags explicitly still works.
                 createTopicAndAssertEffective(admin, "classic-to-diskless-explicit", Map.of(), "false", "false");
@@ -342,9 +337,8 @@ public class DisklessAndRemoteStorageConfigsTest {
                     DISKLESS_ENABLE_CONFIG, "true",
                     REMOTE_LOG_STORAGE_ENABLE_CONFIG, "true")).isEmpty(),
                     "classic-to-diskless switch should succeed with both flags set explicitly");
-                var explicitConfig = getTopicConfig(admin, "classic-to-diskless-explicit");
-                assertEquals("true", explicitConfig.get(DISKLESS_ENABLE_CONFIG));
-                assertEquals("true", explicitConfig.get(REMOTE_LOG_STORAGE_ENABLE_CONFIG));
+                TopicConfigTestUtils.waitForTopicConfigValue(admin, "classic-to-diskless-explicit", DISKLESS_ENABLE_CONFIG, "true");
+                TopicConfigTestUtils.waitForTopicConfigValue(admin, "classic-to-diskless-explicit", REMOTE_LOG_STORAGE_ENABLE_CONFIG, "true");
 
                 // Scenario 4c: a COMPACTED classic topic cannot switch (fail-fast).
                 // A diskless topic requires remote storage, which requires cleanup.policy=delete,
@@ -357,7 +351,7 @@ public class DisklessAndRemoteStorageConfigsTest {
                 assertTrue(compactError.isPresent(), "Compacted topic switch to diskless should be rejected");
                 assertTrue(compactError.get().contains("cleanup.policy=delete"),
                     "Expected delete-policy rejection, got: " + compactError.get());
-                var stillClassic = getTopicConfig(admin, "compacted-classic");
+                var stillClassic = TopicConfigTestUtils.getTopicConfig(admin, "compacted-classic");
                 assertEquals("false", stillClassic.get(DISKLESS_ENABLE_CONFIG),
                     "Rejected switch must not have half-applied diskless.enable");
                 assertEquals("false", stillClassic.get(REMOTE_LOG_STORAGE_ENABLE_CONFIG),
@@ -370,9 +364,8 @@ public class DisklessAndRemoteStorageConfigsTest {
                     DISKLESS_ENABLE_CONFIG, "true",
                     REMOTE_LOG_STORAGE_ENABLE_CONFIG, "true")).isEmpty(),
                     "TIERED→DISKLESS switch should succeed with allow-from-classic");
-                var tieredConfig = getTopicConfig(admin, "tiered-to-diskless");
-                assertEquals("true", tieredConfig.get(DISKLESS_ENABLE_CONFIG));
-                assertEquals("true", tieredConfig.get(REMOTE_LOG_STORAGE_ENABLE_CONFIG));
+                TopicConfigTestUtils.waitForTopicConfigValue(admin, "tiered-to-diskless", DISKLESS_ENABLE_CONFIG, "true");
+                TopicConfigTestUtils.waitForTopicConfigValue(admin, "tiered-to-diskless", REMOTE_LOG_STORAGE_ENABLE_CONFIG, "true");
 
                 // Scenario 8: DISKLESS cannot disable remote storage
                 createTopicAndAssertEffective(admin, "diskless-no-disable-rs", Map.of(
@@ -470,28 +463,4 @@ public class DisklessAndRemoteStorageConfigsTest {
         }
     }
 
-    private Map<String, String> getTopicConfig(Admin admin, String topic)
-        throws ExecutionException, InterruptedException, TimeoutException {
-        int maxRetries = 3;
-        long retryDelayMs = 1000;
-        for (int attempt = 1; attempt <= maxRetries; attempt++) {
-            try {
-                var topicResource = new ConfigResource(ConfigResource.Type.TOPIC, topic);
-                var describeConfigsResult = admin.describeConfigs(Collections.singletonList(topicResource));
-                var allConfigs = describeConfigsResult.all().get(10, TimeUnit.SECONDS);
-                return allConfigs.get(topicResource).entries().stream().collect(
-                    HashMap::new,
-                    (map, entry) -> map.put(entry.name(), entry.value()),
-                    HashMap::putAll
-                );
-            } catch (ExecutionException e) {
-                if (e.getCause() instanceof UnknownTopicOrPartitionException && attempt < maxRetries) {
-                    Thread.sleep(retryDelayMs);
-                } else {
-                    throw e;
-                }
-            }
-        }
-        throw new IllegalStateException("Exited retry loop unexpectedly.");
-    }
 }

--- a/core/src/test/java/kafka/server/DisklessAndRemoteStorageConfigsTest.java
+++ b/core/src/test/java/kafka/server/DisklessAndRemoteStorageConfigsTest.java
@@ -274,7 +274,7 @@ public class DisklessAndRemoteStorageConfigsTest {
                                                String expectedDiskless,
                                                String expectedRemoteStorage) throws Exception {
         assertTrue(createTopic(admin, topic, configs).isEmpty());
-        var topicConfig = TopicConfigTestUtils.getTopicConfig(admin, topic);
+        var topicConfig = TopicMetadataProbe.configs(admin, topic);
         assertEquals(expectedDiskless, topicConfig.get(DISKLESS_ENABLE_CONFIG));
         assertEquals(expectedRemoteStorage, topicConfig.get(REMOTE_LOG_STORAGE_ENABLE_CONFIG));
     }
@@ -328,8 +328,8 @@ public class DisklessAndRemoteStorageConfigsTest {
                 assertTrue(incrementalAlterTopicConfig(admin, "classic-to-diskless", Map.of(
                     DISKLESS_ENABLE_CONFIG, "true")).isEmpty(),
                     "classic-to-diskless switch should succeed and auto-enable remote storage");
-                TopicConfigTestUtils.waitForTopicConfigValue(admin, "classic-to-diskless", DISKLESS_ENABLE_CONFIG, "true");
-                TopicConfigTestUtils.waitForTopicConfigValue(admin, "classic-to-diskless", REMOTE_LOG_STORAGE_ENABLE_CONFIG, "true");
+                TopicMetadataProbe.awaitValue(admin, "classic-to-diskless", DISKLESS_ENABLE_CONFIG, "true");
+                TopicMetadataProbe.awaitValue(admin, "classic-to-diskless", REMOTE_LOG_STORAGE_ENABLE_CONFIG, "true");
 
                 // Scenario 4b: classic-to-diskless switch setting both flags explicitly still works.
                 createTopicAndAssertEffective(admin, "classic-to-diskless-explicit", Map.of(), "false", "false");
@@ -337,8 +337,8 @@ public class DisklessAndRemoteStorageConfigsTest {
                     DISKLESS_ENABLE_CONFIG, "true",
                     REMOTE_LOG_STORAGE_ENABLE_CONFIG, "true")).isEmpty(),
                     "classic-to-diskless switch should succeed with both flags set explicitly");
-                TopicConfigTestUtils.waitForTopicConfigValue(admin, "classic-to-diskless-explicit", DISKLESS_ENABLE_CONFIG, "true");
-                TopicConfigTestUtils.waitForTopicConfigValue(admin, "classic-to-diskless-explicit", REMOTE_LOG_STORAGE_ENABLE_CONFIG, "true");
+                TopicMetadataProbe.awaitValue(admin, "classic-to-diskless-explicit", DISKLESS_ENABLE_CONFIG, "true");
+                TopicMetadataProbe.awaitValue(admin, "classic-to-diskless-explicit", REMOTE_LOG_STORAGE_ENABLE_CONFIG, "true");
 
                 // Scenario 4c: a COMPACTED classic topic cannot switch (fail-fast).
                 // A diskless topic requires remote storage, which requires cleanup.policy=delete,
@@ -351,7 +351,7 @@ public class DisklessAndRemoteStorageConfigsTest {
                 assertTrue(compactError.isPresent(), "Compacted topic switch to diskless should be rejected");
                 assertTrue(compactError.get().contains("cleanup.policy=delete"),
                     "Expected delete-policy rejection, got: " + compactError.get());
-                var stillClassic = TopicConfigTestUtils.getTopicConfig(admin, "compacted-classic");
+                var stillClassic = TopicMetadataProbe.configs(admin, "compacted-classic");
                 assertEquals("false", stillClassic.get(DISKLESS_ENABLE_CONFIG),
                     "Rejected switch must not have half-applied diskless.enable");
                 assertEquals("false", stillClassic.get(REMOTE_LOG_STORAGE_ENABLE_CONFIG),
@@ -364,8 +364,8 @@ public class DisklessAndRemoteStorageConfigsTest {
                     DISKLESS_ENABLE_CONFIG, "true",
                     REMOTE_LOG_STORAGE_ENABLE_CONFIG, "true")).isEmpty(),
                     "TIERED→DISKLESS switch should succeed with allow-from-classic");
-                TopicConfigTestUtils.waitForTopicConfigValue(admin, "tiered-to-diskless", DISKLESS_ENABLE_CONFIG, "true");
-                TopicConfigTestUtils.waitForTopicConfigValue(admin, "tiered-to-diskless", REMOTE_LOG_STORAGE_ENABLE_CONFIG, "true");
+                TopicMetadataProbe.awaitValue(admin, "tiered-to-diskless", DISKLESS_ENABLE_CONFIG, "true");
+                TopicMetadataProbe.awaitValue(admin, "tiered-to-diskless", REMOTE_LOG_STORAGE_ENABLE_CONFIG, "true");
 
                 // Scenario 8: DISKLESS cannot disable remote storage
                 createTopicAndAssertEffective(admin, "diskless-no-disable-rs", Map.of(

--- a/core/src/test/java/kafka/server/InklessConfigsTest.java
+++ b/core/src/test/java/kafka/server/InklessConfigsTest.java
@@ -163,7 +163,7 @@ public class InklessConfigsTest {
         final String disklessTopic = "disklessTopic";
         createTopic(admin, disklessTopic, Map.of(DISKLESS_ENABLE_CONFIG, "true"));
         // Then diskless.enable is set to true in the topic config
-        var disklessTopicConfig = TopicConfigTestUtils.getTopicConfig(admin, disklessTopic);
+        var disklessTopicConfig = TopicMetadataProbe.configs(admin, disklessTopic);
         assertEquals("true", disklessTopicConfig.get(DISKLESS_ENABLE_CONFIG));
         // Then it's not possible turn off diskless after the topic is created
         assertThrows(ExecutionException.class, () -> alterTopicConfig(admin, disklessTopic, Map.of(DISKLESS_ENABLE_CONFIG, "false")));
@@ -190,7 +190,7 @@ public class InklessConfigsTest {
         final String classicTopic = "classicTopic";
         createTopic(admin, classicTopic, Map.of());
         // Then diskless.enable is set to false in the topic config
-        var classicTopicConfig = TopicConfigTestUtils.getTopicConfig(admin, classicTopic);
+        var classicTopicConfig = TopicMetadataProbe.configs(admin, classicTopic);
         assertEquals("false", classicTopicConfig.get(DISKLESS_ENABLE_CONFIG));
         // Then it's not possible turn on diskless after the topic is created
         assertThrows(ExecutionException.class, () -> alterTopicConfig(admin, classicTopic, Map.of(DISKLESS_ENABLE_CONFIG, "true")));
@@ -203,7 +203,7 @@ public class InklessConfigsTest {
         final String disklessDisabledTopic = "disklessDisabledTopic";
         createTopic(admin, disklessDisabledTopic, Map.of(DISKLESS_ENABLE_CONFIG, "false"));
         // Then diskless.enable is set to false in the topic config
-        var disklessDisabledTopicConfig = TopicConfigTestUtils.getTopicConfig(admin, disklessDisabledTopic);
+        var disklessDisabledTopicConfig = TopicMetadataProbe.configs(admin, disklessDisabledTopic);
         assertEquals("false", disklessDisabledTopicConfig.get(DISKLESS_ENABLE_CONFIG));
         // Then it's not possible turn on diskless after the topic is created
         assertThrows(ExecutionException.class, () -> alterTopicConfig(admin, disklessDisabledTopic, Map.of(
@@ -230,7 +230,7 @@ public class InklessConfigsTest {
             final String disklessDisabledTopic = "disklessDisabledTopic";
             createTopic(admin, disklessDisabledTopic, Map.of(DISKLESS_ENABLE_CONFIG, "false"));
             // Then diskless.enable is set to false in the topic config
-            var disklessDisabledTopicConfig = TopicConfigTestUtils.getTopicConfig(admin, disklessDisabledTopic);
+            var disklessDisabledTopicConfig = TopicMetadataProbe.configs(admin, disklessDisabledTopic);
             assertEquals("false", disklessDisabledTopicConfig.get(DISKLESS_ENABLE_CONFIG));
             // Then it's not possible turn on diskless after the topic is created
             assertThrows(ExecutionException.class, () -> alterTopicConfig(admin, disklessDisabledTopic, Map.of(
@@ -262,17 +262,17 @@ public class InklessConfigsTest {
             try (final Admin admin = AdminClient.create(clientConfigs)) {
                 final String noRemoteConfigTopic = "classic-no-remote-config";
                 assertEquals("true", createTopicAndGetRemoteStorageFromCreateResponse(admin, noRemoteConfigTopic, Map.of()));
-                assertEquals("true", TopicConfigTestUtils.getTopicConfig(admin, noRemoteConfigTopic).get(REMOTE_LOG_STORAGE_ENABLE_CONFIG));
+                assertEquals("true", TopicMetadataProbe.configs(admin, noRemoteConfigTopic).get(REMOTE_LOG_STORAGE_ENABLE_CONFIG));
 
                 final String remoteFalseTopic = "classic-remote-false";
                 assertEquals("true", createTopicAndGetRemoteStorageFromCreateResponse(
                     admin, remoteFalseTopic, Map.of(REMOTE_LOG_STORAGE_ENABLE_CONFIG, "false")));
-                assertEquals("true", TopicConfigTestUtils.getTopicConfig(admin, remoteFalseTopic).get(REMOTE_LOG_STORAGE_ENABLE_CONFIG));
+                assertEquals("true", TopicMetadataProbe.configs(admin, remoteFalseTopic).get(REMOTE_LOG_STORAGE_ENABLE_CONFIG));
 
                 final String remoteTrueTopic = "classic-remote-true";
                 assertEquals("true", createTopicAndGetRemoteStorageFromCreateResponse(
                     admin, remoteTrueTopic, Map.of(REMOTE_LOG_STORAGE_ENABLE_CONFIG, "true")));
-                assertEquals("true", TopicConfigTestUtils.getTopicConfig(admin, remoteTrueTopic).get(REMOTE_LOG_STORAGE_ENABLE_CONFIG));
+                assertEquals("true", TopicMetadataProbe.configs(admin, remoteTrueTopic).get(REMOTE_LOG_STORAGE_ENABLE_CONFIG));
             } finally {
                 cluster.close();
             }
@@ -289,7 +289,7 @@ public class InklessConfigsTest {
                 final String compactedNoRemoteTopic = "compacted-no-remote";
                 assertEquals("false", createTopicAndGetRemoteStorageFromCreateResponse(
                     admin, compactedNoRemoteTopic, Map.of(CLEANUP_POLICY_CONFIG, CLEANUP_POLICY_COMPACT)));
-                assertEquals("false", TopicConfigTestUtils.getTopicConfig(admin, compactedNoRemoteTopic).get(REMOTE_LOG_STORAGE_ENABLE_CONFIG));
+                assertEquals("false", TopicMetadataProbe.configs(admin, compactedNoRemoteTopic).get(REMOTE_LOG_STORAGE_ENABLE_CONFIG));
 
                 // Setting remote.storage.enable=false is allowed for a compacted topic
                 final String compactedRemoteFalseTopic = "compacted-remote-false";
@@ -300,7 +300,7 @@ public class InklessConfigsTest {
                         CLEANUP_POLICY_CONFIG, CLEANUP_POLICY_COMPACT,
                         REMOTE_LOG_STORAGE_ENABLE_CONFIG, "false"
                     )));
-                assertEquals("false", TopicConfigTestUtils.getTopicConfig(admin, compactedRemoteFalseTopic).get(REMOTE_LOG_STORAGE_ENABLE_CONFIG));
+                assertEquals("false", TopicMetadataProbe.configs(admin, compactedRemoteFalseTopic).get(REMOTE_LOG_STORAGE_ENABLE_CONFIG));
 
                 // Compacted tiered topics are not supported by Kafka
                 final String compactedRemoteTrueTopic = "compacted-remote-true";
@@ -334,19 +334,19 @@ public class InklessConfigsTest {
                 // Excluded topic gets remote.storage.enable=false when not setting it
                 final String schemasTopic = "_schemas";
                 assertEquals("false", createTopicAndGetRemoteStorageFromCreateResponse(admin, schemasTopic, Map.of()));
-                assertEquals("false", TopicConfigTestUtils.getTopicConfig(admin, schemasTopic).get(REMOTE_LOG_STORAGE_ENABLE_CONFIG));
+                assertEquals("false", TopicMetadataProbe.configs(admin, schemasTopic).get(REMOTE_LOG_STORAGE_ENABLE_CONFIG));
 
                 // Setting remote.storage.enable=false is allowed for an excluded topic
                 final String mm2TopicRemoteFalse = "mm2-heartbeats";
                 assertEquals("false", createTopicAndGetRemoteStorageFromCreateResponse(
                     admin, mm2TopicRemoteFalse, Map.of(REMOTE_LOG_STORAGE_ENABLE_CONFIG, "false")));
-                assertEquals("false", TopicConfigTestUtils.getTopicConfig(admin, mm2TopicRemoteFalse).get(REMOTE_LOG_STORAGE_ENABLE_CONFIG));
+                assertEquals("false", TopicMetadataProbe.configs(admin, mm2TopicRemoteFalse).get(REMOTE_LOG_STORAGE_ENABLE_CONFIG));
 
                 // Excluded topic can still have remote.storage.enable=true if explicitly set
                 final String mm2TopicRemoteTrue = "mm2-checkpoints";
                 assertEquals("true", createTopicAndGetRemoteStorageFromCreateResponse(
                     admin, mm2TopicRemoteTrue, Map.of(REMOTE_LOG_STORAGE_ENABLE_CONFIG, "true")));
-                assertEquals("true", TopicConfigTestUtils.getTopicConfig(admin, mm2TopicRemoteTrue).get(REMOTE_LOG_STORAGE_ENABLE_CONFIG));
+                assertEquals("true", TopicMetadataProbe.configs(admin, mm2TopicRemoteTrue).get(REMOTE_LOG_STORAGE_ENABLE_CONFIG));
             } finally {
                 cluster.close();
             }
@@ -365,7 +365,7 @@ public class InklessConfigsTest {
                     compactedSchemasTopic,
                     Map.of(CLEANUP_POLICY_CONFIG, CLEANUP_POLICY_COMPACT)
                 ));
-                assertEquals("false", TopicConfigTestUtils.getTopicConfig(admin, compactedSchemasTopic).get(REMOTE_LOG_STORAGE_ENABLE_CONFIG));
+                assertEquals("false", TopicMetadataProbe.configs(admin, compactedSchemasTopic).get(REMOTE_LOG_STORAGE_ENABLE_CONFIG));
             } finally {
                 cluster.close();
             }
@@ -384,13 +384,13 @@ public class InklessConfigsTest {
             try (final Admin admin = AdminClient.create(clientConfigs)) {
                 final String topicWithoutDisklessSet = "classic-topic-no-diskless";
                 createTopic(admin, topicWithoutDisklessSet, Map.of());
-                assertEquals("false", TopicConfigTestUtils.getTopicConfig(admin, topicWithoutDisklessSet).get(DISKLESS_ENABLE_CONFIG));
+                assertEquals("false", TopicMetadataProbe.configs(admin, topicWithoutDisklessSet).get(DISKLESS_ENABLE_CONFIG));
                 assertThrows(ExecutionException.class,
                     () -> alterTopicConfig(admin, topicWithoutDisklessSet, Map.of(DISKLESS_ENABLE_CONFIG, "true")));
 
                 final String topicWithDisklessFalse = "classic-topic-diskless-false";
                 createTopic(admin, topicWithDisklessFalse, Map.of(DISKLESS_ENABLE_CONFIG, "false"));
-                assertEquals("false", TopicConfigTestUtils.getTopicConfig(admin, topicWithDisklessFalse).get(DISKLESS_ENABLE_CONFIG));
+                assertEquals("false", TopicMetadataProbe.configs(admin, topicWithDisklessFalse).get(DISKLESS_ENABLE_CONFIG));
                 assertThrows(ExecutionException.class,
                     () -> alterTopicConfig(admin, topicWithDisklessFalse, Map.of(DISKLESS_ENABLE_CONFIG, "true")));
             } finally {
@@ -407,10 +407,10 @@ public class InklessConfigsTest {
             try (final Admin admin = AdminClient.create(clientConfigs)) {
                 final String topic = "classic-topic-to-diskless";
                 createTopic(admin, topic, Map.of());
-                assertEquals("false", TopicConfigTestUtils.getTopicConfig(admin, topic).get(DISKLESS_ENABLE_CONFIG));
+                assertEquals("false", TopicMetadataProbe.configs(admin, topic).get(DISKLESS_ENABLE_CONFIG));
 
                 alterTopicConfig(admin, topic, Map.of(DISKLESS_ENABLE_CONFIG, "true"));
-                TopicConfigTestUtils.waitForTopicConfigValue(admin, topic, DISKLESS_ENABLE_CONFIG, "true");
+                TopicMetadataProbe.awaitValue(admin, topic, DISKLESS_ENABLE_CONFIG, "true");
             } finally {
                 cluster.close();
             }

--- a/core/src/test/java/kafka/server/InklessConfigsTest.java
+++ b/core/src/test/java/kafka/server/InklessConfigsTest.java
@@ -24,7 +24,6 @@ import org.apache.kafka.clients.admin.ConfigEntry;
 import org.apache.kafka.clients.admin.CreateTopicsResult;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.common.config.ConfigResource;
-import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.AlterConfigsRequest;
@@ -54,7 +53,6 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 import io.aiven.inkless.config.InklessConfig;
 import io.aiven.inkless.control_plane.postgres.PostgresControlPlane;
@@ -165,7 +163,7 @@ public class InklessConfigsTest {
         final String disklessTopic = "disklessTopic";
         createTopic(admin, disklessTopic, Map.of(DISKLESS_ENABLE_CONFIG, "true"));
         // Then diskless.enable is set to true in the topic config
-        var disklessTopicConfig = getTopicConfig(admin, disklessTopic);
+        var disklessTopicConfig = TopicConfigTestUtils.getTopicConfig(admin, disklessTopic);
         assertEquals("true", disklessTopicConfig.get(DISKLESS_ENABLE_CONFIG));
         // Then it's not possible turn off diskless after the topic is created
         assertThrows(ExecutionException.class, () -> alterTopicConfig(admin, disklessTopic, Map.of(DISKLESS_ENABLE_CONFIG, "false")));
@@ -192,7 +190,7 @@ public class InklessConfigsTest {
         final String classicTopic = "classicTopic";
         createTopic(admin, classicTopic, Map.of());
         // Then diskless.enable is set to false in the topic config
-        var classicTopicConfig = getTopicConfig(admin, classicTopic);
+        var classicTopicConfig = TopicConfigTestUtils.getTopicConfig(admin, classicTopic);
         assertEquals("false", classicTopicConfig.get(DISKLESS_ENABLE_CONFIG));
         // Then it's not possible turn on diskless after the topic is created
         assertThrows(ExecutionException.class, () -> alterTopicConfig(admin, classicTopic, Map.of(DISKLESS_ENABLE_CONFIG, "true")));
@@ -205,7 +203,7 @@ public class InklessConfigsTest {
         final String disklessDisabledTopic = "disklessDisabledTopic";
         createTopic(admin, disklessDisabledTopic, Map.of(DISKLESS_ENABLE_CONFIG, "false"));
         // Then diskless.enable is set to false in the topic config
-        var disklessDisabledTopicConfig = getTopicConfig(admin, disklessDisabledTopic);
+        var disklessDisabledTopicConfig = TopicConfigTestUtils.getTopicConfig(admin, disklessDisabledTopic);
         assertEquals("false", disklessDisabledTopicConfig.get(DISKLESS_ENABLE_CONFIG));
         // Then it's not possible turn on diskless after the topic is created
         assertThrows(ExecutionException.class, () -> alterTopicConfig(admin, disklessDisabledTopic, Map.of(
@@ -232,7 +230,7 @@ public class InklessConfigsTest {
             final String disklessDisabledTopic = "disklessDisabledTopic";
             createTopic(admin, disklessDisabledTopic, Map.of(DISKLESS_ENABLE_CONFIG, "false"));
             // Then diskless.enable is set to false in the topic config
-            var disklessDisabledTopicConfig = getTopicConfig(admin, disklessDisabledTopic);
+            var disklessDisabledTopicConfig = TopicConfigTestUtils.getTopicConfig(admin, disklessDisabledTopic);
             assertEquals("false", disklessDisabledTopicConfig.get(DISKLESS_ENABLE_CONFIG));
             // Then it's not possible turn on diskless after the topic is created
             assertThrows(ExecutionException.class, () -> alterTopicConfig(admin, disklessDisabledTopic, Map.of(
@@ -264,17 +262,17 @@ public class InklessConfigsTest {
             try (final Admin admin = AdminClient.create(clientConfigs)) {
                 final String noRemoteConfigTopic = "classic-no-remote-config";
                 assertEquals("true", createTopicAndGetRemoteStorageFromCreateResponse(admin, noRemoteConfigTopic, Map.of()));
-                assertEquals("true", getTopicConfig(admin, noRemoteConfigTopic).get(REMOTE_LOG_STORAGE_ENABLE_CONFIG));
+                assertEquals("true", TopicConfigTestUtils.getTopicConfig(admin, noRemoteConfigTopic).get(REMOTE_LOG_STORAGE_ENABLE_CONFIG));
 
                 final String remoteFalseTopic = "classic-remote-false";
                 assertEquals("true", createTopicAndGetRemoteStorageFromCreateResponse(
                     admin, remoteFalseTopic, Map.of(REMOTE_LOG_STORAGE_ENABLE_CONFIG, "false")));
-                assertEquals("true", getTopicConfig(admin, remoteFalseTopic).get(REMOTE_LOG_STORAGE_ENABLE_CONFIG));
+                assertEquals("true", TopicConfigTestUtils.getTopicConfig(admin, remoteFalseTopic).get(REMOTE_LOG_STORAGE_ENABLE_CONFIG));
 
                 final String remoteTrueTopic = "classic-remote-true";
                 assertEquals("true", createTopicAndGetRemoteStorageFromCreateResponse(
                     admin, remoteTrueTopic, Map.of(REMOTE_LOG_STORAGE_ENABLE_CONFIG, "true")));
-                assertEquals("true", getTopicConfig(admin, remoteTrueTopic).get(REMOTE_LOG_STORAGE_ENABLE_CONFIG));
+                assertEquals("true", TopicConfigTestUtils.getTopicConfig(admin, remoteTrueTopic).get(REMOTE_LOG_STORAGE_ENABLE_CONFIG));
             } finally {
                 cluster.close();
             }
@@ -291,7 +289,7 @@ public class InklessConfigsTest {
                 final String compactedNoRemoteTopic = "compacted-no-remote";
                 assertEquals("false", createTopicAndGetRemoteStorageFromCreateResponse(
                     admin, compactedNoRemoteTopic, Map.of(CLEANUP_POLICY_CONFIG, CLEANUP_POLICY_COMPACT)));
-                assertEquals("false", getTopicConfig(admin, compactedNoRemoteTopic).get(REMOTE_LOG_STORAGE_ENABLE_CONFIG));
+                assertEquals("false", TopicConfigTestUtils.getTopicConfig(admin, compactedNoRemoteTopic).get(REMOTE_LOG_STORAGE_ENABLE_CONFIG));
 
                 // Setting remote.storage.enable=false is allowed for a compacted topic
                 final String compactedRemoteFalseTopic = "compacted-remote-false";
@@ -302,7 +300,7 @@ public class InklessConfigsTest {
                         CLEANUP_POLICY_CONFIG, CLEANUP_POLICY_COMPACT,
                         REMOTE_LOG_STORAGE_ENABLE_CONFIG, "false"
                     )));
-                assertEquals("false", getTopicConfig(admin, compactedRemoteFalseTopic).get(REMOTE_LOG_STORAGE_ENABLE_CONFIG));
+                assertEquals("false", TopicConfigTestUtils.getTopicConfig(admin, compactedRemoteFalseTopic).get(REMOTE_LOG_STORAGE_ENABLE_CONFIG));
 
                 // Compacted tiered topics are not supported by Kafka
                 final String compactedRemoteTrueTopic = "compacted-remote-true";
@@ -336,19 +334,19 @@ public class InklessConfigsTest {
                 // Excluded topic gets remote.storage.enable=false when not setting it
                 final String schemasTopic = "_schemas";
                 assertEquals("false", createTopicAndGetRemoteStorageFromCreateResponse(admin, schemasTopic, Map.of()));
-                assertEquals("false", getTopicConfig(admin, schemasTopic).get(REMOTE_LOG_STORAGE_ENABLE_CONFIG));
+                assertEquals("false", TopicConfigTestUtils.getTopicConfig(admin, schemasTopic).get(REMOTE_LOG_STORAGE_ENABLE_CONFIG));
 
                 // Setting remote.storage.enable=false is allowed for an excluded topic
                 final String mm2TopicRemoteFalse = "mm2-heartbeats";
                 assertEquals("false", createTopicAndGetRemoteStorageFromCreateResponse(
                     admin, mm2TopicRemoteFalse, Map.of(REMOTE_LOG_STORAGE_ENABLE_CONFIG, "false")));
-                assertEquals("false", getTopicConfig(admin, mm2TopicRemoteFalse).get(REMOTE_LOG_STORAGE_ENABLE_CONFIG));
+                assertEquals("false", TopicConfigTestUtils.getTopicConfig(admin, mm2TopicRemoteFalse).get(REMOTE_LOG_STORAGE_ENABLE_CONFIG));
 
                 // Excluded topic can still have remote.storage.enable=true if explicitly set
                 final String mm2TopicRemoteTrue = "mm2-checkpoints";
                 assertEquals("true", createTopicAndGetRemoteStorageFromCreateResponse(
                     admin, mm2TopicRemoteTrue, Map.of(REMOTE_LOG_STORAGE_ENABLE_CONFIG, "true")));
-                assertEquals("true", getTopicConfig(admin, mm2TopicRemoteTrue).get(REMOTE_LOG_STORAGE_ENABLE_CONFIG));
+                assertEquals("true", TopicConfigTestUtils.getTopicConfig(admin, mm2TopicRemoteTrue).get(REMOTE_LOG_STORAGE_ENABLE_CONFIG));
             } finally {
                 cluster.close();
             }
@@ -367,7 +365,7 @@ public class InklessConfigsTest {
                     compactedSchemasTopic,
                     Map.of(CLEANUP_POLICY_CONFIG, CLEANUP_POLICY_COMPACT)
                 ));
-                assertEquals("false", getTopicConfig(admin, compactedSchemasTopic).get(REMOTE_LOG_STORAGE_ENABLE_CONFIG));
+                assertEquals("false", TopicConfigTestUtils.getTopicConfig(admin, compactedSchemasTopic).get(REMOTE_LOG_STORAGE_ENABLE_CONFIG));
             } finally {
                 cluster.close();
             }
@@ -386,13 +384,13 @@ public class InklessConfigsTest {
             try (final Admin admin = AdminClient.create(clientConfigs)) {
                 final String topicWithoutDisklessSet = "classic-topic-no-diskless";
                 createTopic(admin, topicWithoutDisklessSet, Map.of());
-                assertEquals("false", getTopicConfig(admin, topicWithoutDisklessSet).get(DISKLESS_ENABLE_CONFIG));
+                assertEquals("false", TopicConfigTestUtils.getTopicConfig(admin, topicWithoutDisklessSet).get(DISKLESS_ENABLE_CONFIG));
                 assertThrows(ExecutionException.class,
                     () -> alterTopicConfig(admin, topicWithoutDisklessSet, Map.of(DISKLESS_ENABLE_CONFIG, "true")));
 
                 final String topicWithDisklessFalse = "classic-topic-diskless-false";
                 createTopic(admin, topicWithDisklessFalse, Map.of(DISKLESS_ENABLE_CONFIG, "false"));
-                assertEquals("false", getTopicConfig(admin, topicWithDisklessFalse).get(DISKLESS_ENABLE_CONFIG));
+                assertEquals("false", TopicConfigTestUtils.getTopicConfig(admin, topicWithDisklessFalse).get(DISKLESS_ENABLE_CONFIG));
                 assertThrows(ExecutionException.class,
                     () -> alterTopicConfig(admin, topicWithDisklessFalse, Map.of(DISKLESS_ENABLE_CONFIG, "true")));
             } finally {
@@ -409,10 +407,10 @@ public class InklessConfigsTest {
             try (final Admin admin = AdminClient.create(clientConfigs)) {
                 final String topic = "classic-topic-to-diskless";
                 createTopic(admin, topic, Map.of());
-                assertEquals("false", getTopicConfig(admin, topic).get(DISKLESS_ENABLE_CONFIG));
+                assertEquals("false", TopicConfigTestUtils.getTopicConfig(admin, topic).get(DISKLESS_ENABLE_CONFIG));
 
                 alterTopicConfig(admin, topic, Map.of(DISKLESS_ENABLE_CONFIG, "true"));
-                assertEquals("true", getTopicConfig(admin, topic).get(DISKLESS_ENABLE_CONFIG));
+                TopicConfigTestUtils.waitForTopicConfigValue(admin, topic, DISKLESS_ENABLE_CONFIG, "true");
             } finally {
                 cluster.close();
             }
@@ -503,41 +501,6 @@ public class InklessConfigsTest {
             .get(REMOTE_LOG_STORAGE_ENABLE_CONFIG);
         assertNotNull(remoteStorageConfig);
         return remoteStorageConfig.value();
-    }
-
-    private Map<String, String> getTopicConfig(Admin admin, String topic)
-        throws ExecutionException, InterruptedException, TimeoutException {
-        int maxRetries = 3;
-        long retryDelayMs = 1000; // 1 second
-
-        for (int attempt = 1; attempt <= maxRetries; attempt++) {
-            try {
-                var topicResource = new ConfigResource(ConfigResource.Type.TOPIC, topic);
-                var describeConfigsResult = admin.describeConfigs(Collections.singletonList(topicResource));
-                var allConfigs = describeConfigsResult.all().get(10, TimeUnit.SECONDS);
-
-                return allConfigs
-                    .get(topicResource).entries().stream()
-                    .collect(
-                        HashMap::new,
-                        (map, entry) -> map.put(entry.name(), entry.value()),
-                        HashMap::putAll
-                    );
-            } catch (ExecutionException e) {
-                if (e.getCause() instanceof UnknownTopicOrPartitionException) {
-                    System.err.println(
-                        "Attempt " + attempt + " failed: " + e.getCause().getMessage() + ". Retrying..."
-                    );
-                    if (attempt == maxRetries) {
-                        throw e;
-                    }
-                    Thread.sleep(retryDelayMs);
-                } else {
-                    throw e;
-                }
-            }
-        }
-        throw new IllegalStateException("Exited retry loop unexpectedly.");
     }
 
     private void alterTopicConfig(Admin admin, String topic, Map<String, String> newConfigs) throws Exception {

--- a/core/src/test/java/kafka/server/InklessConsolidatedDisklessTopicsTest.java
+++ b/core/src/test/java/kafka/server/InklessConsolidatedDisklessTopicsTest.java
@@ -290,9 +290,9 @@ public class InklessConsolidatedDisklessTopicsTest {
         try (Admin admin = AdminClient.create(commonConfigs)) {
             // Phase 1: create a CLASSIC topic (diskless.enable=false, remote.storage.enable=false).
             topicUuid = createClassicTopic(admin);
-            assertEquals("false", TopicConfigTestUtils.getTopicConfigValue(admin, topicName, DISKLESS_ENABLE_CONFIG),
+            assertEquals("false", TopicMetadataProbe.readValue(admin, topicName, DISKLESS_ENABLE_CONFIG),
                 "Topic should start as a classic (non-diskless) topic");
-            assertEquals("false", TopicConfigTestUtils.getTopicConfigValue(admin, topicName, REMOTE_LOG_STORAGE_ENABLE_CONFIG),
+            assertEquals("false", TopicMetadataProbe.readValue(admin, topicName, REMOTE_LOG_STORAGE_ENABLE_CONFIG),
                 "Classic topic should not have remote storage enabled");
 
             // Produce a baseline of records into the classic topic. These offsets form the classic
@@ -318,8 +318,8 @@ public class InklessConsolidatedDisklessTopicsTest {
             try {
                 log.info("Migrating classic topic {} to diskless (remote storage auto-enabled atomically)", topicName);
                 incrementalAlterTopicConfigs(admin, Map.of(DISKLESS_ENABLE_CONFIG, "true"));
-                TopicConfigTestUtils.waitForTopicConfigValue(admin, topicName, DISKLESS_ENABLE_CONFIG, "true");
-                TopicConfigTestUtils.waitForTopicConfigValue(admin, topicName, REMOTE_LOG_STORAGE_ENABLE_CONFIG, "true");
+                TopicMetadataProbe.awaitValue(admin, topicName, DISKLESS_ENABLE_CONFIG, "true");
+                TopicMetadataProbe.awaitValue(admin, topicName, REMOTE_LOG_STORAGE_ENABLE_CONFIG, "true");
             } finally {
                 producerThread.join(TimeUnit.SECONDS.toMillis(120));
                 // If the producer is still running (e.g. a send blocked), interrupt it so it unwinds
@@ -334,9 +334,9 @@ public class InklessConsolidatedDisklessTopicsTest {
                 throw new RuntimeException("Producer failed while the topic was being consolidated", producerFailure.get());
             }
 
-            assertEquals("true", TopicConfigTestUtils.getTopicConfigValue(admin, topicName, DISKLESS_ENABLE_CONFIG),
+            assertEquals("true", TopicMetadataProbe.readValue(admin, topicName, DISKLESS_ENABLE_CONFIG),
                 "Topic should be diskless after the switch");
-            assertEquals("true", TopicConfigTestUtils.getTopicConfigValue(admin, topicName, REMOTE_LOG_STORAGE_ENABLE_CONFIG),
+            assertEquals("true", TopicMetadataProbe.readValue(admin, topicName, REMOTE_LOG_STORAGE_ENABLE_CONFIG),
                 "Switch should auto-enable remote storage atomically (consolidated diskless topic)");
         }
 

--- a/core/src/test/java/kafka/server/InklessConsolidatedDisklessTopicsTest.java
+++ b/core/src/test/java/kafka/server/InklessConsolidatedDisklessTopicsTest.java
@@ -20,7 +20,6 @@ import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AlterConfigOp;
-import org.apache.kafka.clients.admin.Config;
 import org.apache.kafka.clients.admin.ConfigEntry;
 import org.apache.kafka.clients.admin.CreateTopicsResult;
 import org.apache.kafka.clients.admin.ListOffsetsResult;
@@ -49,7 +48,6 @@ import org.apache.kafka.server.config.ServerConfigs;
 import org.apache.kafka.server.log.remote.metadata.storage.TopicBasedRemoteLogMetadataManager;
 import org.apache.kafka.server.log.remote.metadata.storage.TopicBasedRemoteLogMetadataManagerConfig;
 import org.apache.kafka.server.log.remote.storage.RemoteLogManagerConfig;
-import org.apache.kafka.test.NoRetryException;
 import org.apache.kafka.test.TestUtils;
 
 import org.junit.jupiter.api.AfterEach;
@@ -292,9 +290,9 @@ public class InklessConsolidatedDisklessTopicsTest {
         try (Admin admin = AdminClient.create(commonConfigs)) {
             // Phase 1: create a CLASSIC topic (diskless.enable=false, remote.storage.enable=false).
             topicUuid = createClassicTopic(admin);
-            assertEquals("false", getTopicConfigValue(admin, DISKLESS_ENABLE_CONFIG),
+            assertEquals("false", TopicConfigTestUtils.getTopicConfigValue(admin, topicName, DISKLESS_ENABLE_CONFIG),
                 "Topic should start as a classic (non-diskless) topic");
-            assertEquals("false", getTopicConfigValue(admin, REMOTE_LOG_STORAGE_ENABLE_CONFIG),
+            assertEquals("false", TopicConfigTestUtils.getTopicConfigValue(admin, topicName, REMOTE_LOG_STORAGE_ENABLE_CONFIG),
                 "Classic topic should not have remote storage enabled");
 
             // Produce a baseline of records into the classic topic. These offsets form the classic
@@ -320,8 +318,8 @@ public class InklessConsolidatedDisklessTopicsTest {
             try {
                 log.info("Migrating classic topic {} to diskless (remote storage auto-enabled atomically)", topicName);
                 incrementalAlterTopicConfigs(admin, Map.of(DISKLESS_ENABLE_CONFIG, "true"));
-                waitForTopicConfigValue(admin, DISKLESS_ENABLE_CONFIG, "true");
-                waitForTopicConfigValue(admin, REMOTE_LOG_STORAGE_ENABLE_CONFIG, "true");
+                TopicConfigTestUtils.waitForTopicConfigValue(admin, topicName, DISKLESS_ENABLE_CONFIG, "true");
+                TopicConfigTestUtils.waitForTopicConfigValue(admin, topicName, REMOTE_LOG_STORAGE_ENABLE_CONFIG, "true");
             } finally {
                 producerThread.join(TimeUnit.SECONDS.toMillis(120));
                 // If the producer is still running (e.g. a send blocked), interrupt it so it unwinds
@@ -336,9 +334,9 @@ public class InklessConsolidatedDisklessTopicsTest {
                 throw new RuntimeException("Producer failed while the topic was being consolidated", producerFailure.get());
             }
 
-            assertEquals("true", getTopicConfigValue(admin, DISKLESS_ENABLE_CONFIG),
+            assertEquals("true", TopicConfigTestUtils.getTopicConfigValue(admin, topicName, DISKLESS_ENABLE_CONFIG),
                 "Topic should be diskless after the switch");
-            assertEquals("true", getTopicConfigValue(admin, REMOTE_LOG_STORAGE_ENABLE_CONFIG),
+            assertEquals("true", TopicConfigTestUtils.getTopicConfigValue(admin, topicName, REMOTE_LOG_STORAGE_ENABLE_CONFIG),
                 "Switch should auto-enable remote storage atomically (consolidated diskless topic)");
         }
 
@@ -405,43 +403,6 @@ public class InklessConsolidatedDisklessTopicsTest {
         admin.incrementalAlterConfigs(Map.of(resource, ops)).all().get(30, TimeUnit.SECONDS);
     }
 
-    private String getTopicConfigValue(Admin admin, String key)
-        throws ExecutionException, InterruptedException, TimeoutException {
-        final ConfigResource resource = new ConfigResource(ConfigResource.Type.TOPIC, topicName);
-        // Shorter timeout because this is invoked from polling loops (waitForTopicConfigValue).
-        final Config config = admin.describeConfigs(Collections.singletonList(resource))
-            .all().get(10, TimeUnit.SECONDS)
-            .get(resource);
-        if (config == null) {
-            throw new IllegalStateException("describeConfigs returned no config for topic " + topicName);
-        }
-        final ConfigEntry entry = config.get(key);
-        if (entry == null) {
-            throw new IllegalStateException("Config '" + key + "' is missing for topic " + topicName);
-        }
-        return entry.value();
-    }
-
-    private void waitForTopicConfigValue(Admin admin, String key, String expectedValue) throws InterruptedException {
-        TestUtils.waitForCondition(() -> {
-            try {
-                return expectedValue.equals(getTopicConfigValue(admin, key));
-            } catch (ExecutionException e) {
-                // Right after create/alter the topic metadata may not have propagated to the broker serving
-                // the describeConfigs request yet; that is the only case worth retrying.
-                if (e.getCause() instanceof UnknownTopicOrPartitionException) {
-                    return false;
-                }
-                throw new NoRetryException(e.getCause() != null ? e.getCause() : e);
-            } catch (TimeoutException e) {
-                // A describeConfigs request timing out is transient under load; keep polling.
-                return false;
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                throw new NoRetryException(e);
-            }
-        }, 60_000, () -> "Topic config " + key + " should become " + expectedValue);
-    }
 
     /**
      * Queries {@link OffsetSpec#earliest()} via the admin client (same basis as consumer

--- a/core/src/test/java/kafka/server/InklessTopicTypeSwitcherClusterTest.java
+++ b/core/src/test/java/kafka/server/InklessTopicTypeSwitcherClusterTest.java
@@ -68,7 +68,6 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -197,9 +196,9 @@ public class InklessTopicTypeSwitcherClusterTest {
             createTopics.all().get(30, TimeUnit.SECONDS);
             log.warn("[stage=topics-created] Created all topics");
 
-            assertEquals("true", getTopicConfig(admin, disklessTopic).get(TopicConfig.DISKLESS_ENABLE_CONFIG));
-            assertEquals("false", getTopicConfig(admin, classicTopic).get(TopicConfig.DISKLESS_ENABLE_CONFIG));
-            assertEquals("false", getTopicConfig(admin, classicToDisklessTopic).get(TopicConfig.DISKLESS_ENABLE_CONFIG));
+            TopicConfigTestUtils.waitForTopicConfigValue(admin, disklessTopic, TopicConfig.DISKLESS_ENABLE_CONFIG, "true");
+            TopicConfigTestUtils.waitForTopicConfigValue(admin, classicTopic, TopicConfig.DISKLESS_ENABLE_CONFIG, "false");
+            TopicConfigTestUtils.waitForTopicConfigValue(admin, classicToDisklessTopic, TopicConfig.DISKLESS_ENABLE_CONFIG, "false");
 
             final AtomicBoolean keepProducing = new AtomicBoolean(true);
             final AtomicReference<Throwable> producerFailure = new AtomicReference<>(null);
@@ -229,7 +228,7 @@ public class InklessTopicTypeSwitcherClusterTest {
                 alterTopicConfig(admin, classicToDisklessTopic, Map.of(TopicConfig.DISKLESS_ENABLE_CONFIG, "true"), alterConfigsMode);
 
                 log.warn("[stage=await-switch] Waiting for diskless.enable=true on topic={}", classicToDisklessTopic);
-                waitForTopicDisklessValue(admin, classicToDisklessTopic, "true");
+                TopicConfigTestUtils.waitForTopicConfigValue(admin, classicToDisklessTopic, TopicConfig.DISKLESS_ENABLE_CONFIG, "true");
             } finally {
                 keepProducing.set(false);
                 producerThread.join(TimeUnit.SECONDS.toMillis(60));
@@ -245,9 +244,9 @@ public class InklessTopicTypeSwitcherClusterTest {
                 produceRounds(producer, topics, producedCounts, 1, true);
             }
 
-            assertEquals("true", getTopicConfig(admin, disklessTopic).get(TopicConfig.DISKLESS_ENABLE_CONFIG));
-            assertEquals("false", getTopicConfig(admin, classicTopic).get(TopicConfig.DISKLESS_ENABLE_CONFIG));
-            assertEquals("true", getTopicConfig(admin, classicToDisklessTopic).get(TopicConfig.DISKLESS_ENABLE_CONFIG));
+            TopicConfigTestUtils.waitForTopicConfigValue(admin, disklessTopic, TopicConfig.DISKLESS_ENABLE_CONFIG, "true");
+            TopicConfigTestUtils.waitForTopicConfigValue(admin, classicTopic, TopicConfig.DISKLESS_ENABLE_CONFIG, "false");
+            TopicConfigTestUtils.waitForTopicConfigValue(admin, classicToDisklessTopic, TopicConfig.DISKLESS_ENABLE_CONFIG, "true");
             log.warn("[stage=post-switch-validated] Topic configurations and placement checks passed");
         }
 
@@ -369,20 +368,6 @@ public class InklessTopicTypeSwitcherClusterTest {
         return true;
     }
 
-    private void waitForTopicDisklessValue(final Admin admin,
-                                           final String topic,
-                                           final String expectedValue) throws Exception {
-        final long deadline = System.currentTimeMillis() + Duration.ofSeconds(60).toMillis();
-        while (System.currentTimeMillis() < deadline) {
-            final String disklessValue = getTopicConfig(admin, topic).get(TopicConfig.DISKLESS_ENABLE_CONFIG);
-            if (expectedValue.equals(disklessValue)) {
-                return;
-            }
-            Thread.sleep(500);
-        }
-        assertEquals(expectedValue, getTopicConfig(admin, topic).get(TopicConfig.DISKLESS_ENABLE_CONFIG));
-    }
-
     private void alterTopicConfig(final Admin admin,
                                   final String topic,
                                   final Map<String, String> newConfigs,
@@ -438,7 +423,7 @@ public class InklessTopicTypeSwitcherClusterTest {
 
             // Now the switch should succeed
             alterTopicConfigWithIncrementalAlterConfigs(admin, topic, Map.of(TopicConfig.DISKLESS_ENABLE_CONFIG, "true"));
-            waitForTopicDisklessValue(admin, topic, "true");
+            TopicConfigTestUtils.waitForTopicConfigValue(admin, topic, TopicConfig.DISKLESS_ENABLE_CONFIG, "true");
         }
     }
 
@@ -521,6 +506,10 @@ public class InklessTopicTypeSwitcherClusterTest {
                 new NewTopic(topic, 1, (short) 3)
                     .configs(Map.of(TopicConfig.DISKLESS_ENABLE_CONFIG, "false"))
             )).all().get(30, TimeUnit.SECONDS);
+            // createTopics returns once the controller commits the topic, but metadata propagation
+            // to brokers is asynchronous. Wait for the topic to be visible before polling the seal
+            // offset so readSealOffset doesn't mask a genuinely missing topic as a transient delay.
+            TopicConfigTestUtils.waitForTopicToExist(admin, topic);
             waitForSealOffset(admin, topic, 0,
                 offset -> offset == PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET);
 
@@ -647,26 +636,5 @@ public class InklessTopicTypeSwitcherClusterTest {
         }
         throw new AssertionError("ISR for " + topic + "-" + partition +
             " did not recover to " + expectedIsrSize + " within timeout");
-    }
-
-    private Map<String, String> getTopicConfig(final Admin admin, final String topic) throws Exception {
-        int maxRetries = 5;
-        long retryDelayMs = 1000;
-        for (int attempt = 1; attempt <= maxRetries; attempt++) {
-            try {
-                final ConfigResource topicResource = new ConfigResource(ConfigResource.Type.TOPIC, topic);
-                final var configsResult = admin.describeConfigs(Collections.singletonList(topicResource));
-                final var allConfigs = configsResult.all().get(10, TimeUnit.SECONDS);
-                final Map<String, String> topicConfigs = new HashMap<>();
-                allConfigs.get(topicResource).entries().forEach(entry -> topicConfigs.put(entry.name(), entry.value()));
-                return topicConfigs;
-            } catch (ExecutionException e) {
-                if (attempt == maxRetries) {
-                    throw e;
-                }
-                Thread.sleep(retryDelayMs);
-            }
-        }
-        throw new IllegalStateException("Exited retry loop unexpectedly.");
     }
 }

--- a/core/src/test/java/kafka/server/InklessTopicTypeSwitcherClusterTest.java
+++ b/core/src/test/java/kafka/server/InklessTopicTypeSwitcherClusterTest.java
@@ -196,9 +196,9 @@ public class InklessTopicTypeSwitcherClusterTest {
             createTopics.all().get(30, TimeUnit.SECONDS);
             log.warn("[stage=topics-created] Created all topics");
 
-            TopicConfigTestUtils.waitForTopicConfigValue(admin, disklessTopic, TopicConfig.DISKLESS_ENABLE_CONFIG, "true");
-            TopicConfigTestUtils.waitForTopicConfigValue(admin, classicTopic, TopicConfig.DISKLESS_ENABLE_CONFIG, "false");
-            TopicConfigTestUtils.waitForTopicConfigValue(admin, classicToDisklessTopic, TopicConfig.DISKLESS_ENABLE_CONFIG, "false");
+            TopicMetadataProbe.awaitValue(admin, disklessTopic, TopicConfig.DISKLESS_ENABLE_CONFIG, "true");
+            TopicMetadataProbe.awaitValue(admin, classicTopic, TopicConfig.DISKLESS_ENABLE_CONFIG, "false");
+            TopicMetadataProbe.awaitValue(admin, classicToDisklessTopic, TopicConfig.DISKLESS_ENABLE_CONFIG, "false");
 
             final AtomicBoolean keepProducing = new AtomicBoolean(true);
             final AtomicReference<Throwable> producerFailure = new AtomicReference<>(null);
@@ -228,7 +228,7 @@ public class InklessTopicTypeSwitcherClusterTest {
                 alterTopicConfig(admin, classicToDisklessTopic, Map.of(TopicConfig.DISKLESS_ENABLE_CONFIG, "true"), alterConfigsMode);
 
                 log.warn("[stage=await-switch] Waiting for diskless.enable=true on topic={}", classicToDisklessTopic);
-                TopicConfigTestUtils.waitForTopicConfigValue(admin, classicToDisklessTopic, TopicConfig.DISKLESS_ENABLE_CONFIG, "true");
+                TopicMetadataProbe.awaitValue(admin, classicToDisklessTopic, TopicConfig.DISKLESS_ENABLE_CONFIG, "true");
             } finally {
                 keepProducing.set(false);
                 producerThread.join(TimeUnit.SECONDS.toMillis(60));
@@ -244,9 +244,9 @@ public class InklessTopicTypeSwitcherClusterTest {
                 produceRounds(producer, topics, producedCounts, 1, true);
             }
 
-            TopicConfigTestUtils.waitForTopicConfigValue(admin, disklessTopic, TopicConfig.DISKLESS_ENABLE_CONFIG, "true");
-            TopicConfigTestUtils.waitForTopicConfigValue(admin, classicTopic, TopicConfig.DISKLESS_ENABLE_CONFIG, "false");
-            TopicConfigTestUtils.waitForTopicConfigValue(admin, classicToDisklessTopic, TopicConfig.DISKLESS_ENABLE_CONFIG, "true");
+            TopicMetadataProbe.awaitValue(admin, disklessTopic, TopicConfig.DISKLESS_ENABLE_CONFIG, "true");
+            TopicMetadataProbe.awaitValue(admin, classicTopic, TopicConfig.DISKLESS_ENABLE_CONFIG, "false");
+            TopicMetadataProbe.awaitValue(admin, classicToDisklessTopic, TopicConfig.DISKLESS_ENABLE_CONFIG, "true");
             log.warn("[stage=post-switch-validated] Topic configurations and placement checks passed");
         }
 
@@ -423,7 +423,7 @@ public class InklessTopicTypeSwitcherClusterTest {
 
             // Now the switch should succeed
             alterTopicConfigWithIncrementalAlterConfigs(admin, topic, Map.of(TopicConfig.DISKLESS_ENABLE_CONFIG, "true"));
-            TopicConfigTestUtils.waitForTopicConfigValue(admin, topic, TopicConfig.DISKLESS_ENABLE_CONFIG, "true");
+            TopicMetadataProbe.awaitValue(admin, topic, TopicConfig.DISKLESS_ENABLE_CONFIG, "true");
         }
     }
 
@@ -509,7 +509,7 @@ public class InklessTopicTypeSwitcherClusterTest {
             // createTopics returns once the controller commits the topic, but metadata propagation
             // to brokers is asynchronous. Wait for the topic to be visible before polling the seal
             // offset so readSealOffset doesn't mask a genuinely missing topic as a transient delay.
-            TopicConfigTestUtils.waitForTopicToExist(admin, topic);
+            TopicMetadataProbe.awaitVisible(admin, topic);
             waitForSealOffset(admin, topic, 0,
                 offset -> offset == PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET);
 

--- a/core/src/test/java/kafka/server/TopicConfigTestUtils.java
+++ b/core/src/test/java/kafka/server/TopicConfigTestUtils.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.server;
+
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.common.config.ConfigResource;
+import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
+import org.apache.kafka.common.message.DescribeTopicPartitionsResponseData;
+import org.apache.kafka.test.NoRetryException;
+import org.apache.kafka.test.TestUtils;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Shared helpers for reading and polling topic configuration via {@link Admin} in integration tests.
+ *
+ * <p>After {@code createTopics} or {@code incrementalAlterConfigs} returns, the controller has
+ * committed the change, but the broker's metadata cache may still serve the stale value (or
+ * {@link UnknownTopicOrPartitionException}) to a subsequent {@code describeConfigs} call. The
+ * helpers here retry on that transient case and (for {@link #waitForTopicConfigValue}) poll until
+ * the value converges.
+ */
+public final class TopicConfigTestUtils {
+
+    private TopicConfigTestUtils() {
+    }
+
+    /**
+     * Read all config entries for a topic via {@code describeConfigs}. Retries up to 3 times
+     * (1s delay) on {@link UnknownTopicOrPartitionException} to ride out metadata propagation
+     * delays after topic creation or config alteration.
+     */
+    public static Map<String, String> getTopicConfig(Admin admin, String topic)
+            throws ExecutionException, InterruptedException, TimeoutException {
+        final int maxRetries = 3;
+        final long retryDelayMs = 1000;
+        for (int attempt = 1; attempt <= maxRetries; attempt++) {
+            try {
+                final ConfigResource resource = new ConfigResource(ConfigResource.Type.TOPIC, topic);
+                final var config = admin.describeConfigs(Collections.singletonList(resource))
+                    .all().get(10, TimeUnit.SECONDS)
+                    .get(resource);
+                if (config == null) {
+                    throw new IllegalStateException("describeConfigs returned no config for topic " + topic);
+                }
+                final Map<String, String> configs = new HashMap<>();
+                config.entries().forEach(entry -> configs.put(entry.name(), entry.value()));
+                return configs;
+            } catch (ExecutionException e) {
+                if (e.getCause() instanceof UnknownTopicOrPartitionException && attempt < maxRetries) {
+                    Thread.sleep(retryDelayMs);
+                } else {
+                    throw e;
+                }
+            }
+        }
+        throw new IllegalStateException("Exited retry loop unexpectedly.");
+    }
+
+    /**
+     * Read a single topic config value via {@code describeConfigs}. Retries on transient
+     * {@link UnknownTopicOrPartitionException} (see {@link #getTopicConfig}).
+     *
+     * @throws IllegalStateException if the config {@code key} is absent for the topic (unlike
+     *         {@code getTopicConfig(...).get(key)}, which returns {@code null} in that case)
+     */
+    public static String getTopicConfigValue(Admin admin, String topic, String key)
+            throws ExecutionException, InterruptedException, TimeoutException {
+        final String value = getTopicConfig(admin, topic).get(key);
+        if (value == null) {
+            throw new IllegalStateException("Config '" + key + "' is missing for topic " + topic);
+        }
+        return value;
+    }
+
+    /**
+     * Poll until the given topic config {@code key} reaches {@code expectedValue}.
+     *
+     * <p>After {@code createTopics} or {@code incrementalAlterConfigs} returns, the controller has
+     * committed the change but the broker's metadata cache may still serve the old value. This
+     * method polls (60s deadline) until the value converges, treating
+     * {@link UnknownTopicOrPartitionException} and {@link TimeoutException} as transient.
+     */
+    public static void waitForTopicConfigValue(Admin admin, String topic, String key, String expectedValue)
+            throws InterruptedException {
+        TestUtils.waitForCondition(() -> {
+            try {
+                return expectedValue.equals(getTopicConfigValue(admin, topic, key));
+            } catch (ExecutionException e) {
+                if (e.getCause() instanceof UnknownTopicOrPartitionException) {
+                    return false;
+                }
+                throw new NoRetryException(e.getCause() != null ? e.getCause() : e);
+            } catch (TimeoutException e) {
+                return false;
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new NoRetryException(e);
+            }
+        }, 60_000, () -> "Topic config " + key + " for topic " + topic + " should become " + expectedValue);
+    }
+
+    /**
+     * Wait until the topic is visible in the broker metadata. {@code createTopics} returns once
+     * the controller has committed the topic, but the metadata propagates to brokers asynchronously.
+     * Until propagation completes, {@code describeTopicPartitions} fails with
+     * {@link UnknownTopicOrPartitionException}. This method polls (30s deadline) until the
+     * topic is visible, treating {@link UnknownTopicOrPartitionException} and
+     * {@link TimeoutException} as transient.
+     */
+    public static void waitForTopicToExist(Admin admin, String topic) throws InterruptedException {
+        TestUtils.waitForCondition(() -> {
+            try {
+                final DescribeTopicPartitionsResponseData responseData =
+                    admin.describeTopicPartitions(List.of(topic)).rawResponse().get(10, TimeUnit.SECONDS);
+                return responseData.topics().find(topic) != null;
+            } catch (ExecutionException e) {
+                if (e.getCause() instanceof UnknownTopicOrPartitionException) {
+                    return false;
+                }
+                throw new NoRetryException(e.getCause() != null ? e.getCause() : e);
+            } catch (TimeoutException e) {
+                return false;
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new NoRetryException(e);
+            }
+        }, 30_000, () -> "Topic " + topic + " was not visible in broker metadata within 30s");
+    }
+}

--- a/core/src/test/java/kafka/server/TopicConfigTestUtils.java
+++ b/core/src/test/java/kafka/server/TopicConfigTestUtils.java
@@ -34,10 +34,12 @@ import java.util.concurrent.TimeoutException;
 /**
  * Shared helpers for reading and polling topic configuration via {@link Admin} in integration tests.
  *
- * <p>After {@code createTopics} or {@code incrementalAlterConfigs} returns, the controller has
- * committed the change, but the broker's metadata cache may still serve the stale value (or
- * {@link UnknownTopicOrPartitionException}) to a subsequent {@code describeConfigs} call. The
- * helpers here retry on that transient case and (for {@link #waitForTopicConfigValue}) poll until
+ * <p>After {@code createTopics} returns, the controller has committed the topic, but the
+ * metadata propagates to brokers asynchronously — a subsequent {@code describeConfigs} call may
+ * throw {@link UnknownTopicOrPartitionException} (topic not yet visible) or return stale config
+ * values. After {@code incrementalAlterConfigs} returns, the topic is already visible but the
+ * broker's metadata cache may still serve the old config value. The helpers here retry on
+ * {@link UnknownTopicOrPartitionException} and (for {@link #waitForTopicConfigValue}) poll until
  * the value converges.
  */
 public final class TopicConfigTestUtils {
@@ -48,7 +50,7 @@ public final class TopicConfigTestUtils {
     /**
      * Read all config entries for a topic via {@code describeConfigs}. Retries up to 3 times
      * (1s delay) on {@link UnknownTopicOrPartitionException} to ride out metadata propagation
-     * delays after topic creation or config alteration.
+     * delays after topic creation.
      */
     public static Map<String, String> getTopicConfig(Admin admin, String topic)
             throws ExecutionException, InterruptedException, TimeoutException {
@@ -96,10 +98,11 @@ public final class TopicConfigTestUtils {
     /**
      * Poll until the given topic config {@code key} reaches {@code expectedValue}.
      *
-     * <p>After {@code createTopics} or {@code incrementalAlterConfigs} returns, the controller has
-     * committed the change but the broker's metadata cache may still serve the old value. This
-     * method polls (60s deadline) until the value converges, treating
-     * {@link UnknownTopicOrPartitionException} and {@link TimeoutException} as transient.
+     * <p>After {@code createTopics} returns, the topic may not yet be visible to the broker
+     * serving the request ({@link UnknownTopicOrPartitionException}); after
+     * {@code incrementalAlterConfigs} returns, the topic is visible but the broker may still
+     * serve the old config value. This method polls (60s deadline) until the value converges,
+     * treating {@link UnknownTopicOrPartitionException} and {@link TimeoutException} as transient.
      */
     public static void waitForTopicConfigValue(Admin admin, String topic, String key, String expectedValue)
             throws InterruptedException {

--- a/core/src/test/java/kafka/server/TopicMetadataProbe.java
+++ b/core/src/test/java/kafka/server/TopicMetadataProbe.java
@@ -39,12 +39,12 @@ import java.util.concurrent.TimeoutException;
  * throw {@link UnknownTopicOrPartitionException} (topic not yet visible) or return stale config
  * values. After {@code incrementalAlterConfigs} returns, the topic is already visible but the
  * broker's metadata cache may still serve the old config value. The helpers here retry on
- * {@link UnknownTopicOrPartitionException} and (for {@link #waitForTopicConfigValue}) poll until
+ * {@link UnknownTopicOrPartitionException} and (for {@link #awaitValue}) poll until
  * the value converges.
  */
-public final class TopicConfigTestUtils {
+public final class TopicMetadataProbe {
 
-    private TopicConfigTestUtils() {
+    private TopicMetadataProbe() {
     }
 
     /**
@@ -52,7 +52,7 @@ public final class TopicConfigTestUtils {
      * (1s delay) on {@link UnknownTopicOrPartitionException} to ride out metadata propagation
      * delays after topic creation.
      */
-    public static Map<String, String> getTopicConfig(Admin admin, String topic)
+    public static Map<String, String> configs(Admin admin, String topic)
             throws ExecutionException, InterruptedException, TimeoutException {
         final int maxRetries = 3;
         final long retryDelayMs = 1000;
@@ -81,14 +81,14 @@ public final class TopicConfigTestUtils {
 
     /**
      * Read a single topic config value via {@code describeConfigs}. Retries on transient
-     * {@link UnknownTopicOrPartitionException} (see {@link #getTopicConfig}).
+     * {@link UnknownTopicOrPartitionException} (see {@link #configs}).
      *
      * @throws IllegalStateException if the config {@code key} is absent for the topic (unlike
      *         {@code getTopicConfig(...).get(key)}, which returns {@code null} in that case)
      */
-    public static String getTopicConfigValue(Admin admin, String topic, String key)
+    public static String readValue(Admin admin, String topic, String key)
             throws ExecutionException, InterruptedException, TimeoutException {
-        final String value = getTopicConfig(admin, topic).get(key);
+        final String value = configs(admin, topic).get(key);
         if (value == null) {
             throw new IllegalStateException("Config '" + key + "' is missing for topic " + topic);
         }
@@ -104,11 +104,11 @@ public final class TopicConfigTestUtils {
      * serve the old config value. This method polls (60s deadline) until the value converges,
      * treating {@link UnknownTopicOrPartitionException} and {@link TimeoutException} as transient.
      */
-    public static void waitForTopicConfigValue(Admin admin, String topic, String key, String expectedValue)
+    public static void awaitValue(Admin admin, String topic, String key, String expectedValue)
             throws InterruptedException {
         TestUtils.waitForCondition(() -> {
             try {
-                return expectedValue.equals(getTopicConfigValue(admin, topic, key));
+                return expectedValue.equals(readValue(admin, topic, key));
             } catch (ExecutionException e) {
                 if (e.getCause() instanceof UnknownTopicOrPartitionException) {
                     return false;
@@ -131,7 +131,7 @@ public final class TopicConfigTestUtils {
      * topic is visible, treating {@link UnknownTopicOrPartitionException} and
      * {@link TimeoutException} as transient.
      */
-    public static void waitForTopicToExist(Admin admin, String topic) throws InterruptedException {
+    public static void awaitVisible(Admin admin, String topic) throws InterruptedException {
         TestUtils.waitForCondition(() -> {
             try {
                 final DescribeTopicPartitionsResponseData responseData =


### PR DESCRIPTION
Extracts common test helper methods from Inkless tests and adds some hardening to these tests as there were recent flaky failures were caused by metadata propagation issues.