### PR TITLE
fix(inkless:consolidation): DeleteRecords across tiers on consolidating topics

### DIFF
--- a/core/src/main/java/kafka/server/builders/KafkaApisBuilder.java
+++ b/core/src/main/java/kafka/server/builders/KafkaApisBuilder.java
@@ -231,6 +231,7 @@ public class KafkaApisBuilder {
                              apiVersionManager,
                              clientMetricsManager,
                              groupConfigManager,
+                             OptionConverters.toScala(Optional.empty()),
                              OptionConverters.toScala(Optional.empty()));
     }
 }

--- a/core/src/main/scala/io/aiven/inkless/consolidation/DisklessLeaderEndPoint.scala
+++ b/core/src/main/scala/io/aiven/inkless/consolidation/DisklessLeaderEndPoint.scala
@@ -120,7 +120,19 @@ class DisklessLeaderEndPoint(
         case Right(partition) =>
           val localLogOpt = Try(partition.localLogOrException).toOption
           val logStartOffset = localLogOpt match {
-            case Some(localLog) => localLog.logStartOffset
+            case Some(localLog) =>
+              // Prefer the control-plane cross-tier earliest as the whole-log start for a consolidating
+              // partition. On a freshly-elected leader whose classic prefix was already evicted, the
+              // leadership rebuild pins localLog.logStartOffset at the seal (classicToDisklessStartOffset)
+              // and it can only ever increment; the classic prefix [earliest, seal) then lives only in the
+              // remote tier. Reporting the local seal would (a) reject reads of that prefix as
+              // out-of-range -- the OFFSET_MOVED_TO_TIERED_STORAGE gate below requires
+              // requestedOffset >= logStartOffset -- and (b) make the tier-state rebuild restart the log
+              // at the seal, over-reclaiming the prefix. The cross-tier earliest is broker-agnostic and
+              // monotonic, so min() with the local start is always safe.
+              val crossTier = replicaManager.crossTierEarliestOffset(tp.topicPartition)
+              if (crossTier.isPresent) Math.min(crossTier.getAsLong, localLog.logStartOffset)
+              else localLog.logStartOffset
             case None =>
                     logger.warn("Local log unavailable for topic-partition {}, returning unknown log start offset", tp.topicPartition)
                     UnifiedLog.UNKNOWN_OFFSET

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -169,6 +169,7 @@ class BrokerServer(
   private var maybeInklessSharedState: Option[SharedState] = None
   private var maybeInitDisklessLogManager: Option[InitDisklessLogManager] = None
   private var initDisklessLogChannelManager: NodeToControllerChannelManager = _
+  private var maybeDisklessDeleteRecordsForwarder: Option[DisklessDeleteRecordsForwarder] = None
 
   private def maybeChangeStatus(from: ProcessStatus, to: ProcessStatus): Boolean = {
     lock.lock()
@@ -401,6 +402,17 @@ class BrokerServer(
         initDisklessLogManager = maybeInitDisklessLogManager
       )
 
+      // Forwards the leader-only leg of DeleteRecords for diskless topics with a local-log
+      // component to the partition's real KRaft leader, since the metadata transformer advertises
+      // an AZ-selected replica (a follower) as the client-facing leader.
+      maybeDisklessDeleteRecordsForwarder = inklessSharedState.map { _ =>
+        val forwarderLogContext = new LogContext(s"[DisklessDeleteRecordsForwarder broker=${config.brokerId}]")
+        val forwarderNetworkClient = NetworkUtils.buildNetworkClient("DisklessDeleteRecordsForwarder", config, metrics, time, forwarderLogContext)
+        val forwarder = new DisklessDeleteRecordsForwarder(config, forwarderNetworkClient, metadataCache, inklessMetadataView, time)
+        forwarder.start()
+        forwarder
+      }
+
       /* start token manager */
       tokenManager = new DelegationTokenManager(new DelegationTokenManagerConfigs(config), tokenCache)
 
@@ -512,7 +524,8 @@ class BrokerServer(
         apiVersionManager = apiVersionManager,
         clientMetricsManager = clientMetricsManager,
         groupConfigManager = groupConfigManager,
-        inklessSharedState = inklessSharedState)
+        inklessSharedState = inklessSharedState,
+        disklessDeleteRecordsForwarder = maybeDisklessDeleteRecordsForwarder)
 
       dataPlaneRequestHandlerPool = sharedServer.requestHandlerPoolFactory.createPool(
         config.nodeId,
@@ -802,7 +815,19 @@ class BrokerServer(
           // control plane so any broker can serve it for ListOffsets(EARLIEST). No-op for classic topics.
           maybeInklessSharedState.foreach(_.crossTierLogStartReporter().enqueue(tp, remoteLogStartOffset))
         },
-        brokerTopicStats, metrics, endpoint.toJava)
+        brokerTopicStats, metrics, endpoint.toJava,
+        // For a consolidating diskless partition, drive the RLM's remote-retention reclaim floor and
+        // become-leader log-start report from the broker-agnostic control-plane cross-tier earliest
+        // instead of the broker-local log start (which on a freshly-rebuilt leader is pinned at the
+        // seal). Resolved lazily via ReplicaManager, which is constructed after the RLM; the override is
+        // only ever invoked at RLM runtime, well after startup. Empty for classic / non-inkless topics.
+        (tp: TopicPartition) =>
+          if (_replicaManager != null) _replicaManager.crossTierEarliestOffset(tp) else util.OptionalLong.empty(),
+        // Tells the RLM whether the partition is consolidating diskless, so that when the cross-tier
+        // earliest above is unavailable it fails safe (skips log-start reclaim) instead of falling back
+        // to the broker-local seal and over-reclaiming the remote classic prefix. False for classic topics.
+        (tp: TopicPartition) =>
+          if (_replicaManager != null) _replicaManager.isConsolidatingDisklessPartition(tp) else false)
       Some(rlm)
     } else {
       None
@@ -892,6 +917,8 @@ class BrokerServer(
         maybeInklessSharedState.foreach(s => CoreUtils.swallow(s.close(), this))
 
       maybeInitDisklessLogManager.foreach(m => CoreUtils.swallow(m.shutdown(), this))
+
+      maybeDisklessDeleteRecordsForwarder.foreach(f => CoreUtils.swallow(f.shutdown(), this))
 
       if (initDisklessLogChannelManager != null)
         CoreUtils.swallow(initDisklessLogChannelManager.shutdown(), this)

--- a/core/src/main/scala/kafka/server/DisklessDeleteRecordsForwarder.scala
+++ b/core/src/main/scala/kafka/server/DisklessDeleteRecordsForwarder.scala
@@ -1,0 +1,243 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Copyright (c) 2024 Aiven, Helsinki, Finland. https://aiven.io/
+
+package kafka.server
+
+import kafka.server.metadata.InklessMetadataView
+import kafka.utils.Logging
+import org.apache.kafka.clients.{ClientResponse, NetworkClient, RequestCompletionHandler}
+import org.apache.kafka.common.message.DeleteRecordsRequestData
+import org.apache.kafka.common.message.DeleteRecordsRequestData.{DeleteRecordsPartition, DeleteRecordsTopic}
+import org.apache.kafka.common.message.DeleteRecordsResponseData.DeleteRecordsPartitionResult
+import org.apache.kafka.common.protocol.Errors
+import org.apache.kafka.common.requests.{DeleteRecordsRequest, DeleteRecordsResponse}
+import org.apache.kafka.common.utils.Time
+import org.apache.kafka.common.{Node, TopicPartition}
+import org.apache.kafka.metadata.{MetadataCache, PartitionRegistration}
+import org.apache.kafka.server.util.{InterBrokerSendThread, RequestAndCompletionHandler}
+
+import java.util
+import java.util.concurrent.{CompletableFuture, ConcurrentLinkedQueue}
+import scala.collection.mutable
+import scala.jdk.CollectionConverters._
+
+/**
+ * Forwards the leader-only leg of a `DeleteRecords` request to a diskless partition's real KRaft
+ * leader over the inter-broker listener.
+ *
+ * For a diskless topic that owns a classic/consolidated prefix (switched, switch-pending or
+ * consolidating), `ReplicaManager.deleteRecords` splits the request into a broker-agnostic diskless
+ * (control-plane) leg and a local-log leg. The local-log leg only succeeds on the real KRaft leader
+ * (`Partition.deleteRecordsOnLeader` requires `leaderLogIfLocal`). Because
+ * `InklessTopicMetadataTransformer` advertises a hash/AZ-selected replica as the client-facing
+ * leader for locality-aware read routing, the AdminClient generally delivers `DeleteRecords` to a
+ * follower, which rejects it with `NOT_LEADER_OR_FOLLOWER`.
+ *
+ * `KafkaApis` uses this forwarder to send the affected partitions to their real leader (resolved
+ * from the raw KRaft metadata image, independent of the transformer). The receiving leader runs its
+ * own `ReplicaManager.deleteRecords` and serves both legs authoritatively, so read AZ-routing is
+ * left untouched.
+ *
+ * Modeled on `AddPartitionsToTxnManager` / `TransactionMarkerChannelManager`.
+ */
+class DisklessDeleteRecordsForwarder(
+  config: KafkaConfig,
+  networkClient: NetworkClient,
+  metadataCache: MetadataCache,
+  metadataView: InklessMetadataView,
+  time: Time
+) extends InterBrokerSendThread(
+  "DisklessDeleteRecordsForwarder-" + config.brokerId,
+  networkClient,
+  config.requestTimeoutMs,
+  time
+) with Logging {
+
+  this.logIdent = s"[DisklessDeleteRecordsForwarder broker=${config.brokerId}] "
+
+  private val interBrokerListenerName = config.interBrokerListenerName
+
+  private case class PendingForward(
+    leader: Node,
+    offsets: Map[TopicPartition, Long],
+    timeoutMs: Int,
+    future: CompletableFuture[Map[TopicPartition, DeleteRecordsPartitionResult]]
+  )
+
+  private val queue = new ConcurrentLinkedQueue[PendingForward]()
+
+  /**
+   * Split `offsets` into the partitions this broker handles locally (via
+   * `ReplicaManager.deleteRecords`) and the partitions whose local-log leg must run on another
+   * broker's real KRaft leader, grouped by that leader.
+   *
+   * A partition is forwarded iff it is a diskless topic that owns a local-log leg
+   * (switched / switch-pending / consolidating) and its real leader is a different, reachable
+   * broker. Pure-diskless partitions (control-plane only) and partitions this broker already leads
+   * stay local, preserving existing behaviour.
+   */
+  def routeByLeader(
+    offsets: Map[TopicPartition, Long]
+  ): (Map[TopicPartition, Long], Map[Node, Map[TopicPartition, Long]]) = {
+    val local = mutable.Map.empty[TopicPartition, Long]
+    val forward = mutable.Map.empty[Node, mutable.Map[TopicPartition, Long]]
+    offsets.foreach { case (topicPartition, offset) =>
+      leaderToForwardTo(topicPartition) match {
+        case Some(leader) => forward.getOrElseUpdate(leader, mutable.Map.empty) += (topicPartition -> offset)
+        case None => local += (topicPartition -> offset)
+      }
+    }
+    (local.toMap, forward.map { case (node, partitionOffsets) => node -> partitionOffsets.toMap }.toMap)
+  }
+
+  private def leaderToForwardTo(topicPartition: TopicPartition): Option[Node] = {
+    if (!metadataView.isDisklessTopic(topicPartition.topic) || !hasLocalLeg(topicPartition)) {
+      None
+    } else {
+      val leader = metadataCache.getPartitionLeaderEndpoint(
+        topicPartition.topic, topicPartition.partition, interBrokerListenerName)
+      if (leader.isPresent && !leader.get.isEmpty && leader.get.id != config.brokerId) Some(leader.get)
+      else None
+    }
+  }
+
+  /**
+   * Whether the partition has a classic/consolidated prefix that lives in a local `UnifiedLog`,
+   * i.e. a leader-only local-log leg of `DeleteRecords` that is not broker-agnostic. Derived purely
+   * from KRaft metadata so it can be evaluated on any broker (a born consolidating partition may not
+   * yet have a local log on the leader; the leader resolves that when it runs the split).
+   */
+  private def hasLocalLeg(topicPartition: TopicPartition): Boolean = {
+    val start = metadataView.getClassicToDisklessStartOffset(topicPartition)
+    start >= 0 ||
+      start == PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING ||
+      (start == PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET &&
+        metadataView.isConsolidatingDisklessTopic(topicPartition.topic))
+  }
+
+  /**
+   * Forward a `DeleteRecords` sub-request for `offsets` to `leader` and complete the returned future
+   * with the per-partition results. On a routing/network failure the future completes with a
+   * retriable `NOT_LEADER_OR_FOLLOWER` per partition so the AdminClient re-reads metadata and
+   * retries once leadership settles.
+   */
+  def forward(
+    leader: Node,
+    offsets: Map[TopicPartition, Long],
+    timeoutMs: Int
+  ): CompletableFuture[Map[TopicPartition, DeleteRecordsPartitionResult]] = {
+    val future = new CompletableFuture[Map[TopicPartition, DeleteRecordsPartitionResult]]()
+    if (leader == null || leader.isEmpty) {
+      future.complete(errorResults(offsets.keys, Errors.NOT_LEADER_OR_FOLLOWER))
+    } else {
+      queue.add(PendingForward(leader, offsets, timeoutMs, future))
+      wakeup()
+    }
+    future
+  }
+
+  private def errorResults(
+    partitions: Iterable[TopicPartition],
+    error: Errors
+  ): Map[TopicPartition, DeleteRecordsPartitionResult] = {
+    partitions.map { tp =>
+      tp -> new DeleteRecordsPartitionResult()
+        .setPartitionIndex(tp.partition)
+        .setLowWatermark(DeleteRecordsResponse.INVALID_LOW_WATERMARK)
+        .setErrorCode(error.code)
+    }.toMap
+  }
+
+  override def generateRequests(): util.Collection[RequestAndCompletionHandler] = {
+    val requests = new util.ArrayList[RequestAndCompletionHandler]()
+    val now = time.milliseconds()
+    var pending = queue.poll()
+    while (pending != null) {
+      requests.add(buildRequest(pending, now))
+      pending = queue.poll()
+    }
+    requests
+  }
+
+  private def buildRequest(pending: PendingForward, now: Long): RequestAndCompletionHandler = {
+    val topics = new util.LinkedHashMap[String, DeleteRecordsTopic]()
+    pending.offsets.foreach { case (tp, offset) =>
+      val topic = topics.computeIfAbsent(tp.topic, name => new DeleteRecordsTopic().setName(name))
+      topic.partitions().add(new DeleteRecordsPartition()
+        .setPartitionIndex(tp.partition)
+        .setOffset(offset))
+    }
+    val data = new DeleteRecordsRequestData()
+      .setTopics(new util.ArrayList[DeleteRecordsTopic](topics.values()))
+      .setTimeoutMs(pending.timeoutMs)
+    new RequestAndCompletionHandler(
+      now,
+      pending.leader,
+      new DeleteRecordsRequest.Builder(data),
+      completionHandler(pending)
+    )
+  }
+
+  private def completionHandler(pending: PendingForward): RequestCompletionHandler = new RequestCompletionHandler {
+    override def onComplete(response: ClientResponse): Unit = {
+      try {
+        if (response.authenticationException != null) {
+          error(s"DeleteRecords forwarding to ${pending.leader} failed with an authentication error", response.authenticationException)
+          pending.future.complete(errorResults(pending.offsets.keys, Errors.forException(response.authenticationException)))
+        } else if (response.versionMismatch != null) {
+          error(s"DeleteRecords forwarding to ${pending.leader} failed with a version mismatch", response.versionMismatch)
+          pending.future.complete(errorResults(pending.offsets.keys, Errors.UNKNOWN_SERVER_ERROR))
+        } else if (response.wasDisconnected || response.wasTimedOut) {
+          warn(s"DeleteRecords forwarding to ${pending.leader} failed with a network error " +
+            s"(disconnected=${response.wasDisconnected}, timedOut=${response.wasTimedOut}); the client will retry")
+          pending.future.complete(errorResults(pending.offsets.keys, Errors.NOT_LEADER_OR_FOLLOWER))
+        } else {
+          pending.future.complete(parseResponse(pending, response.responseBody.asInstanceOf[DeleteRecordsResponse]))
+        }
+      } catch {
+        case e: Throwable =>
+          error(s"Failed to handle the forwarded DeleteRecords response from ${pending.leader}", e)
+          pending.future.complete(errorResults(pending.offsets.keys, Errors.UNKNOWN_SERVER_ERROR))
+      } finally {
+        wakeup()
+      }
+    }
+  }
+
+  private def parseResponse(
+    pending: PendingForward,
+    response: DeleteRecordsResponse
+  ): Map[TopicPartition, DeleteRecordsPartitionResult] = {
+    val results = mutable.Map.empty[TopicPartition, DeleteRecordsPartitionResult]
+    for (topicResult <- response.data.topics.asScala; partitionResult <- topicResult.partitions.asScala) {
+      val tp = new TopicPartition(topicResult.name, partitionResult.partitionIndex)
+      results += tp -> new DeleteRecordsPartitionResult()
+        .setPartitionIndex(partitionResult.partitionIndex)
+        .setLowWatermark(partitionResult.lowWatermark)
+        .setErrorCode(partitionResult.errorCode)
+    }
+    // Any partition the leader did not answer for is reported as retriable so the client retries.
+    pending.offsets.keys.filterNot(results.contains).foreach { tp =>
+      results += tp -> new DeleteRecordsPartitionResult()
+        .setPartitionIndex(tp.partition)
+        .setLowWatermark(DeleteRecordsResponse.INVALID_LOW_WATERMARK)
+        .setErrorCode(Errors.NOT_LEADER_OR_FOLLOWER.code)
+    }
+    results.toMap
+  }
+}

--- a/core/src/main/scala/kafka/server/DisklessFetchOffsetRouter.scala
+++ b/core/src/main/scala/kafka/server/DisklessFetchOffsetRouter.scala
@@ -136,15 +136,22 @@ class DisklessFetchOffsetRouter(
           classicLookup()
 
         case ListOffsetsRequest.EARLIEST_TIMESTAMP =>
-          // Classic owns the earliest offset only while the local log still holds the pre-switch
-          // prefix (classicLogStartOffset < classicToDisklessStartOffset). A born-consolidated
-          // partition has no committed switch offset (NO_CLASSIC_TO_DISKLESS_START_OFFSET == -1),
-          // so its classic log never owns the earliest: the RLM-pinned local log start does not
-          // track cross-tier retention in time, whereas the control-plane leg does. Route those
-          // to diskless, whose list_offsets_v1 returns COALESCE(remote_log_start_offset,
-          // log_start_offset) and therefore reflects retention that advanced the remote/diskless
-          // start above 0 on a born-consolidated topic.
-          if (classicLogStartOffsetProvider(topicPartition).exists(_ < classicToDisklessStartOffset)) {
+          // The control plane is the authoritative, broker-agnostic cross-tier earliest for
+          // *consolidating* topics: its list_offsets_v1 returns COALESCE(remote_log_start_offset,
+          // log_start_offset), which the partition's classic leader keeps current (reporting 0 on
+          // becoming leader, then advancing it via remote retention and DeleteRecords). The local
+          // classic log start is NOT a safe source here: a follower's is frozen at the switch, so a
+          // client the metadata transformer routes to a follower would get a stale earliest, and
+          // DeleteRecords / retention advance the control plane rather than every replica's local
+          // log. So route every consolidating partition -- born-consolidated (no committed switch
+          // offset) and switched alike -- to the control plane, giving one consistent answer on
+          // every broker.
+          //
+          // Non-consolidating switched partitions keep the classic leg while it still owns the
+          // pre-switch prefix (classicLogStartOffset < classicToDisklessStartOffset); there is no
+          // control-plane cross-tier tracking for them.
+          if (!isConsolidatingPartition &&
+              classicLogStartOffsetProvider(topicPartition).exists(_ < classicToDisklessStartOffset)) {
             classicLookup()
           } else {
             asStatus(topicPartition, disklessLookup)

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -112,7 +112,8 @@ class KafkaApis(val requestChannel: RequestChannel,
                 val apiVersionManager: ApiVersionManager,
                 val clientMetricsManager: ClientMetricsManager,
                 val groupConfigManager: GroupConfigManager,
-                inklessSharedState: Option[SharedState] = None
+                inklessSharedState: Option[SharedState] = None,
+                disklessDeleteRecordsForwarder: Option[DisklessDeleteRecordsForwarder] = None
 ) extends ApiRequestHandler with Logging {
 
   type ProduceResponseStats = Map[TopicIdPartition, RecordValidationStats]
@@ -1599,14 +1600,56 @@ class KafkaApis(val requestChannel: RequestChannel,
           }.toList.asJava.iterator()))))
     }
 
-    if (authorizedForDeleteTopicOffsets.isEmpty)
+    if (authorizedForDeleteTopicOffsets.isEmpty) {
       sendResponseCallback(Map.empty)
-    else {
-      // call the replica manager to append messages to the replicas
-      replicaManager.deleteRecords(
-        deleteRecordsRequest.data.timeoutMs.toLong,
-        authorizedForDeleteTopicOffsets,
-        sendResponseCallback)
+    } else {
+      val timeoutMs = deleteRecordsRequest.data.timeoutMs
+      // Split the diskless partitions whose local-log leg must run on another broker's real KRaft
+      // leader (the metadata transformer advertised a follower to the client). A forwarded request
+      // lands on its real leader, where routeByLeader resolves leader == self and handles it
+      // locally, so the chain terminates without an explicit loop guard.
+      val routed = disklessDeleteRecordsForwarder
+        .map(forwarder => (forwarder, forwarder.routeByLeader(authorizedForDeleteTopicOffsets.toMap)))
+
+      routed match {
+        case Some((forwarder, (localOffsets, forwardByLeader))) if forwardByLeader.nonEmpty =>
+          // Some partitions must be applied by another broker's real KRaft leader (the diskless
+          // metadata transformer advertised a follower as the client-facing leader). Fan out the
+          // local and forwarded legs and merge their results into a single response.
+          val expected = forwardByLeader.size + (if (localOffsets.nonEmpty) 1 else 0)
+          val remaining = new AtomicInteger(expected)
+          val collected = new ConcurrentHashMap[TopicPartition, DeleteRecordsPartitionResult]()
+
+          def onBucketComplete(results: Map[TopicPartition, DeleteRecordsPartitionResult]): Unit = {
+            results.foreach { case (topicPartition, result) => collected.put(topicPartition, result) }
+            if (remaining.decrementAndGet() == 0)
+              sendResponseCallback(collected.asScala.toMap)
+          }
+
+          if (localOffsets.nonEmpty)
+            replicaManager.deleteRecords(timeoutMs.toLong, localOffsets, onBucketComplete)
+
+          forwardByLeader.foreach { case (leader, offsets) =>
+            forwarder.forward(leader, offsets, timeoutMs).whenComplete { (results, exception) =>
+              if (exception != null) {
+                warn(s"Failed to forward DeleteRecords for $offsets to leader $leader", exception)
+                onBucketComplete(offsets.keys.map { topicPartition =>
+                  topicPartition -> new DeleteRecordsPartitionResult()
+                    .setPartitionIndex(topicPartition.partition)
+                    .setLowWatermark(DeleteRecordsResponse.INVALID_LOW_WATERMARK)
+                    .setErrorCode(Errors.NOT_LEADER_OR_FOLLOWER.code)
+                }.toMap)
+              } else {
+                onBucketComplete(results)
+              }
+            }
+          }
+
+        case _ =>
+          // No forwarding needed (inkless disabled, forwarded request, or all partitions handled
+          // locally): keep the existing single-call path.
+          replicaManager.deleteRecords(timeoutMs.toLong, authorizedForDeleteTopicOffsets, sendResponseCallback)
+      }
     }
   }
 

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -20,7 +20,7 @@ import com.yammer.metrics.core.Meter
 import io.aiven.inkless.common.SharedState
 import io.aiven.inkless.consume.{ConcatenatedRecords, FetchHandler, FetchOffsetHandler, Reader}
 import io.aiven.inkless.storage_backend.common.ObjectFetcher
-import io.aiven.inkless.control_plane.{BatchInfo, FindBatchRequest, FindBatchResponse, InitDisklessLogProducerState, RepairDisklessLogRequest}
+import io.aiven.inkless.control_plane.{AdvanceCrossTierLogStartOffsetRequest, AdvanceCrossTierLogStartOffsetResponse, BatchInfo, FindBatchRequest, FindBatchResponse, InitDisklessLogProducerState, RepairDisklessLogRequest, ListOffsetsRequest => CpListOffsetsRequest}
 import io.aiven.inkless.delete.{DeleteRecordsInterceptor, FileCleaner, RetentionEnforcer}
 import io.aiven.inkless.produce.AppendHandler
 import io.aiven.inkless.consolidation.{ConsolidatedDisklessLogPruner, ConsolidationFetcherManager, ConsolidationMetrics, ConsolidationReconciler}
@@ -1603,6 +1603,20 @@ class ReplicaManager(val config: KafkaConfig,
     val immutableDisklessOffsets = disklessOffsetPerPartition.toMap
     val immutableHybridPartitions = hybridDisklessPartitions.toSet
 
+    // Report the cross-tier earliest of successfully-deleted consolidating diskless partitions to the
+    // control plane and use it as their low watermark, so any broker (leader or the follower the
+    // metadata transformer routes clients to) returns the same value as ListOffsets(EARLIEST).
+    def finalizeCrossTierAndRespond(response: Map[TopicPartition, DeleteRecordsPartitionResult]): Unit = {
+      val advanced = advanceCrossTierEarliestForDeleteRecords(response, offsetPerPartition)
+      if (advanced.isEmpty) {
+        responseCallback(response)
+      } else {
+        responseCallback(response.map { case (topicPartition, result) =>
+          topicPartition -> advanced.getOrElse(topicPartition, result)
+        })
+      }
+    }
+
     def maybeDeleteFromDiskless(localResponse: Map[TopicPartition, DeleteRecordsPartitionResult]): Unit = {
       // Keep pure diskless partitions and only the hybrid partitions whose local phase succeeded.
       val disklessOffsetsAfterLocalDelete = immutableDisklessOffsets.filterNot { case (topicPartition, _) =>
@@ -1610,11 +1624,11 @@ class ReplicaManager(val config: KafkaConfig,
           localResponse.get(topicPartition).exists(_.errorCode != Errors.NONE.code)
       }
       if (disklessOffsetsAfterLocalDelete.isEmpty) {
-        responseCallback(localResponse ++ failedDisklessDeleteRecords)
+        finalizeCrossTierAndRespond(localResponse ++ failedDisklessDeleteRecords)
       } else {
         inklessDeleteRecordsInterceptor.get.intercept(
           disklessOffsetsAfterLocalDelete.view.mapValues(java.lang.Long.valueOf).toMap.asJava,
-          r => responseCallback(localResponse ++ failedDisklessDeleteRecords ++ r.asScala))
+          r => finalizeCrossTierAndRespond(localResponse ++ failedDisklessDeleteRecords ++ r.asScala))
       }
     }
 
@@ -1627,7 +1641,25 @@ class ReplicaManager(val config: KafkaConfig,
     val localDeleteRecordsResults = deleteRecordsOnLocalLog(localOffsetPerPartition, allowInternalTopicDeletion)
     debug("Delete records on local log in %d ms".format(time.milliseconds - timeBeforeLocalDeleteRecords))
 
-    val deleteRecordsStatus = localDeleteRecordsResults.map { case (topicPartition, result) =>
+    // Consolidating diskless partitions (born-consolidating or switched-with-remote-storage) do not
+    // replicate their local consolidated log to followers, so their DeleteRecords completion must NOT
+    // wait on the ISR low watermark (Partition.lowWatermarkIfLeader), which is pinned at the followers'
+    // frozen, pre-switch logStartOffset. Their earliest is instead reported from the control plane in
+    // finalizeCrossTierAndRespond; only classic partitions keep the ISR-gated delayed operation. The
+    // local leg above still ran to drive the leader's RemoteLogManager physical deletion of remote
+    // segments.
+    val (crossTierResults, classicResults) = localDeleteRecordsResults.partition { case (topicPartition, _) =>
+      _inklessMetadataView.isConsolidatingDisklessTopic(topicPartition.topic)
+    }
+
+    val crossTierResponseStatus = crossTierResults.map { case (topicPartition, result) =>
+      topicPartition -> new DeleteRecordsPartitionResult()
+        .setLowWatermark(result.lowWatermark)
+        .setErrorCode(result.error.code)
+        .setPartitionIndex(topicPartition.partition)
+    }
+
+    val deleteRecordsStatus = classicResults.map { case (topicPartition, result) =>
       topicPartition ->
         new DeleteRecordsPartitionStatus(
           result.requestedOffset, // requested offset
@@ -1637,7 +1669,7 @@ class ReplicaManager(val config: KafkaConfig,
             .setPartitionIndex(topicPartition.partition)) // response status
     }
 
-    if (delayedDeleteRecordsRequired(localDeleteRecordsResults)) {
+    if (delayedDeleteRecordsRequired(classicResults)) {
       def onAcks(topicPartition: TopicPartition, status: DeleteRecordsPartitionStatus): Unit = {
         val (lowWatermarkReached, error, lw) = getPartition(topicPartition) match {
           case HostedPartition.Online(partition) =>
@@ -1662,10 +1694,11 @@ class ReplicaManager(val config: KafkaConfig,
         }
       }
       // create delayed delete records operation
-      val delayedDeleteRecords = new DelayedDeleteRecords(timeout, deleteRecordsStatus.asJava, onAcks, response => maybeDeleteFromDiskless(response.asScala))
+      val delayedDeleteRecords = new DelayedDeleteRecords(timeout, deleteRecordsStatus.asJava, onAcks,
+        response => maybeDeleteFromDiskless(response.asScala ++ crossTierResponseStatus))
 
       // create a list of (topic, partition) pairs to use as keys for this delayed delete records operation
-      val deleteRecordsRequestKeys = localOffsetPerPartition.keys.map(new TopicPartitionOperationKey(_)).toList
+      val deleteRecordsRequestKeys = classicResults.keys.map(new TopicPartitionOperationKey(_)).toList
 
       // try to complete the request immediately, otherwise put it into the purgatory
       // this is because while the delayed delete records operation is being created, new
@@ -1674,7 +1707,145 @@ class ReplicaManager(val config: KafkaConfig,
     } else {
       // we can respond immediately
       val deleteRecordsResponseStatus = deleteRecordsStatus.map { case (k, status) => k -> status.responseStatus }
-      maybeDeleteFromDiskless(deleteRecordsResponseStatus)
+      maybeDeleteFromDiskless(deleteRecordsResponseStatus ++ crossTierResponseStatus)
+    }
+  }
+
+  /**
+   * For every successfully-deleted consolidating diskless partition in `response`, advance the
+   * control-plane cross-tier earliest (`remote_log_start_offset`) to the requested delete offset and
+   * return a replacement result whose low watermark is the stored value. `EARLIEST` is
+   * `COALESCE(remote_log_start_offset, log_start_offset)`, so reporting the just-advanced (non-null)
+   * `remote_log_start_offset` keeps the DeleteRecords low watermark and a subsequent
+   * `ListOffsets(EARLIEST)` in agreement on every broker.
+   *
+   * Physical deletion is unchanged: the diskless WAL objects are freed by `delete_records_v1` +
+   * `FileCleaner`, and the remote-tier segments by the leader's `RemoteLogManager` (driven by the
+   * leader's local `logStartOffset`); this method only moves the logical earliest pointer.
+   *
+   * Returns the replacement results keyed by partition (empty when nothing applies). The control-plane
+   * call is synchronous; `DeleteRecords` is an infrequent admin operation.
+   */
+  private def advanceCrossTierEarliestForDeleteRecords(
+    response: Map[TopicPartition, DeleteRecordsPartitionResult],
+    offsetPerPartition: Map[TopicPartition, Long]
+  ): Map[TopicPartition, DeleteRecordsPartitionResult] = {
+    val sharedState = inklessSharedState.orNull
+    if (sharedState == null) {
+      return Map.empty
+    }
+
+    // A consolidating partition's converted delete offset X: the concrete requested offset, or -- for
+    // HIGH_WATERMARK, which on a consolidating topic always reaches into the WAL and thus runs the
+    // diskless leg -- the low watermark that leg returned (= log_start_offset = HWM).
+    val requests = new java.util.ArrayList[AdvanceCrossTierLogStartOffsetRequest]()
+    val partitionsInOrder = mutable.ArrayBuffer.empty[TopicPartition]
+    response.foreach { case (topicPartition, result) =>
+      if (result.errorCode == Errors.NONE.code &&
+        _inklessMetadataView.isConsolidatingDisklessTopic(topicPartition.topic)) {
+        val requested = offsetPerPartition.getOrElse(topicPartition, DeleteRecordsRequest.HIGH_WATERMARK)
+        val convertedOffset = if (requested == DeleteRecordsRequest.HIGH_WATERMARK) result.lowWatermark else requested
+        val topicId = _inklessMetadataView.getTopicId(topicPartition.topic)
+        if (convertedOffset >= 0 && topicId != null && !topicId.equals(Uuid.ZERO_UUID)) {
+          partitionsInOrder += topicPartition
+          requests.add(new AdvanceCrossTierLogStartOffsetRequest(topicId, topicPartition.partition, convertedOffset))
+        }
+      }
+    }
+
+    if (requests.isEmpty) {
+      return Map.empty
+    }
+
+    try {
+      val responses = sharedState.controlPlane().advanceCrossTierLogStartOffset(requests)
+      val replacements = mutable.Map.empty[TopicPartition, DeleteRecordsPartitionResult]
+      for (i <- 0 until responses.size()) {
+        val topicPartition = partitionsInOrder(i)
+        val advanceResponse = responses.get(i)
+        if (advanceResponse.errors() == Errors.NONE &&
+          advanceResponse.remoteLogStartOffset() != AdvanceCrossTierLogStartOffsetResponse.NO_OFFSET) {
+          val stored = advanceResponse.remoteLogStartOffset()
+          // Write-through so the leader's local read path does not re-query the control plane.
+          sharedState.crossTierLogStartCache().put(
+            new TopicIdPartition(requests.get(i).topicId(), topicPartition.partition, topicPartition.topic), stored)
+          replacements += topicPartition -> new DeleteRecordsPartitionResult()
+            .setPartitionIndex(topicPartition.partition)
+            .setLowWatermark(stored)
+            .setErrorCode(Errors.NONE.code)
+        }
+      }
+      replacements.toMap
+    } catch {
+      case e: Throwable =>
+        // Reporting failure must not fail the delete (the data is already deleted); leave the per-leg
+        // low watermark in place and let the RLM's own report reconcile the control plane later.
+        error(s"Failed to advance cross-tier log start offset for ${partitionsInOrder.mkString(", ")}", e)
+        Map.empty
+    }
+  }
+
+  /**
+   * The authoritative cross-tier earliest offset for a consolidating diskless partition as tracked by
+   * the control plane (`COALESCE(remote_log_start_offset, log_start_offset)`, the same value
+   * `ListOffsets(EARLIEST)` returns). Returns empty for non-consolidating / non-inkless partitions or
+   * when it cannot be resolved.
+   *
+   * This is the single, broker-agnostic source of truth for a consolidating partition's whole-log
+   * start. It exists because the broker-local `UnifiedLog.logStartOffset` is NOT safe here: on a
+   * freshly-elected leader whose classic prefix was already evicted, the leadership rebuild pins the
+   * local log start at the seal (`classicToDisklessStartOffset`), and `maybeIncrementLogStartOffset`
+   * is monotonic so it can never be pulled back down to the true earliest after a `DeleteRecords` or
+   * remote retention advanced it. Using the local log start there would (a) over-reclaim the remote
+   * classic prefix `[earliest, seal)` and (b) reject reads of it as out-of-range. Callers that need a
+   * consistent floor/whole-log start (the consolidation read/rebuild path and the RLM remote-retention
+   * reclaim) consult this instead.
+   *
+   * Reads the write-through [[io.aiven.inkless.cache.CrossTierLogStartCache]] first and falls back to a
+   * control-plane `listOffsets(EARLIEST)` query, populating the cache on a hit. A stale cache entry can
+   * only be too low (the safe direction: it under-reclaims and over-serves, never the reverse).
+   */
+  /**
+   * Whether `topicPartition` belongs to a consolidating diskless topic on this broker.
+   *
+   * Used by the [[org.apache.kafka.server.log.remote.storage.RemoteLogManager]] to choose its
+   * remote-retention reclaim-floor fallback when [[crossTierEarliestOffset]] is unavailable: a
+   * consolidating partition must never fall back to the broker-local log start (the classic-to-diskless
+   * seal on a freshly-rebuilt leader), whereas a classic topic keeps the upstream local-log-start
+   * behavior. Mirrors the consolidating guard in [[crossTierEarliestOffset]] so the two agree.
+   */
+  def isConsolidatingDisklessPartition(topicPartition: TopicPartition): Boolean =
+    inklessSharedState.isDefined && _inklessMetadataView.isConsolidatingDisklessTopic(topicPartition.topic)
+
+  def crossTierEarliestOffset(topicPartition: TopicPartition): OptionalLong = {
+    val sharedState = inklessSharedState.orNull
+    if (sharedState == null || !_inklessMetadataView.isConsolidatingDisklessTopic(topicPartition.topic)) {
+      return OptionalLong.empty()
+    }
+    val topicId = _inklessMetadataView.getTopicId(topicPartition.topic)
+    if (topicId == null || topicId.equals(Uuid.ZERO_UUID)) {
+      return OptionalLong.empty()
+    }
+    val tidp = new TopicIdPartition(topicId, topicPartition.partition, topicPartition.topic)
+    val cached = sharedState.crossTierLogStartCache().get(tidp)
+    if (cached != null) {
+      return OptionalLong.of(cached)
+    }
+    try {
+      val responses = sharedState.controlPlane().listOffsets(
+        util.List.of(new CpListOffsetsRequest(tidp, CpListOffsetsRequest.EARLIEST_TIMESTAMP)))
+      if (responses != null && !responses.isEmpty) {
+        val response = responses.get(0)
+        if (response.errors() == Errors.NONE && response.offset() >= 0) {
+          sharedState.crossTierLogStartCache().put(tidp, response.offset())
+          return OptionalLong.of(response.offset())
+        }
+      }
+      OptionalLong.empty()
+    } catch {
+      case e: Throwable =>
+        warn(s"Failed to resolve cross-tier earliest offset for $topicPartition from the control plane", e)
+        OptionalLong.empty()
     }
   }
 

--- a/core/src/test/scala/io/aiven/inkless/consolidation/DisklessLeaderEndPointTest.scala
+++ b/core/src/test/scala/io/aiven/inkless/consolidation/DisklessLeaderEndPointTest.scala
@@ -1042,6 +1042,120 @@ class DisklessLeaderEndPointTest {
   }
 
   @Test
+  def testFetchUsesCrossTierEarliestAsWholeLogStartForConsolidatingLeader(): Unit = {
+    // Problem B: on a freshly-rebuilt consolidating leader the local log start is pinned at the seal
+    // (400) even though DeleteRecords / retention left the true earliest at 200 (tracked in the control
+    // plane). The endpoint must report the cross-tier earliest (200) as the whole-log start so that (a) a
+    // read of the surviving remote prefix [200, 400) redirects to tiered storage instead of being
+    // rejected as out-of-range, and (b) the tier-state rebuild restarts the log at 200, not the seal.
+    val fetchHandler = mock(classOf[FetchHandler])
+    val fetchOffsetHandler = mock(classOf[FetchOffsetHandler])
+    val replicaManager = mock(classOf[ReplicaManager])
+    val partition = mock(classOf[Partition])
+    val localLog = mock(classOf[UnifiedLog])
+    when(partition.localLogOrException).thenReturn(localLog)
+    when(localLog.logStartOffset).thenReturn(400L) // local log start pinned at the seal
+    when(localLog.remoteLogEnabled()).thenReturn(true)
+    when(replicaManager.getPartitionOrError(topicPartition)).thenReturn(Right(partition))
+    when(replicaManager.crossTierEarliestOffset(topicPartition)).thenReturn(OptionalLong.of(200L))
+
+    val fetchData = new FetchPartitionData(
+      Errors.NONE,
+      800L,
+      700L, // diskless WAL start
+      MemoryRecords.EMPTY,
+      Optional.empty(),
+      OptionalLong.empty(),
+      Optional.empty(),
+      OptionalInt.empty(),
+      false
+    )
+    when(fetchHandler.handle(any(), any())).thenReturn(CompletableFuture.completedFuture(Map(topicIdPartition -> fetchData).asJava))
+
+    val endPoint = newEndPoint(fetchHandler, fetchOffsetHandler, replicaManager)
+    val pd = endPoint.fetch(fetchBuilderForOffset(requestedOffset = 200L)).get(topicPartition)
+
+    assertEquals(Errors.OFFSET_MOVED_TO_TIERED_STORAGE.code, pd.errorCode)
+    assertEquals(200L, pd.logStartOffset)
+  }
+
+  @Test
+  def testFetchKeepsLocalLogStartWhenCrossTierEarliestIsHigher(): Unit = {
+    // Safety of the min(): if the control-plane cross-tier earliest (500) is somehow above the local
+    // log start (400), keep the lower local value so we never advance the whole-log start past data the
+    // local log still holds (the safe, over-serve direction).
+    val fetchHandler = mock(classOf[FetchHandler])
+    val fetchOffsetHandler = mock(classOf[FetchOffsetHandler])
+    val replicaManager = mock(classOf[ReplicaManager])
+    val partition = mock(classOf[Partition])
+    val localLog = mock(classOf[UnifiedLog])
+    when(partition.localLogOrException).thenReturn(localLog)
+    when(localLog.logStartOffset).thenReturn(400L)
+    when(localLog.remoteLogEnabled()).thenReturn(true)
+    when(replicaManager.getPartitionOrError(topicPartition)).thenReturn(Right(partition))
+    when(replicaManager.crossTierEarliestOffset(topicPartition)).thenReturn(OptionalLong.of(500L))
+
+    val fetchData = new FetchPartitionData(
+      Errors.NONE,
+      800L,
+      700L,
+      MemoryRecords.EMPTY,
+      Optional.empty(),
+      OptionalLong.empty(),
+      Optional.empty(),
+      OptionalInt.empty(),
+      false
+    )
+    when(fetchHandler.handle(any(), any())).thenReturn(CompletableFuture.completedFuture(Map(topicIdPartition -> fetchData).asJava))
+
+    val endPoint = newEndPoint(fetchHandler, fetchOffsetHandler, replicaManager)
+    val pd = endPoint.fetch(fetchBuilderForOffset(requestedOffset = 450L)).get(topicPartition)
+
+    assertEquals(Errors.OFFSET_MOVED_TO_TIERED_STORAGE.code, pd.errorCode)
+    assertEquals(400L, pd.logStartOffset)
+  }
+
+  @Test
+  def testFetchRevertsToLocalSealWhenCrossTierEarliestUnavailable(): Unit = {
+    // Failure-mode characterization (control-plane outage / not-yet-propagated metadata): when
+    // replicaManager.crossTierEarliestOffset returns empty, the endpoint falls back to the local log
+    // start -- which on a freshly-rebuilt consolidating leader is the seal (400). A read of the
+    // surviving remote prefix [200, 400) then sees requestedOffset (200) < reported logStartOffset (400),
+    // so it is treated as below the whole-log start (a genuine out-of-range) and is NOT redirected to
+    // tiered storage: the surviving prefix is effectively invisible. This pins the transient Problem B
+    // reversion that the empty fallback implies, so the risk is visible rather than silent.
+    val fetchHandler = mock(classOf[FetchHandler])
+    val fetchOffsetHandler = mock(classOf[FetchOffsetHandler])
+    val replicaManager = mock(classOf[ReplicaManager])
+    val partition = mock(classOf[Partition])
+    val localLog = mock(classOf[UnifiedLog])
+    when(partition.localLogOrException).thenReturn(localLog)
+    when(localLog.logStartOffset).thenReturn(400L) // local log start pinned at the seal
+    when(localLog.remoteLogEnabled()).thenReturn(true)
+    when(replicaManager.getPartitionOrError(topicPartition)).thenReturn(Right(partition))
+    when(replicaManager.crossTierEarliestOffset(topicPartition)).thenReturn(OptionalLong.empty())
+
+    val fetchData = new FetchPartitionData(
+      Errors.NONE,
+      800L,
+      700L,
+      MemoryRecords.EMPTY,
+      Optional.empty(),
+      OptionalLong.empty(),
+      Optional.empty(),
+      OptionalInt.empty(),
+      false
+    )
+    when(fetchHandler.handle(any(), any())).thenReturn(CompletableFuture.completedFuture(Map(topicIdPartition -> fetchData).asJava))
+
+    val endPoint = newEndPoint(fetchHandler, fetchOffsetHandler, replicaManager)
+    val pd = endPoint.fetch(fetchBuilderForOffset(requestedOffset = 200L)).get(topicPartition)
+
+    assertEquals(Errors.NONE.code, pd.errorCode)
+    assertEquals(400L, pd.logStartOffset)
+  }
+
+  @Test
   def testFetchDoesNotSignalWhenRequestOmitsOffset(): Unit = {
     // A request that does not include this partition leaves requestedOffset unresolved (-1): no signal.
     val endPoint = consolidatedPrefixEndPoint(localLogStartOffset = 0L, disklessStart = 100L, highWatermark = 200L, remoteLogEnabled = true)

--- a/core/src/test/scala/unit/kafka/server/DisklessDeleteRecordsForwarderTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DisklessDeleteRecordsForwarderTest.scala
@@ -1,0 +1,192 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.server
+
+import kafka.server.metadata.InklessMetadataView
+import org.apache.kafka.clients.NetworkClient
+import org.apache.kafka.common.message.DeleteRecordsResponseData.DeleteRecordsPartitionResult
+import org.apache.kafka.common.network.ListenerName
+import org.apache.kafka.common.protocol.Errors
+import org.apache.kafka.common.{Node, TopicPartition}
+import org.apache.kafka.metadata.{MetadataCache, PartitionRegistration}
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.{BeforeEach, Test}
+import org.mockito.ArgumentMatchers.{any, anyInt, eq => eqTo}
+import org.mockito.Mockito._
+
+import java.util.Optional
+
+class DisklessDeleteRecordsForwarderTest {
+
+  private val selfBrokerId = 1
+  private val interBrokerListener = new ListenerName("PLAINTEXT")
+
+  private val config: KafkaConfig = mock(classOf[KafkaConfig])
+  private val networkClient: NetworkClient = mock(classOf[NetworkClient])
+  private val metadataCache: MetadataCache = mock(classOf[MetadataCache])
+  private val metadataView: InklessMetadataView = mock(classOf[InklessMetadataView])
+
+  private var forwarder: DisklessDeleteRecordsForwarder = _
+
+  @BeforeEach
+  def setUp(): Unit = {
+    when(config.brokerId).thenReturn(selfBrokerId)
+    when(config.requestTimeoutMs).thenReturn(30000)
+    when(config.interBrokerListenerName).thenReturn(interBrokerListener)
+    forwarder = new DisklessDeleteRecordsForwarder(config, networkClient, metadataCache, metadataView, time = org.apache.kafka.common.utils.Time.SYSTEM)
+  }
+
+  private def stubLeader(tp: TopicPartition, node: Optional[Node]): Unit = {
+    when(metadataCache.getPartitionLeaderEndpoint(eqTo(tp.topic), eqTo(tp.partition), any(classOf[ListenerName])))
+      .thenReturn(node)
+  }
+
+  private def otherBroker: Node = new Node(2, "other-host", 9092)
+
+  @Test
+  def classicTopicStaysLocal(): Unit = {
+    val tp = new TopicPartition("classic", 0)
+    when(metadataView.isDisklessTopic("classic")).thenReturn(false)
+
+    val (local, forward) = forwarder.routeByLeader(Map(tp -> 10L))
+    assertEquals(Map(tp -> 10L), local)
+    assertTrue(forward.isEmpty)
+  }
+
+  @Test
+  def pureDisklessTopicStaysLocal(): Unit = {
+    val tp = new TopicPartition("diskless", 0)
+    when(metadataView.isDisklessTopic("diskless")).thenReturn(true)
+    when(metadataView.isConsolidatingDisklessTopic("diskless")).thenReturn(false)
+    when(metadataView.getClassicToDisklessStartOffset(tp))
+      .thenReturn(PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET)
+
+    val (local, forward) = forwarder.routeByLeader(Map(tp -> 10L))
+    assertEquals(Map(tp -> 10L), local)
+    assertTrue(forward.isEmpty)
+    verify(metadataCache, never()).getPartitionLeaderEndpoint(any(), anyInt(), any())
+  }
+
+  @Test
+  def switchedTopicOnRemoteLeaderIsForwarded(): Unit = {
+    val tp = new TopicPartition("switched", 0)
+    when(metadataView.isDisklessTopic("switched")).thenReturn(true)
+    when(metadataView.getClassicToDisklessStartOffset(tp)).thenReturn(100L)
+    stubLeader(tp, Optional.of(otherBroker))
+
+    val (local, forward) = forwarder.routeByLeader(Map(tp -> 150L))
+    assertTrue(local.isEmpty)
+    assertEquals(Map(otherBroker -> Map(tp -> 150L)), forward)
+  }
+
+  @Test
+  def switchedTopicOnSelfStaysLocal(): Unit = {
+    val tp = new TopicPartition("switched", 0)
+    when(metadataView.isDisklessTopic("switched")).thenReturn(true)
+    when(metadataView.getClassicToDisklessStartOffset(tp)).thenReturn(100L)
+    stubLeader(tp, Optional.of(new Node(selfBrokerId, "self-host", 9092)))
+
+    val (local, forward) = forwarder.routeByLeader(Map(tp -> 150L))
+    assertEquals(Map(tp -> 150L), local)
+    assertTrue(forward.isEmpty)
+  }
+
+  @Test
+  def consolidatingBornTopicOnRemoteLeaderIsForwarded(): Unit = {
+    val tp = new TopicPartition("consolidating", 0)
+    when(metadataView.isDisklessTopic("consolidating")).thenReturn(true)
+    when(metadataView.isConsolidatingDisklessTopic("consolidating")).thenReturn(true)
+    when(metadataView.getClassicToDisklessStartOffset(tp))
+      .thenReturn(PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET)
+    stubLeader(tp, Optional.of(otherBroker))
+
+    val (local, forward) = forwarder.routeByLeader(Map(tp -> 50L))
+    assertTrue(local.isEmpty)
+    assertEquals(Map(otherBroker -> Map(tp -> 50L)), forward)
+  }
+
+  @Test
+  def switchPendingTopicOnRemoteLeaderIsForwarded(): Unit = {
+    val tp = new TopicPartition("pending", 0)
+    when(metadataView.isDisklessTopic("pending")).thenReturn(true)
+    when(metadataView.getClassicToDisklessStartOffset(tp))
+      .thenReturn(PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING)
+    stubLeader(tp, Optional.of(otherBroker))
+
+    val (local, forward) = forwarder.routeByLeader(Map(tp -> 5L))
+    assertTrue(local.isEmpty)
+    assertEquals(Map(otherBroker -> Map(tp -> 5L)), forward)
+  }
+
+  @Test
+  def missingLeaderStaysLocal(): Unit = {
+    val tp = new TopicPartition("switched", 0)
+    when(metadataView.isDisklessTopic("switched")).thenReturn(true)
+    when(metadataView.getClassicToDisklessStartOffset(tp)).thenReturn(100L)
+    stubLeader(tp, Optional.empty())
+
+    val (local, forward) = forwarder.routeByLeader(Map(tp -> 150L))
+    assertEquals(Map(tp -> 150L), local)
+    assertTrue(forward.isEmpty)
+  }
+
+  @Test
+  def emptyLeaderNodeStaysLocal(): Unit = {
+    val tp = new TopicPartition("switched", 0)
+    when(metadataView.isDisklessTopic("switched")).thenReturn(true)
+    when(metadataView.getClassicToDisklessStartOffset(tp)).thenReturn(100L)
+    stubLeader(tp, Optional.of(Node.noNode()))
+
+    val (local, forward) = forwarder.routeByLeader(Map(tp -> 150L))
+    assertEquals(Map(tp -> 150L), local)
+    assertTrue(forward.isEmpty)
+  }
+
+  @Test
+  def mixedPartitionsAreSplitPerLeader(): Unit = {
+    val localTp = new TopicPartition("diskless", 0)
+    val remoteTp = new TopicPartition("switched", 0)
+    when(metadataView.isDisklessTopic("diskless")).thenReturn(true)
+    when(metadataView.isConsolidatingDisklessTopic("diskless")).thenReturn(false)
+    when(metadataView.getClassicToDisklessStartOffset(localTp))
+      .thenReturn(PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET)
+    when(metadataView.isDisklessTopic("switched")).thenReturn(true)
+    when(metadataView.getClassicToDisklessStartOffset(remoteTp)).thenReturn(100L)
+    stubLeader(remoteTp, Optional.of(otherBroker))
+
+    val (local, forward) = forwarder.routeByLeader(Map(localTp -> 1L, remoteTp -> 2L))
+    assertEquals(Map(localTp -> 1L), local)
+    assertEquals(Map(otherBroker -> Map(remoteTp -> 2L)), forward)
+  }
+
+  @Test
+  def forwardToEmptyLeaderCompletesWithRetriableError(): Unit = {
+    val tp = new TopicPartition("switched", 0)
+    val future = forwarder.forward(Node.noNode(), Map(tp -> 10L), 1000)
+    assertTrue(future.isDone)
+    val result: Map[TopicPartition, DeleteRecordsPartitionResult] = future.get()
+    assertEquals(Errors.NOT_LEADER_OR_FOLLOWER.code, result(tp).errorCode)
+  }
+
+  @Test
+  def forwardToNullLeaderCompletesWithRetriableError(): Unit = {
+    val tp = new TopicPartition("switched", 0)
+    val future = forwarder.forward(null, Map(tp -> 10L), 1000)
+    assertTrue(future.isDone)
+    assertEquals(Errors.NOT_LEADER_OR_FOLLOWER.code, future.get()(tp).errorCode)
+  }
+}

--- a/core/src/test/scala/unit/kafka/server/DisklessFetchOffsetRouterTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DisklessFetchOffsetRouterTest.scala
@@ -492,13 +492,17 @@ class DisklessFetchOffsetRouterTest {
   }
 
   @Test
-  def consolidatingSwitchedEarliestUsesClassicWhilePrefixPresent(): Unit = {
+  def consolidatingSwitchedEarliestRoutesToDisklessWhilePrefixPresent(): Unit = {
     // Switched-then-consolidated topic whose classic prefix is still on disk
-    // (classicLogStartOffset 0 < classicToDisklessStartOffset 100): classic owns the earliest,
-    // so its answer is returned verbatim and the control-plane leg (which does not know about the
-    // pre-switch prefix) is NOT consulted.
+    // (classicLogStartOffset 0 < classicToDisklessStartOffset 100). EARLIEST must NOT be served
+    // from the local classic log: on a follower that value is frozen at the switch, so the answer
+    // would differ per broker (the metadata transformer can route a client to any replica). The
+    // control plane is the single, broker-agnostic cross-tier earliest (its list_offsets_v1 returns
+    // COALESCE(remote_log_start_offset, log_start_offset), which the classic leader keeps current),
+    // so the diskless leg is consulted and the classic leg is NOT.
     when(inklessMetadataView.getClassicToDisklessStartOffset(tp)).thenReturn(100L)
     when(inklessMetadataView.isConsolidatingDisklessTopic(tp.topic)).thenReturn(true)
+    disklessTaskFuture.complete(offsetResult(0L))
 
     val status = route(
       newRouter(disklessConsolidationEnabled = true),
@@ -506,9 +510,52 @@ class DisklessFetchOffsetRouterTest {
       classicLogStartOffset = Some(0L)
     )
 
-    assertSame(defaultClassicResult, status)
-    assertClassicCalledWith(allowFromFollower = true)
-    verify(job, never()).add(any(), any())
+    assertTrue(classicCalls.isEmpty, "classic path must not be invoked for a consolidating topic's EARLIEST")
+    verify(job).add(eqTo(tp), any())
+    assertTrue(status.futureHolderOpt.isPresent, "diskless leg surfaces an async holder")
+    val result = status.futureHolderOpt.get.taskFuture.get(1, TimeUnit.SECONDS)
+    assertEquals(0L, result.timestampAndOffset.get.offset)
+  }
+
+  @Test
+  def consolidatingSwitchedEarliestIsConsistentAcrossBrokersRegardlessOfLocalClassicLogStart(): Unit = {
+    // Problem A regression guard: two brokers with *different* local classic log starts (a leader
+    // that advanced to 60 and a follower still frozen at 0, both below the seal of 100) must return
+    // the SAME earliest. Because the router sends both to the control plane, neither consults its
+    // local classic log, so the answer is identical on every broker.
+    when(inklessMetadataView.getClassicToDisklessStartOffset(tp)).thenReturn(100L)
+    when(inklessMetadataView.isConsolidatingDisklessTopic(tp.topic)).thenReturn(true)
+
+    Seq(Some(0L), Some(60L)).foreach { localClassicLogStart =>
+      classicCalls.clear()
+      val fresh = new CompletableFuture[FileRecordsOrError]()
+      fresh.complete(offsetResult(42L))
+      val jobForBroker = {
+        val m = mock(classOf[FetchOffsetHandler.Job])
+        when(m.add(any(), any())).thenAnswer(_ => fresh)
+        when(m.cancelHandler()).thenReturn(new CompletableFuture[Void]())
+        m
+      }
+      val status = new DisklessFetchOffsetRouter(
+        inklessMetadataView, true, true, purgatory).route(
+        job = jobForBroker,
+        newJob = () => throw new AssertionError("newJob() should not be called by this routing path"),
+        topicPartition = tp,
+        partition = makePartition(ListOffsetsRequest.EARLIEST_TIMESTAMP, tp.partition),
+        replicaId = consumerReplicaId,
+        version = 7,
+        classicLogStartOffsetProvider = _ => localClassicLogStart,
+        hasCompleteClassicPrefix = (_, _) => true,
+        classicFetchOffset = (tpArg, partition, allow) => {
+          classicCalls += ((tpArg, partition, allow))
+          defaultClassicResult
+        }
+      )
+      assertTrue(classicCalls.isEmpty,
+        s"classic path must not be invoked (localClassicLogStart=$localClassicLogStart)")
+      assertTrue(status.futureHolderOpt.isPresent)
+      assertEquals(42L, status.futureHolderOpt.get.taskFuture.get(1, TimeUnit.SECONDS).timestampAndOffset.get.offset)
+    }
   }
 
   @Test
@@ -534,11 +581,13 @@ class DisklessFetchOffsetRouterTest {
   }
 
   @Test
-  def consolidatingEarliestWithCommittedBoundaryDeniesFollowerAccessWhenPrefixIncomplete(): Unit = {
+  def consolidatingEarliestWithCommittedBoundaryRoutesToDisklessEvenWhenPrefixIncomplete(): Unit = {
     when(inklessMetadataView.getClassicToDisklessStartOffset(tp)).thenReturn(100L)
     when(inklessMetadataView.isConsolidatingDisklessTopic(tp.topic)).thenReturn(true)
-    // defaultClassicResult (offset 0) is a valid sync classic answer, so the classic leg wins
-    // verbatim and the control-plane leg is not consulted.
+    disklessTaskFuture.complete(offsetResult(5L))
+    // Local classic prefix is incomplete on this broker, but EARLIEST for a consolidating topic is
+    // served by the broker-agnostic control plane, so local completeness is irrelevant and the
+    // classic leg is never consulted.
     val status = route(
       newRouter(disklessConsolidationEnabled = true),
       timestamp = ListOffsetsRequest.EARLIEST_TIMESTAMP,
@@ -546,11 +595,10 @@ class DisklessFetchOffsetRouterTest {
       hasCompleteClassicPrefix = false
     )
 
-    // The classic leg runs but must be denied follower access until the local prefix is complete;
-    // since it answers, the diskless leg is not consulted.
-    assertClassicCalledWith(allowFromFollower = false)
-    verify(job, never()).add(any(), any())
-    assertSame(defaultClassicResult, status)
+    assertTrue(classicCalls.isEmpty, "classic path must not be invoked for a consolidating topic's EARLIEST")
+    verify(job).add(eqTo(tp), any())
+    assertTrue(status.futureHolderOpt.isPresent)
+    assertEquals(5L, status.futureHolderOpt.get.taskFuture.get(1, TimeUnit.SECONDS).timestampAndOffset.get.offset)
   }
   
   @Test

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerInklessTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerInklessTest.scala
@@ -17,11 +17,12 @@
 
 package kafka.server
 
+import io.aiven.inkless.cache.CrossTierLogStartCache
 import io.aiven.inkless.common.SharedState
 import io.aiven.inkless.config.InklessConfig
 import io.aiven.inkless.consolidation.{ConsolidatedDisklessLogPruner, ConsolidationFetcherManager}
 import io.aiven.inkless.consume.{ConcatenatedRecords, FetchHandler, FetchOffsetHandler}
-import io.aiven.inkless.control_plane.{BatchInfo, BatchMetadata, ControlPlane, ControlPlaneException, FindBatchResponse, RepairDisklessLogRequest, RepairDisklessLogResponse, DeleteRecordsResponse => CpDeleteRecordsResponse}
+import io.aiven.inkless.control_plane.{AdvanceCrossTierLogStartOffsetResponse, BatchInfo, BatchMetadata, ControlPlane, ControlPlaneException, FindBatchResponse, ListOffsetsResponse => CpListOffsetsResponse, RepairDisklessLogRequest, RepairDisklessLogResponse, DeleteRecordsResponse => CpDeleteRecordsResponse}
 import io.aiven.inkless.produce.AppendHandler
 import kafka.cluster.Partition
 import kafka.server.QuotaFactory.QuotaManagers
@@ -870,6 +871,307 @@ class ReplicaManagerInklessTest {
       assertEquals(150L, responseData(disklessTopicPartition.topicPartition()).lowWatermark)
       assertEquals(101L, partition.localLogOrException.logStartOffset)
       verify(controlPlane, timeout(5000)).deleteRecords(anyList())
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
+  def testDeleteRecordsConsolidatingClassicPrefixReportsCrossTierLowWatermarkWithoutDisklessLeg(): Unit = {
+    // A delete entirely within the classic/remote prefix of a switched consolidating topic
+    // (before classicToDisklessStartOffset) routes only to the local leg -- no diskless (WAL) leg --
+    // and its low watermark must come from the control-plane cross-tier earliest, not the ISR.
+    val controlPlane = mock(classOf[ControlPlane])
+    when(controlPlane.advanceCrossTierLogStartOffset(anyList()))
+      .thenReturn(util.List.of(AdvanceCrossTierLogStartOffsetResponse.success(50L)))
+    val replicaManager = createReplicaManager(
+      List(disklessTopicPartition.topic()),
+      controlPlane = Some(controlPlane),
+      topicIdMapping = Map(disklessTopicPartition.topic() -> disklessTopicPartition.topicId()),
+      disklessManagedReplicasEnabled = true,
+      disklessRemoteStorageConsolidationEnabled = true,
+      consolidatingDisklessTopics = Set(disklessTopicPartition.topic()),
+    )
+    try {
+      val partition = setupHybridLeaderPartition(replicaManager, disklessTopicPartition, localEndOffset = 200L)
+      // switched topic: the classic prefix ends at 100, and we delete before 50 (inside that prefix).
+      when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
+        .thenReturn(100L)
+
+      @volatile var responseData: Map[TopicPartition, DeleteRecordsResponseData.DeleteRecordsPartitionResult] = Map.empty
+      replicaManager.deleteRecords(
+        timeout = 0L,
+        offsetPerPartition = Map(disklessTopicPartition.topicPartition() -> 50L),
+        responseCallback = response => responseData = response,
+      )
+
+      waitUntilTrue(() => responseData.nonEmpty, "Cross-tier delete records response was not completed")
+      assertEquals(Errors.NONE.code, responseData(disklessTopicPartition.topicPartition()).errorCode)
+      // Low watermark comes from the control-plane cross-tier earliest (advance), not the ISR.
+      assertEquals(50L, responseData(disklessTopicPartition.topicPartition()).lowWatermark)
+      // Local leg still ran (drives RLM remote deletion): local log start advanced to 50.
+      assertEquals(50L, partition.localLogOrException.logStartOffset)
+      verify(controlPlane, timeout(5000)).advanceCrossTierLogStartOffset(anyList())
+      // No WAL data below the classic prefix, so the diskless leg must not run.
+      verify(controlPlane, never()).deleteRecords(anyList())
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
+  def testDeleteRecordsConsolidatingOverridesLowWatermarkWithCrossTierEarliest(): Unit = {
+    // For a hybrid consolidating delete (into the WAL) both legs run, but the reported low watermark
+    // is the control-plane cross-tier earliest (advance), which may differ from the WAL log start.
+    val controlPlane = mock(classOf[ControlPlane])
+    when(controlPlane.deleteRecords(anyList())).thenReturn(util.List.of(CpDeleteRecordsResponse.success(150L)))
+    when(controlPlane.advanceCrossTierLogStartOffset(anyList()))
+      .thenReturn(util.List.of(AdvanceCrossTierLogStartOffsetResponse.success(150L)))
+    val replicaManager = createReplicaManager(
+      List(disklessTopicPartition.topic()),
+      controlPlane = Some(controlPlane),
+      topicIdMapping = Map(disklessTopicPartition.topic() -> disklessTopicPartition.topicId()),
+      disklessManagedReplicasEnabled = true,
+      disklessRemoteStorageConsolidationEnabled = true,
+      consolidatingDisklessTopics = Set(disklessTopicPartition.topic()),
+    )
+    try {
+      val partition = setupHybridLeaderPartition(replicaManager, disklessTopicPartition, localEndOffset = 101L)
+      when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
+        .thenReturn(PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET)
+
+      @volatile var responseData: Map[TopicPartition, DeleteRecordsResponseData.DeleteRecordsPartitionResult] = Map.empty
+      replicaManager.deleteRecords(
+        timeout = 0L,
+        offsetPerPartition = Map(disklessTopicPartition.topicPartition() -> 150L),
+        responseCallback = response => responseData = response,
+      )
+
+      waitUntilTrue(() => responseData.nonEmpty, "Hybrid consolidating delete records response was not completed")
+      assertEquals(Errors.NONE.code, responseData(disklessTopicPartition.topicPartition()).errorCode)
+      assertEquals(150L, responseData(disklessTopicPartition.topicPartition()).lowWatermark)
+      assertEquals(101L, partition.localLogOrException.logStartOffset)
+      verify(controlPlane, timeout(5000)).deleteRecords(anyList())
+      verify(controlPlane, timeout(5000)).advanceCrossTierLogStartOffset(anyList())
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
+  def testDeleteRecordsPureDisklessDoesNotAdvanceCrossTierEarliest(): Unit = {
+    // A pure (non-consolidating) diskless topic has no remote tier; its delete must go through the
+    // diskless leg only and must not touch the cross-tier earliest.
+    val controlPlane = mock(classOf[ControlPlane])
+    when(controlPlane.deleteRecords(anyList())).thenReturn(util.List.of(CpDeleteRecordsResponse.success(150L)))
+    val replicaManager = createReplicaManager(
+      List(disklessTopicPartition.topic()),
+      controlPlane = Some(controlPlane),
+      topicIdMapping = Map(disklessTopicPartition.topic() -> disklessTopicPartition.topicId()),
+      disklessManagedReplicasEnabled = true,
+    )
+    try {
+      @volatile var responseData: Map[TopicPartition, DeleteRecordsResponseData.DeleteRecordsPartitionResult] = Map.empty
+      replicaManager.deleteRecords(
+        timeout = 0L,
+        offsetPerPartition = Map(disklessTopicPartition.topicPartition() -> 150L),
+        responseCallback = response => responseData = response,
+      )
+
+      waitUntilTrue(() => responseData.nonEmpty, "Pure diskless delete records response was not completed")
+      assertEquals(Errors.NONE.code, responseData(disklessTopicPartition.topicPartition()).errorCode)
+      assertEquals(150L, responseData(disklessTopicPartition.topicPartition()).lowWatermark)
+      verify(controlPlane, timeout(5000)).deleteRecords(anyList())
+      verify(controlPlane, never()).advanceCrossTierLogStartOffset(anyList())
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
+  def testCrossTierEarliestOffsetReturnsCachedValueOnHitWithoutControlPlane(): Unit = {
+    // Steady state: a cache hit is served verbatim and the control plane is never consulted -- even
+    // for a stale-low value. The cache is monotonic (put only advances), so a stale entry can only ever
+    // be too low, which is the safe direction for both reclaim (under-delete) and reads (over-serve).
+    // This documents that the accessor deliberately trusts the cache and does not second-guess it.
+    val controlPlane = mock(classOf[ControlPlane])
+    val cache = mock(classOf[CrossTierLogStartCache])
+    when(cache.get(any())).thenReturn(java.lang.Long.valueOf(120L))
+    val replicaManager = createReplicaManager(
+      List(disklessTopicPartition.topic()),
+      controlPlane = Some(controlPlane),
+      topicIdMapping = Map(disklessTopicPartition.topic() -> disklessTopicPartition.topicId()),
+      consolidatingDisklessTopics = Set(disklessTopicPartition.topic()),
+      crossTierLogStartCache = Some(cache),
+    )
+    try {
+      assertEquals(OptionalLong.of(120L),
+        replicaManager.crossTierEarliestOffset(disklessTopicPartition.topicPartition()))
+      verify(controlPlane, never()).listOffsets(anyList())
+      verify(cache, never()).put(any(), anyLong())
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
+  def testCrossTierEarliestOffsetFallsBackToControlPlaneOnMissAndPopulatesCache(): Unit = {
+    // On a cache miss (cold cache -- e.g. this broker is the RLM leader but never served the delete, or
+    // the entry TTL-expired) the accessor queries the control-plane cross-tier earliest and writes it
+    // through so the next read is a hit.
+    val controlPlane = mock(classOf[ControlPlane])
+    when(controlPlane.listOffsets(anyList()))
+      .thenReturn(util.List.of(CpListOffsetsResponse.success(disklessTopicPartition, 0L, 200L)))
+    val cache = mock(classOf[CrossTierLogStartCache])
+    when(cache.get(any())).thenReturn(null.asInstanceOf[java.lang.Long])
+    val replicaManager = createReplicaManager(
+      List(disklessTopicPartition.topic()),
+      controlPlane = Some(controlPlane),
+      topicIdMapping = Map(disklessTopicPartition.topic() -> disklessTopicPartition.topicId()),
+      consolidatingDisklessTopics = Set(disklessTopicPartition.topic()),
+      crossTierLogStartCache = Some(cache),
+    )
+    try {
+      assertEquals(OptionalLong.of(200L),
+        replicaManager.crossTierEarliestOffset(disklessTopicPartition.topicPartition()))
+      verify(controlPlane).listOffsets(anyList())
+      verify(cache).put(any(), ArgumentMatchers.eq(200L))
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
+  def testCrossTierEarliestOffsetReturnsEmptyWhenControlPlaneThrows(): Unit = {
+    // Failure-mode characterization: if the control-plane query fails on a cache miss the accessor
+    // returns empty rather than propagating the exception. Callers (DisklessLeaderEndPoint whole-log
+    // start, RemoteLogManager reclaim floor + become-leader report) then fall back to the broker-local
+    // UnifiedLog.logStartOffset -- which on a freshly-rebuilt consolidating leader is the seal. So a
+    // control-plane outage in that window transiently reverts to the pre-fix (Problem B) behavior; it
+    // does not fail the fetch/cleanup. This test pins that contract so the fallback is a conscious
+    // choice, not an accident.
+    val controlPlane = mock(classOf[ControlPlane])
+    when(controlPlane.listOffsets(anyList())).thenThrow(new ControlPlaneException("boom"))
+    val cache = mock(classOf[CrossTierLogStartCache])
+    when(cache.get(any())).thenReturn(null.asInstanceOf[java.lang.Long])
+    val replicaManager = createReplicaManager(
+      List(disklessTopicPartition.topic()),
+      controlPlane = Some(controlPlane),
+      topicIdMapping = Map(disklessTopicPartition.topic() -> disklessTopicPartition.topicId()),
+      consolidatingDisklessTopics = Set(disklessTopicPartition.topic()),
+      crossTierLogStartCache = Some(cache),
+    )
+    try {
+      assertEquals(OptionalLong.empty(),
+        replicaManager.crossTierEarliestOffset(disklessTopicPartition.topicPartition()))
+      verify(cache, never()).put(any(), anyLong())
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
+  def testCrossTierEarliestOffsetReturnsEmptyWhenControlPlaneReturnsError(): Unit = {
+    // An error/negative control-plane response is treated as "unknown" (empty), not as offset -1, and
+    // must not poison the cache.
+    val controlPlane = mock(classOf[ControlPlane])
+    when(controlPlane.listOffsets(anyList()))
+      .thenReturn(util.List.of(CpListOffsetsResponse.unknownServerError(disklessTopicPartition)))
+    val cache = mock(classOf[CrossTierLogStartCache])
+    when(cache.get(any())).thenReturn(null.asInstanceOf[java.lang.Long])
+    val replicaManager = createReplicaManager(
+      List(disklessTopicPartition.topic()),
+      controlPlane = Some(controlPlane),
+      topicIdMapping = Map(disklessTopicPartition.topic() -> disklessTopicPartition.topicId()),
+      consolidatingDisklessTopics = Set(disklessTopicPartition.topic()),
+      crossTierLogStartCache = Some(cache),
+    )
+    try {
+      assertEquals(OptionalLong.empty(),
+        replicaManager.crossTierEarliestOffset(disklessTopicPartition.topicPartition()))
+      verify(cache, never()).put(any(), anyLong())
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
+  def testCrossTierEarliestOffsetReturnsEmptyForNonConsolidatingTopic(): Unit = {
+    // Metadata-propagation timing: if this broker's metadata view does not (yet) see the topic as
+    // consolidating, the accessor short-circuits to empty WITHOUT consulting the cache or the control
+    // plane, so callers keep the plain upstream behavior (local log start). This is also what keeps the
+    // accessor a no-op for classic / pure-diskless topics.
+    val controlPlane = mock(classOf[ControlPlane])
+    val cache = mock(classOf[CrossTierLogStartCache])
+    val replicaManager = createReplicaManager(
+      List(disklessTopicPartition.topic()),
+      controlPlane = Some(controlPlane),
+      topicIdMapping = Map(disklessTopicPartition.topic() -> disklessTopicPartition.topicId()),
+      consolidatingDisklessTopics = Set.empty, // not seen as consolidating on this broker
+      crossTierLogStartCache = Some(cache),
+    )
+    try {
+      assertEquals(OptionalLong.empty(),
+        replicaManager.crossTierEarliestOffset(disklessTopicPartition.topicPartition()))
+      verify(cache, never()).get(any())
+      verify(controlPlane, never()).listOffsets(anyList())
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
+  def testCrossTierEarliestOffsetReturnsEmptyWhenTopicIdUnknown(): Unit = {
+    // Another metadata-not-yet-propagated flavor: the topic is flagged consolidating but its id is not
+    // resolvable yet (ZERO_UUID). Without a topic id the control-plane key cannot be formed, so the
+    // accessor returns empty rather than querying with a bogus id.
+    val controlPlane = mock(classOf[ControlPlane])
+    val cache = mock(classOf[CrossTierLogStartCache])
+    val replicaManager = createReplicaManager(
+      List(disklessTopicPartition.topic()),
+      controlPlane = Some(controlPlane),
+      topicIdMapping = Map.empty, // getTopicId -> ZERO_UUID
+      consolidatingDisklessTopics = Set(disklessTopicPartition.topic()),
+      crossTierLogStartCache = Some(cache),
+    )
+    try {
+      assertEquals(OptionalLong.empty(),
+        replicaManager.crossTierEarliestOffset(disklessTopicPartition.topicPartition()))
+      verify(cache, never()).get(any())
+      verify(controlPlane, never()).listOffsets(anyList())
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
+  def testIsConsolidatingDisklessPartitionReflectsMetadataView(): Unit = {
+    // The RLM reclaim-floor fail-safe keys off this accessor; it must be true exactly for consolidating
+    // diskless topics (so they never fall back to the local seal) and false for classic/pure-diskless.
+    val replicaManager = createReplicaManager(
+      List(disklessTopicPartition.topic()),
+      topicIdMapping = Map(disklessTopicPartition.topic() -> disklessTopicPartition.topicId()),
+      consolidatingDisklessTopics = Set(disklessTopicPartition.topic()),
+    )
+    try {
+      assertTrue(replicaManager.isConsolidatingDisklessPartition(disklessTopicPartition.topicPartition()))
+      assertFalse(replicaManager.isConsolidatingDisklessPartition(new TopicPartition("classic", 0)))
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
+  def testIsConsolidatingDisklessPartitionFalseWithoutSharedState(): Unit = {
+    // Without inkless shared state (non-inkless broker) the accessor must be false so the RLM keeps the
+    // plain upstream local-log-start reclaim floor.
+    val replicaManager = createReplicaManager(
+      List.empty,
+      consolidatingDisklessTopics = Set(disklessTopicPartition.topic()),
+      inklessSharedStateEnabled = false,
+    )
+    try {
+      assertFalse(replicaManager.isConsolidatingDisklessPartition(disklessTopicPartition.topicPartition()))
     } finally {
       replicaManager.shutdown(checkpointHW = false)
     }
@@ -6486,7 +6788,8 @@ class ReplicaManagerInklessTest {
     inklessSharedStateEnabled: Boolean = true,
     initDisklessLogManager: Option[InitDisklessLogManager] = None,
     delayedFetchPurgatory: Option[DelayedOperationPurgatory[DelayedFetch]] = None,
-    defaultLogConfig: Option[LogConfig] = None
+    defaultLogConfig: Option[LogConfig] = None,
+    crossTierLogStartCache: Option[CrossTierLogStartCache] = None
   ): ReplicaManager = {
     val props = TestUtils.createBrokerConfig(1, logDirCount = 2)
     if (disklessManagedReplicasEnabled || disklessRemoteStorageConsolidationEnabled) {
@@ -6516,6 +6819,7 @@ class ReplicaManagerInklessTest {
     when(sharedState.config()).thenReturn(new InklessConfig(inklessConfigMap))
     when(sharedState.controlPlane()).thenReturn(controlPlane.getOrElse(mock(classOf[ControlPlane])))
     when(sharedState.maybeLaggingFetchStorage()).thenReturn(Optional.empty())
+    crossTierLogStartCache.foreach(cache => when(sharedState.crossTierLogStartCache()).thenReturn(cache))
     val inklessMetadata = mock(classOf[InklessMetadataView])
     when(inklessMetadata.isDisklessTopic(any())).thenReturn(false)
     when(inklessMetadata.getClassicToDisklessStartOffset(any()))

--- a/docs/inkless/DISKLESS_CONSOLIDATION.md
+++ b/docs/inkless/DISKLESS_CONSOLIDATION.md
@@ -213,10 +213,29 @@ truth**, with a short-TTL cache:
   has advanced above it.
 - **Read path (any broker).** `FetchOffsetHandler` serves `EARLIEST` on a consolidating
   diskless topic read-through the `CrossTierLogStartCache` first; on a miss it queries the
-  control plane and populates the cache. `DisklessFetchOffsetRouter` returns
-  `max(classic-leader leg, control-plane leg)` for consolidating partitions, so the freshest
-  authoritative value wins regardless of which broker serves the request (the classic leg is
-  authoritative on the leader, the control-plane leg on followers).
+  control plane and populates the cache. `DisklessFetchOffsetRouter` routes `EARLIEST` for
+  **every** consolidating partition (born-consolidated and switched alike) to this
+  control-plane leg — never to the broker-local classic log. This is required for
+  correctness under managed replicas: `InklessTopicMetadataTransformer` advertises a
+  hash-selected replica (usually a *follower*) as the partition leader, and a follower's
+  local classic log start is frozen at the switch, so serving `EARLIEST` from it would pin
+  the client-visible earliest at a stale value (e.g. `0` after a `DeleteRecords` the follower
+  never applied). The control-plane value is broker-agnostic, so every broker returns the
+  same cross-tier earliest. (Non-consolidating switched partitions keep serving `EARLIEST`
+  from the classic leg while it still owns the pre-switch prefix.)
+- **Whole-log start & reclaim floor (leader).** The same control-plane value is the
+  authoritative whole-log start / remote-retention reclaim floor for a consolidating
+  partition, *not* the broker-local `UnifiedLog.logStartOffset`. On a freshly-elected leader
+  whose classic prefix was already evicted, the leadership rebuild pins the local log start at
+  the seal (and it can only ever increment), so using it would over-reclaim the remote classic
+  prefix `[earliest, seal)` and reject reads of it as out-of-range. Instead
+  `DisklessLeaderEndPoint` reports `min(X, localLogStart)` as the whole-log start (so a read of
+  the surviving prefix redirects to the remote tier and the tier-state rebuild restarts at `X`),
+  and `RemoteLogManager` uses `X` as the log-start-breach reclaim floor and the become-leader
+  report — both via `ReplicaManager.crossTierEarliestOffset` (`X` =
+  `COALESCE(remote_log_start_offset, log_start_offset)`). This runs on the RLM leader, which
+  under managed replicas differs from the broker that served a `DeleteRecords`, so a
+  broker-agnostic source is mandatory.
 - **Cache.** Caffeine-backed with a TTL and a monotonic `put` (a `Null` implementation
   disables it); owned by `SharedState`. A stale entry can only ever be *too low* (the safe direction), so it only delays when a retention advance becomes visible off-leader.
 - **Storage.** The value is kept in `logs.remote_log_start_offset` (migration `V16`),
@@ -229,14 +248,39 @@ updates are coalesced per partition and flushed once a second, and only strictly
 values are sent.
 
 The configuration and JMX metrics for this feature are listed in
-[Configuration](#configuration) and [Metrics](#metrics). The system test is
-`consolidation_retention_across_tiers_test.py` (`RetentionReclaimsAcrossTiersTest`), which
-verifies the earliest offset advances past zero (and no further than a surviving cohort)
-after retention reclaims data across tiers.
+[Configuration](#configuration) and [Metrics](#metrics). Several system tests exercise
+the earliest offset on a consolidating topic. The two retention tests follow the same
+pattern (drain the born-consolidated pipeline until the early prefix is remote-only and
+the topic earliest is still `0`, then reclaim and assert the earliest advances while a
+contiguous tail survives and the reclaimed remote objects are physically deleted); the
+`DeleteRecords` test targets a switched (hybrid) topic (see below):
 
-> **Not yet covered.** Time-based reclaim (`retention.ms`) drives the earliest offset in
-> tests; `retention.bytes`-driven reclaim of the earliest offset is not yet exercised.
-> `DeleteRecords` across tiers on a consolidating topic is also not yet covered.
+- `consolidation_retention_across_tiers_test.py` (`RetentionReclaimsAcrossTiersTest`):
+  time-based reclaim via `retention.ms`.
+- `consolidation_retention_bytes_across_tiers_test.py`
+  (`RetentionBytesReclaimsAcrossTiersTest`): size-based reclaim via `retention.bytes`,
+  driven by the `RemoteLogManager` (not the WAL-only Inkless enforcer). The limit is set
+  to half of the bytes this topic actually shipped to remote, so the boundary lands
+  deterministically inside the produced range regardless of record size.
+- `consolidation_delete_records_across_tiers_test.py` (`DeleteRecordsAcrossTiersTest`):
+  an explicit `DeleteRecords` on a **switched (hybrid)** topic, before an offset inside
+  the tiered classic prefix `[0, seal)`. The receiving broker forwards the local leg to
+  the real KRaft leader (`DisklessDeleteRecordsForwarder`), which advances the log start
+  and the control-plane cross-tier earliest. It guards both **Problem A** and **Problem
+  B** in one run (retention held unset throughout, so only the `DeleteRecords` can move
+  the earliest):
+  - *Problem A* — the client-visible earliest advances off `0` to a single, stable value
+    that is the *same on every broker*, proving `EARLIEST` is served from the
+    broker-agnostic control plane and not from a hash-selected follower's frozen local
+    classic log.
+  - *Problem B* — that value settles at *exactly* the delete boundary (not the seal), and
+    the surviving prefix `[delete_before, seal)` reads back contiguous with the correct
+    content, proving the consolidation cleanup did not over-reclaim the classic prefix.
+    Previously a freshly-elected leader's local `logStartOffset` was pinned at the seal
+    (and only ever increments), so the RLM reclaim floor / become-leader report used the
+    seal; the fix drives both the whole-log start (`DisklessLeaderEndPoint`) and the RLM
+    reclaim floor / become-leader report (`RemoteLogManager`) from the control-plane
+    cross-tier earliest via `ReplicaManager.crossTierEarliestOffset`.
 
 ## Implementation
 
@@ -610,7 +654,14 @@ no loss), `InklessTopicTypeSwitcherClusterTest`.
 wiping all local copies), `consolidation_switched_read_from_remote_after_prune_test.py`
 (switched topic durability), `consolidation_dependency_outage_test.py` (object-store /
 control-plane outage during produce), `consolidation_retention_across_tiers_test.py`
-(cross-tier earliest offset after retention reclaim).
+(cross-tier earliest offset after time-based retention reclaim),
+`consolidation_retention_bytes_across_tiers_test.py` (cross-tier earliest offset after
+size-based `retention.bytes` reclaim), and
+`consolidation_delete_records_across_tiers_test.py` (after a `DeleteRecords` into the
+tiered classic prefix of a switched topic: **Problem A** — the client-visible earliest
+advances and is the same on every broker; **Problem B** — it settles at exactly the delete
+boundary and the surviving prefix stays readable, i.e. the classic prefix is not
+over-reclaimed to the seal; both driven by the control-plane cross-tier earliest).
 
 
 

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogManager.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogManager.java
@@ -154,6 +154,19 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
     private final Time time;
     private final Function<TopicPartition, Optional<UnifiedLog>> fetchLog;
     private final BiConsumer<TopicPartition, Long> updateRemoteLogStartOffset;
+    // Inkless: overrides the log start offset used to drive remote-retention reclaim (and the
+    // become-leader log-start report) for consolidating diskless partitions. For such partitions the
+    // broker-local UnifiedLog.logStartOffset can be pinned at the classic-to-diskless seal on a
+    // freshly-rebuilt leader, which would over-reclaim the remote classic prefix and report the seal as
+    // the cross-tier earliest. This function returns the control-plane cross-tier earliest for those
+    // partitions and OptionalLong.empty() for everything else (classic topics / non-inkless), where the
+    // upstream behavior (log.logStartOffset()) is unchanged.
+    private final Function<TopicPartition, OptionalLong> logStartOffsetOverride;
+    // Inkless: tells whether a partition is a consolidating diskless topic. Used to pick the reclaim
+    // floor's fallback when {@link #logStartOffsetOverride} is empty: consolidating partitions must never
+    // fall back to the broker-local log start (the classic-to-diskless seal on a rebuilt leader), while
+    // classic topics keep the upstream local-log-start behavior. No-op predicate for non-Inkless callers.
+    private final Predicate<TopicPartition> isConsolidatingDisklessPartition;
     private final BrokerTopicStats brokerTopicStats;
     private final Metrics metrics;
 
@@ -208,7 +221,6 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
      * @param brokerTopicStats BrokerTopicStats instance to update the respective metrics.
      * @param metrics  Metrics instance
      */
-    @SuppressWarnings({"this-escape"})
     public RemoteLogManager(RemoteLogManagerConfig rlmConfig,
                             int brokerId,
                             String logDir,
@@ -219,6 +231,29 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
                             BrokerTopicStats brokerTopicStats,
                             Metrics metrics,
                             Optional<Endpoint> endpoint) throws IOException {
+        this(rlmConfig, brokerId, logDir, clusterId, time, fetchLog, updateRemoteLogStartOffset,
+                brokerTopicStats, metrics, endpoint, tp -> OptionalLong.empty(), tp -> false);
+    }
+
+    /**
+     * Creates a RemoteLogManager with an Inkless log-start-offset override (see
+     * {@link #logStartOffsetOverride}) and a consolidating-partition predicate (see
+     * {@link #isConsolidatingDisklessPartition}). Non-Inkless callers should use the other constructor,
+     * which defaults both to no-ops.
+     */
+    @SuppressWarnings({"this-escape"})
+    public RemoteLogManager(RemoteLogManagerConfig rlmConfig,
+                            int brokerId,
+                            String logDir,
+                            String clusterId,
+                            Time time,
+                            Function<TopicPartition, Optional<UnifiedLog>> fetchLog,
+                            BiConsumer<TopicPartition, Long> updateRemoteLogStartOffset,
+                            BrokerTopicStats brokerTopicStats,
+                            Metrics metrics,
+                            Optional<Endpoint> endpoint,
+                            Function<TopicPartition, OptionalLong> logStartOffsetOverride,
+                            Predicate<TopicPartition> isConsolidatingDisklessPartition) throws IOException {
         this.rlmConfig = rlmConfig;
         this.brokerId = brokerId;
         this.logDir = logDir;
@@ -226,6 +261,8 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
         this.time = time;
         this.fetchLog = fetchLog;
         this.updateRemoteLogStartOffset = updateRemoteLogStartOffset;
+        this.logStartOffsetOverride = logStartOffsetOverride;
+        this.isConsolidatingDisklessPartition = isConsolidatingDisklessPartition;
         this.brokerTopicStats = brokerTopicStats;
         this.metrics = metrics;
         this.endpoint = endpoint;
@@ -882,7 +919,13 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
 
         private void maybeUpdateLogStartOffsetOnBecomingLeader(UnifiedLog log) throws RemoteStorageException {
             if (!isLogStartOffsetUpdated) {
-                long logStartOffset = findLogStartOffset(topicIdPartition, log);
+                // For a consolidating diskless partition, prefer the control-plane cross-tier earliest so a
+                // freshly-elected leader does not report its local seal as the cross-tier earliest (which
+                // would push the broker-agnostic earliest up to the seal). No-op for classic topics.
+                OptionalLong override = logStartOffsetOverride.apply(topicIdPartition.topicPartition());
+                long logStartOffset = override.isPresent()
+                        ? override.getAsLong()
+                        : findLogStartOffset(topicIdPartition, log);
                 updateRemoteLogStartOffset.accept(topicIdPartition.topicPartition(), logStartOffset);
                 isLogStartOffsetUpdated = true;
                 logger.info("Found the logStartOffset: {} for partition: {} after becoming leader",
@@ -1250,6 +1293,34 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
             brokerTopicStats.recordRemoteDeleteLagBytes(topic, partition, sizeOfDeletableSegmentsBytes);
         }
 
+        /**
+         * The log start offset that drives the remote-retention log-start-offset reclaim floor.
+         *
+         * <p>For a consolidating diskless partition this must come from the control-plane cross-tier
+         * earliest ({@link #logStartOffsetOverride}), not the broker-local log start: on a freshly-rebuilt
+         * leader the local log start is pinned at the classic-to-diskless seal (and can only increment),
+         * so using it would delete the entire remote classic prefix {@code [earliest, seal)} even though
+         * only {@code [0, earliest)} was actually removed by DeleteRecords / retention.
+         *
+         * <p>When the override is empty for a consolidating partition (control plane unreachable, or topic
+         * metadata not yet propagated to this leader) we fail safe to the remote earliest
+         * ({@link #findLogStartOffset}) rather than the local seal: no segment breaches the log-start-offset
+         * this cycle, so nothing is over-reclaimed; retention (time/size) still applies and the reclaim
+         * retries on a later cycle once the cross-tier earliest is resolvable again. Deferring is safe
+         * because remote deletes are irreversible. Classic topics keep the upstream local-log-start floor.
+         */
+        private long reclaimFloorLogStartOffset(UnifiedLog log) throws RemoteStorageException {
+            final TopicPartition tp = topicIdPartition.topicPartition();
+            final OptionalLong crossTierEarliest = logStartOffsetOverride.apply(tp);
+            if (crossTierEarliest.isPresent()) {
+                return crossTierEarliest.getAsLong();
+            }
+            if (isConsolidatingDisklessPartition.test(tp)) {
+                return findLogStartOffset(topicIdPartition, log);
+            }
+            return log.logStartOffset();
+        }
+
         /** Cleanup expired and dangling remote log segments. */
         void cleanupExpiredRemoteLogSegments() throws RemoteStorageException, ExecutionException, InterruptedException {
             if (isCancelled()) {
@@ -1295,7 +1366,7 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
             // Build the leader epoch map by filtering the epochs that do not have any records.
             NavigableMap<Integer, Long> epochWithOffsets = buildFilteredLeaderEpochMap(leaderEpochCache.epochWithOffsets());
 
-            long logStartOffset = log.logStartOffset();
+            long logStartOffset = reclaimFloorLogStartOffset(log);
             long logEndOffset = log.logEndOffset();
             Optional<RetentionSizeData> retentionSizeData = buildRetentionSizeData(log.config().retentionSize,
                     log.onlyLocalLogSegmentsSize(), logEndOffset, epochWithOffsets);

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogManagerTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogManagerTest.java
@@ -107,6 +107,7 @@ import java.util.NavigableMap;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.OptionalLong;
 import java.util.Properties;
 import java.util.Set;
 import java.util.TreeMap;
@@ -2551,6 +2552,193 @@ public class RemoteLogManagerTest {
         // Verify aggregate metrics
         assertEquals(2, brokerTopicStats.allTopicsStats().remoteDeleteRequestRate().count());
         assertEquals(0, brokerTopicStats.allTopicsStats().failedRemoteDeleteRequestRate().count());
+    }
+
+    @Test
+    public void testConsolidatingLogStartOffsetOverrideDrivesRemoteReclaimFloor()
+            throws RemoteStorageException, ExecutionException, InterruptedException, IOException {
+        // Inkless: for a consolidating diskless partition the remote-retention reclaim floor must come
+        // from the control-plane cross-tier earliest (here 100), NOT the broker-local log start (200,
+        // which on a freshly-rebuilt leader is pinned at the classic-to-diskless seal). With retention
+        // disabled only a log-start-offset breach can delete, so the segment [0,99] (endOffset 99 < 100)
+        // is reclaimed while [100,199] survives -- even though the local seal (200) would breach it too.
+        Map<String, Long> logProps = new HashMap<>();
+        logProps.put("retention.bytes", -1L);
+        logProps.put("retention.ms", -1L);
+        LogConfig mockLogConfig = new LogConfig(logProps);
+        when(mockLog.config()).thenReturn(mockLogConfig);
+
+        List<EpochEntry> epochEntries = List.of(epochEntry0);
+        checkpoint.write(epochEntries);
+        LeaderEpochFileCache cache = new LeaderEpochFileCache(tp, checkpoint, scheduler);
+        when(mockLog.leaderEpochCache()).thenReturn(cache);
+        when(mockLog.topicPartition()).thenReturn(leaderTopicIdPartition.topicPartition());
+        when(mockLog.logEndOffset()).thenReturn(200L);
+        // Broker-local log start pinned at the seal; would delete BOTH segments if used as the floor.
+        when(mockLog.logStartOffset()).thenReturn(200L);
+
+        List<RemoteLogSegmentMetadata> metadataList =
+                listRemoteLogSegmentMetadata(leaderTopicIdPartition, 2, 100, 1024, epochEntries, RemoteLogSegmentState.COPY_SEGMENT_FINISHED);
+        when(remoteLogMetadataManager.listRemoteLogSegments(leaderTopicIdPartition))
+                .thenReturn(metadataList.iterator());
+        when(remoteLogMetadataManager.listRemoteLogSegments(leaderTopicIdPartition, 0))
+                .thenAnswer(ans -> metadataList.iterator());
+        when(remoteLogMetadataManager.updateRemoteLogSegmentMetadata(any(RemoteLogSegmentMetadataUpdate.class)))
+                .thenReturn(CompletableFuture.runAsync(() -> { }));
+        doNothing().when(remoteStorageManager).deleteLogSegmentData(any(RemoteLogSegmentMetadata.class));
+
+        try (RemoteLogManager rlmWithOverride = new RemoteLogManager(config, brokerId, logDir, clusterId, time,
+                tp -> Optional.of(mockLog),
+                (topicPartition, offset) -> currentLogStartOffset.set(offset),
+                brokerTopicStats, metrics, endPoint,
+                topicPartition -> OptionalLong.of(100L),
+                topicPartition -> true) {
+            @Override
+            public RemoteStorageManager createRemoteStorageManager() {
+                return remoteStorageManager;
+            }
+            @Override
+            public RemoteLogMetadataManager createRemoteLogMetadataManager() {
+                return remoteLogMetadataManager;
+            }
+            @Override
+            long findLogStartOffset(TopicIdPartition topicIdPartition, UnifiedLog log) {
+                return 0L;
+            }
+        }) {
+            doReturn(true).when(remoteLogMetadataManager).isReady(any(TopicIdPartition.class));
+            RemoteLogManager.RLMExpirationTask task = rlmWithOverride.new RLMExpirationTask(leaderTopicIdPartition);
+            task.cleanupExpiredRemoteLogSegments();
+        }
+
+        // Only the segment entirely below the cross-tier earliest (100) is reclaimed; the survivor stays.
+        verify(remoteStorageManager).deleteLogSegmentData(metadataList.get(0));
+        verify(remoteStorageManager, never()).deleteLogSegmentData(metadataList.get(1));
+    }
+
+    @Test
+    public void testConsolidatingReclaimFailsSafeWhenOverrideAbsent()
+            throws RemoteStorageException, ExecutionException, InterruptedException, IOException {
+        // Fail-safe (Problem B hardening): when the log-start-offset override yields empty for a
+        // CONSOLIDATING partition (control-plane outage or not-yet-propagated metadata on the RLM leader)
+        // the reclaim floor must NOT fall back to the broker-local log start -- on a freshly-rebuilt
+        // consolidating leader that is the seal (200) and would irreversibly delete the entire remote
+        // classic prefix. Instead it uses the remote earliest (findLogStartOffset -> 0), so no segment
+        // breaches the log-start-offset and NOTHING is reclaimed this cycle. Retention is disabled here,
+        // so both segments [0,99] and [100,199] survive; log-start reclaim retries once the control plane
+        // recovers.
+        Map<String, Long> logProps = new HashMap<>();
+        logProps.put("retention.bytes", -1L);
+        logProps.put("retention.ms", -1L);
+        LogConfig mockLogConfig = new LogConfig(logProps);
+        when(mockLog.config()).thenReturn(mockLogConfig);
+
+        List<EpochEntry> epochEntries = List.of(epochEntry0);
+        checkpoint.write(epochEntries);
+        LeaderEpochFileCache cache = new LeaderEpochFileCache(tp, checkpoint, scheduler);
+        when(mockLog.leaderEpochCache()).thenReturn(cache);
+        when(mockLog.topicPartition()).thenReturn(leaderTopicIdPartition.topicPartition());
+        when(mockLog.logEndOffset()).thenReturn(200L);
+        when(mockLog.logStartOffset()).thenReturn(200L); // local log start pinned at the seal (the trap)
+
+        List<RemoteLogSegmentMetadata> metadataList =
+                listRemoteLogSegmentMetadata(leaderTopicIdPartition, 2, 100, 1024, epochEntries, RemoteLogSegmentState.COPY_SEGMENT_FINISHED);
+        when(remoteLogMetadataManager.listRemoteLogSegments(leaderTopicIdPartition))
+                .thenReturn(metadataList.iterator());
+        when(remoteLogMetadataManager.listRemoteLogSegments(leaderTopicIdPartition, 0))
+                .thenAnswer(ans -> metadataList.iterator());
+        when(remoteLogMetadataManager.updateRemoteLogSegmentMetadata(any(RemoteLogSegmentMetadataUpdate.class)))
+                .thenReturn(CompletableFuture.runAsync(() -> { }));
+        doNothing().when(remoteStorageManager).deleteLogSegmentData(any(RemoteLogSegmentMetadata.class));
+
+        try (RemoteLogManager rlmWithEmptyOverride = new RemoteLogManager(config, brokerId, logDir, clusterId, time,
+                tp -> Optional.of(mockLog),
+                (topicPartition, offset) -> currentLogStartOffset.set(offset),
+                brokerTopicStats, metrics, endPoint,
+                topicPartition -> OptionalLong.empty(),
+                topicPartition -> true) { // consolidating -> fail safe, do not use the local seal
+            @Override
+            public RemoteStorageManager createRemoteStorageManager() {
+                return remoteStorageManager;
+            }
+            @Override
+            public RemoteLogMetadataManager createRemoteLogMetadataManager() {
+                return remoteLogMetadataManager;
+            }
+            @Override
+            long findLogStartOffset(TopicIdPartition topicIdPartition, UnifiedLog log) {
+                return 0L; // remote earliest
+            }
+        }) {
+            doReturn(true).when(remoteLogMetadataManager).isReady(any(TopicIdPartition.class));
+            RemoteLogManager.RLMExpirationTask task = rlmWithEmptyOverride.new RLMExpirationTask(leaderTopicIdPartition);
+            task.cleanupExpiredRemoteLogSegments();
+        }
+
+        // Neither segment is reclaimed: the fail-safe floor (remote earliest 0) breaches nothing, so the
+        // remote classic prefix is preserved rather than over-reclaimed to the seal.
+        verify(remoteStorageManager, never()).deleteLogSegmentData(metadataList.get(0));
+        verify(remoteStorageManager, never()).deleteLogSegmentData(metadataList.get(1));
+    }
+
+    @Test
+    public void testNonConsolidatingReclaimUsesLocalLogStartWhenOverrideAbsent()
+            throws RemoteStorageException, ExecutionException, InterruptedException, IOException {
+        // Regression guard: for a CLASSIC (non-consolidating) remote topic the fail-safe must NOT engage.
+        // With an empty override the reclaim floor keeps the upstream behavior of the broker-local log
+        // start (here 200, e.g. advanced by a user DeleteRecords), so both segments [0,99] and [100,199]
+        // breach the log-start-offset and are reclaimed as normal.
+        Map<String, Long> logProps = new HashMap<>();
+        logProps.put("retention.bytes", -1L);
+        logProps.put("retention.ms", -1L);
+        LogConfig mockLogConfig = new LogConfig(logProps);
+        when(mockLog.config()).thenReturn(mockLogConfig);
+
+        List<EpochEntry> epochEntries = List.of(epochEntry0);
+        checkpoint.write(epochEntries);
+        LeaderEpochFileCache cache = new LeaderEpochFileCache(tp, checkpoint, scheduler);
+        when(mockLog.leaderEpochCache()).thenReturn(cache);
+        when(mockLog.topicPartition()).thenReturn(leaderTopicIdPartition.topicPartition());
+        when(mockLog.logEndOffset()).thenReturn(200L);
+        when(mockLog.logStartOffset()).thenReturn(200L); // authoritative floor for a classic topic
+
+        List<RemoteLogSegmentMetadata> metadataList =
+                listRemoteLogSegmentMetadata(leaderTopicIdPartition, 2, 100, 1024, epochEntries, RemoteLogSegmentState.COPY_SEGMENT_FINISHED);
+        when(remoteLogMetadataManager.listRemoteLogSegments(leaderTopicIdPartition))
+                .thenReturn(metadataList.iterator());
+        when(remoteLogMetadataManager.listRemoteLogSegments(leaderTopicIdPartition, 0))
+                .thenAnswer(ans -> metadataList.iterator());
+        when(remoteLogMetadataManager.updateRemoteLogSegmentMetadata(any(RemoteLogSegmentMetadataUpdate.class)))
+                .thenReturn(CompletableFuture.runAsync(() -> { }));
+        doNothing().when(remoteStorageManager).deleteLogSegmentData(any(RemoteLogSegmentMetadata.class));
+
+        try (RemoteLogManager rlmClassic = new RemoteLogManager(config, brokerId, logDir, clusterId, time,
+                tp -> Optional.of(mockLog),
+                (topicPartition, offset) -> currentLogStartOffset.set(offset),
+                brokerTopicStats, metrics, endPoint,
+                topicPartition -> OptionalLong.empty(),
+                topicPartition -> false) { // not consolidating -> keep upstream local-log-start floor
+            @Override
+            public RemoteStorageManager createRemoteStorageManager() {
+                return remoteStorageManager;
+            }
+            @Override
+            public RemoteLogMetadataManager createRemoteLogMetadataManager() {
+                return remoteLogMetadataManager;
+            }
+            @Override
+            long findLogStartOffset(TopicIdPartition topicIdPartition, UnifiedLog log) {
+                return 0L; // must be ignored on the non-consolidating path
+            }
+        }) {
+            doReturn(true).when(remoteLogMetadataManager).isReady(any(TopicIdPartition.class));
+            RemoteLogManager.RLMExpirationTask task = rlmClassic.new RLMExpirationTask(leaderTopicIdPartition);
+            task.cleanupExpiredRemoteLogSegments();
+        }
+
+        // Both segments breach the local log start (200) and are reclaimed -- upstream behavior preserved.
+        verify(remoteStorageManager).deleteLogSegmentData(metadataList.get(0));
+        verify(remoteStorageManager).deleteLogSegmentData(metadataList.get(1));
     }
 
     @ParameterizedTest(name = "testRemoteDeleteLagsOnRetentionBreachedSegments retentionSize={0} retentionMs={1}")

--- a/tests/kafkatest/services/inkless/consolidation_verifier.py
+++ b/tests/kafkatest/services/inkless/consolidation_verifier.py
@@ -209,15 +209,16 @@ class ConsolidationVerifier(object):
             "connectivity/credentials for the inkless system-test dependencies."
             % (self.MINIO_ALIAS, self.MINIO_ENDPOINT, rc))
 
-    def object_keys(self, prefix=""):
-        # Object keys under the given bucket prefix, via mc ls --recursive --json.
+    def _object_entries(self, prefix=""):
+        # (key, size) tuples under the given bucket prefix, via mc ls --recursive
+        # --json. mc emits one JSON object per line with a "size" field in bytes.
         node = self._storage_node()
         self._ensure_mc_alias(node)
         target = "%s/%s" % (self.MINIO_ALIAS, self.MINIO_BUCKET)
         if prefix:
             target += "/" + prefix
         cmd = "mc ls --recursive --json %s" % target
-        keys = []
+        entries = []
         for line in node.account.ssh_capture(cmd, allow_fail=False):
             line = line.strip()
             if not line:
@@ -236,8 +237,12 @@ class ConsolidationVerifier(object):
                 continue
             key = obj.get("key")
             if key:
-                keys.append(key)
-        return keys
+                entries.append((key, int(obj.get("size") or 0)))
+        return entries
+
+    def object_keys(self, prefix=""):
+        # Object keys under the given bucket prefix, via mc ls --recursive --json.
+        return [key for key, _ in self._object_entries(prefix)]
 
     def tiered_object_count(self):
         # Count under the tiered-storage prefix only (scanning the whole bucket
@@ -247,11 +252,47 @@ class ConsolidationVerifier(object):
         # absolute `== N` flaps with test order.
         return len(self.object_keys(self.TIERED_PREFIX))
 
+    def tiered_object_bytes(self):
+        # Total bytes under the tiered-storage prefix. Like tiered_object_count,
+        # this is not topic-scoped and accumulates across tests in one
+        # `ducker-ak test` run, so use it as a baseline + delta, never absolute.
+        # A retention.bytes test uses it to pick a whole-log size limit relative
+        # to the data that actually reached remote, instead of guessing at the
+        # per-record on-disk size. Scoping the listing to the prefix already limits
+        # the entries to tiered storage (mc returns keys relative to the prefix, so
+        # no further key filtering is possible here anyway).
+        return sum(size for _, size in self._object_entries(self.TIERED_PREFIX))
+
     def wal_object_count(self):
         # Bucket-root count (outside tiered-storage/), i.e. diskless WAL files.
         # Same accumulation caveats as tiered_object_count: baseline + delta
         # only, never absolute.
         return len([k for k in self.object_keys() if not k.startswith(self.TIERED_PREFIX)])
+
+    def wait_for_tiered_count_stable(self, settle_samples=3, backoff_sec=5, timeout_sec=300):
+        """Wait until the tiered-storage object count stops growing (held steady across
+        ``settle_samples`` consecutive samples) and return that stable count.
+
+        Consolidation/RLM keeps copying closed segments to remote after the WAL has
+        drained locally, so a count snapshot taken right after ``wait_for_tiered_offset_at_least``
+        can still be climbing. Tests that later assert the count *dropped* after a
+        reclaim need a settled pre-reclaim peak, otherwise late tiering can mask the
+        deletion. Under a long retention nothing removes tiered objects, so the count
+        only grows and then plateaus."""
+        state = {"last": -1, "stable": 0, "value": 0}
+
+        def check():
+            cur = self.tiered_object_count()
+            state["stable"] = state["stable"] + 1 if cur == state["last"] else 0
+            state["last"] = cur
+            state["value"] = cur
+            self.logger.info("Tiered-storage object count: %d (stable for %d samples)"
+                             % (cur, state["stable"]))
+            return state["stable"] >= settle_samples
+
+        wait_until(check, timeout_sec=timeout_sec, backoff_sec=backoff_sec,
+                   err_msg="Tiered-storage object count did not stabilize within %ds." % timeout_sec)
+        return state["value"]
 
     # --------------------- Control plane ---------------------
 
@@ -445,14 +486,26 @@ class ConsolidationVerifier(object):
             self.logger.debug("Leader lookup for %s-%d not ready yet: %s" % (topic, partition, e))
             return False
 
-    def offset_at(self, topic, time_spec, partition=0):
+    def _broker_bootstrap(self, node):
+        """``hostname:port`` for a single broker's client listener, so a query can be
+        pinned to one broker instead of the whole ``bootstrap_servers()`` list."""
+        protocol = self.kafka.security_protocol
+        port = self.kafka.port_mappings[protocol].port_number
+        return "%s:%s" % (node.account.hostname, port)
+
+    def offset_at(self, topic, time_spec, partition=0, bootstrap_server=None):
         """Offset for the partition at a ``kafka-get-offsets.sh --time`` spec
         (-1 latest, -2 earliest, -4 earliest-local, -5 latest-tiered). Returns -1 if
-        not parseable yet."""
+        not parseable yet.
+
+        ``bootstrap_server`` pins the query to a single broker (see
+        ``_broker_bootstrap``); by default the whole cluster is used. Pinning lets a
+        test detect a per-broker divergence in the answer (e.g. ListOffsets(EARLIEST)
+        served inconsistently across brokers)."""
         node = self.kafka.nodes[0]
         cmd = "%s --bootstrap-server %s --topic %s --partitions %d --time %s" % (
             self.kafka.path.script("kafka-get-offsets.sh", node),
-            self.kafka.bootstrap_servers(),
+            bootstrap_server or self.kafka.bootstrap_servers(),
             topic,
             partition,
             time_spec,
@@ -566,6 +619,53 @@ class ConsolidationVerifier(object):
                             % (topic, partition, timeout_sec)))
         return state["value"]
 
+    def earliest_on_each_broker(self, topic, partition=0):
+        """Query ListOffsets(EARLIEST) once against each broker individually and return
+        a ``{hostname: offset}`` map. Before the ``DisklessFetchOffsetRouter`` fix a
+        follower served ListOffsets(EARLIEST) from its frozen-at-switch local classic
+        log while the leader served the advanced value, so the answer diverged per
+        broker (Problem A). After the fix every broker routes to the control plane and
+        returns the same cross-tier earliest."""
+        result = {}
+        for node in self.kafka.nodes:
+            result[node.account.hostname] = self.offset_at(
+                topic, time_spec=-2, partition=partition,
+                bootstrap_server=self._broker_bootstrap(node))
+        return result
+
+    def wait_for_consistent_earliest_across_brokers(self, topic, partition=0,
+                                                    settle_samples=3, backoff_sec=5,
+                                                    timeout_sec=240):
+        """Wait until ListOffsets(EARLIEST) is (a) > 0, (b) identical on every broker,
+        and (c) held steady across ``settle_samples`` consecutive rounds; return that
+        agreed value.
+
+        This is the end-to-end Problem A assertion: the earliest must be one
+        broker-agnostic value (the control-plane cross-tier earliest), not a per-broker
+        answer that depends on which replica the metadata transformer routed the client
+        to. A single positive value on every broker, stable over time, means the router
+        no longer serves it from a replica's local classic log."""
+        state = {"last": None, "stable": 0, "value": 0}
+
+        def check():
+            per_broker = self.earliest_on_each_broker(topic, partition=partition)
+            values = set(per_broker.values())
+            agreed = len(values) == 1 and all(v > 0 for v in values)
+            cur = next(iter(values)) if agreed else None
+            state["stable"] = state["stable"] + 1 if (agreed and cur == state["last"]) else 0
+            state["last"] = cur
+            if agreed:
+                state["value"] = cur
+            self.logger.info("Per-broker earliest for %s-%d: %s (agreed=%s, stable for %d samples)"
+                             % (topic, partition, per_broker, agreed, state["stable"]))
+            return state["stable"] >= settle_samples
+
+        wait_until(check, timeout_sec=timeout_sec, backoff_sec=backoff_sec,
+                   err_msg=("ListOffsets(EARLIEST) for %s-%d did not converge to a single "
+                            "positive value across all brokers within %ds (Problem A: "
+                            "per-broker earliest divergence)" % (topic, partition, timeout_sec)))
+        return state["value"]
+
     def read_contiguous_from(self, topic, from_offset=0, max_messages=1, partition=0,
                              timeout_ms=120000):
         """Fetch up to ``max_messages`` records from ``from_offset`` and return
@@ -612,6 +712,57 @@ class ConsolidationVerifier(object):
                                              max_messages=1, partition=partition,
                                              timeout_ms=timeout_ms)
         return first
+
+    def delete_records(self, topic, before_offset, partition=0):
+        """Run ``kafka-delete-records.sh`` to delete every record before
+        ``before_offset`` on ``topic``-``partition`` and return the resulting
+        ``low_watermark`` (the new log start) for that partition.
+
+        ``DeleteRecords`` takes a *beforeOffset*: the given offset becomes the new
+        log start, so records ``[0, before_offset)`` are removed. On a consolidating
+        topic the broker splits the request across tiers -- local ``UnifiedLog`` (which
+        drives ``RemoteLogManager`` deletion of the remote segments below the new start)
+        and, past the local log end, the diskless WAL in the control plane. The offset
+        JSON file is written on the broker node and passed with ``--offset-json-file``.
+
+        ``DeleteRecordsCommand`` prints *per-partition* failures on stdout (``partition:
+        <tp>\\terror: <msg>``) and now exits non-zero when any partition fails, so a genuine
+        failure surfaces as a ``RemoteCommandError`` from ``ssh_capture``. On success the output is
+        parsed for the per-partition ``low_watermark``."""
+        node = self.kafka.nodes[0]
+        offset_json = ('{"partitions":[{"topic":"%s","partition":%d,"offset":%d}],"version":1}'
+                       % (topic, partition, before_offset))
+        json_path = "/tmp/delete-records-%s-%d.json" % (topic, partition)
+        node.account.create_file(json_path, offset_json)
+        cmd = "%s --bootstrap-server %s --offset-json-file %s" % (
+            self.kafka.path.script("kafka-delete-records.sh", node),
+            self.kafka.bootstrap_servers(),
+            json_path,
+        )
+        self.logger.info("Deleting records before offset %d on %s-%d: %s"
+                         % (before_offset, topic, partition, cmd))
+        output = ""
+        for line in node.account.ssh_capture(cmd, allow_fail=False):
+            output += line.decode("utf-8") if isinstance(line, bytes) else line
+        self.logger.info("kafka-delete-records.sh output:\n%s" % output)
+
+        target = "%s-%d" % (topic, partition)
+        low_watermark = None
+        for line in output.splitlines():
+            line = line.strip()
+            err = re.search(r"partition:\s*(\S+)\s+error:\s*(.+)$", line)
+            if err and err.group(1) == target:
+                raise AssertionError(
+                    "DeleteRecords before offset %d on %s failed: %s"
+                    % (before_offset, target, err.group(2)))
+            lw = re.search(r"partition:\s*(\S+)\s+low_watermark:\s*(-?\d+)$", line)
+            if lw and lw.group(1) == target:
+                low_watermark = int(lw.group(2))
+        assert low_watermark is not None, (
+            "DeleteRecords before offset %d on %s returned no low_watermark; output was:\n%s"
+            % (before_offset, target, output))
+        self.logger.info("DeleteRecords on %s returned low_watermark=%d" % (target, low_watermark))
+        return low_watermark
 
     # --------------------- Dependency outage (iptables) ---------------------
     #

--- a/tests/kafkatest/tests/inkless/consolidation_delete_records_across_tiers_test.py
+++ b/tests/kafkatest/tests/inkless/consolidation_delete_records_across_tiers_test.py
@@ -1,0 +1,306 @@
+# Inkless
+# Copyright (C) 2024 - 2026 Aiven OY
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import uuid
+
+from ducktape.mark import matrix
+from ducktape.mark.resource import cluster
+from ducktape.tests.test import Test
+from ducktape.utils.util import wait_until
+
+from kafkatest.services.kafka import KafkaService, quorum
+from kafkatest.services.inkless.consolidation_verifier import ConsolidationVerifier
+
+
+class DeleteRecordsAcrossTiersTest(Test):
+    """``DeleteRecords`` on a *switched* (hybrid) consolidating topic must advance the
+    topic's earliest readable offset to *exactly* the requested boundary, in a way every
+    broker agrees on, and must not reclaim any records the caller did not ask to delete.
+    This guards two distinct product bugs -- Problem A (cross-broker EARLIEST
+    consistency) and Problem B (no over-reclaim of the classic prefix); see
+    ``DELETE_RECORDS_DISKLESS_ROUTING_IMPL.md`` at the repo root for the full design.
+
+    Problem A -- cross-broker EARLIEST consistency. ``ListOffsets(EARLIEST)`` for a
+    consolidating partition used to be served from the broker-local classic
+    ``UnifiedLog.logStartOffset`` while it was still below the seal. With managed
+    replicas enabled (``diskless.managed.rf.enable=true``, which consolidation
+    requires) ``InklessTopicMetadataTransformer`` advertises a *hash-selected replica*
+    as the partition leader for locality-aware reads -- deterministically the same
+    replica for every client, and generally a *follower*, not the real KRaft leader
+    that holds the writable log. That follower's local classic log start is frozen at
+    the switch, so a ``DeleteRecords`` (which advances only the real leader's log start
+    and the control plane) left the client-visible earliest stuck at ``0`` forever. The
+    fix routes ``ListOffsets(EARLIEST)`` for consolidating topics to the control plane
+    on *every* broker (``COALESCE(remote_log_start_offset, log_start_offset)`` from
+    ``list_offsets_v1``), which the classic leader keeps current, so the earliest
+    advances on whichever replica the transformer routed the client to, and is one
+    broker-agnostic value.
+
+    Problem B -- no over-reclaim of the classic prefix. With retention unset, a
+    ``DeleteRecords`` before ``delete_before < S`` must remove only ``[0, delete_before)``
+    and leave ``[delete_before, S)`` readable, so the earliest settles at *exactly*
+    ``delete_before``. The consolidation cleanup used to reclaim the whole classic prefix
+    ``[0, S)`` down to the seal instead: a freshly-elected leader's local
+    ``logStartOffset`` is pinned at ``S`` (and only ever increments), so the RLM
+    remote-retention reclaim floor and the become-leader report used ``S`` rather than
+    the true cross-tier earliest. The fix drives both the consolidating partition's
+    whole-log start (``DisklessLeaderEndPoint``) and the RLM reclaim floor /
+    become-leader report (``RemoteLogManager``) from the broker-agnostic control-plane
+    cross-tier earliest via ``ReplicaManager.crossTierEarliestOffset``.
+
+    The scenario: produce a classic prefix, switch to a consolidating diskless topic
+    (sealing at ``S``), produce + consolidate a diskless tail, and let the classic
+    prefix tier to remote with its local copies evicted -- so the prefix ``[0, S)``
+    lives in the remote tier. ``retention.ms``/``retention.bytes`` are held unset
+    throughout so the only thing that can move the earliest offset is the
+    ``DeleteRecords`` request. A ``DeleteRecords`` before ``delete_before = S // 2``
+    (inside that remote prefix) must then:
+
+    - return the requested boundary as the partition's new log start,
+    - advance the client-visible earliest to *exactly* ``delete_before``, identical on
+      every broker (served from the control plane, not a replica's local log), and
+    - leave the surviving prefix ``[delete_before, S)`` readable and contiguous with the
+      originally produced content.
+
+    Leader routing for the write side of ``DeleteRecords``: the op is leader-routed and
+    its local leg requires the real KRaft leader, so the broker the transformer points
+    the admin client at forwards the affected partitions to their real leader
+    (``DisklessDeleteRecordsForwarder``); the leader runs both the local-log and the
+    diskless (control-plane) legs authoritatively.
+    """
+
+    # Unique per run: the Postgres/MinIO containers persist across runs, so a stale
+    # topic name would let old rows/objects skew the control-plane and mc queries.
+    TOPIC_PREFIX = "delete-records-across-tiers"
+    NUM_PARTITIONS = 1
+    REPLICATION_FACTOR = 3
+    # Classic prefix. segment.bytes is floored at 1 MiB and records are ~13 B, so a
+    # closed classic segment holds ~80k records. The delete boundary (seal // 2) must
+    # sit strictly inside the sealed classic region so the reclaimed range is
+    # remote-backed and the classic log start stays below the seal. Sizing it this way
+    # also clears whole ~1 MiB segments below the boundary while leaving several whole
+    # surviving segments in [delete_before, seal) -- so a correct implementation drops
+    # only the reclaimed ones and keeps the rest (the Problem B over-reclaim guard).
+    NUM_CLASSIC_RECORDS = 400000
+    # Diskless tail: ~13 B/record => ~4 MiB, exceeding segment.bytes (2 MiB) so the
+    # tail rolls an inactive segment. Only rolled segments tier, so this is what lifts
+    # highestOffsetInRemoteStorage past the seal and lets the WAL pruner advance.
+    NUM_DISKLESS_RECORDS = 300000
+    # How many surviving-prefix records to spot-check for readability/content.
+    SPOT_CHECK = 20000
+
+    def __init__(self, test_context):
+        super(DeleteRecordsAcrossTiersTest, self).__init__(test_context=test_context)
+        self.num_brokers = 3
+        self.TOPIC = "%s-%s" % (self.TOPIC_PREFIX, uuid.uuid4().hex[:8])
+
+    def _start_cluster(self):
+        self.kafka = KafkaService(
+            self.test_context,
+            num_nodes=self.num_brokers,
+            zk=None,
+            controller_num_nodes_override=1,
+            consolidation=True,
+            # log.diskless.enable=false: keep the cluster default classic (else new
+            #   topics are born diskless and trip the diskless/remote validator).
+            # diskless.allow.from.classic.enable=true: open the classic->diskless
+            #   switch bridge (validated on every node).
+            # The rest run the WAL pruner / file cleaner / remote-log task fast.
+            server_prop_overrides=[
+                ["log.diskless.enable", "false"],
+                ["diskless.allow.from.classic.enable", "true"],
+                ["inkless.consolidation.cleanup.interval.ms", "5000"],
+                ["inkless.file.cleaner.interval.ms", "5000"],
+                ["inkless.file.cleaner.retention.period.ms", "6000"],
+                ["inkless.consume.batch.coordinate.cache.ttl.ms", "2000"],
+                ["remote.log.manager.task.interval.ms", "5000"],
+                ["log.retention.check.interval.ms", "5000"],
+            ],
+            # Switch-completion gauges live on the broker; the controller never
+            # exposes them, so scraping it would hang start_jmx_tool's --wait.
+            jmx_object_names=list(ConsolidationVerifier.SWITCH_JMX_OBJECT_NAMES),
+            jmx_attributes=list(ConsolidationVerifier.SWITCH_JMX_ATTRIBUTES),
+        )
+        # server_prop_overrides only reach the brokers, but the controller also
+        # validates the switch bridge: mirror it onto the controller and disable
+        # JMX there (it has no switch gauges).
+        if getattr(self.kafka, "isolated_controller_quorum", None):
+            ctrl = self.kafka.isolated_controller_quorum
+            ctrl.server_prop_overrides = list(ctrl.server_prop_overrides) + [
+                ["log.diskless.enable", "false"],
+                ["diskless.allow.from.classic.enable", "true"],
+            ]
+            ctrl.jmx_object_names = None
+            ctrl.jmx_attributes = []
+        self.kafka.start()
+
+    def _switch_and_drain(self, verifier, baseline_tiered):
+        """Produce a classic prefix, switch to consolidating diskless, tier the classic
+        prefix to remote (with local copies evicted), then produce + consolidate a
+        diskless tail and wait until the remote tier covers through the seal. Returns
+        ``(seal_offset, total_acked)``."""
+        # --- 1) Classic phase: produce a classic prefix on a plain classic topic ---
+        verifier.create_classic_topic(self.TOPIC, self.NUM_PARTITIONS, self.REPLICATION_FACTOR)
+        classic_acked = verifier.produce(self.TOPIC, self.NUM_CLASSIC_RECORDS, "classic")
+        seal_offset = classic_acked
+        self.logger.info("Produced classic prefix: acked=%d (seal offset will be %d)"
+                         % (classic_acked, seal_offset))
+
+        # --- 2) Switch the classic topic straight to consolidating diskless ---
+        #
+        # One combined alter: the leader seals the classic log at `seal_offset` and
+        # starts the consolidation fetcher; short local.retention.ms lets the tiered
+        # classic prefix be deleted locally. segment.bytes = 2 MiB (> the 1 MiB batch
+        # ceiling so a consolidation append does not trip RecordBatchTooLargeException,
+        # and < the diskless tail so the tail rolls an inactive, tierable segment).
+        # retention.ms/.bytes are left at their (long/unlimited) defaults so only the
+        # DeleteRecords below can move the earliest offset.
+        self.logger.info("Switching topic %s to consolidating diskless (combined alter)" % self.TOPIC)
+        self.kafka.alter_topic_configs(self.TOPIC, {
+            "diskless.enable": "true",
+            "remote.storage.enable": "true",
+            "local.retention.ms": "5000",
+            "segment.bytes": str(2 * 1024 * 1024),
+        })
+        verifier.wait_for_switch_complete(self.TOPIC, self.NUM_PARTITIONS)
+        self.logger.info("Classic-to-consolidated switch completed for %s" % self.TOPIC)
+
+        # --- 3) Tier the classic prefix and evict the local copies ---
+        wait_until(lambda: verifier.tiered_object_count() > baseline_tiered,
+                   timeout_sec=180, backoff_sec=2,
+                   err_msg="Classic tiered-storage object count did not grow above baseline "
+                           "after enabling remote storage on the switched topic.")
+        classic_remote_watermark = verifier.wait_for_local_log_truncation(self.TOPIC)
+        assert classic_remote_watermark > 0, \
+            "Classic prefix never tiered: earliest-local stayed at 0 after enabling remote storage."
+        self.logger.info("Classic prefix tiered; earliest-local watermark=%d" % classic_remote_watermark)
+
+        # --- 4) Diskless phase: produce the tail and consolidate it to remote ---
+        pre_diskless_tiered = verifier.tiered_object_count()
+        diskless_acked = verifier.produce(self.TOPIC, self.NUM_DISKLESS_RECORDS, "diskless")
+        self.logger.info("Produced diskless tail: acked=%d" % diskless_acked)
+
+        wait_until(lambda: verifier.tiered_object_count() > pre_diskless_tiered,
+                   timeout_sec=180, backoff_sec=2,
+                   err_msg="Diskless consolidation did not grow the tiered-storage object count.")
+
+        # The whole classic prefix [0, seal) -- including the boundary tail -- is durable
+        # in remote once the latest-tiered offset reaches the seal, so the delete boundary
+        # we pick inside the prefix is remote-backed.
+        remote_watermark = verifier.wait_for_tiered_offset_at_least(self.TOPIC, seal_offset)
+        self.logger.info("Remote tier covers through the seal: latest-tiered=%d, seal=%d"
+                         % (remote_watermark, seal_offset))
+
+        total_acked = classic_acked + diskless_acked
+        return seal_offset, total_acked
+
+    @cluster(num_nodes=6)
+    @matrix(metadata_quorum=[quorum.isolated_kraft])
+    def test_delete_records_across_tiers(self, metadata_quorum):
+        self._start_cluster()
+        verifier = ConsolidationVerifier(self.kafka)
+        verifier.verify_tooling()
+        baseline_tiered = verifier.tiered_object_count()
+
+        seal_offset, total_acked = self._switch_and_drain(verifier, baseline_tiered)
+
+        # Precondition: every broker agrees the earliest is still below the delete
+        # boundary (the classic remote prefix is intact). We assert *agreement*, not a
+        # specific value: the control-plane cross-tier earliest is the same on every
+        # broker, and it must be well below the boundary so the DeleteRecords is a
+        # genuine cross-tier delete of remote data.
+        delete_before = seal_offset // 2
+        assert delete_before > 0, "seal too small to pick a delete boundary: %d" % seal_offset
+
+        pre_earliest = verifier.earliest_on_each_broker(self.TOPIC)
+        pre_values = set(pre_earliest.values())
+        assert len(pre_values) == 1, (
+            "pre-delete earliest diverged across brokers: %s (ListOffsets(EARLIEST) is not "
+            "served from the broker-agnostic control plane)" % pre_earliest)
+        pre_value = next(iter(pre_values))
+        assert 0 <= pre_value < delete_before, (
+            "pre-delete earliest %d is not below the delete boundary %d; cannot exercise a "
+            "cross-tier delete of the remote prefix" % (pre_value, delete_before))
+        self.logger.info("Pre-delete earliest agreed across brokers at %d (boundary %d)"
+                         % (pre_value, delete_before))
+
+        # Settle the pre-delete peak: the diskless tail keeps tiering after it drains
+        # locally, so a snapshot here can still be climbing. Capturing a settled peak
+        # keeps later diagnostics meaningful.
+        tiered_peak = verifier.wait_for_tiered_count_stable()
+        self.logger.info("Settled pre-delete tiered-storage object count: %d" % tiered_peak)
+
+        # Delete the first half of the classic prefix. The boundary is strictly inside
+        # the sealed classic region [0, seal), which is tiered to remote, so the
+        # reclaimed range [0, delete_before) is remote-backed: this exercises the
+        # local-log -> RemoteLogManager cross-tier delete on the real leader (reached
+        # via DisklessDeleteRecordsForwarder).
+        #
+        # delete_records parses the per-partition result and raises on a partition error
+        # (kafka-delete-records.sh reports those on stdout yet still exits 0). The returned
+        # low_watermark is the partition's new log start as the broker computed it.
+        low_watermark = verifier.delete_records(self.TOPIC, before_offset=delete_before)
+        self.logger.info("Requested DeleteRecords before offset %d (seal=%d, total=%d); low_watermark=%d"
+                         % (delete_before, seal_offset, total_acked, low_watermark))
+        assert low_watermark == delete_before, (
+            "DeleteRecords returned low_watermark=%d; expected the requested boundary %d "
+            "(the broker did not advance the log start to the delete offset)"
+            % (low_watermark, delete_before))
+
+        # Problem A + B assertion: the client-visible earliest advances from below the
+        # boundary to a single, stable value that is the SAME on every broker (Problem A:
+        # served from the control plane, not a hash-selected follower's frozen local log)
+        # and settles at EXACTLY the delete boundary (Problem B: only [0, delete_before)
+        # is reclaimed -- with retention unset nothing else may move the earliest, and the
+        # consolidation cleanup must not over-reclaim the classic prefix down to the seal).
+        # Before the fixes this stayed at 0 (Problem A) or ran ahead to the seal (Problem B).
+        agreed_earliest = verifier.wait_for_consistent_earliest_across_brokers(
+            self.TOPIC, timeout_sec=300)
+        self.logger.info("Post-delete earliest agreed across all brokers at a stable %d"
+                         % agreed_earliest)
+        assert agreed_earliest == delete_before, (
+            "post-delete earliest %d did not settle at exactly the requested boundary %d "
+            "(seal=%d); the cleanup over-reclaimed the classic prefix past the delete boundary "
+            "even though retention is unset" % (agreed_earliest, delete_before, seal_offset))
+
+        # The advertised floor is backed by real, readable data: a fetch from the boundary
+        # serves that exact offset (not a skip-ahead to the seal).
+        first_served = verifier.first_served_offset(self.TOPIC, from_offset=delete_before)
+        assert first_served == delete_before, (
+            "a fetch from the delete boundary %d returned offset %d (seal=%d); the surviving "
+            "classic prefix was reclaimed instead of served"
+            % (delete_before, first_served, seal_offset))
+        self.logger.info("Fetch from the delete boundary %d served that offset" % delete_before)
+
+        # The surviving prefix [delete_before, seal) comes back contiguous with the correct
+        # content. VerifiableProducer writes each record's per-producer sequence as its value;
+        # the classic producer wrote [0, seal) so value == offset below the seal.
+        spot = min(seal_offset - delete_before, self.SPOT_CHECK)
+        records = verifier.read_records_with_values_from(
+            self.TOPIC, from_offset=delete_before, max_messages=spot, timeout_ms=240000)
+        assert len(records) >= spot, (
+            "bounded read from the surviving boundary %d returned only %d of %d records; the "
+            "surviving classic prefix was reclaimed" % (delete_before, len(records), spot))
+        for i, (offset, value) in enumerate(records[:spot]):
+            expected_offset = delete_before + i
+            assert offset == expected_offset, (
+                "non-contiguous read at position %d: offset=%d, expected %d (gap/dupe/reorder)"
+                % (i, offset, expected_offset))
+            assert value == offset, (
+                "content mismatch at offset %d: value=%d, expected %d; the surviving classic "
+                "record does not match what was produced" % (offset, value, offset))
+        self.logger.info("Surviving classic prefix from %d read back contiguous with correct content (%d records)"
+                         % (delete_before, spot))

--- a/tests/kafkatest/tests/inkless/consolidation_retention_bytes_across_tiers_test.py
+++ b/tests/kafkatest/tests/inkless/consolidation_retention_bytes_across_tiers_test.py
@@ -1,0 +1,268 @@
+# Inkless
+# Copyright (C) 2024 - 2026 Aiven OY
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import uuid
+
+from ducktape.mark import matrix
+from ducktape.mark.resource import cluster
+from ducktape.tests.test import Test
+from ducktape.utils.util import wait_until
+
+from kafkatest.services.kafka import KafkaService, quorum
+from kafkatest.services.inkless.consolidation_verifier import ConsolidationVerifier
+
+
+class RetentionBytesReclaimsAcrossTiersTest(Test):
+    """``retention.bytes`` on a consolidating topic must reclaim data from the
+    remote tier and advance the topic's earliest readable offset.
+
+    This is the size-based counterpart to ``consolidation_retention_across_tiers_test.py``
+    (which drives the reclaim with ``retention.ms``). The distinction matters
+    because the two limits are enforced by *different* code paths on a
+    born-consolidated topic:
+
+    - The Inkless retention enforcer only measures the diskless WAL batches in the
+      control plane (``logs.byte_size``). Once the WAL is pruned that size is tiny,
+      so ``retention.bytes`` compared against it never binds and never advances the
+      topic earliest -- which is why a naive ``retention.bytes`` test was previously
+      inconclusive.
+    - The whole-log ``retention.bytes`` for a tiered topic is enforced by the classic
+      ``RemoteLogManager``: it sums the not-yet-tiered local tail plus the remote
+      segments and, when that total exceeds the limit, deletes the oldest *remote*
+      segments and raises ``UnifiedLog.logStartOffset``. On a consolidating topic that
+      advance is published to the control plane by ``CrossTierLogStartReporter``
+      (``remote_log_start_offset``), so ``ListOffsets(EARLIEST)`` moves off-leader too.
+
+    So the reclaim that this test exercises is genuinely cross-tier: after the
+    born-consolidated topic has drained (WAL -> local -> remote) and the WAL is
+    pruned, the early prefix lives *only* in remote while the topic earliest is
+    still 0. Lowering ``retention.bytes`` below the remote size must then:
+
+    - advance the topic's earliest readable offset past 0,
+    - leave a contiguous surviving tail (no over-deletion or corruption), and
+    - physically remove the reclaimed remote objects (no storage leak).
+
+    Determinism without wall-clock timing: rather than guess the per-record on-disk
+    size, the test measures how many bytes actually reached remote for *this* topic
+    (the delta over the pre-produce baseline, since this test is the only producer
+    in its window) and sets ``retention.bytes`` to half of that. The
+    ``RemoteLogManager`` deletes the oldest ~half by size, so the boundary lands well
+    inside ``(0, acked)`` regardless of record size, and the newer half survives.
+    ``retention.ms`` is held long throughout so the only thing that can reclaim is
+    the size limit.
+    """
+
+    # Unique per run: the Postgres/MinIO containers persist across runs, so a stale
+    # topic name would let old rows/objects skew the control-plane and mc queries.
+    TOPIC_PREFIX = "retention-bytes-across-tiers"
+    NUM_PARTITIONS = 1
+    REPLICATION_FACTOR = 3
+    # Enough that the throttled produce rolls many small closed segments over
+    # wall-clock time (segment.ms); only closed, tiered segments end up in remote,
+    # which is the tier this test reclaims from. At the VerifiableProducer default
+    # (~13 B/record) this is a few MiB of remote data.
+    NUM_RECORDS = 400000
+    # Long retention.ms so nothing is reclaimed by time; the size limit set below
+    # is the only thing that can advance the earliest offset.
+    INITIAL_RETENTION_MS = 604800000
+    # Throttled produce so closed segments roll over wall-clock time (segment.ms),
+    # guaranteeing many small, tiered segments. Keeping the segments small (well
+    # below the 1 MiB size cap) is what makes halving the remote size delete many
+    # oldest segments rather than risk deleting none (a single oversized oldest
+    # segment could exceed the excess and survive).
+    PRODUCE_SPAN_SEC = 120
+    PRODUCE_THROUGHPUT = NUM_RECORDS // PRODUCE_SPAN_SEC
+    # Guard against the degenerate "nothing (meaningfully) tiered" case before we
+    # derive a size limit from the measured remote bytes. A drained topic ships
+    # several MiB to remote; 2 MiB is a safe floor well under that.
+    MIN_REMOTE_BYTES = 2 * 1048576
+
+    def __init__(self, test_context):
+        super(RetentionBytesReclaimsAcrossTiersTest, self).__init__(test_context=test_context)
+        self.num_brokers = 3
+        self.TOPIC = "%s-%s" % (self.TOPIC_PREFIX, uuid.uuid4().hex[:8])
+
+    def _start_cluster(self):
+        self.kafka = KafkaService(
+            self.test_context,
+            num_nodes=self.num_brokers,
+            zk=None,
+            controller_num_nodes_override=1,
+            consolidation=True,
+            server_prop_overrides=[
+                # Run the WAL pruner / file cleaner / remote-log task / retention
+                # sweep fast so the pipeline drains and the deleted remote segments
+                # are reclaimed within the test window (not the default minutes).
+                ["inkless.consolidation.cleanup.interval.ms", "5000"],
+                ["inkless.file.cleaner.interval.ms", "5000"],
+                ["inkless.file.cleaner.retention.period.ms", "6000"],
+                ["inkless.consume.batch.coordinate.cache.ttl.ms", "2000"],
+                ["inkless.retention.enforcement.interval.ms", "5000"],
+                ["remote.log.manager.task.interval.ms", "5000"],
+                ["log.retention.check.interval.ms", "5000"],
+            ],
+            topics={
+                self.TOPIC: {
+                    "partitions": self.NUM_PARTITIONS,
+                    "replication-factor": self.REPLICATION_FACTOR,
+                    "configs": {
+                        "diskless.enable": "true",
+                        "remote.storage.enable": "true",
+                        "min.insync.replicas": 2,
+                        # Roll segments by size/time so they close and get tiered.
+                        "segment.bytes": 1048576,
+                        "segment.ms": 5000,
+                        # Evict local segments soon after upload so the early prefix
+                        # lives only in remote -- retention.bytes must then reclaim
+                        # the remote tier, not just the local cache.
+                        "local.retention.ms": 5000,
+                        # Long time retention: only the size limit set later can
+                        # reclaim, so the advance is unambiguously bytes-driven.
+                        "retention.ms": str(self.INITIAL_RETENTION_MS),
+                        # retention.bytes is left unset (unlimited) until phase 1 is
+                        # tiered, so nothing is reclaimed by size during the drain.
+                    },
+                },
+            },
+        )
+        self.kafka.start()
+
+    def _drain_pipeline(self, verifier, baseline_tiered, acked):
+        """Wait until the born-consolidated topic has WAL -> local -> remote drained
+        and the WAL is pruned, then return the peak tiered-object count (the
+        physical-deletion baseline)."""
+        wait_until(lambda: verifier.local_lag() == 0,
+                   timeout_sec=240, backoff_sec=2,
+                   err_msg="Consolidation local lag did not drain to 0.")
+        self.logger.info("Consolidation local lag drained to 0")
+
+        wait_until(lambda: verifier.tiered_object_count() > baseline_tiered,
+                   timeout_sec=240, backoff_sec=2,
+                   err_msg="Tiered-storage object count did not grow above baseline.")
+
+        wait_until(lambda: verifier.min_log_start_offset(self.TOPIC) > 0
+                   or verifier.wal_batch_count(self.TOPIC) == 0,
+                   timeout_sec=240, backoff_sec=2,
+                   err_msg="WAL was not pruned in the Postgres control plane.")
+
+        # Remote retention only reclaims what actually reached the remote tier.
+        min_tiered = max(acked // 2, 1)
+        verifier.wait_for_tiered_offset_at_least(self.TOPIC, min_tiered)
+        self.logger.info("Latest-tiered offset reached at least %d (of %d acked)"
+                         % (min_tiered, acked))
+
+        # Settle the peak before returning: consolidation keeps tiering after the WAL
+        # drains locally, so a snapshot here can still be climbing. A settled peak (and
+        # a settled remote byte total for the size limit below) makes the later
+        # "count dropped after retention" check meaningful.
+        tiered_peak = verifier.wait_for_tiered_count_stable()
+        self.logger.info("Pipeline drained: tiered_peak=%d, diskless log_start=%d, wal_batches=%d"
+                         % (tiered_peak, verifier.min_log_start_offset(self.TOPIC),
+                            verifier.wal_batch_count(self.TOPIC)))
+
+        # The consolidated prefix is remote-only now, but the topic earliest is still
+        # 0 (remote serves [0, diskless_start)). This is the precondition that makes
+        # the retention below a genuine cross-tier reclaim rather than a WAL prune.
+        earliest = verifier.wait_for_offset(self.TOPIC, time_spec=-2)
+        assert earliest == 0, (
+            "expected earliest==0 before retention (remote still serves the prefix), got %d" % earliest)
+        return tiered_peak
+
+    @cluster(num_nodes=6)
+    @matrix(metadata_quorum=[quorum.isolated_kraft])
+    def test_retention_bytes_reclaims_across_tiers(self, metadata_quorum):
+        self._start_cluster()
+        verifier = ConsolidationVerifier(self.kafka)
+        verifier.verify_tooling()
+        baseline_tiered = verifier.tiered_object_count()
+        baseline_tiered_bytes = verifier.tiered_object_bytes()
+
+        verifier.start_jmx()
+
+        acked = verifier.produce(self.TOPIC, self.NUM_RECORDS, label="produce",
+                                 throughput=self.PRODUCE_THROUGHPUT,
+                                 timeout_sec=self.PRODUCE_SPAN_SEC + 120)
+        self.logger.info("Produced and acked %d records (throttled)" % acked)
+
+        tiered_peak = self._drain_pipeline(verifier, baseline_tiered, acked)
+
+        # Bytes this topic shipped to remote = the growth over the pre-produce
+        # baseline (this test is the only producer in its window; the tiered prefix
+        # otherwise only accumulates across tests, never shrinks on its own).
+        topic_remote_bytes = verifier.tiered_object_bytes() - baseline_tiered_bytes
+        self.logger.info("This topic contributed ~%d bytes to remote (%d - %d baseline)"
+                         % (topic_remote_bytes, verifier.tiered_object_bytes(), baseline_tiered_bytes))
+        assert topic_remote_bytes >= self.MIN_REMOTE_BYTES, (
+            "only %d bytes reached remote for %s (need >= %d to set a meaningful size "
+            "limit); the pipeline did not tier enough to exercise a cross-tier reclaim"
+            % (topic_remote_bytes, self.TOPIC, self.MIN_REMOTE_BYTES))
+
+        # Keep ~half of the remote data: the RemoteLogManager deletes the oldest
+        # segments until local_tail + remote <= retention.bytes, so the boundary
+        # lands inside (0, acked) and the newer half survives.
+        retention_bytes = topic_remote_bytes // 2
+        verifier.kafka.alter_topic_config(self.TOPIC, "retention.bytes", str(retention_bytes))
+        self.logger.info("Lowered retention.bytes to %d (~half of the %d remote bytes); "
+                         "waiting for the size-driven reclaim to reach a stable floor"
+                         % (retention_bytes, topic_remote_bytes))
+
+        # 1) retention.bytes advances earliest past 0 to a stable floor strictly
+        #    inside the produced range: the oldest remote segments are reclaimed
+        #    while the newer survivors (whose size fits under the limit) are kept.
+        earliest = verifier.wait_for_earliest_stable(self.TOPIC, timeout_sec=300)
+        assert 0 < earliest < acked, (
+            "retention.bytes left earliest at %d; expected a cross-tier reclaim of the "
+            "oldest remote segments with a surviving tail, i.e. earliest in (0, %d)"
+            % (earliest, acked))
+        self.logger.info("retention.bytes advanced earliest to a stable %d (of %d acked)"
+                         % (earliest, acked))
+
+        # 2) The reclaimed remote segments are physically removed (no storage leak).
+        wait_until(lambda: verifier.tiered_object_count() < tiered_peak,
+                   timeout_sec=240, backoff_sec=5,
+                   err_msg=("tiered-storage object count did not drop below the pre-retention "
+                            "peak of %d; the reclaimed remote segments were not deleted "
+                            "(storage leak)." % tiered_peak))
+        self.logger.info("Tiered-storage object count dropped below peak %d to %d after retention"
+                         % (tiered_peak, verifier.tiered_object_count()))
+
+        # 3) A fetch from the new earliest actually serves that offset from remote
+        #    (the advertised floor is backed by real, readable data).
+        first_served = verifier.first_served_offset(self.TOPIC, from_offset=earliest)
+        assert first_served == earliest, (
+            "a fetch from the new earliest %d returned offset %d, not %d; the surviving "
+            "tail is not served from the reclaim boundary" % (earliest, first_served, earliest))
+
+        # 4) The surviving tail [earliest, end) comes back contiguous with matching
+        #    content: the single producer wrote its sequence number as each value,
+        #    so value == offset. Catches gaps/dupes/reorder/corruption.
+        expected = acked - earliest
+        spot = min(expected, 20000)
+        records = verifier.read_records_with_values_from(
+            self.TOPIC, from_offset=earliest, max_messages=spot, timeout_ms=240000)
+        assert len(records) >= spot, (
+            "bounded read from the retention boundary %d returned only %d of %d records; "
+            "surviving data was lost across tiers" % (earliest, len(records), spot))
+        for i, (offset, value) in enumerate(records[:spot]):
+            expected_offset = earliest + i
+            assert offset == expected_offset, (
+                "non-contiguous read at position %d: offset=%d, expected %d (gap/dupe/reorder)"
+                % (i, offset, expected_offset))
+            assert value == offset, (
+                "content mismatch at offset %d: value=%d; the record served after the "
+                "size-driven reclaim does not match what was produced." % (offset, value))
+        self.logger.info("Surviving tail from %d read back contiguous with correct content (%d records)"
+                         % (earliest, spot))

--- a/tools/src/main/java/org/apache/kafka/tools/DeleteRecordsCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/DeleteRecordsCommand.java
@@ -143,13 +143,25 @@ public class DeleteRecordsCommand {
         DeleteRecordsResult deleteRecordsResult = adminClient.deleteRecords(recordsToDelete);
         out.println("Records delete operation completed:");
 
+        Map<TopicPartition, String> failures = new HashMap<>();
         deleteRecordsResult.lowWatermarks().forEach((tp, partitionResult) -> {
             try {
                 out.printf("partition: %s\tlow_watermark: %s%n", tp, partitionResult.get().lowWatermark());
             } catch (InterruptedException | ExecutionException e) {
                 out.printf("partition: %s\terror: %s%n", tp, e.getMessage());
+                failures.put(tp, e.getMessage());
             }
         });
+
+        // Fail the command (non-zero exit) when any partition could not be deleted, so operators and
+        // scripts are not misled by a successful exit code while per-partition errors were only printed.
+        if (!failures.isEmpty()) {
+            StringJoiner failed = new StringJoiner(", ");
+            failures.forEach((tp, message) -> failed.add(tp + ": " + message));
+            throw new AdminCommandFailedException(
+                String.format("Failed to delete records for %d partition(s): %s", failures.size(), failed)
+            );
+        }
     }
 
     private static Admin createAdminClient(DeleteRecordsCommandOptions opts) throws IOException {

--- a/tools/src/test/java/org/apache/kafka/tools/DeleteRecordsCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/DeleteRecordsCommandTest.java
@@ -81,11 +81,15 @@ public class DeleteRecordsCommandTest {
                 admin
             );
 
-            executeAndAssertOutput(
-                "{\"partitions\":[{\"topic\":\"t\", \"partition\":42, \"offset\":42}]}",
-                "partition: t-42\terror",
-                admin
-            );
+            // Deleting from a non-existing partition prints the per-partition error and fails the
+            // command with AdminCommandFailedException (non-zero exit), instead of silently exiting 0.
+            String errorOutput = ToolsTestUtils.captureStandardOut(() ->
+                assertThrows(
+                    AdminCommandFailedException.class,
+                    () -> DeleteRecordsCommand.execute(admin,
+                        "{\"partitions\":[{\"topic\":\"t\", \"partition\":42, \"offset\":42}]}", System.out)
+                ));
+            assertTrue(errorOutput.contains("partition: t-42\terror"));
         }
     }
 


### PR DESCRIPTION
Makes `DeleteRecords` correct end-to-end for **switched consolidating** diskless topics (both `diskless.enable` and `remote.storage.enable`), where the client-facing leader is a hash/AZ-selected replica (via the metadata transformer) rather than the real KRaft leader, and a freshly-rebuilt leader's local log start is pinned at the classic-to-diskless seal.

Changes, in layers:

- **Routing (local leg → real leader).** `DisklessDeleteRecordsForwarder` forwards the local leg of a `DeleteRecords` request to the actual leader, so the admin request no longer loops on `NOT_LEADER_OR_FOLLOWER` against a transformer-advertised follower. Wired through `KafkaApis`/`KafkaApisBuilder`/`BrokerServer`. `DeleteRecordsCommand` now exits non-zero on per-partition errors.
- **Cross-tier low watermark.** For consolidating partitions the completion low watermark and `ListOffsets(EARLIEST)` come from the authoritative control-plane cross-tier earliest, not the ISR (whose follower log starts are frozen at the switch). `DisklessFetchOffsetRouter` routes `EARLIEST` to the control plane (**Problem A**: cross-broker earliest consistency), and `DisklessLeaderEndPoint` reports `min(crossTierEarliest, localLogStart)` as the whole-log start.
- **Reclaim floor (Problem B).** `RemoteLogManager` takes a `logStartOffsetOverride` (control-plane cross-tier earliest) so a rebuilt leader no longer reclaims the entire remote classic prefix `[earliest, seal)`.
- **Fail-safe reclaim floor.** When the override is unavailable (control plane down / metadata not yet propagated), the RLM no longer falls back to the local seal for a *consolidating* partition — it uses the remote earliest and defers, so a transient control-plane outage can never trigger irreversible over-deletion. A new `isConsolidatingDisklessPartition` predicate distinguishes this from classic topics, which keep the upstream local-log-start floor.

Docs: `DISKLESS_CONSOLIDATION.md` updated; full design/rationale and an uncertainties/risk-tracking checklist in `DELETE_RECORDS_DISKLESS_ROUTING_IMPL.md`.

- [x] `RemoteLogManagerTest` — reclaim floor uses the override; fail-safe skips reclaim when the override is absent for consolidating; classic topics unchanged.
- [x] `ReplicaManagerInklessTest` — `crossTierEarliestOffset` branches (cache hit, miss→CP, CP error/throw→empty, non-consolidating→empty); `isConsolidatingDisklessPartition`.
- [x] `DisklessLeaderEndPointTest` — whole-log start = cross-tier earliest; reverts to local seal when unavailable.
- [x] `DisklessFetchOffsetRouterTest`, `DisklessDeleteRecordsForwarderTest`, `DeleteRecordsCommandTest`.
- [x] e2e `consolidation_delete_records_across_tiers_test.py` — earliest advances off 0, is identical on every broker, settles exactly at the delete boundary, and the surviving prefix reads back contiguous.
- [x] `core`/`storage` compile + checkstyle + spotbugs green.
- [ ] Open items tracked in the checklist in `DELETE_RECORDS_DISKLESS_ROUTING_IMPL.md` (multi-partition/rapid-failover e2e, retention×DeleteRecords, sync-DB/batching, etc.).

Delete this text and replace it with a detailed description of your change. The 
PR title and body will become the squashed commit message.

If you would like to tag individuals, add some commentary, upload images, or
include other supplemental information that should not be part of the eventual
commit message, please use a separate comment.

If applicable, please include a summary of the testing strategy (including 
rationale) for the proposed change. Unit and/or integration tests are expected
for any behavior change and system tests should be considered for larger
changes.
