### PR TITLE
test(inkless): give each broker an exclusive TS fetch chunk cache dir

### DIFF
--- a/core/src/test/java/kafka/server/InklessConsolidatedDisklessReassignmentTest.java
+++ b/core/src/test/java/kafka/server/InklessConsolidatedDisklessReassignmentTest.java
@@ -57,7 +57,6 @@ import org.slf4j.LoggerFactory;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -213,9 +212,14 @@ public class InklessConsolidatedDisklessReassignmentTest {
     }
 
     private KafkaClusterTestKit createCluster() throws Exception {
+        String rsmPrefix = RemoteLogManagerConfig.DEFAULT_REMOTE_STORAGE_MANAGER_CONFIG_PREFIX;
         Map<Integer, Map<String, String>> perServerProps = new HashMap<>();
+        // Per-broker cache dir: DiskChunkCache wipes its path on startup, so a shared dir races.
         for (int i = 0; i < NUM_BROKERS; i++) {
-            perServerProps.put(i, Map.of(ServerConfigs.BROKER_RACK_CONFIG, "az" + (i + 1)));
+            Path brokerFetchChunkCachePath = Files.createDirectories(tempCacheDir.resolve("ts-fetch-chunk-cache-" + i));
+            perServerProps.put(i, Map.of(
+                ServerConfigs.BROKER_RACK_CONFIG, "az" + (i + 1),
+                rsmPrefix + "fetch.chunk.cache.path", brokerFetchChunkCachePath.toAbsolutePath().toString()));
         }
         final TestKitNodes nodes = new TestKitNodes.Builder()
             .setCombined(true)
@@ -264,8 +268,8 @@ public class InklessConsolidatedDisklessReassignmentTest {
             .setConfigProp(prefix + S3StorageConfig.AWS_SECRET_ACCESS_KEY_CONFIG, s3Container.getSecretKey());
     }
 
-    private void configureTieredStorage(KafkaClusterTestKit.Builder builder) throws IOException {
-        Path fetchChunkCachePath = Files.createDirectories(tempCacheDir.resolve("ts-fetch-chunk-cache"));
+    private void configureTieredStorage(KafkaClusterTestKit.Builder builder) {
+        // fetch.chunk.cache.path is set per broker in createCluster (must be broker-exclusive).
         String rsmPrefix = RemoteLogManagerConfig.DEFAULT_REMOTE_STORAGE_MANAGER_CONFIG_PREFIX;
         builder
             .setConfigProp(RemoteLogManagerConfig.REMOTE_LOG_STORAGE_SYSTEM_ENABLE_PROP, "true")
@@ -278,7 +282,6 @@ public class InklessConsolidatedDisklessReassignmentTest {
             .setConfigProp(RemoteLogManagerConfig.REMOTE_STORAGE_MANAGER_CLASS_NAME_PROP, "io.aiven.kafka.tieredstorage.RemoteStorageManager")
             .setConfigProp(rsmPrefix + "chunk.size", 1048576)
             .setConfigProp(rsmPrefix + "fetch.chunk.cache.class", "io.aiven.kafka.tieredstorage.fetch.cache.DiskChunkCache")
-            .setConfigProp(rsmPrefix + "fetch.chunk.cache.path", fetchChunkCachePath.toAbsolutePath().toString())
             .setConfigProp(rsmPrefix + "fetch.chunk.cache.size", "10737418")
             .setConfigProp(rsmPrefix + "fetch.chunk.cache.prefetch.max.size", "16777216")
             .setConfigProp(rsmPrefix + "fetch.chunk.cache.retention.ms", "16777216")

--- a/core/src/test/java/kafka/server/InklessConsolidatedDisklessTopicsTest.java
+++ b/core/src/test/java/kafka/server/InklessConsolidatedDisklessTopicsTest.java
@@ -54,12 +54,14 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
@@ -120,17 +122,24 @@ public class InklessConsolidatedDisklessTopicsTest {
     private String topicName = "consolidated-diskless-topic";
     private int numPartitions = 2;
 
+    @TempDir
+    private Path tempCacheDir;
+
     @BeforeEach
     public void setup(final TestInfo testInfo) throws Exception {
         s3Container.createBucket(testInfo);
         pgContainer.createDatabase(testInfo);
 
         // Create 2-broker cluster with rack assignments (matching docker compose setup)
-        // Node 0: combined broker+controller, Node 1: broker-only
-        Map<Integer, Map<String, String>> perServerProps = Map.of(
-            0, Map.of(ServerConfigs.BROKER_RACK_CONFIG, "az1"),
-            1, Map.of(ServerConfigs.BROKER_RACK_CONFIG, "az2")
-        );
+        // Node 0: combined broker+controller, Node 1: broker-only.
+        Map<Integer, Map<String, String>> perServerProps = new HashMap<>();
+        // Per-broker cache dir: DiskChunkCache wipes its path on startup, so a shared dir races.
+        for (int brokerId = 0; brokerId < 2; brokerId++) {
+            perServerProps.put(brokerId, Map.of(
+                ServerConfigs.BROKER_RACK_CONFIG, "az" + (brokerId + 1),
+                RSM_CONFIG_PREFIX + "fetch.chunk.cache.path",
+                Files.createDirectories(tempCacheDir.resolve("ts-fetch-chunk-cache-" + brokerId)).toAbsolutePath().toString()));
+        }
         final TestKitNodes nodes = new TestKitNodes.Builder()
             .setCombined(true)
             .setNumBrokerNodes(2)
@@ -173,8 +182,7 @@ public class InklessConsolidatedDisklessTopicsTest {
             .setConfigProp(RemoteLogManagerConfig.REMOTE_STORAGE_MANAGER_CLASS_NAME_PROP, "io.aiven.kafka.tieredstorage.RemoteStorageManager")
             .setConfigProp(RSM_CONFIG_PREFIX + "chunk.size", 1048576)
             .setConfigProp(RSM_CONFIG_PREFIX + "fetch.chunk.cache.class", "io.aiven.kafka.tieredstorage.fetch.cache.DiskChunkCache")
-            .setConfigProp(RSM_CONFIG_PREFIX + "fetch.chunk.cache.path",
-                Files.createTempDirectory("ts-fetch-chunk-cache").toAbsolutePath().toString())
+            // fetch.chunk.cache.path is set per broker in perServerProps (must be broker-exclusive).
             .setConfigProp(RSM_CONFIG_PREFIX + "fetch.chunk.cache.size", "10737418")
             .setConfigProp(RSM_CONFIG_PREFIX + "fetch.chunk.cache.prefetch.max.size", "16777216")
             .setConfigProp(RSM_CONFIG_PREFIX + "fetch.chunk.cache.retention.ms", "16777216")


### PR DESCRIPTION
DiskChunkCache wipes its base directory on every configure() and promotes any IO error (including concurrent-delete races) to a fatal ConfigException. Both InklessConsolidatedDisklessReassignmentTest and InklessConsolidatedDisklessTopicsTest pointed every combined broker at a single fetch.chunk.cache.path set cluster-wide, so the brokers' startup wipes raced on that one directory and intermittently aborted KafkaClusterTestKit.startup with "Failed to reset cache directory".

Set fetch.chunk.cache.path per broker via per-server properties so each broker owns its cache directory.