### PR TITLE
fix(inkless:consolidation): route DeleteRecords to the real leader and report cross-tier low watermark [KC-332]

### DIFF
--- a/core/src/main/java/kafka/server/builders/KafkaApisBuilder.java
+++ b/core/src/main/java/kafka/server/builders/KafkaApisBuilder.java
@@ -231,6 +231,7 @@ public class KafkaApisBuilder {
                              apiVersionManager,
                              clientMetricsManager,
                              groupConfigManager,
+                             OptionConverters.toScala(Optional.empty()),
                              OptionConverters.toScala(Optional.empty()));
     }
 }

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -169,6 +169,7 @@ class BrokerServer(
   private var maybeInklessSharedState: Option[SharedState] = None
   private var maybeInitDisklessLogManager: Option[InitDisklessLogManager] = None
   private var initDisklessLogChannelManager: NodeToControllerChannelManager = _
+  private var maybeDisklessDeleteRecordsForwarder: Option[DisklessDeleteRecordsForwarder] = None
 
   private def maybeChangeStatus(from: ProcessStatus, to: ProcessStatus): Boolean = {
     lock.lock()
@@ -401,6 +402,17 @@ class BrokerServer(
         initDisklessLogManager = maybeInitDisklessLogManager
       )
 
+      // Forwards the leader-only leg of DeleteRecords for diskless topics with a local-log
+      // component to the partition's real KRaft leader, since the metadata transformer advertises
+      // an AZ-selected replica (a follower) as the client-facing leader.
+      maybeDisklessDeleteRecordsForwarder = inklessSharedState.map { _ =>
+        val forwarderLogContext = new LogContext(s"[DisklessDeleteRecordsForwarder broker=${config.brokerId}]")
+        val forwarderNetworkClient = NetworkUtils.buildNetworkClient("DisklessDeleteRecordsForwarder", config, metrics, time, forwarderLogContext)
+        val forwarder = new DisklessDeleteRecordsForwarder(config, forwarderNetworkClient, metadataCache, inklessMetadataView, time)
+        forwarder.start()
+        forwarder
+      }
+
       /* start token manager */
       tokenManager = new DelegationTokenManager(new DelegationTokenManagerConfigs(config), tokenCache)
 
@@ -512,7 +524,8 @@ class BrokerServer(
         apiVersionManager = apiVersionManager,
         clientMetricsManager = clientMetricsManager,
         groupConfigManager = groupConfigManager,
-        inklessSharedState = inklessSharedState)
+        inklessSharedState = inklessSharedState,
+        disklessDeleteRecordsForwarder = maybeDisklessDeleteRecordsForwarder)
 
       dataPlaneRequestHandlerPool = sharedServer.requestHandlerPoolFactory.createPool(
         config.nodeId,
@@ -892,6 +905,8 @@ class BrokerServer(
         maybeInklessSharedState.foreach(s => CoreUtils.swallow(s.close(), this))
 
       maybeInitDisklessLogManager.foreach(m => CoreUtils.swallow(m.shutdown(), this))
+
+      maybeDisklessDeleteRecordsForwarder.foreach(f => CoreUtils.swallow(f.shutdown(), this))
 
       if (initDisklessLogChannelManager != null)
         CoreUtils.swallow(initDisklessLogChannelManager.shutdown(), this)

--- a/core/src/main/scala/kafka/server/DisklessDeleteRecordsForwarder.scala
+++ b/core/src/main/scala/kafka/server/DisklessDeleteRecordsForwarder.scala
@@ -1,0 +1,243 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Copyright (c) 2024 Aiven, Helsinki, Finland. https://aiven.io/
+
+package kafka.server
+
+import kafka.server.metadata.InklessMetadataView
+import kafka.utils.Logging
+import org.apache.kafka.clients.{ClientResponse, NetworkClient, RequestCompletionHandler}
+import org.apache.kafka.common.message.DeleteRecordsRequestData
+import org.apache.kafka.common.message.DeleteRecordsRequestData.{DeleteRecordsPartition, DeleteRecordsTopic}
+import org.apache.kafka.common.message.DeleteRecordsResponseData.DeleteRecordsPartitionResult
+import org.apache.kafka.common.protocol.Errors
+import org.apache.kafka.common.requests.{DeleteRecordsRequest, DeleteRecordsResponse}
+import org.apache.kafka.common.utils.Time
+import org.apache.kafka.common.{Node, TopicPartition}
+import org.apache.kafka.metadata.{MetadataCache, PartitionRegistration}
+import org.apache.kafka.server.util.{InterBrokerSendThread, RequestAndCompletionHandler}
+
+import java.util
+import java.util.concurrent.{CompletableFuture, ConcurrentLinkedQueue}
+import scala.collection.mutable
+import scala.jdk.CollectionConverters._
+
+/**
+ * Forwards the leader-only leg of a `DeleteRecords` request to a diskless partition's real KRaft
+ * leader over the inter-broker listener.
+ *
+ * For a diskless topic that owns a classic/consolidated prefix (switched, switch-pending or
+ * consolidating), `ReplicaManager.deleteRecords` splits the request into a broker-agnostic diskless
+ * (control-plane) leg and a local-log leg. The local-log leg only succeeds on the real KRaft leader
+ * (`Partition.deleteRecordsOnLeader` requires `leaderLogIfLocal`). Because
+ * `InklessTopicMetadataTransformer` advertises a hash/AZ-selected replica as the client-facing
+ * leader for locality-aware read routing, the AdminClient generally delivers `DeleteRecords` to a
+ * follower, which rejects it with `NOT_LEADER_OR_FOLLOWER`.
+ *
+ * `KafkaApis` uses this forwarder to send the affected partitions to their real leader (resolved
+ * from the raw KRaft metadata image, independent of the transformer). The receiving leader runs its
+ * own `ReplicaManager.deleteRecords` and serves both legs authoritatively, so read AZ-routing is
+ * left untouched.
+ *
+ * Modeled on `AddPartitionsToTxnManager` / `TransactionMarkerChannelManager`.
+ */
+class DisklessDeleteRecordsForwarder(
+  config: KafkaConfig,
+  networkClient: NetworkClient,
+  metadataCache: MetadataCache,
+  metadataView: InklessMetadataView,
+  time: Time
+) extends InterBrokerSendThread(
+  "DisklessDeleteRecordsForwarder-" + config.brokerId,
+  networkClient,
+  config.requestTimeoutMs,
+  time
+) with Logging {
+
+  this.logIdent = s"[DisklessDeleteRecordsForwarder broker=${config.brokerId}] "
+
+  private val interBrokerListenerName = config.interBrokerListenerName
+
+  private case class PendingForward(
+    leader: Node,
+    offsets: Map[TopicPartition, Long],
+    timeoutMs: Int,
+    future: CompletableFuture[Map[TopicPartition, DeleteRecordsPartitionResult]]
+  )
+
+  private val queue = new ConcurrentLinkedQueue[PendingForward]()
+
+  /**
+   * Split `offsets` into the partitions this broker handles locally (via
+   * `ReplicaManager.deleteRecords`) and the partitions whose local-log leg must run on another
+   * broker's real KRaft leader, grouped by that leader.
+   *
+   * A partition is forwarded iff it is a diskless topic that owns a local-log leg
+   * (switched / switch-pending / consolidating) and its real leader is a different, reachable
+   * broker. Pure-diskless partitions (control-plane only) and partitions this broker already leads
+   * stay local, preserving existing behaviour.
+   */
+  def routeByLeader(
+    offsets: Map[TopicPartition, Long]
+  ): (Map[TopicPartition, Long], Map[Node, Map[TopicPartition, Long]]) = {
+    val local = mutable.Map.empty[TopicPartition, Long]
+    val forward = mutable.Map.empty[Node, mutable.Map[TopicPartition, Long]]
+    offsets.foreach { case (topicPartition, offset) =>
+      leaderToForwardTo(topicPartition) match {
+        case Some(leader) => forward.getOrElseUpdate(leader, mutable.Map.empty) += (topicPartition -> offset)
+        case None => local += (topicPartition -> offset)
+      }
+    }
+    (local.toMap, forward.map { case (node, partitionOffsets) => node -> partitionOffsets.toMap }.toMap)
+  }
+
+  private def leaderToForwardTo(topicPartition: TopicPartition): Option[Node] = {
+    if (!metadataView.isDisklessTopic(topicPartition.topic) || !hasLocalLeg(topicPartition)) {
+      None
+    } else {
+      val leader = metadataCache.getPartitionLeaderEndpoint(
+        topicPartition.topic, topicPartition.partition, interBrokerListenerName)
+      if (leader.isPresent && !leader.get.isEmpty && leader.get.id != config.brokerId) Some(leader.get)
+      else None
+    }
+  }
+
+  /**
+   * Whether the partition has a classic/consolidated prefix that lives in a local `UnifiedLog`,
+   * i.e. a leader-only local-log leg of `DeleteRecords` that is not broker-agnostic. Derived purely
+   * from KRaft metadata so it can be evaluated on any broker (a born consolidating partition may not
+   * yet have a local log on the leader; the leader resolves that when it runs the split).
+   */
+  private def hasLocalLeg(topicPartition: TopicPartition): Boolean = {
+    val start = metadataView.getClassicToDisklessStartOffset(topicPartition)
+    start >= 0 ||
+      start == PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING ||
+      (start == PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET &&
+        metadataView.isConsolidatingDisklessTopic(topicPartition.topic))
+  }
+
+  /**
+   * Forward a `DeleteRecords` sub-request for `offsets` to `leader` and complete the returned future
+   * with the per-partition results. On a routing/network failure the future completes with a
+   * retriable `NOT_LEADER_OR_FOLLOWER` per partition so the AdminClient re-reads metadata and
+   * retries once leadership settles.
+   */
+  def forward(
+    leader: Node,
+    offsets: Map[TopicPartition, Long],
+    timeoutMs: Int
+  ): CompletableFuture[Map[TopicPartition, DeleteRecordsPartitionResult]] = {
+    val future = new CompletableFuture[Map[TopicPartition, DeleteRecordsPartitionResult]]()
+    if (leader == null || leader.isEmpty) {
+      future.complete(errorResults(offsets.keys, Errors.NOT_LEADER_OR_FOLLOWER))
+    } else {
+      queue.add(PendingForward(leader, offsets, timeoutMs, future))
+      wakeup()
+    }
+    future
+  }
+
+  private def errorResults(
+    partitions: Iterable[TopicPartition],
+    error: Errors
+  ): Map[TopicPartition, DeleteRecordsPartitionResult] = {
+    partitions.map { tp =>
+      tp -> new DeleteRecordsPartitionResult()
+        .setPartitionIndex(tp.partition)
+        .setLowWatermark(DeleteRecordsResponse.INVALID_LOW_WATERMARK)
+        .setErrorCode(error.code)
+    }.toMap
+  }
+
+  override def generateRequests(): util.Collection[RequestAndCompletionHandler] = {
+    val requests = new util.ArrayList[RequestAndCompletionHandler]()
+    val now = time.milliseconds()
+    var pending = queue.poll()
+    while (pending != null) {
+      requests.add(buildRequest(pending, now))
+      pending = queue.poll()
+    }
+    requests
+  }
+
+  private def buildRequest(pending: PendingForward, now: Long): RequestAndCompletionHandler = {
+    val topics = new util.LinkedHashMap[String, DeleteRecordsTopic]()
+    pending.offsets.foreach { case (tp, offset) =>
+      val topic = topics.computeIfAbsent(tp.topic, name => new DeleteRecordsTopic().setName(name))
+      topic.partitions().add(new DeleteRecordsPartition()
+        .setPartitionIndex(tp.partition)
+        .setOffset(offset))
+    }
+    val data = new DeleteRecordsRequestData()
+      .setTopics(new util.ArrayList[DeleteRecordsTopic](topics.values()))
+      .setTimeoutMs(pending.timeoutMs)
+    new RequestAndCompletionHandler(
+      now,
+      pending.leader,
+      new DeleteRecordsRequest.Builder(data),
+      completionHandler(pending)
+    )
+  }
+
+  private def completionHandler(pending: PendingForward): RequestCompletionHandler = new RequestCompletionHandler {
+    override def onComplete(response: ClientResponse): Unit = {
+      try {
+        if (response.authenticationException != null) {
+          error(s"DeleteRecords forwarding to ${pending.leader} failed with an authentication error", response.authenticationException)
+          pending.future.complete(errorResults(pending.offsets.keys, Errors.forException(response.authenticationException)))
+        } else if (response.versionMismatch != null) {
+          error(s"DeleteRecords forwarding to ${pending.leader} failed with a version mismatch", response.versionMismatch)
+          pending.future.complete(errorResults(pending.offsets.keys, Errors.UNKNOWN_SERVER_ERROR))
+        } else if (response.wasDisconnected || response.wasTimedOut) {
+          warn(s"DeleteRecords forwarding to ${pending.leader} failed with a network error " +
+            s"(disconnected=${response.wasDisconnected}, timedOut=${response.wasTimedOut}); the client will retry")
+          pending.future.complete(errorResults(pending.offsets.keys, Errors.NOT_LEADER_OR_FOLLOWER))
+        } else {
+          pending.future.complete(parseResponse(pending, response.responseBody.asInstanceOf[DeleteRecordsResponse]))
+        }
+      } catch {
+        case e: Throwable =>
+          error(s"Failed to handle the forwarded DeleteRecords response from ${pending.leader}", e)
+          pending.future.complete(errorResults(pending.offsets.keys, Errors.UNKNOWN_SERVER_ERROR))
+      } finally {
+        wakeup()
+      }
+    }
+  }
+
+  private def parseResponse(
+    pending: PendingForward,
+    response: DeleteRecordsResponse
+  ): Map[TopicPartition, DeleteRecordsPartitionResult] = {
+    val results = mutable.Map.empty[TopicPartition, DeleteRecordsPartitionResult]
+    for (topicResult <- response.data.topics.asScala; partitionResult <- topicResult.partitions.asScala) {
+      val tp = new TopicPartition(topicResult.name, partitionResult.partitionIndex)
+      results += tp -> new DeleteRecordsPartitionResult()
+        .setPartitionIndex(partitionResult.partitionIndex)
+        .setLowWatermark(partitionResult.lowWatermark)
+        .setErrorCode(partitionResult.errorCode)
+    }
+    // Any partition the leader did not answer for is reported as retriable so the client retries.
+    pending.offsets.keys.filterNot(results.contains).foreach { tp =>
+      results += tp -> new DeleteRecordsPartitionResult()
+        .setPartitionIndex(tp.partition)
+        .setLowWatermark(DeleteRecordsResponse.INVALID_LOW_WATERMARK)
+        .setErrorCode(Errors.NOT_LEADER_OR_FOLLOWER.code)
+    }
+    results.toMap
+  }
+}

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -112,7 +112,8 @@ class KafkaApis(val requestChannel: RequestChannel,
                 val apiVersionManager: ApiVersionManager,
                 val clientMetricsManager: ClientMetricsManager,
                 val groupConfigManager: GroupConfigManager,
-                inklessSharedState: Option[SharedState] = None
+                inklessSharedState: Option[SharedState] = None,
+                disklessDeleteRecordsForwarder: Option[DisklessDeleteRecordsForwarder] = None
 ) extends ApiRequestHandler with Logging {
 
   type ProduceResponseStats = Map[TopicIdPartition, RecordValidationStats]
@@ -1599,14 +1600,56 @@ class KafkaApis(val requestChannel: RequestChannel,
           }.toList.asJava.iterator()))))
     }
 
-    if (authorizedForDeleteTopicOffsets.isEmpty)
+    if (authorizedForDeleteTopicOffsets.isEmpty) {
       sendResponseCallback(Map.empty)
-    else {
-      // call the replica manager to append messages to the replicas
-      replicaManager.deleteRecords(
-        deleteRecordsRequest.data.timeoutMs.toLong,
-        authorizedForDeleteTopicOffsets,
-        sendResponseCallback)
+    } else {
+      val timeoutMs = deleteRecordsRequest.data.timeoutMs
+      // Split the diskless partitions whose local-log leg must run on another broker's real KRaft
+      // leader (the metadata transformer advertised a follower to the client). A forwarded request
+      // lands on its real leader, where routeByLeader resolves leader == self and handles it
+      // locally, so the chain terminates without an explicit loop guard.
+      val routed = disklessDeleteRecordsForwarder
+        .map(forwarder => (forwarder, forwarder.routeByLeader(authorizedForDeleteTopicOffsets.toMap)))
+
+      routed match {
+        case Some((forwarder, (localOffsets, forwardByLeader))) if forwardByLeader.nonEmpty =>
+          // Some partitions must be applied by another broker's real KRaft leader (the diskless
+          // metadata transformer advertised a follower as the client-facing leader). Fan out the
+          // local and forwarded legs and merge their results into a single response.
+          val expected = forwardByLeader.size + (if (localOffsets.nonEmpty) 1 else 0)
+          val remaining = new AtomicInteger(expected)
+          val collected = new ConcurrentHashMap[TopicPartition, DeleteRecordsPartitionResult]()
+
+          def onBucketComplete(results: Map[TopicPartition, DeleteRecordsPartitionResult]): Unit = {
+            results.foreach { case (topicPartition, result) => collected.put(topicPartition, result) }
+            if (remaining.decrementAndGet() == 0)
+              sendResponseCallback(collected.asScala.toMap)
+          }
+
+          if (localOffsets.nonEmpty)
+            replicaManager.deleteRecords(timeoutMs.toLong, localOffsets, onBucketComplete)
+
+          forwardByLeader.foreach { case (leader, offsets) =>
+            forwarder.forward(leader, offsets, timeoutMs).whenComplete { (results, exception) =>
+              if (exception != null) {
+                warn(s"Failed to forward DeleteRecords for $offsets to leader $leader", exception)
+                onBucketComplete(offsets.keys.map { topicPartition =>
+                  topicPartition -> new DeleteRecordsPartitionResult()
+                    .setPartitionIndex(topicPartition.partition)
+                    .setLowWatermark(DeleteRecordsResponse.INVALID_LOW_WATERMARK)
+                    .setErrorCode(Errors.NOT_LEADER_OR_FOLLOWER.code)
+                }.toMap)
+              } else {
+                onBucketComplete(results)
+              }
+            }
+          }
+
+        case _ =>
+          // No forwarding needed (inkless disabled, forwarded request, or all partitions handled
+          // locally): keep the existing single-call path.
+          replicaManager.deleteRecords(timeoutMs.toLong, authorizedForDeleteTopicOffsets, sendResponseCallback)
+      }
     }
   }
 

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1735,12 +1735,13 @@ class ReplicaManager(val config: KafkaConfig,
       return Map.empty
     }
 
-    // A consolidating partition's converted delete offset X: the concrete requested offset, or -- for
-    // HIGH_WATERMARK, which on a consolidating topic always reaches into the WAL and thus runs the
-    // diskless leg -- the low watermark that leg returned (= log_start_offset = HWM).
+    // Convert each delete offset: use the requested offset, or the leg's returned low watermark when
+    // the request was HIGH_WATERMARK (which always reaches the WAL, so the diskless leg ran).
     val requests = new java.util.ArrayList[AdvanceCrossTierLogStartOffsetRequest]()
     val partitionsInOrder = mutable.ArrayBuffer.empty[TopicPartition]
     response.foreach { case (topicPartition, result) =>
+      // Non-consolidating partitions and errors will be skipped here as they're handled in the caller
+      // finalizeCrossTierAndRespond by returning their original response.
       if (result.errorCode == Errors.NONE.code &&
         _inklessMetadataView.isConsolidatingDisklessTopic(topicPartition.topic)) {
         val requested = offsetPerPartition.getOrElse(topicPartition, DeleteRecordsRequest.HIGH_WATERMARK)

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -20,7 +20,7 @@ import com.yammer.metrics.core.Meter
 import io.aiven.inkless.common.SharedState
 import io.aiven.inkless.consume.{ConcatenatedRecords, FetchHandler, FetchOffsetHandler, Reader}
 import io.aiven.inkless.storage_backend.common.ObjectFetcher
-import io.aiven.inkless.control_plane.{BatchInfo, FindBatchRequest, FindBatchResponse, InitDisklessLogProducerState, RepairDisklessLogRequest}
+import io.aiven.inkless.control_plane.{AdvanceCrossTierLogStartOffsetRequest, AdvanceCrossTierLogStartOffsetResponse, BatchInfo, FindBatchRequest, FindBatchResponse, InitDisklessLogProducerState, RepairDisklessLogRequest}
 import io.aiven.inkless.delete.{DeleteRecordsInterceptor, FileCleaner, RetentionEnforcer}
 import io.aiven.inkless.produce.AppendHandler
 import io.aiven.inkless.consolidation.{ConsolidatedDisklessLogPruner, ConsolidationFetcherManager, ConsolidationMetrics, ConsolidationReconciler}
@@ -1603,6 +1603,20 @@ class ReplicaManager(val config: KafkaConfig,
     val immutableDisklessOffsets = disklessOffsetPerPartition.toMap
     val immutableHybridPartitions = hybridDisklessPartitions.toSet
 
+    // Report the cross-tier earliest of successfully-deleted consolidating diskless partitions to the
+    // control plane and use it as their low watermark, so any broker (leader or the follower the
+    // metadata transformer routes clients to) returns the same value as ListOffsets(EARLIEST).
+    def finalizeCrossTierAndRespond(response: Map[TopicPartition, DeleteRecordsPartitionResult]): Unit = {
+      val advanced = advanceCrossTierEarliestForDeleteRecords(response, offsetPerPartition)
+      if (advanced.isEmpty) {
+        responseCallback(response)
+      } else {
+        responseCallback(response.map { case (topicPartition, result) =>
+          topicPartition -> advanced.getOrElse(topicPartition, result)
+        })
+      }
+    }
+
     def maybeDeleteFromDiskless(localResponse: Map[TopicPartition, DeleteRecordsPartitionResult]): Unit = {
       // Keep pure diskless partitions and only the hybrid partitions whose local phase succeeded.
       val disklessOffsetsAfterLocalDelete = immutableDisklessOffsets.filterNot { case (topicPartition, _) =>
@@ -1610,11 +1624,11 @@ class ReplicaManager(val config: KafkaConfig,
           localResponse.get(topicPartition).exists(_.errorCode != Errors.NONE.code)
       }
       if (disklessOffsetsAfterLocalDelete.isEmpty) {
-        responseCallback(localResponse ++ failedDisklessDeleteRecords)
+        finalizeCrossTierAndRespond(localResponse ++ failedDisklessDeleteRecords)
       } else {
         inklessDeleteRecordsInterceptor.get.intercept(
           disklessOffsetsAfterLocalDelete.view.mapValues(java.lang.Long.valueOf).toMap.asJava,
-          r => responseCallback(localResponse ++ failedDisklessDeleteRecords ++ r.asScala))
+          r => finalizeCrossTierAndRespond(localResponse ++ failedDisklessDeleteRecords ++ r.asScala))
       }
     }
 
@@ -1627,7 +1641,25 @@ class ReplicaManager(val config: KafkaConfig,
     val localDeleteRecordsResults = deleteRecordsOnLocalLog(localOffsetPerPartition, allowInternalTopicDeletion)
     debug("Delete records on local log in %d ms".format(time.milliseconds - timeBeforeLocalDeleteRecords))
 
-    val deleteRecordsStatus = localDeleteRecordsResults.map { case (topicPartition, result) =>
+    // Consolidating diskless partitions (born-consolidating or switched-with-remote-storage) do not
+    // replicate their local consolidated log to followers, so their DeleteRecords completion must NOT
+    // wait on the ISR low watermark (Partition.lowWatermarkIfLeader), which is pinned at the followers'
+    // frozen, pre-switch logStartOffset. Their earliest is instead reported from the control plane in
+    // finalizeCrossTierAndRespond; only classic partitions keep the ISR-gated delayed operation. The
+    // local leg above still ran to drive the leader's RemoteLogManager physical deletion of remote
+    // segments.
+    val (crossTierResults, classicResults) = localDeleteRecordsResults.partition { case (topicPartition, _) =>
+      _inklessMetadataView.isConsolidatingDisklessTopic(topicPartition.topic)
+    }
+
+    val crossTierResponseStatus = crossTierResults.map { case (topicPartition, result) =>
+      topicPartition -> new DeleteRecordsPartitionResult()
+        .setLowWatermark(result.lowWatermark)
+        .setErrorCode(result.error.code)
+        .setPartitionIndex(topicPartition.partition)
+    }
+
+    val deleteRecordsStatus = classicResults.map { case (topicPartition, result) =>
       topicPartition ->
         new DeleteRecordsPartitionStatus(
           result.requestedOffset, // requested offset
@@ -1637,7 +1669,7 @@ class ReplicaManager(val config: KafkaConfig,
             .setPartitionIndex(topicPartition.partition)) // response status
     }
 
-    if (delayedDeleteRecordsRequired(localDeleteRecordsResults)) {
+    if (delayedDeleteRecordsRequired(classicResults)) {
       def onAcks(topicPartition: TopicPartition, status: DeleteRecordsPartitionStatus): Unit = {
         val (lowWatermarkReached, error, lw) = getPartition(topicPartition) match {
           case HostedPartition.Online(partition) =>
@@ -1662,10 +1694,11 @@ class ReplicaManager(val config: KafkaConfig,
         }
       }
       // create delayed delete records operation
-      val delayedDeleteRecords = new DelayedDeleteRecords(timeout, deleteRecordsStatus.asJava, onAcks, response => maybeDeleteFromDiskless(response.asScala))
+      val delayedDeleteRecords = new DelayedDeleteRecords(timeout, deleteRecordsStatus.asJava, onAcks,
+        response => maybeDeleteFromDiskless(response.asScala ++ crossTierResponseStatus))
 
       // create a list of (topic, partition) pairs to use as keys for this delayed delete records operation
-      val deleteRecordsRequestKeys = localOffsetPerPartition.keys.map(new TopicPartitionOperationKey(_)).toList
+      val deleteRecordsRequestKeys = classicResults.keys.map(new TopicPartitionOperationKey(_)).toList
 
       // try to complete the request immediately, otherwise put it into the purgatory
       // this is because while the delayed delete records operation is being created, new
@@ -1674,7 +1707,81 @@ class ReplicaManager(val config: KafkaConfig,
     } else {
       // we can respond immediately
       val deleteRecordsResponseStatus = deleteRecordsStatus.map { case (k, status) => k -> status.responseStatus }
-      maybeDeleteFromDiskless(deleteRecordsResponseStatus)
+      maybeDeleteFromDiskless(deleteRecordsResponseStatus ++ crossTierResponseStatus)
+    }
+  }
+
+  /**
+   * For every successfully-deleted consolidating diskless partition in `response`, advance the
+   * control-plane cross-tier earliest (`remote_log_start_offset`) to the requested delete offset and
+   * return a replacement result whose low watermark is the stored value. `EARLIEST` is
+   * `COALESCE(remote_log_start_offset, log_start_offset)`, so reporting the just-advanced (non-null)
+   * `remote_log_start_offset` keeps the DeleteRecords low watermark and a subsequent
+   * `ListOffsets(EARLIEST)` in agreement on every broker.
+   *
+   * Physical deletion is unchanged: the diskless WAL objects are freed by `delete_records_v1` +
+   * `FileCleaner`, and the remote-tier segments by the leader's `RemoteLogManager` (driven by the
+   * leader's local `logStartOffset`); this method only moves the logical earliest pointer.
+   *
+   * Returns the replacement results keyed by partition (empty when nothing applies). The control-plane
+   * call is synchronous; `DeleteRecords` is an infrequent admin operation.
+   */
+  private def advanceCrossTierEarliestForDeleteRecords(
+    response: Map[TopicPartition, DeleteRecordsPartitionResult],
+    offsetPerPartition: Map[TopicPartition, Long]
+  ): Map[TopicPartition, DeleteRecordsPartitionResult] = {
+    val sharedState = inklessSharedState.orNull
+    if (sharedState == null) {
+      return Map.empty
+    }
+
+    // A consolidating partition's converted delete offset X: the concrete requested offset, or -- for
+    // HIGH_WATERMARK, which on a consolidating topic always reaches into the WAL and thus runs the
+    // diskless leg -- the low watermark that leg returned (= log_start_offset = HWM).
+    val requests = new java.util.ArrayList[AdvanceCrossTierLogStartOffsetRequest]()
+    val partitionsInOrder = mutable.ArrayBuffer.empty[TopicPartition]
+    response.foreach { case (topicPartition, result) =>
+      if (result.errorCode == Errors.NONE.code &&
+        _inklessMetadataView.isConsolidatingDisklessTopic(topicPartition.topic)) {
+        val requested = offsetPerPartition.getOrElse(topicPartition, DeleteRecordsRequest.HIGH_WATERMARK)
+        val convertedOffset = if (requested == DeleteRecordsRequest.HIGH_WATERMARK) result.lowWatermark else requested
+        val topicId = _inklessMetadataView.getTopicId(topicPartition.topic)
+        if (convertedOffset >= 0 && topicId != null && !topicId.equals(Uuid.ZERO_UUID)) {
+          partitionsInOrder += topicPartition
+          requests.add(new AdvanceCrossTierLogStartOffsetRequest(topicId, topicPartition.partition, convertedOffset))
+        }
+      }
+    }
+
+    if (requests.isEmpty) {
+      return Map.empty
+    }
+
+    try {
+      val responses = sharedState.controlPlane().advanceCrossTierLogStartOffset(requests)
+      val replacements = mutable.Map.empty[TopicPartition, DeleteRecordsPartitionResult]
+      for (i <- 0 until responses.size()) {
+        val topicPartition = partitionsInOrder(i)
+        val advanceResponse = responses.get(i)
+        if (advanceResponse.errors() == Errors.NONE &&
+          advanceResponse.remoteLogStartOffset() != AdvanceCrossTierLogStartOffsetResponse.NO_OFFSET) {
+          val stored = advanceResponse.remoteLogStartOffset()
+          // Write-through so the leader's local read path does not re-query the control plane.
+          sharedState.crossTierLogStartCache().put(
+            new TopicIdPartition(requests.get(i).topicId(), topicPartition.partition, topicPartition.topic), stored)
+          replacements += topicPartition -> new DeleteRecordsPartitionResult()
+            .setPartitionIndex(topicPartition.partition)
+            .setLowWatermark(stored)
+            .setErrorCode(Errors.NONE.code)
+        }
+      }
+      replacements.toMap
+    } catch {
+      case e: Throwable =>
+        // Reporting failure must not fail the delete (the data is already deleted); leave the per-leg
+        // low watermark in place and let the RLM's own report reconcile the control plane later.
+        error(s"Failed to advance cross-tier log start offset for ${partitionsInOrder.mkString(", ")}", e)
+        Map.empty
     }
   }
 

--- a/core/src/test/scala/unit/kafka/server/DisklessDeleteRecordsForwarderTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DisklessDeleteRecordsForwarderTest.scala
@@ -1,0 +1,192 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.server
+
+import kafka.server.metadata.InklessMetadataView
+import org.apache.kafka.clients.NetworkClient
+import org.apache.kafka.common.message.DeleteRecordsResponseData.DeleteRecordsPartitionResult
+import org.apache.kafka.common.network.ListenerName
+import org.apache.kafka.common.protocol.Errors
+import org.apache.kafka.common.{Node, TopicPartition}
+import org.apache.kafka.metadata.{MetadataCache, PartitionRegistration}
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.{BeforeEach, Test}
+import org.mockito.ArgumentMatchers.{any, anyInt, eq => eqTo}
+import org.mockito.Mockito._
+
+import java.util.Optional
+
+class DisklessDeleteRecordsForwarderTest {
+
+  private val selfBrokerId = 1
+  private val interBrokerListener = new ListenerName("PLAINTEXT")
+
+  private val config: KafkaConfig = mock(classOf[KafkaConfig])
+  private val networkClient: NetworkClient = mock(classOf[NetworkClient])
+  private val metadataCache: MetadataCache = mock(classOf[MetadataCache])
+  private val metadataView: InklessMetadataView = mock(classOf[InklessMetadataView])
+
+  private var forwarder: DisklessDeleteRecordsForwarder = _
+
+  @BeforeEach
+  def setUp(): Unit = {
+    when(config.brokerId).thenReturn(selfBrokerId)
+    when(config.requestTimeoutMs).thenReturn(30000)
+    when(config.interBrokerListenerName).thenReturn(interBrokerListener)
+    forwarder = new DisklessDeleteRecordsForwarder(config, networkClient, metadataCache, metadataView, time = org.apache.kafka.common.utils.Time.SYSTEM)
+  }
+
+  private def stubLeader(tp: TopicPartition, node: Optional[Node]): Unit = {
+    when(metadataCache.getPartitionLeaderEndpoint(eqTo(tp.topic), eqTo(tp.partition), any(classOf[ListenerName])))
+      .thenReturn(node)
+  }
+
+  private def otherBroker: Node = new Node(2, "other-host", 9092)
+
+  @Test
+  def classicTopicStaysLocal(): Unit = {
+    val tp = new TopicPartition("classic", 0)
+    when(metadataView.isDisklessTopic("classic")).thenReturn(false)
+
+    val (local, forward) = forwarder.routeByLeader(Map(tp -> 10L))
+    assertEquals(Map(tp -> 10L), local)
+    assertTrue(forward.isEmpty)
+  }
+
+  @Test
+  def pureDisklessTopicStaysLocal(): Unit = {
+    val tp = new TopicPartition("diskless", 0)
+    when(metadataView.isDisklessTopic("diskless")).thenReturn(true)
+    when(metadataView.isConsolidatingDisklessTopic("diskless")).thenReturn(false)
+    when(metadataView.getClassicToDisklessStartOffset(tp))
+      .thenReturn(PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET)
+
+    val (local, forward) = forwarder.routeByLeader(Map(tp -> 10L))
+    assertEquals(Map(tp -> 10L), local)
+    assertTrue(forward.isEmpty)
+    verify(metadataCache, never()).getPartitionLeaderEndpoint(any(), anyInt(), any())
+  }
+
+  @Test
+  def switchedTopicOnRemoteLeaderIsForwarded(): Unit = {
+    val tp = new TopicPartition("switched", 0)
+    when(metadataView.isDisklessTopic("switched")).thenReturn(true)
+    when(metadataView.getClassicToDisklessStartOffset(tp)).thenReturn(100L)
+    stubLeader(tp, Optional.of(otherBroker))
+
+    val (local, forward) = forwarder.routeByLeader(Map(tp -> 150L))
+    assertTrue(local.isEmpty)
+    assertEquals(Map(otherBroker -> Map(tp -> 150L)), forward)
+  }
+
+  @Test
+  def switchedTopicOnSelfStaysLocal(): Unit = {
+    val tp = new TopicPartition("switched", 0)
+    when(metadataView.isDisklessTopic("switched")).thenReturn(true)
+    when(metadataView.getClassicToDisklessStartOffset(tp)).thenReturn(100L)
+    stubLeader(tp, Optional.of(new Node(selfBrokerId, "self-host", 9092)))
+
+    val (local, forward) = forwarder.routeByLeader(Map(tp -> 150L))
+    assertEquals(Map(tp -> 150L), local)
+    assertTrue(forward.isEmpty)
+  }
+
+  @Test
+  def consolidatingBornTopicOnRemoteLeaderIsForwarded(): Unit = {
+    val tp = new TopicPartition("consolidating", 0)
+    when(metadataView.isDisklessTopic("consolidating")).thenReturn(true)
+    when(metadataView.isConsolidatingDisklessTopic("consolidating")).thenReturn(true)
+    when(metadataView.getClassicToDisklessStartOffset(tp))
+      .thenReturn(PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET)
+    stubLeader(tp, Optional.of(otherBroker))
+
+    val (local, forward) = forwarder.routeByLeader(Map(tp -> 50L))
+    assertTrue(local.isEmpty)
+    assertEquals(Map(otherBroker -> Map(tp -> 50L)), forward)
+  }
+
+  @Test
+  def switchPendingTopicOnRemoteLeaderIsForwarded(): Unit = {
+    val tp = new TopicPartition("pending", 0)
+    when(metadataView.isDisklessTopic("pending")).thenReturn(true)
+    when(metadataView.getClassicToDisklessStartOffset(tp))
+      .thenReturn(PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING)
+    stubLeader(tp, Optional.of(otherBroker))
+
+    val (local, forward) = forwarder.routeByLeader(Map(tp -> 5L))
+    assertTrue(local.isEmpty)
+    assertEquals(Map(otherBroker -> Map(tp -> 5L)), forward)
+  }
+
+  @Test
+  def missingLeaderStaysLocal(): Unit = {
+    val tp = new TopicPartition("switched", 0)
+    when(metadataView.isDisklessTopic("switched")).thenReturn(true)
+    when(metadataView.getClassicToDisklessStartOffset(tp)).thenReturn(100L)
+    stubLeader(tp, Optional.empty())
+
+    val (local, forward) = forwarder.routeByLeader(Map(tp -> 150L))
+    assertEquals(Map(tp -> 150L), local)
+    assertTrue(forward.isEmpty)
+  }
+
+  @Test
+  def emptyLeaderNodeStaysLocal(): Unit = {
+    val tp = new TopicPartition("switched", 0)
+    when(metadataView.isDisklessTopic("switched")).thenReturn(true)
+    when(metadataView.getClassicToDisklessStartOffset(tp)).thenReturn(100L)
+    stubLeader(tp, Optional.of(Node.noNode()))
+
+    val (local, forward) = forwarder.routeByLeader(Map(tp -> 150L))
+    assertEquals(Map(tp -> 150L), local)
+    assertTrue(forward.isEmpty)
+  }
+
+  @Test
+  def mixedPartitionsAreSplitPerLeader(): Unit = {
+    val localTp = new TopicPartition("diskless", 0)
+    val remoteTp = new TopicPartition("switched", 0)
+    when(metadataView.isDisklessTopic("diskless")).thenReturn(true)
+    when(metadataView.isConsolidatingDisklessTopic("diskless")).thenReturn(false)
+    when(metadataView.getClassicToDisklessStartOffset(localTp))
+      .thenReturn(PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET)
+    when(metadataView.isDisklessTopic("switched")).thenReturn(true)
+    when(metadataView.getClassicToDisklessStartOffset(remoteTp)).thenReturn(100L)
+    stubLeader(remoteTp, Optional.of(otherBroker))
+
+    val (local, forward) = forwarder.routeByLeader(Map(localTp -> 1L, remoteTp -> 2L))
+    assertEquals(Map(localTp -> 1L), local)
+    assertEquals(Map(otherBroker -> Map(remoteTp -> 2L)), forward)
+  }
+
+  @Test
+  def forwardToEmptyLeaderCompletesWithRetriableError(): Unit = {
+    val tp = new TopicPartition("switched", 0)
+    val future = forwarder.forward(Node.noNode(), Map(tp -> 10L), 1000)
+    assertTrue(future.isDone)
+    val result: Map[TopicPartition, DeleteRecordsPartitionResult] = future.get()
+    assertEquals(Errors.NOT_LEADER_OR_FOLLOWER.code, result(tp).errorCode)
+  }
+
+  @Test
+  def forwardToNullLeaderCompletesWithRetriableError(): Unit = {
+    val tp = new TopicPartition("switched", 0)
+    val future = forwarder.forward(null, Map(tp -> 10L), 1000)
+    assertTrue(future.isDone)
+    assertEquals(Errors.NOT_LEADER_OR_FOLLOWER.code, future.get()(tp).errorCode)
+  }
+}

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerInklessTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerInklessTest.scala
@@ -21,7 +21,7 @@ import io.aiven.inkless.common.SharedState
 import io.aiven.inkless.config.InklessConfig
 import io.aiven.inkless.consolidation.{ConsolidatedDisklessLogPruner, ConsolidationFetcherManager}
 import io.aiven.inkless.consume.{ConcatenatedRecords, FetchHandler, FetchOffsetHandler}
-import io.aiven.inkless.control_plane.{BatchInfo, BatchMetadata, ControlPlane, ControlPlaneException, FindBatchResponse, RepairDisklessLogRequest, RepairDisklessLogResponse, DeleteRecordsResponse => CpDeleteRecordsResponse}
+import io.aiven.inkless.control_plane.{AdvanceCrossTierLogStartOffsetResponse, BatchInfo, BatchMetadata, ControlPlane, ControlPlaneException, FindBatchResponse, RepairDisklessLogRequest, RepairDisklessLogResponse, DeleteRecordsResponse => CpDeleteRecordsResponse}
 import io.aiven.inkless.produce.AppendHandler
 import kafka.cluster.Partition
 import kafka.server.QuotaFactory.QuotaManagers
@@ -870,6 +870,118 @@ class ReplicaManagerInklessTest {
       assertEquals(150L, responseData(disklessTopicPartition.topicPartition()).lowWatermark)
       assertEquals(101L, partition.localLogOrException.logStartOffset)
       verify(controlPlane, timeout(5000)).deleteRecords(anyList())
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
+  def testDeleteRecordsConsolidatingClassicPrefixReportsCrossTierLowWatermarkWithoutDisklessLeg(): Unit = {
+    // A delete entirely within the classic/remote prefix of a switched consolidating topic
+    // (before classicToDisklessStartOffset) routes only to the local leg -- no diskless (WAL) leg --
+    // and its low watermark must come from the control-plane cross-tier earliest, not the ISR.
+    val controlPlane = mock(classOf[ControlPlane])
+    when(controlPlane.advanceCrossTierLogStartOffset(anyList()))
+      .thenReturn(util.List.of(AdvanceCrossTierLogStartOffsetResponse.success(50L)))
+    val replicaManager = createReplicaManager(
+      List(disklessTopicPartition.topic()),
+      controlPlane = Some(controlPlane),
+      topicIdMapping = Map(disklessTopicPartition.topic() -> disklessTopicPartition.topicId()),
+      disklessManagedReplicasEnabled = true,
+      disklessRemoteStorageConsolidationEnabled = true,
+      consolidatingDisklessTopics = Set(disklessTopicPartition.topic()),
+    )
+    try {
+      val partition = setupHybridLeaderPartition(replicaManager, disklessTopicPartition, localEndOffset = 200L)
+      // switched topic: the classic prefix ends at 100, and we delete before 50 (inside that prefix).
+      when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
+        .thenReturn(100L)
+
+      @volatile var responseData: Map[TopicPartition, DeleteRecordsResponseData.DeleteRecordsPartitionResult] = Map.empty
+      replicaManager.deleteRecords(
+        timeout = 0L,
+        offsetPerPartition = Map(disklessTopicPartition.topicPartition() -> 50L),
+        responseCallback = response => responseData = response,
+      )
+
+      waitUntilTrue(() => responseData.nonEmpty, "Cross-tier delete records response was not completed")
+      assertEquals(Errors.NONE.code, responseData(disklessTopicPartition.topicPartition()).errorCode)
+      // Low watermark comes from the control-plane cross-tier earliest (advance), not the ISR.
+      assertEquals(50L, responseData(disklessTopicPartition.topicPartition()).lowWatermark)
+      // Local leg still ran (drives RLM remote deletion): local log start advanced to 50.
+      assertEquals(50L, partition.localLogOrException.logStartOffset)
+      verify(controlPlane, timeout(5000)).advanceCrossTierLogStartOffset(anyList())
+      // No WAL data below the classic prefix, so the diskless leg must not run.
+      verify(controlPlane, never()).deleteRecords(anyList())
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
+  def testDeleteRecordsConsolidatingOverridesLowWatermarkWithCrossTierEarliest(): Unit = {
+    // For a hybrid consolidating delete (into the WAL) both legs run, but the reported low watermark
+    // is the control-plane cross-tier earliest (advance), which may differ from the WAL log start.
+    val controlPlane = mock(classOf[ControlPlane])
+    when(controlPlane.deleteRecords(anyList())).thenReturn(util.List.of(CpDeleteRecordsResponse.success(150L)))
+    when(controlPlane.advanceCrossTierLogStartOffset(anyList()))
+      .thenReturn(util.List.of(AdvanceCrossTierLogStartOffsetResponse.success(150L)))
+    val replicaManager = createReplicaManager(
+      List(disklessTopicPartition.topic()),
+      controlPlane = Some(controlPlane),
+      topicIdMapping = Map(disklessTopicPartition.topic() -> disklessTopicPartition.topicId()),
+      disklessManagedReplicasEnabled = true,
+      disklessRemoteStorageConsolidationEnabled = true,
+      consolidatingDisklessTopics = Set(disklessTopicPartition.topic()),
+    )
+    try {
+      val partition = setupHybridLeaderPartition(replicaManager, disklessTopicPartition, localEndOffset = 101L)
+      when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
+        .thenReturn(PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET)
+
+      @volatile var responseData: Map[TopicPartition, DeleteRecordsResponseData.DeleteRecordsPartitionResult] = Map.empty
+      replicaManager.deleteRecords(
+        timeout = 0L,
+        offsetPerPartition = Map(disklessTopicPartition.topicPartition() -> 150L),
+        responseCallback = response => responseData = response,
+      )
+
+      waitUntilTrue(() => responseData.nonEmpty, "Hybrid consolidating delete records response was not completed")
+      assertEquals(Errors.NONE.code, responseData(disklessTopicPartition.topicPartition()).errorCode)
+      assertEquals(150L, responseData(disklessTopicPartition.topicPartition()).lowWatermark)
+      assertEquals(101L, partition.localLogOrException.logStartOffset)
+      verify(controlPlane, timeout(5000)).deleteRecords(anyList())
+      verify(controlPlane, timeout(5000)).advanceCrossTierLogStartOffset(anyList())
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
+  def testDeleteRecordsPureDisklessDoesNotAdvanceCrossTierEarliest(): Unit = {
+    // A pure (non-consolidating) diskless topic has no remote tier; its delete must go through the
+    // diskless leg only and must not touch the cross-tier earliest.
+    val controlPlane = mock(classOf[ControlPlane])
+    when(controlPlane.deleteRecords(anyList())).thenReturn(util.List.of(CpDeleteRecordsResponse.success(150L)))
+    val replicaManager = createReplicaManager(
+      List(disklessTopicPartition.topic()),
+      controlPlane = Some(controlPlane),
+      topicIdMapping = Map(disklessTopicPartition.topic() -> disklessTopicPartition.topicId()),
+      disklessManagedReplicasEnabled = true,
+    )
+    try {
+      @volatile var responseData: Map[TopicPartition, DeleteRecordsResponseData.DeleteRecordsPartitionResult] = Map.empty
+      replicaManager.deleteRecords(
+        timeout = 0L,
+        offsetPerPartition = Map(disklessTopicPartition.topicPartition() -> 150L),
+        responseCallback = response => responseData = response,
+      )
+
+      waitUntilTrue(() => responseData.nonEmpty, "Pure diskless delete records response was not completed")
+      assertEquals(Errors.NONE.code, responseData(disklessTopicPartition.topicPartition()).errorCode)
+      assertEquals(150L, responseData(disklessTopicPartition.topicPartition()).lowWatermark)
+      verify(controlPlane, timeout(5000)).deleteRecords(anyList())
+      verify(controlPlane, never()).advanceCrossTierLogStartOffset(anyList())
     } finally {
       replicaManager.shutdown(checkpointHW = false)
     }


### PR DESCRIPTION
For a switched consolidating diskless topic the metadata transformer advertises an AZ-selected replica (a follower) as the client-facing leader, so a DeleteRecords request looped on NOT_LEADER_OR_FOLLOWER and timed out. DisklessDeleteRecordsForwarder forwards the leader-only leg to the partition's real KRaft leader; KafkaApis fans the request out into local and forwarded legs and combines the results (KafkaApisBuilder / BrokerServer wire the forwarder).

Completion no longer waits on the ISR low watermark for consolidating partitions (their follower log starts are frozen at the switch). Instead ReplicaManager.deleteRecords advances the control-plane cross-tier earliest and reports it as the low watermark, so DeleteRecords and a subsequent ListOffsets(EARLIEST) agree on every broker. Adds the shared crossTierEarliestOffset / isConsolidatingDisklessPartition accessors.