### PR TITLE
fix(inkless:consolidation): route ListOffsets(EARLIEST) to the control plane for consolidating topics [KC-332]

### DIFF
--- a/core/src/main/scala/kafka/server/DisklessFetchOffsetRouter.scala
+++ b/core/src/main/scala/kafka/server/DisklessFetchOffsetRouter.scala
@@ -136,15 +136,15 @@ class DisklessFetchOffsetRouter(
           classicLookup()
 
         case ListOffsetsRequest.EARLIEST_TIMESTAMP =>
-          // Classic owns the earliest offset only while the local log still holds the pre-switch
-          // prefix (classicLogStartOffset < classicToDisklessStartOffset). A born-consolidated
-          // partition has no committed switch offset (NO_CLASSIC_TO_DISKLESS_START_OFFSET == -1),
-          // so its classic log never owns the earliest: the RLM-pinned local log start does not
-          // track cross-tier retention in time, whereas the control-plane leg does. Route those
-          // to diskless, whose list_offsets_v1 returns COALESCE(remote_log_start_offset,
-          // log_start_offset) and therefore reflects retention that advanced the remote/diskless
-          // start above 0 on a born-consolidated topic.
-          if (classicLogStartOffsetProvider(topicPartition).exists(_ < classicToDisklessStartOffset)) {
+          // Route every consolidating partition to the control plane, the authoritative
+          // broker-agnostic cross-tier earliest (COALESCE(remote_log_start_offset, log_start_offset)).
+          // The local classic log start is unsafe: it is frozen at the switch on followers, so a
+          // client the metadata transformer sends to a follower would see a stale earliest, and
+          // retention/DeleteRecords advance the control plane, not every replica's local log.
+          // Non-consolidating switched partitions have no such tracking, so they keep the classic leg
+          // while it still owns the pre-switch prefix (classicLogStartOffset < classicToDisklessStartOffset).
+          if (!isConsolidatingPartition &&
+              classicLogStartOffsetProvider(topicPartition).exists(_ < classicToDisklessStartOffset)) {
             classicLookup()
           } else {
             asStatus(topicPartition, disklessLookup)

--- a/core/src/test/scala/unit/kafka/server/DisklessFetchOffsetRouterTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DisklessFetchOffsetRouterTest.scala
@@ -492,13 +492,14 @@ class DisklessFetchOffsetRouterTest {
   }
 
   @Test
-  def consolidatingSwitchedEarliestUsesClassicWhilePrefixPresent(): Unit = {
+  def consolidatingSwitchedEarliestRoutesToDisklessWhilePrefixPresent(): Unit = {
     // Switched-then-consolidated topic whose classic prefix is still on disk
-    // (classicLogStartOffset 0 < classicToDisklessStartOffset 100): classic owns the earliest,
-    // so its answer is returned verbatim and the control-plane leg (which does not know about the
-    // pre-switch prefix) is NOT consulted.
+    // (classicLogStartOffset 0 < classicToDisklessStartOffset 100). Even so, EARLIEST goes to the
+    // broker-agnostic control plane, not the local classic log (which is frozen at the switch on
+    // followers and would differ per broker): the diskless leg is consulted, the classic leg is not.
     when(inklessMetadataView.getClassicToDisklessStartOffset(tp)).thenReturn(100L)
     when(inklessMetadataView.isConsolidatingDisklessTopic(tp.topic)).thenReturn(true)
+    disklessTaskFuture.complete(offsetResult(0L))
 
     val status = route(
       newRouter(disklessConsolidationEnabled = true),
@@ -506,9 +507,51 @@ class DisklessFetchOffsetRouterTest {
       classicLogStartOffset = Some(0L)
     )
 
-    assertSame(defaultClassicResult, status)
-    assertClassicCalledWith(allowFromFollower = true)
-    verify(job, never()).add(any(), any())
+    assertTrue(classicCalls.isEmpty, "classic path must not be invoked for a consolidating topic's EARLIEST")
+    verify(job).add(eqTo(tp), any())
+    assertTrue(status.futureHolderOpt.isPresent, "diskless leg surfaces an async holder")
+    val result = status.futureHolderOpt.get.taskFuture.get(1, TimeUnit.SECONDS)
+    assertEquals(0L, result.timestampAndOffset.get.offset)
+  }
+
+  @Test
+  def consolidatingSwitchedEarliestIsConsistentAcrossBrokersRegardlessOfLocalClassicLogStart(): Unit = {
+    // Problem A regression guard: two brokers with different local classic log starts (leader at 60,
+    // follower still frozen at 0, both below the seal of 100) must return the SAME earliest. Both
+    // route to the control plane, so neither consults its local classic log.
+    when(inklessMetadataView.getClassicToDisklessStartOffset(tp)).thenReturn(100L)
+    when(inklessMetadataView.isConsolidatingDisklessTopic(tp.topic)).thenReturn(true)
+
+    Seq(Some(0L), Some(60L)).foreach { localClassicLogStart =>
+      classicCalls.clear()
+      val fresh = new CompletableFuture[FileRecordsOrError]()
+      fresh.complete(offsetResult(42L))
+      val jobForBroker = {
+        val m = mock(classOf[FetchOffsetHandler.Job])
+        when(m.add(any(), any())).thenAnswer(_ => fresh)
+        when(m.cancelHandler()).thenReturn(new CompletableFuture[Void]())
+        m
+      }
+      val status = new DisklessFetchOffsetRouter(
+        inklessMetadataView, true, true, purgatory).route(
+        job = jobForBroker,
+        newJob = () => throw new AssertionError("newJob() should not be called by this routing path"),
+        topicPartition = tp,
+        partition = makePartition(ListOffsetsRequest.EARLIEST_TIMESTAMP, tp.partition),
+        replicaId = consumerReplicaId,
+        version = 7,
+        classicLogStartOffsetProvider = _ => localClassicLogStart,
+        hasCompleteClassicPrefix = (_, _) => true,
+        classicFetchOffset = (tpArg, partition, allow) => {
+          classicCalls += ((tpArg, partition, allow))
+          defaultClassicResult
+        }
+      )
+      assertTrue(classicCalls.isEmpty,
+        s"classic path must not be invoked (localClassicLogStart=$localClassicLogStart)")
+      assertTrue(status.futureHolderOpt.isPresent)
+      assertEquals(42L, status.futureHolderOpt.get.taskFuture.get(1, TimeUnit.SECONDS).timestampAndOffset.get.offset)
+    }
   }
 
   @Test
@@ -534,11 +577,12 @@ class DisklessFetchOffsetRouterTest {
   }
 
   @Test
-  def consolidatingEarliestWithCommittedBoundaryDeniesFollowerAccessWhenPrefixIncomplete(): Unit = {
+  def consolidatingEarliestWithCommittedBoundaryRoutesToDisklessEvenWhenPrefixIncomplete(): Unit = {
     when(inklessMetadataView.getClassicToDisklessStartOffset(tp)).thenReturn(100L)
     when(inklessMetadataView.isConsolidatingDisklessTopic(tp.topic)).thenReturn(true)
-    // defaultClassicResult (offset 0) is a valid sync classic answer, so the classic leg wins
-    // verbatim and the control-plane leg is not consulted.
+    disklessTaskFuture.complete(offsetResult(5L))
+    // The local classic prefix is incomplete here, but EARLIEST for a consolidating topic is served
+    // by the control plane, so local completeness is irrelevant and the classic leg is never consulted.
     val status = route(
       newRouter(disklessConsolidationEnabled = true),
       timestamp = ListOffsetsRequest.EARLIEST_TIMESTAMP,
@@ -546,11 +590,10 @@ class DisklessFetchOffsetRouterTest {
       hasCompleteClassicPrefix = false
     )
 
-    // The classic leg runs but must be denied follower access until the local prefix is complete;
-    // since it answers, the diskless leg is not consulted.
-    assertClassicCalledWith(allowFromFollower = false)
-    verify(job, never()).add(any(), any())
-    assertSame(defaultClassicResult, status)
+    assertTrue(classicCalls.isEmpty, "classic path must not be invoked for a consolidating topic's EARLIEST")
+    verify(job).add(eqTo(tp), any())
+    assertTrue(status.futureHolderOpt.isPresent)
+    assertEquals(5L, status.futureHolderOpt.get.taskFuture.get(1, TimeUnit.SECONDS).timestampAndOffset.get.offset)
   }
   
   @Test


### PR DESCRIPTION
For a switched consolidating topic the earliest offset was served from the broker-local classic UnifiedLog.logStartOffset, which is frozen at the switch on followers, so ListOffsets(EARLIEST) diverged across brokers depending on which replica the metadata transformer routed the client to.
DisklessFetchOffsetRouter now routes EARLIEST for every consolidating partition (born-consolidated and switched) to the authoritative control-plane cross-tier earliest, giving one consistent answer on every broker. Non-consolidating switched partitions keep the classic leg while it still owns the pre-switch prefix.
