### PR TITLE
fix(inkless:ci): green the upstream test suite (diskless test fixes + flaky quarantine)

### DIFF
--- a/.github/scripts/junit.py
+++ b/.github/scripts/junit.py
@@ -347,6 +347,11 @@ if __name__ == "__main__":
     exit_code = get_env("GRADLE_TEST_EXIT_CODE", int)
     junit_report_url = get_env("JUNIT_REPORT_URL")
     thread_dump_url = get_env("THREAD_DUMP_URL")
+    # Inkless: in the flaky/quarantine test job, tests fail by definition (they are @Flaky-tagged
+    # and known unreliable). Their failures must not fail the job, otherwise the workflow shows a
+    # red signal even when nothing at the Kafka coverage level is broken. Real infrastructure
+    # problems (timeout=124, thread dumps, missing exit code) still fail the job below.
+    run_flaky = (get_env("RUN_FLAKY") or "").lower() == "true"
 
     if exit_code is None:
         failure_messages.append("Missing required GRADLE_TEST_EXIT_CODE environment variable. Failing this script.")
@@ -357,7 +362,7 @@ if __name__ == "__main__":
         # this script. If any task fails due to timeout, we want to fail the overall build since it will not
         # include all the test results
         failure_messages.append(f"Gradle task had a timeout. Failing this script. These are partial results!")
-    elif exit_code > 0:
+    elif exit_code > 0 and not run_flaky:
         failure_messages.append(f"Gradle task had a failure exit code. Failing this script.")
 
     if thread_dump_url:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -273,6 +273,9 @@ jobs:
           JUNIT_REPORT_URL: ${{ steps.archive-junit-html.outputs.artifact-url }}
           THREAD_DUMP_URL: ${{ steps.archive-thread-dump.outputs.artifact-url }}
           GRADLE_TEST_EXIT_CODE: ${{ steps.junit-test.outputs.gradle-exitcode }}
+          # Inkless: flaky-test failures in the flaky job are expected and must not fail the job,
+          # so the workflow only goes red when something at the Kafka coverage level actually breaks.
+          RUN_FLAKY: ${{ matrix.run-flaky }}
         run: |
           python .github/scripts/junit.py \
            --path build/junit-xml >> $GITHUB_STEP_SUMMARY

--- a/build.gradle
+++ b/build.gradle
@@ -3027,6 +3027,7 @@ project(':streams') {
     testCompileOnly libs.bndlib
 
     testImplementation project(':clients').sourceSets.test.output
+    testImplementation project(':test-common:test-common-util')
     testImplementation libs.jacksonDataformatYaml
     testImplementation libs.junitJupiter
     testImplementation libs.bcpkix
@@ -4192,6 +4193,7 @@ project(':connect:mirror') {
     testImplementation project(':connect:runtime').sourceSets.test.output
     testImplementation project(':core')
     testImplementation project(':test-common:test-common-runtime')
+    testImplementation project(':test-common:test-common-util')
     testImplementation project(':server')
     testImplementation project(':server-common')
 

--- a/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/ShareConsumerTest.java
+++ b/clients/clients-integration-tests/src/test/java/org/apache/kafka/clients/consumer/ShareConsumerTest.java
@@ -62,6 +62,7 @@ import org.apache.kafka.common.test.ClusterInstance;
 import org.apache.kafka.common.test.api.ClusterConfigProperty;
 import org.apache.kafka.common.test.api.ClusterTest;
 import org.apache.kafka.common.test.api.ClusterTestDefaults;
+import org.apache.kafka.common.test.api.Flaky;
 import org.apache.kafka.common.test.api.Type;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.coordinator.group.GroupConfig;
@@ -1716,6 +1717,7 @@ public class ShareConsumerTest {
      * causes it to throw InterruptException
      */
     @ClusterTest
+    @Flaky(value = "KAFKA-19961", comment = "Flaky ShareConsumerTest#testPollThrowsInterruptExceptionIfInterrupted.")
     public void testPollThrowsInterruptExceptionIfInterrupted() {
         alterShareAutoOffsetReset("group1", "earliest");
         try (ShareConsumer<byte[], byte[]> shareConsumer = createShareConsumer("group1")) {

--- a/clients/src/test/java/org/apache/kafka/clients/NodeApiVersionsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/NodeApiVersionsTest.java
@@ -58,8 +58,10 @@ public class NodeApiVersionsTest {
 
     @Test
     public void testUnknownApiVersionsToString() {
-        NodeApiVersions versions = NodeApiVersions.create((short) 337, (short) 0, (short) 1);
-        assertTrue(versions.toString().endsWith("UNKNOWN(337): 0 to 1)"));
+        // Inkless: use an id above all real ApiKeys (incl. diskless keys 500/501) so that the
+        // unknown key sorts last in NodeApiVersions.toString()'s ascending-by-id output.
+        NodeApiVersions versions = NodeApiVersions.create(Short.MAX_VALUE, (short) 0, (short) 1);
+        assertTrue(versions.toString().endsWith("UNKNOWN(" + Short.MAX_VALUE + "): 0 to 1)"));
     }
 
     @Test

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationBaseTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationBaseTest.java
@@ -35,6 +35,7 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.config.TopicConfig;
+import org.apache.kafka.common.test.api.Flaky;
 import org.apache.kafka.common.utils.Exit;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Timer;
@@ -280,6 +281,7 @@ public class MirrorConnectorsIntegrationBaseTest {
     }
     
     @Test
+    @Flaky(value = "KAFKA-16488", comment = "Chronically flaky MM2 integration test across all subclasses; see also KAFKA-12566.")
     public void testReplication() throws Exception {
         produceMessages(primaryProducer, "test-topic-1");
         String backupTopic1 = remoteTopicName("test-topic-1", PRIMARY_CLUSTER_ALIAS);
@@ -816,6 +818,7 @@ public class MirrorConnectorsIntegrationBaseTest {
     }
 
     @Test
+    @Flaky(value = "KAFKA-15945", comment = "Chronically flaky MM2 integration test across all subclasses; see also KAFKA-15523, KAFKA-14971.")
     public void testSyncTopicConfigs() throws InterruptedException {
         mm2Config = new MirrorMakerConfig(mm2Props);
 
@@ -859,6 +862,7 @@ public class MirrorConnectorsIntegrationBaseTest {
     }
 
     @Test
+    @Flaky(value = "KAFKA-15926", comment = "Chronically flaky MM2 integration test across all subclasses; open tickets KAFKA-15926 (SSL), KAFKA-15927 (ExactlyOnce).")
     public void testReplicateSourceDefault() throws Exception {
         mm2Props.put(DefaultConfigPropertyFilter.USE_DEFAULTS_FROM, "source");
         mm2Config = new MirrorMakerConfig(mm2Props);
@@ -901,6 +905,7 @@ public class MirrorConnectorsIntegrationBaseTest {
     }
 
     @Test
+    @Flaky(value = "KAFKA-15926", comment = "No dedicated ticket; same MM2 replication-harness flakiness as testReplicateSourceDefault (KAFKA-15926/KAFKA-15927).")
     public void testReplicateTargetDefault() throws Exception {
         mm2Config = new MirrorMakerConfig(mm2Props);
 

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationExactlyOnceTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationExactlyOnceTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.connect.mirror.integration;
 
+import org.apache.kafka.common.test.api.Flaky;
 import org.apache.kafka.connect.connector.Connector;
 import org.apache.kafka.connect.mirror.MirrorSourceConnector;
 import org.apache.kafka.connect.runtime.distributed.DistributedConfig;
@@ -54,6 +55,7 @@ public class MirrorConnectorsIntegrationExactlyOnceTest extends MirrorConnectors
 
     @Override
     @Test
+    @Flaky(value = "KAFKA-16488", comment = "Chronically flaky MM2 integration test across all subclasses; see also KAFKA-12566.")
     public void testReplication() throws Exception {
         super.testReplication();
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/MonitorableSinkIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/MonitorableSinkIntegrationTest.java
@@ -18,6 +18,7 @@ package org.apache.kafka.connect.integration;
 
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.metrics.KafkaMetric;
+import org.apache.kafka.common.test.api.Flaky;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorStateInfo;
 import org.apache.kafka.connect.storage.StringConverter;
 import org.apache.kafka.connect.util.clusters.EmbeddedConnectStandalone;
@@ -80,6 +81,7 @@ public class MonitorableSinkIntegrationTest {
     }
 
     @Test
+    @Flaky(value = "KAFKA-18952", comment = "Flaky in CI; upstream ticket resolved but still recurs in the fork.")
     public void testMonitorableSinkConnectorAndTask() throws Exception {
         connect.kafka().createTopic("test-topic");
 

--- a/core/src/test/scala/integration/kafka/api/SaslOAuthBearerSslEndToEndAuthorizationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslOAuthBearerSslEndToEndAuthorizationTest.scala
@@ -17,11 +17,22 @@
 package kafka.api
 
 import kafka.security.JaasTestUtils
+import kafka.utils.TestInfoUtils
 import org.apache.kafka.common.security.auth._
+import org.apache.kafka.common.test.api.Flaky
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
 
 class SaslOAuthBearerSslEndToEndAuthorizationTest extends SaslEndToEndAuthorizationTest {
   override protected def kafkaClientSaslMechanism = "OAUTHBEARER"
   override protected def kafkaServerSaslMechanisms = List(kafkaClientSaslMechanism)
   override val clientPrincipal = new KafkaPrincipal(KafkaPrincipal.USER_TYPE, JaasTestUtils.KAFKA_OAUTH_BEARER_USER)
   override val kafkaPrincipal = new KafkaPrincipal(KafkaPrincipal.USER_TYPE, JaasTestUtils.KAFKA_OAUTH_BEARER_ADMIN)
+
+  // Override solely to mark the OAUTHBEARER variant flaky; other SASL mechanisms keep upstream coverage.
+  @ParameterizedTest(name = TestInfoUtils.TestWithParameterizedGroupProtocolNames)
+  @MethodSource(Array("getTestGroupProtocolParametersAll"))
+  @Flaky(value = "KAFKA-9655", comment = "Flaky only for the OAUTHBEARER variant; non-critical for the fork, upstream covers the other mechanisms.")
+  override def testNoConsumeWithoutDescribeAclViaSubscribe(groupProtocol: String): Unit =
+    super.testNoConsumeWithoutDescribeAclViaSubscribe(groupProtocol)
 }

--- a/core/src/test/scala/unit/kafka/metrics/MetricsTest.scala
+++ b/core/src/test/scala/unit/kafka/metrics/MetricsTest.scala
@@ -139,8 +139,15 @@ class MetricsTest extends KafkaServerTestHarness with Logging {
     createTopic(topic, 2)
 
     // The broker metrics for all topics should be greedily registered
-    assertTrue(topicMetrics(None).nonEmpty, "General topic metrics don't exist")
-    assertEquals(brokers.head.brokerTopicStats.allTopicsStats.metricMapKeySet().size, topicMetrics(None).size)
+    val allTopicsMetrics = topicMetrics(None)
+    assertTrue(allTopicsMetrics.nonEmpty, "General topic metrics don't exist")
+    // Inkless: all-topics BytesIn/BytesOut meters are registered for both topicType=classic and
+    // topicType=diskless. The diskless variants share the same metric name as their classic
+    // counterparts (they differ only by tag), so they are not tracked as extra keys in
+    // metricMapKeySet() but do appear as separate JMX MBeans. Account for those duplicates.
+    val disklessAllTopicsMetrics = allTopicsMetrics.count(_.contains("topicType=diskless"))
+    assertEquals(brokers.head.brokerTopicStats.allTopicsStats.metricMapKeySet().size + disklessAllTopicsMetrics,
+      allTopicsMetrics.size)
     assertEquals(0, brokers.head.brokerTopicStats.allTopicsStats.metricGaugeMap.size)
     // topic metrics should be lazily registered
     assertTrue(topicMetricGroups(topic).isEmpty, "Topic metrics aren't lazily registered")

--- a/metadata/src/test/java/org/apache/kafka/image/node/TopicImageNodeTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/node/TopicImageNodeTest.java
@@ -83,7 +83,8 @@ public class TopicImageNodeTest {
         assertEquals("PartitionRegistration(replicas=[2, 3, 4], " +
                 "directories=[AAAAAAAAAAAAAAAAAAAAAA, AAAAAAAAAAAAAAAAAAAAAA, AAAAAAAAAAAAAAAAAAAAAA], " +
                 "isr=[2, 3], removingReplicas=[], addingReplicas=[], elr=[], lastKnownElr=[], leader=2, " +
-                "leaderRecoveryState=RECOVERED, leaderEpoch=1, partitionEpoch=345)", stringifier.toString());
+                "leaderRecoveryState=RECOVERED, leaderEpoch=1, partitionEpoch=345, " +
+                "classicToDisklessStartOffset=-1, disklessProducerStates=[], disklessLeaderEpoch=-1)", stringifier.toString());
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/TaskAssignorConvergenceTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/TaskAssignorConvergenceTest.java
@@ -21,6 +21,7 @@ import org.apache.kafka.common.Node;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.TopicPartitionInfo;
+import org.apache.kafka.common.test.api.Flaky;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.StreamsConfig;
@@ -475,6 +476,7 @@ public class TaskAssignorConvergenceTest {
         StreamsConfig.RACK_AWARE_ASSIGNMENT_STRATEGY_MIN_TRAFFIC,
         StreamsConfig.RACK_AWARE_ASSIGNMENT_STRATEGY_BALANCE_SUBTOPOLOGY
     })
+    @Flaky(value = "KAFKA-16491", comment = "Flaky for rackAwareStrategy=balance_subtopology.")
     public void randomClusterPerturbationsShouldConverge(final String rackAwareStrategy) {
         setUp(rackAwareStrategy);
         // do as many tests as we can in 10 seconds


### PR DESCRIPTION
Upstream Kafka tests broken on main (see https://github.com/aiven/inkless/actions/runs/29324563467/job/87077973795) because they were not adapted to Inkless changes or are flaky. 

This PR makes the JUnit test workflow a trustable signal: green unless a non-flaky test breaks or infrastructure fails. Three independent concerns, one commit each:

1. Three upstream Kafka unit tests were failing deterministically because they were never adapted to Inkless (Diskless Topics) changes. Fixed the stale expectations. Test-only, no production code touched.
2. A set of upstream integration tests that are documented-flaky on Apache Kafka (several with currently-open flaky-test JIRA tickets) were reddening the `noflaky-nonew` CI bucket independent of any Inkless change. Tagged them `@Flaky` so they run only in the flaky bucket while tracking the upstream tickets.
3. The flaky/quarantine job itself was going red whenever a quarantined test flaked, which is expected noise rather than a real break. Made that job report-only (fail only on real infrastructure problems), so the workflow is trustable.

## Commit 1 - `fix(inkless:ci): update upstream tests for diskless additions`

| Test | Root cause | Fix |
| ---- | ---------- | --- |
| `TopicImageNodeTest.testChildPartitionId` | `PartitionRegistration.toString()` now includes the diskless fields (`classicToDisklessStartOffset`, `disklessProducerStates`, `disklessLeaderEpoch`) | Update expected string |
| `NodeApiVersionsTest.testUnknownApiVersionsToString` | The "unknown" apiKey `337` no longer sorts last once the diskless client APIs (`INIT_DISKLESS_LOG`=500, `ALTER_DISKLESS_SWITCH`=501) exist, so `toString()` no longer ends with it | Use `Short.MAX_VALUE` as the unknown key |
| `MetricsTest.testGeneralBrokerTopicMetricsAreGreedilyRegistered` | All-topics `BytesIn`/`BytesOut` meters are registered for both `topicType=classic` and `topicType=diskless`; the diskless variants share a metric name with their classic counterparts, so they are extra JMX MBeans but not extra `metricMapKeySet()` entries (22 vs 24) | Account for the diskless-tagged duplicates in the assertion; capture `topicMetrics(None)` once |

I verified against `apache/trunk` that none of these have an upstream fix to adopt: the upstream tests are byte-identical and pass there because upstream lacks the diskless fields / API keys / dual classic+diskless meters. The divergence is entirely Inkless-introduced, so the fixes belong in the fork.

## Commit 2 - `test(inkless:ci): quarantine known-flaky upstream integration tests with @Flaky`

Each tagged test maps to an upstream Apache Kafka flaky-test JIRA ticket; in several cases the exact method (and parameter) is named, and the ticket is still open. These are not affected by this PR's diff.

| Test | Ticket | Status |
| ---- | ------ | ------ |
| `MirrorConnectorsIntegrationBaseTest.testReplicateSourceDefault` (inherited by 5 subclasses) | KAFKA-15926 (also KAFKA-15927) | open |
| `MirrorConnectorsIntegrationBaseTest.testReplicateTargetDefault` (inherited by 5 subclasses) | KAFKA-15926 (no dedicated ticket; same MM2 harness) | open |
| `MirrorConnectorsIntegrationBaseTest.testSyncTopicConfigs` (inherited by 5 subclasses) | KAFKA-15945 (also KAFKA-15523, KAFKA-14971) | resolved (recurs) |
| `MirrorConnectorsIntegrationBaseTest.testReplication` (inherited by IdentityReplication) | KAFKA-16488 (also KAFKA-12566) | resolved (recurs) |
| `MonitorableSinkIntegrationTest.testMonitorableSinkConnectorAndTask` | KAFKA-18952 | resolved (recurs) |
| `TaskAssignorConvergenceTest.randomClusterPerturbationsShouldConverge[balance_subtopology]` | KAFKA-16491 | open |
| `ShareConsumerTest.testPollThrowsInterruptExceptionIfInterrupted` | KAFKA-19961 | open |
| `SaslOAuthBearerSslEndToEndAuthorizationTest.testNoConsumeWithoutDescribeAclViaSubscribe` | KAFKA-9655 | open |

Notes on placement:

- The MM2 family is tagged once on the base methods in `MirrorConnectorsIntegrationBaseTest`; JUnit propagates the tag to the inherited executions in all subclasses (`IdentityReplication`, `ExactlyOnce`, `SSL`, `Transactions`, `CustomForwardingAdmin`).
- `testNoConsumeWithoutDescribeAclViaSubscribe` is defined in the shared `EndToEndAuthorizationTest` base and inherited by ~10 auth-mechanism subclasses. To avoid silencing it for all mechanisms, it is overridden solely in the OAUTHBEARER subclass to carry the tag; every other SASL variant keeps upstream coverage.
- `build.gradle`: added `testImplementation project(':test-common:test-common-util')` (home of the `@Flaky` annotation) to `:streams` and `:connect:mirror`; the other affected modules already depend on it. The annotation is a thin meta-annotation for `@Tag("flaky")`, which `KafkaPostDiscoveryFilter` excludes from the main suite.

## Commit 3 - `fix(inkless:ci): make the flaky test job report-only so CI is trustable`

The flaky/quarantine matrix job runs only `@Flaky`-tagged tests. `junit.py` previously failed the job on any non-zero Gradle exit code, so a single quarantined test flaking turned the whole workflow red even when nothing at the Kafka coverage level was broken. This defeats the purpose of quarantine and makes the signal untrustworthy.

Change: `junit.py` now treats a non-zero Gradle exit code as non-fatal when running the flaky job (`RUN_FLAKY=true`, passed from the matrix in `build.yml`), while still failing on real infrastructure problems - timeouts (exit 124), thread dumps (hangs), and a missing exit code. Flaky failures are still reported in the job summary tables. The noflaky and new jobs are unaffected and remain the trustable gating signal.

Net effect: the workflow is green unless a non-flaky test breaks or infrastructure fails.

## Verification

- `compileTestJava` / `compileTestScala` + `checkstyleTest` pass for every touched module.
- The three diskless test fixes were confirmed green in CI (run 29402697743): they no longer appear in the failure set; the remaining reds were exactly the flaky integration tests quarantined in commit 2.
- The flaky filter was confirmed to exclude the tagged tests from the `noflaky` bucket on two representative cases (an inherited MM2 method and the SASL override), both reporting "No tests found for given includes" in default mode; they still run in the flaky bucket with retries.
- The MM2 config-sync tests pass locally in isolation, confirming they are load-sensitive flakes (not a code regression), consistent with their upstream flaky tickets.
- `junit.py` exit behavior verified locally: flaky + test failures -> exit 0; noflaky + test failures -> exit 1; flaky + timeout (124) -> exit 1; clean / unset `RUN_FLAKY` -> unchanged.
