### PR TITLE
fix(inkless:consolidation): stop over-reclaiming the classic prefix on rebuilt leaders [KC-332]

### DIFF
--- a/core/src/main/scala/io/aiven/inkless/consolidation/DisklessLeaderEndPoint.scala
+++ b/core/src/main/scala/io/aiven/inkless/consolidation/DisklessLeaderEndPoint.scala
@@ -120,7 +120,19 @@ class DisklessLeaderEndPoint(
         case Right(partition) =>
           val localLogOpt = Try(partition.localLogOrException).toOption
           val logStartOffset = localLogOpt match {
-            case Some(localLog) => localLog.logStartOffset
+            case Some(localLog) =>
+              // Prefer the control-plane cross-tier earliest as the whole-log start for a consolidating
+              // partition. On a freshly-elected leader whose classic prefix was already evicted, the
+              // leadership rebuild pins localLog.logStartOffset at the seal (classicToDisklessStartOffset)
+              // and it can only ever increment; the classic prefix [earliest, seal) then lives only in the
+              // remote tier. Reporting the local seal would (a) reject reads of that prefix as
+              // out-of-range -- the OFFSET_MOVED_TO_TIERED_STORAGE gate below requires
+              // requestedOffset >= logStartOffset -- and (b) make the tier-state rebuild restart the log
+              // at the seal, over-reclaiming the prefix. The cross-tier earliest is broker-agnostic and
+              // monotonic, so min() with the local start is always safe.
+              val crossTier = replicaManager.crossTierEarliestOffset(tp.topicPartition)
+              if (crossTier.isPresent) Math.min(crossTier.getAsLong, localLog.logStartOffset)
+              else localLog.logStartOffset
             case None =>
                     logger.warn("Local log unavailable for topic-partition {}, returning unknown log start offset", tp.topicPartition)
                     UnifiedLog.UNKNOWN_OFFSET

--- a/core/src/main/scala/io/aiven/inkless/consolidation/DisklessLeaderEndPoint.scala
+++ b/core/src/main/scala/io/aiven/inkless/consolidation/DisklessLeaderEndPoint.scala
@@ -122,14 +122,14 @@ class DisklessLeaderEndPoint(
           val logStartOffset = localLogOpt match {
             case Some(localLog) =>
               // Prefer the control-plane cross-tier earliest as the whole-log start for a consolidating
-              // partition. On a freshly-elected leader whose classic prefix was already evicted, the
-              // leadership rebuild pins localLog.logStartOffset at the seal (classicToDisklessStartOffset)
-              // and it can only ever increment; the classic prefix [earliest, seal) then lives only in the
-              // remote tier. Reporting the local seal would (a) reject reads of that prefix as
-              // out-of-range -- the OFFSET_MOVED_TO_TIERED_STORAGE gate below requires
-              // requestedOffset >= logStartOffset -- and (b) make the tier-state rebuild restart the log
-              // at the seal, over-reclaiming the prefix. The cross-tier earliest is broker-agnostic and
-              // monotonic, so min() with the local start is always safe.
+              // partition. On a rebuilt leader the broker-local logStartOffset can sit above the true
+              // cross-tier earliest: earlier data (the classic prefix [earliest, seal) of a switched
+              // partition, or an already-reclaimed born-diskless prefix) lives only in the remote tier, yet
+              // the local start was left higher by the switch/rebuild machinery. Reporting that local start
+              // would reject reads of the surviving remote prefix as out-of-range, since the
+              // OFFSET_MOVED_TO_TIERED_STORAGE gate below requires requestedOffset >= logStartOffset. The
+              // cross-tier earliest is broker-agnostic and authoritative, and min() never advances past data
+              // the local log still holds, so it is the safe whole-log start.
               val crossTier = replicaManager.crossTierEarliestOffset(tp.topicPartition)
               if (crossTier.isPresent) Math.min(crossTier.getAsLong, localLog.logStartOffset)
               else localLog.logStartOffset

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -817,11 +817,14 @@ class BrokerServer(
         },
         brokerTopicStats, metrics, endpoint.toJava,
         // Reclaim-floor / become-leader log-start override: for a consolidating diskless partition use the
-        // broker-agnostic control-plane cross-tier earliest instead of the local log start (pinned at the
-        // seal on a freshly-rebuilt leader). Empty for classic / non-inkless topics. Resolved lazily via
-        // ReplicaManager (constructed after the RLM but only ever invoked at RLM runtime).
+        // raw control-plane remote log start instead of the local log start (pinned at the seal on a
+        // freshly-rebuilt leader). Deliberately the raw remote start, not ListOffsets(EARLIEST): the latter
+        // COALESCEs to the WAL prune frontier when the remote start is unreported, which would over-reclaim
+        // still-live remote segments and lock that wrong value in via the forward-only advance. Empty for
+        // classic / non-inkless topics or an unreported remote start (RLM then fails safe to the true remote
+        // earliest). Resolved lazily via ReplicaManager (constructed after the RLM but only invoked at RLM runtime).
         (tp: TopicPartition) =>
-          if (_replicaManager != null) _replicaManager.crossTierEarliestOffset(tp) else util.OptionalLong.empty(),
+          if (_replicaManager != null) _replicaManager.crossTierRemoteLogStartOffset(tp) else util.OptionalLong.empty(),
         // Whether the partition is consolidating diskless: when the override above is unavailable, this
         // makes the RLM fail safe (skip log-start reclaim) rather than reclaim to the local seal. False for
         // classic topics. The `_replicaManager == null` branch is unreachable (these lambdas run only from

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -815,7 +815,20 @@ class BrokerServer(
           // control plane so any broker can serve it for ListOffsets(EARLIEST). No-op for classic topics.
           maybeInklessSharedState.foreach(_.crossTierLogStartReporter().enqueue(tp, remoteLogStartOffset))
         },
-        brokerTopicStats, metrics, endpoint.toJava)
+        brokerTopicStats, metrics, endpoint.toJava,
+        // Reclaim-floor / become-leader log-start override: for a consolidating diskless partition use the
+        // broker-agnostic control-plane cross-tier earliest instead of the local log start (pinned at the
+        // seal on a freshly-rebuilt leader). Empty for classic / non-inkless topics. Resolved lazily via
+        // ReplicaManager (constructed after the RLM but only ever invoked at RLM runtime).
+        (tp: TopicPartition) =>
+          if (_replicaManager != null) _replicaManager.crossTierEarliestOffset(tp) else util.OptionalLong.empty(),
+        // Whether the partition is consolidating diskless: when the override above is unavailable, this
+        // makes the RLM fail safe (skip log-start reclaim) rather than reclaim to the local seal. False for
+        // classic topics. The `_replicaManager == null` branch is unreachable (these lambdas run only from
+        // leadership-scheduled RLM tasks, applied by ReplicaManager); we still default to the fail-safe
+        // `true` there so an impossible early call can never over-reclaim.
+        (tp: TopicPartition) =>
+          if (_replicaManager != null) _replicaManager.isConsolidatingDisklessPartition(tp) else true)
       Some(rlm)
     } else {
       None

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -826,10 +826,11 @@ class BrokerServer(
         (tp: TopicPartition) =>
           if (_replicaManager != null) _replicaManager.crossTierRemoteLogStartOffset(tp) else util.OptionalLong.empty(),
         // Whether the partition is consolidating diskless: when the override above is unavailable, this
-        // makes the RLM fail safe (skip log-start reclaim) rather than reclaim to the local seal. False for
-        // classic topics. The `_replicaManager == null` branch is unreachable (these lambdas run only from
-        // leadership-scheduled RLM tasks, applied by ReplicaManager); we still default to the fail-safe
-        // `true` there so an impossible early call can never over-reclaim.
+        // makes the RLM fail safe to the true remote earliest (findLogStartOffset walks the cumulative
+        // remote epoch cache) rather than reclaim to the local seal. False for classic topics. The
+        // `_replicaManager == null` branch is unreachable (these lambdas run only from leadership-scheduled
+        // RLM tasks, applied by ReplicaManager); we still default to the fail-safe `true` there so an
+        // impossible early call can never over-reclaim.
         (tp: TopicPartition) =>
           if (_replicaManager != null) _replicaManager.isConsolidatingDisklessPartition(tp) else true)
       Some(rlm)

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -20,7 +20,7 @@ import com.yammer.metrics.core.Meter
 import io.aiven.inkless.common.SharedState
 import io.aiven.inkless.consume.{ConcatenatedRecords, FetchHandler, FetchOffsetHandler, Reader}
 import io.aiven.inkless.storage_backend.common.ObjectFetcher
-import io.aiven.inkless.control_plane.{AdvanceCrossTierLogStartOffsetRequest, AdvanceCrossTierLogStartOffsetResponse, BatchInfo, FindBatchRequest, FindBatchResponse, InitDisklessLogProducerState, RepairDisklessLogRequest}
+import io.aiven.inkless.control_plane.{AdvanceCrossTierLogStartOffsetRequest, AdvanceCrossTierLogStartOffsetResponse, BatchInfo, FindBatchRequest, FindBatchResponse, InitDisklessLogProducerState, RepairDisklessLogRequest, ListOffsetsRequest => CpListOffsetsRequest}
 import io.aiven.inkless.delete.{DeleteRecordsInterceptor, FileCleaner, RetentionEnforcer}
 import io.aiven.inkless.produce.AppendHandler
 import io.aiven.inkless.consolidation.{ConsolidatedDisklessLogPruner, ConsolidationFetcherManager, ConsolidationMetrics, ConsolidationReconciler}
@@ -1783,6 +1783,58 @@ class ReplicaManager(val config: KafkaConfig,
         // low watermark in place and let the RLM's own report reconcile the control plane later.
         error(s"Failed to advance cross-tier log start offset for ${partitionsInOrder.mkString(", ")}", e)
         Map.empty
+    }
+  }
+
+  /**
+   * Whether `topicPartition` is a consolidating diskless topic on this broker. Used by the
+   * [[org.apache.kafka.server.log.remote.storage.RemoteLogManager]] to pick its reclaim-floor fallback
+   * when [[crossTierEarliestOffset]] is unavailable: such a partition must not fall back to the
+   * broker-local log start (pinned at the seal on a rebuilt leader). Mirrors the guard in
+   * [[crossTierEarliestOffset]] so the two agree.
+   */
+  def isConsolidatingDisklessPartition(topicPartition: TopicPartition): Boolean =
+    inklessSharedState.isDefined && _inklessMetadataView.isConsolidatingDisklessTopic(topicPartition.topic)
+
+  /**
+   * The authoritative, broker-agnostic cross-tier earliest offset for a consolidating diskless
+   * partition, as tracked by the control plane (`COALESCE(remote_log_start_offset, log_start_offset)`,
+   * what `ListOffsets(EARLIEST)` returns); empty for non-consolidating/non-inkless partitions or when
+   * unresolved. Preferred over the broker-local `UnifiedLog.logStartOffset`, which on a rebuilt leader
+   * is pinned at the seal and never pulled back down (monotonic), so using it would over-reclaim and
+   * reject reads of the classic prefix `[earliest, seal)`. Reads the write-through
+   * [[io.aiven.inkless.cache.CrossTierLogStartCache]] first, else queries the control plane and caches
+   * the hit; a stale entry can only be too low (safe: under-reclaims/over-serves).
+   */
+  def crossTierEarliestOffset(topicPartition: TopicPartition): OptionalLong = {
+    val sharedState = inklessSharedState.orNull
+    if (sharedState == null || !_inklessMetadataView.isConsolidatingDisklessTopic(topicPartition.topic)) {
+      return OptionalLong.empty()
+    }
+    val topicId = _inklessMetadataView.getTopicId(topicPartition.topic)
+    if (topicId == null || topicId.equals(Uuid.ZERO_UUID)) {
+      return OptionalLong.empty()
+    }
+    val tidp = new TopicIdPartition(topicId, topicPartition.partition, topicPartition.topic)
+    val cached = sharedState.crossTierLogStartCache().get(tidp)
+    if (cached != null) {
+      return OptionalLong.of(cached)
+    }
+    try {
+      val responses = sharedState.controlPlane().listOffsets(
+        util.List.of(new CpListOffsetsRequest(tidp, CpListOffsetsRequest.EARLIEST_TIMESTAMP)))
+      if (responses != null && !responses.isEmpty) {
+        val response = responses.get(0)
+        if (response.errors() == Errors.NONE && response.offset() >= 0) {
+          sharedState.crossTierLogStartCache().put(tidp, response.offset())
+          return OptionalLong.of(response.offset())
+        }
+      }
+      OptionalLong.empty()
+    } catch {
+      case e: Throwable =>
+        warn(s"Failed to resolve cross-tier earliest offset for $topicPartition from the control plane", e)
+        OptionalLong.empty()
     }
   }
 

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1778,7 +1778,9 @@ class ReplicaManager(val config: KafkaConfig,
       }
       replacements.toMap
     } catch {
-      case e: Throwable =>
+      case e: Exception =>
+        // Catch only Exception, not Throwable: control-plane failures are ControlPlaneException (a
+        // RuntimeException), but Errors (e.g. OutOfMemoryError) must propagate rather than fail open.
         // Reporting failure must not fail the delete (the data is already deleted); leave the per-leg
         // low watermark in place and let the RLM's own report reconcile the control plane later.
         error(s"Failed to advance cross-tier log start offset for ${partitionsInOrder.mkString(", ")}", e)

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1789,12 +1789,47 @@ class ReplicaManager(val config: KafkaConfig,
   /**
    * Whether `topicPartition` is a consolidating diskless topic on this broker. Used by the
    * [[org.apache.kafka.server.log.remote.storage.RemoteLogManager]] to pick its reclaim-floor fallback
-   * when [[crossTierEarliestOffset]] is unavailable: such a partition must not fall back to the
+   * when [[crossTierRemoteLogStartOffset]] is unavailable: such a partition must not fall back to the
    * broker-local log start (pinned at the seal on a rebuilt leader). Mirrors the guard in
-   * [[crossTierEarliestOffset]] so the two agree.
+   * [[crossTierRemoteLogStartOffset]] so the two agree.
    */
   def isConsolidatingDisklessPartition(topicPartition: TopicPartition): Boolean =
     inklessSharedState.isDefined && _inklessMetadataView.isConsolidatingDisklessTopic(topicPartition.topic)
+
+  /**
+   * The raw cross-tier remote log start (`logs.remote_log_start_offset`) for a consolidating diskless
+   * partition, present only when the partition's classic leader has actually reported it; empty when it
+   * is unset (NULL), for non-consolidating/non-inkless partitions, or when unresolved.
+   *
+   * This is the reclaim floor and become-leader report source for the
+   * [[org.apache.kafka.server.log.remote.storage.RemoteLogManager]]. Unlike [[crossTierEarliestOffset]]
+   * it deliberately does NOT fall back to `log_start_offset` (the WAL prune frontier): that frontier can
+   * run ahead of the true remote start, so using it as the reclaim floor would delete still-live remote
+   * segments, and reporting it back would lock the wrong value in via the forward-only control-plane
+   * advance. Returning empty here makes the RLM fail safe to the true remote earliest instead.
+   *
+   * Reads the dedicated control-plane accessor rather than the write-through
+   * [[io.aiven.inkless.cache.CrossTierLogStartCache]], since that cache is also populated by
+   * ListOffsets(EARLIEST) read-throughs and can therefore hold a COALESCE'd frontier value.
+   */
+  def crossTierRemoteLogStartOffset(topicPartition: TopicPartition): OptionalLong = {
+    val sharedState = inklessSharedState.orNull
+    if (sharedState == null || !_inklessMetadataView.isConsolidatingDisklessTopic(topicPartition.topic)) {
+      return OptionalLong.empty()
+    }
+    val topicId = _inklessMetadataView.getTopicId(topicPartition.topic)
+    if (topicId == null || topicId.equals(Uuid.ZERO_UUID)) {
+      return OptionalLong.empty()
+    }
+    val tidp = new TopicIdPartition(topicId, topicPartition.partition, topicPartition.topic)
+    try {
+      sharedState.controlPlane().getCrossTierLogStart(tidp)
+    } catch {
+      case e: Exception =>
+        warn(s"Failed to resolve cross-tier remote log start for $topicPartition from the control plane", e)
+        OptionalLong.empty()
+    }
+  }
 
   /**
    * The authoritative, broker-agnostic cross-tier earliest offset for a consolidating diskless
@@ -1832,7 +1867,7 @@ class ReplicaManager(val config: KafkaConfig,
       }
       OptionalLong.empty()
     } catch {
-      case e: Throwable =>
+      case e: Exception =>
         warn(s"Failed to resolve cross-tier earliest offset for $topicPartition from the control plane", e)
         OptionalLong.empty()
     }

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1789,11 +1789,12 @@ class ReplicaManager(val config: KafkaConfig,
   }
 
   /**
-   * Whether `topicPartition` is a consolidating diskless topic on this broker. Used by the
+   * Whether `topicPartition` is a consolidating diskless topic on this broker (covers both switched
+   * partitions, which carry a seal, and born-diskless partitions, which do not). Used by the
    * [[org.apache.kafka.server.log.remote.storage.RemoteLogManager]] to pick its reclaim-floor fallback
    * when [[crossTierRemoteLogStartOffset]] is unavailable: such a partition must not fall back to the
-   * broker-local log start (pinned at the seal on a rebuilt leader). Mirrors the guard in
-   * [[crossTierRemoteLogStartOffset]] so the two agree.
+   * broker-local log start, which on a rebuilt leader can sit above the true cross-tier earliest (at the
+   * seal for a switched partition). Mirrors the guard in [[crossTierRemoteLogStartOffset]] so the two agree.
    */
   def isConsolidatingDisklessPartition(topicPartition: TopicPartition): Boolean =
     inklessSharedState.isDefined && _inklessMetadataView.isConsolidatingDisklessTopic(topicPartition.topic)
@@ -1837,9 +1838,13 @@ class ReplicaManager(val config: KafkaConfig,
    * The authoritative, broker-agnostic cross-tier earliest offset for a consolidating diskless
    * partition, as tracked by the control plane (`COALESCE(remote_log_start_offset, log_start_offset)`,
    * what `ListOffsets(EARLIEST)` returns); empty for non-consolidating/non-inkless partitions or when
-   * unresolved. Preferred over the broker-local `UnifiedLog.logStartOffset`, which on a rebuilt leader
-   * is pinned at the seal and never pulled back down (monotonic), so using it would over-reclaim and
-   * reject reads of the classic prefix `[earliest, seal)`. Reads the write-through
+   * unresolved. Preferred over the broker-local `UnifiedLog.logStartOffset`, which only moves forward
+   * (monotonic) and can sit above the true cross-tier earliest once the earlier data lives only in the
+   * remote tier: on a rebuilt switched leader it is pinned at the seal (`classicToDisklessStartOffset`),
+   * so using it would over-reclaim and reject reads of the surviving prefix `[earliest, seal)`. A
+   * born-diskless partition has no seal; there the equivalent hazard is the control-plane earliest
+   * itself degrading to the WAL prune frontier when `remote_log_start_offset` is NULL, which the raw
+   * [[crossTierRemoteLogStartOffset]] guards for the irreversible reclaim path. Reads the write-through
    * [[io.aiven.inkless.cache.CrossTierLogStartCache]] first, else queries the control plane and caches
    * the hit; a stale entry can only be too low (safe: under-reclaims/over-serves).
    */

--- a/core/src/test/java/kafka/server/InklessConsolidatedDisklessTopicsTest.java
+++ b/core/src/test/java/kafka/server/InklessConsolidatedDisklessTopicsTest.java
@@ -22,9 +22,12 @@ import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AlterConfigOp;
 import org.apache.kafka.clients.admin.ConfigEntry;
 import org.apache.kafka.clients.admin.CreateTopicsResult;
+import org.apache.kafka.clients.admin.DeleteRecordsResult;
+import org.apache.kafka.clients.admin.DeletedRecords;
 import org.apache.kafka.clients.admin.ListOffsetsResult;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.admin.OffsetSpec;
+import org.apache.kafka.clients.admin.RecordsToDelete;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
@@ -416,6 +419,85 @@ public class InklessConsolidatedDisklessTopicsTest {
     }
 
     /**
+     * Cross-tier {@code DeleteRecords} on a switched consolidated topic must advance the earliest to
+     * exactly the requested boundary per partition, never over-reclaim the surviving classic prefix down
+     * to the seal, and honor the forward-only control-plane advance.
+     *
+     * <p>This exercises paths the single-partition ducktape system tests do not: two partitions across two
+     * AZs with managed replicas, a different delete boundary per partition, and repeated/idempotent deletes.
+     * It also asserts the cross-tier earliest bootstraps to {@code 0} in the control plane (never NULL),
+     * the invariant the reclaim floor and become-leader report depend on.
+     */
+    @Test
+    public void testCrossTierDeleteRecordsOnConsolidatedTopic() throws Exception {
+        topicName = "cross-tier-delete-records";
+        // Even split so each partition's seal and offsets are deterministic: 40 records over 2 partitions
+        // means offsets [0, 20) per partition, so the switch seals each partition at 20.
+        final int totalRecords = 40;
+        final long sealPerPartition = totalRecords / numPartitions;
+
+        final Map<String, Object> commonConfigs = new HashMap<>();
+        commonConfigs.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers());
+
+        final Uuid topicUuid;
+        try (Admin admin = AdminClient.create(commonConfigs)) {
+            topicUuid = createClassicTopic(admin);
+            // Produce the whole classic prefix before switching so the per-partition seal is exactly
+            // sealPerPartition; large values roll segments so the prefix tiers to remote.
+            produceRecords(commonConfigs, totalRecords, largeValueRecordFactory());
+            switchTopicToConsolidatedDiskless(admin);
+        }
+
+        // The classic prefix tiers to remote (the switch force-rolls the boundary segment).
+        waitForAtLeastOneTieredObject("after the switch");
+
+        // Everything is readable from 0, and the cross-tier earliest bootstrapped to 0 (not NULL, not the
+        // seal): the value DeleteRecords advances forward from.
+        assertBrokerEarliestOffsetsEqual(commonConfigs, 0L, "after the switch");
+        assertRemoteLogStartOffsetBootstrapped(topicUuid, 0L);
+
+        final TopicPartition p0 = new TopicPartition(topicName, 0);
+        final TopicPartition p1 = new TopicPartition(topicName, 1);
+
+        // 1) Per-partition boundaries, both below the seal and inside the remote classic prefix. The low
+        // watermark is the stored cross-tier earliest, advanced synchronously by the control plane.
+        try (Admin admin = AdminClient.create(commonConfigs)) {
+            final Map<TopicPartition, Long> lw = deleteRecordsBefore(admin, Map.of(p0, 3L, p1, 5L));
+            assertEquals(3L, lw.get(p0).longValue(), "DeleteRecords low watermark for " + p0);
+            assertEquals(5L, lw.get(p1).longValue(), "DeleteRecords low watermark for " + p1);
+        }
+        // Earliest settles at exactly each boundary, not the seal: the reclaim floor / reported earliest is
+        // the delete boundary, so the surviving classic prefix [boundary, seal) is preserved.
+        assertBrokerEarliestOffsets(commonConfigs, Map.of(p0, 3L, p1, 5L), "after per-partition DeleteRecords");
+
+        // 2) Monotonic advance: a higher boundary moves the earliest up on both partitions.
+        try (Admin admin = AdminClient.create(commonConfigs)) {
+            final Map<TopicPartition, Long> lw = deleteRecordsBefore(admin, Map.of(p0, 7L, p1, 7L));
+            assertEquals(7L, lw.get(p0).longValue(), "monotonic advance low watermark for " + p0);
+            assertEquals(7L, lw.get(p1).longValue(), "monotonic advance low watermark for " + p1);
+        }
+
+        // 3) Forward-only: a boundary below the current start is a no-op that returns the current start and
+        // never moves the earliest backwards.
+        try (Admin admin = AdminClient.create(commonConfigs)) {
+            final Map<TopicPartition, Long> lw = deleteRecordsBefore(admin, Map.of(p0, 2L, p1, 2L));
+            assertEquals(7L, lw.get(p0).longValue(), "below-start DeleteRecords must not move " + p0 + " back");
+            assertEquals(7L, lw.get(p1).longValue(), "below-start DeleteRecords must not move " + p1 + " back");
+        }
+        assertBrokerEarliestOffsets(commonConfigs, Map.of(p0, 7L, p1, 7L),
+            "after monotonic advance and below-start no-op");
+
+        // No creep: give the RLM a couple of reclaim cycles and confirm the earliest stays at the delete
+        // boundary rather than drifting up to the seal (the over-reclaim symptom this branch fixes).
+        Thread.sleep(TimeUnit.SECONDS.toMillis(15));
+        assertBrokerEarliestOffsets(commonConfigs, Map.of(p0, 7L, p1, 7L), "after waiting out RLM reclaim cycles");
+
+        // The survivors [7, seal) on each partition are still readable and contiguous across the cut.
+        final int survivorsPerPartition = (int) (sealPerPartition - 7);
+        consumeAndVerify(commonConfigs, survivorsPerPartition * numPartitions);
+    }
+
+    /**
      * A record factory that produces ~104 KB values (large enough to roll segments at
      * {@code segment.bytes=1 MiB} after ~10 records) with round-robin partitioning.
      */
@@ -537,6 +619,89 @@ public class InklessConsolidatedDisklessTopicsTest {
             }
             return out;
         }
+    }
+
+    /**
+     * Issues {@code DeleteRecords} before the given per-partition offsets and returns the resulting low
+     * watermark per partition (for a consolidating topic this is the stored cross-tier earliest, which the
+     * control plane advances synchronously and forward-only).
+     */
+    private Map<TopicPartition, Long> deleteRecordsBefore(Admin admin, Map<TopicPartition, Long> beforeOffsets)
+        throws ExecutionException, InterruptedException, TimeoutException {
+        final Map<TopicPartition, RecordsToDelete> request = new HashMap<>();
+        beforeOffsets.forEach((tp, offset) -> request.put(tp, RecordsToDelete.beforeOffset(offset)));
+        final DeleteRecordsResult result = admin.deleteRecords(request);
+        final Map<TopicPartition, Long> lowWatermarks = new HashMap<>();
+        for (final TopicPartition tp : request.keySet()) {
+            final DeletedRecords deleted = result.lowWatermarks().get(tp).get(30, TimeUnit.SECONDS);
+            lowWatermarks.put(tp, deleted.lowWatermark());
+        }
+        return lowWatermarks;
+    }
+
+    /**
+     * Like {@link #assertBrokerEarliestOffsetsEqual}, but asserts a distinct expected earliest per
+     * partition (waits for convergence, then hard-asserts each partition).
+     */
+    private void assertBrokerEarliestOffsets(Map<String, Object> commonConfigs,
+                                             Map<TopicPartition, Long> expected,
+                                             String context) throws Exception {
+        final AtomicReference<Map<TopicPartition, Long>> lastSeen = new AtomicReference<>();
+        TestUtils.waitForCondition(() -> {
+            Map<TopicPartition, Long> earliest = queryBrokerEarliestOffsets(commonConfigs);
+            lastSeen.set(earliest);
+            return expected.entrySet().stream().allMatch(e -> e.getValue().equals(earliest.get(e.getKey())));
+        }, 90_000, () -> "ListOffsets earliest should converge to " + expected + " " + context
+            + "; last observed: " + lastSeen.get());
+
+        Map<TopicPartition, Long> earliest = queryBrokerEarliestOffsets(commonConfigs);
+        log.info("Broker ListOffsets earliest per partition {}: {}", context, earliest);
+        expected.forEach((tp, exp) -> assertEquals(exp, earliest.get(tp),
+            "ListOffsets earliest for " + tp + " should be " + exp + " " + context));
+    }
+
+    /**
+     * Waits until {@code logs.remote_log_start_offset} for every partition is bootstrapped to
+     * {@code expected} (never NULL). A NULL here would make {@code ListOffsets(EARLIEST)} COALESCE to the
+     * pruned WAL frontier and hide the still-live remote prefix, the regression the become-leader report
+     * exists to prevent.
+     */
+    private void assertRemoteLogStartOffsetBootstrapped(Uuid kafkaTopicId, long expected) throws InterruptedException {
+        final UUID id = toJavaUuid(kafkaTopicId);
+        final AtomicReference<Map<Integer, Long>> lastSeen = new AtomicReference<>();
+        TestUtils.waitForCondition(() -> {
+            try {
+                Map<Integer, Long> perPartition = readRemoteLogStartOffsets(id);
+                lastSeen.set(perPartition);
+                return perPartition.size() == numPartitions
+                    && perPartition.values().stream().allMatch(v -> v != null && v == expected);
+            } catch (SQLException e) {
+                throw new RuntimeException(e);
+            }
+        }, 120_000, () -> "remote_log_start_offset should be bootstrapped to " + expected + " for all "
+            + numPartitions + " partitions (never NULL, never the seal); last observed: " + lastSeen.get());
+    }
+
+    private Map<Integer, Long> readRemoteLogStartOffsets(UUID topicId) throws SQLException {
+        Map<Integer, Long> out = new HashMap<>();
+        try (
+            Connection connection = DriverManager.getConnection(
+                pgContainer.getJdbcUrl(),
+                PostgreSQLTestContainer.USERNAME,
+                PostgreSQLTestContainer.PASSWORD);
+            PreparedStatement ps = connection.prepareStatement(
+                "SELECT partition, remote_log_start_offset FROM logs WHERE topic_id = ?")
+        ) {
+            ps.setObject(1, topicId);
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    int partition = rs.getInt(1);
+                    long value = rs.getLong(2);
+                    out.put(partition, rs.wasNull() ? null : value);
+                }
+            }
+        }
+        return out;
     }
 
     private record ControlPlaneDisklessSnapshot(long batchRowCount, long minLogStartOffset) { }

--- a/core/src/test/scala/io/aiven/inkless/consolidation/DisklessLeaderEndPointTest.scala
+++ b/core/src/test/scala/io/aiven/inkless/consolidation/DisklessLeaderEndPointTest.scala
@@ -1043,7 +1043,7 @@ class DisklessLeaderEndPointTest {
 
   @Test
   def testFetchUsesCrossTierEarliestAsWholeLogStartForConsolidatingLeader(): Unit = {
-    // Problem B: on a freshly-rebuilt consolidating leader the local log start is pinned at the seal
+    // On a freshly-rebuilt consolidating leader the local log start is pinned at the seal
     // (400) even though DeleteRecords / retention left the true earliest at 200 (tracked in the control
     // plane). The endpoint must report the cross-tier earliest (200) as the whole-log start so that (a) a
     // read of the surviving remote prefix [200, 400) redirects to tiered storage instead of being
@@ -1122,8 +1122,8 @@ class DisklessLeaderEndPointTest {
     // start -- which on a freshly-rebuilt consolidating leader is the seal (400). A read of the
     // surviving remote prefix [200, 400) then sees requestedOffset (200) < reported logStartOffset (400),
     // so it is treated as below the whole-log start (a genuine out-of-range) and is NOT redirected to
-    // tiered storage: the surviving prefix is effectively invisible. This pins the transient Problem B
-    // reversion that the empty fallback implies, so the risk is visible rather than silent.
+    // tiered storage: the surviving prefix is effectively invisible. This pins the transient reversion to
+    // the pre-fix seal-based behavior that the empty fallback implies, so the risk is visible rather than silent.
     val fetchHandler = mock(classOf[FetchHandler])
     val fetchOffsetHandler = mock(classOf[FetchOffsetHandler])
     val replicaManager = mock(classOf[ReplicaManager])

--- a/core/src/test/scala/io/aiven/inkless/consolidation/DisklessLeaderEndPointTest.scala
+++ b/core/src/test/scala/io/aiven/inkless/consolidation/DisklessLeaderEndPointTest.scala
@@ -1042,6 +1042,120 @@ class DisklessLeaderEndPointTest {
   }
 
   @Test
+  def testFetchUsesCrossTierEarliestAsWholeLogStartForConsolidatingLeader(): Unit = {
+    // Problem B: on a freshly-rebuilt consolidating leader the local log start is pinned at the seal
+    // (400) even though DeleteRecords / retention left the true earliest at 200 (tracked in the control
+    // plane). The endpoint must report the cross-tier earliest (200) as the whole-log start so that (a) a
+    // read of the surviving remote prefix [200, 400) redirects to tiered storage instead of being
+    // rejected as out-of-range, and (b) the tier-state rebuild restarts the log at 200, not the seal.
+    val fetchHandler = mock(classOf[FetchHandler])
+    val fetchOffsetHandler = mock(classOf[FetchOffsetHandler])
+    val replicaManager = mock(classOf[ReplicaManager])
+    val partition = mock(classOf[Partition])
+    val localLog = mock(classOf[UnifiedLog])
+    when(partition.localLogOrException).thenReturn(localLog)
+    when(localLog.logStartOffset).thenReturn(400L) // local log start pinned at the seal
+    when(localLog.remoteLogEnabled()).thenReturn(true)
+    when(replicaManager.getPartitionOrError(topicPartition)).thenReturn(Right(partition))
+    when(replicaManager.crossTierEarliestOffset(topicPartition)).thenReturn(OptionalLong.of(200L))
+
+    val fetchData = new FetchPartitionData(
+      Errors.NONE,
+      800L,
+      700L, // diskless WAL start
+      MemoryRecords.EMPTY,
+      Optional.empty(),
+      OptionalLong.empty(),
+      Optional.empty(),
+      OptionalInt.empty(),
+      false
+    )
+    when(fetchHandler.handle(any(), any())).thenReturn(CompletableFuture.completedFuture(Map(topicIdPartition -> fetchData).asJava))
+
+    val endPoint = newEndPoint(fetchHandler, fetchOffsetHandler, replicaManager)
+    val pd = endPoint.fetch(fetchBuilderForOffset(requestedOffset = 200L)).get(topicPartition)
+
+    assertEquals(Errors.OFFSET_MOVED_TO_TIERED_STORAGE.code, pd.errorCode)
+    assertEquals(200L, pd.logStartOffset)
+  }
+
+  @Test
+  def testFetchKeepsLocalLogStartWhenCrossTierEarliestIsHigher(): Unit = {
+    // Safety of the min(): if the control-plane cross-tier earliest (500) is somehow above the local
+    // log start (400), keep the lower local value so we never advance the whole-log start past data the
+    // local log still holds (the safe, over-serve direction).
+    val fetchHandler = mock(classOf[FetchHandler])
+    val fetchOffsetHandler = mock(classOf[FetchOffsetHandler])
+    val replicaManager = mock(classOf[ReplicaManager])
+    val partition = mock(classOf[Partition])
+    val localLog = mock(classOf[UnifiedLog])
+    when(partition.localLogOrException).thenReturn(localLog)
+    when(localLog.logStartOffset).thenReturn(400L)
+    when(localLog.remoteLogEnabled()).thenReturn(true)
+    when(replicaManager.getPartitionOrError(topicPartition)).thenReturn(Right(partition))
+    when(replicaManager.crossTierEarliestOffset(topicPartition)).thenReturn(OptionalLong.of(500L))
+
+    val fetchData = new FetchPartitionData(
+      Errors.NONE,
+      800L,
+      700L,
+      MemoryRecords.EMPTY,
+      Optional.empty(),
+      OptionalLong.empty(),
+      Optional.empty(),
+      OptionalInt.empty(),
+      false
+    )
+    when(fetchHandler.handle(any(), any())).thenReturn(CompletableFuture.completedFuture(Map(topicIdPartition -> fetchData).asJava))
+
+    val endPoint = newEndPoint(fetchHandler, fetchOffsetHandler, replicaManager)
+    val pd = endPoint.fetch(fetchBuilderForOffset(requestedOffset = 450L)).get(topicPartition)
+
+    assertEquals(Errors.OFFSET_MOVED_TO_TIERED_STORAGE.code, pd.errorCode)
+    assertEquals(400L, pd.logStartOffset)
+  }
+
+  @Test
+  def testFetchRevertsToLocalSealWhenCrossTierEarliestUnavailable(): Unit = {
+    // Failure-mode characterization (control-plane outage / not-yet-propagated metadata): when
+    // replicaManager.crossTierEarliestOffset returns empty, the endpoint falls back to the local log
+    // start -- which on a freshly-rebuilt consolidating leader is the seal (400). A read of the
+    // surviving remote prefix [200, 400) then sees requestedOffset (200) < reported logStartOffset (400),
+    // so it is treated as below the whole-log start (a genuine out-of-range) and is NOT redirected to
+    // tiered storage: the surviving prefix is effectively invisible. This pins the transient Problem B
+    // reversion that the empty fallback implies, so the risk is visible rather than silent.
+    val fetchHandler = mock(classOf[FetchHandler])
+    val fetchOffsetHandler = mock(classOf[FetchOffsetHandler])
+    val replicaManager = mock(classOf[ReplicaManager])
+    val partition = mock(classOf[Partition])
+    val localLog = mock(classOf[UnifiedLog])
+    when(partition.localLogOrException).thenReturn(localLog)
+    when(localLog.logStartOffset).thenReturn(400L) // local log start pinned at the seal
+    when(localLog.remoteLogEnabled()).thenReturn(true)
+    when(replicaManager.getPartitionOrError(topicPartition)).thenReturn(Right(partition))
+    when(replicaManager.crossTierEarliestOffset(topicPartition)).thenReturn(OptionalLong.empty())
+
+    val fetchData = new FetchPartitionData(
+      Errors.NONE,
+      800L,
+      700L,
+      MemoryRecords.EMPTY,
+      Optional.empty(),
+      OptionalLong.empty(),
+      Optional.empty(),
+      OptionalInt.empty(),
+      false
+    )
+    when(fetchHandler.handle(any(), any())).thenReturn(CompletableFuture.completedFuture(Map(topicIdPartition -> fetchData).asJava))
+
+    val endPoint = newEndPoint(fetchHandler, fetchOffsetHandler, replicaManager)
+    val pd = endPoint.fetch(fetchBuilderForOffset(requestedOffset = 200L)).get(topicPartition)
+
+    assertEquals(Errors.NONE.code, pd.errorCode)
+    assertEquals(400L, pd.logStartOffset)
+  }
+
+  @Test
   def testFetchDoesNotSignalWhenRequestOmitsOffset(): Unit = {
     // A request that does not include this partition leaves requestedOffset unresolved (-1): no signal.
     val endPoint = consolidatedPrefixEndPoint(localLogStartOffset = 0L, disklessStart = 100L, highWatermark = 200L, remoteLogEnabled = true)

--- a/core/src/test/scala/unit/kafka/server/DisklessFetchOffsetRouterTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DisklessFetchOffsetRouterTest.scala
@@ -516,7 +516,7 @@ class DisklessFetchOffsetRouterTest {
 
   @Test
   def consolidatingSwitchedEarliestIsConsistentAcrossBrokersRegardlessOfLocalClassicLogStart(): Unit = {
-    // Problem A regression guard: two brokers with different local classic log starts (leader at 60,
+    // Cross-broker EARLIEST consistency guard: two brokers with different local classic log starts (leader at 60,
     // follower still frozen at 0, both below the seal of 100) must return the SAME earliest. Both
     // route to the control plane, so neither consults its local classic log.
     when(inklessMetadataView.getClassicToDisklessStartOffset(tp)).thenReturn(100L)

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerInklessTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerInklessTest.scala
@@ -17,11 +17,12 @@
 
 package kafka.server
 
+import io.aiven.inkless.cache.CrossTierLogStartCache
 import io.aiven.inkless.common.SharedState
 import io.aiven.inkless.config.InklessConfig
 import io.aiven.inkless.consolidation.{ConsolidatedDisklessLogPruner, ConsolidationFetcherManager}
 import io.aiven.inkless.consume.{ConcatenatedRecords, FetchHandler, FetchOffsetHandler}
-import io.aiven.inkless.control_plane.{AdvanceCrossTierLogStartOffsetResponse, BatchInfo, BatchMetadata, ControlPlane, ControlPlaneException, FindBatchResponse, RepairDisklessLogRequest, RepairDisklessLogResponse, DeleteRecordsResponse => CpDeleteRecordsResponse}
+import io.aiven.inkless.control_plane.{AdvanceCrossTierLogStartOffsetResponse, BatchInfo, BatchMetadata, ControlPlane, ControlPlaneException, FindBatchResponse, ListOffsetsRequest => CpListOffsetsRequest, ListOffsetsResponse => CpListOffsetsResponse, RepairDisklessLogRequest, RepairDisklessLogResponse, DeleteRecordsResponse => CpDeleteRecordsResponse}
 import io.aiven.inkless.produce.AppendHandler
 import kafka.cluster.Partition
 import kafka.server.QuotaFactory.QuotaManagers
@@ -982,6 +983,235 @@ class ReplicaManagerInklessTest {
       assertEquals(150L, responseData(disklessTopicPartition.topicPartition()).lowWatermark)
       verify(controlPlane, timeout(5000)).deleteRecords(anyList())
       verify(controlPlane, never()).advanceCrossTierLogStartOffset(anyList())
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
+  def testCrossTierEarliestOffsetReturnsCachedValueOnHitWithoutControlPlane(): Unit = {
+    // Steady state: a cache hit is served verbatim and the control plane is never consulted -- even
+    // for a stale-low value. The cache is monotonic (put only advances), so a stale entry can only ever
+    // be too low, which is the safe direction for both reclaim (under-delete) and reads (over-serve).
+    // This documents that the accessor deliberately trusts the cache and does not second-guess it.
+    val controlPlane = mock(classOf[ControlPlane])
+    val cache = mock(classOf[CrossTierLogStartCache])
+    when(cache.get(any())).thenReturn(java.lang.Long.valueOf(120L))
+    val replicaManager = createReplicaManager(
+      List(disklessTopicPartition.topic()),
+      controlPlane = Some(controlPlane),
+      topicIdMapping = Map(disklessTopicPartition.topic() -> disklessTopicPartition.topicId()),
+      consolidatingDisklessTopics = Set(disklessTopicPartition.topic()),
+      crossTierLogStartCache = Some(cache),
+    )
+    try {
+      assertEquals(OptionalLong.of(120L),
+        replicaManager.crossTierEarliestOffset(disklessTopicPartition.topicPartition()))
+      verify(controlPlane, never()).listOffsets(anyList())
+      verify(cache, never()).put(any(), anyLong())
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
+  def testCrossTierEarliestOffsetFallsBackToControlPlaneOnMissAndPopulatesCache(): Unit = {
+    // On a cache miss (cold cache -- e.g. this broker is the RLM leader but never served the delete, or
+    // the entry TTL-expired) the accessor queries the control-plane cross-tier earliest and writes it
+    // through so the next read is a hit.
+    val controlPlane = mock(classOf[ControlPlane])
+    when(controlPlane.listOffsets(anyList()))
+      .thenReturn(util.List.of(CpListOffsetsResponse.success(disklessTopicPartition, 0L, 200L)))
+    val cache = mock(classOf[CrossTierLogStartCache])
+    when(cache.get(any())).thenReturn(null.asInstanceOf[java.lang.Long])
+    val replicaManager = createReplicaManager(
+      List(disklessTopicPartition.topic()),
+      controlPlane = Some(controlPlane),
+      topicIdMapping = Map(disklessTopicPartition.topic() -> disklessTopicPartition.topicId()),
+      consolidatingDisklessTopics = Set(disklessTopicPartition.topic()),
+      crossTierLogStartCache = Some(cache),
+    )
+    try {
+      assertEquals(OptionalLong.of(200L),
+        replicaManager.crossTierEarliestOffset(disklessTopicPartition.topicPartition()))
+      verify(controlPlane).listOffsets(anyList())
+      verify(cache).put(any(), ArgumentMatchers.eq(200L))
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
+  def testCrossTierEarliestOffsetReturnsEmptyWhenControlPlaneThrows(): Unit = {
+    // Failure-mode characterization: if the control-plane query fails on a cache miss the accessor
+    // returns empty rather than propagating the exception. Callers (DisklessLeaderEndPoint whole-log
+    // start, RemoteLogManager reclaim floor + become-leader report) then fall back to the broker-local
+    // UnifiedLog.logStartOffset -- which on a freshly-rebuilt consolidating leader is the seal. So a
+    // control-plane outage in that window transiently reverts to the pre-fix (Problem B) behavior; it
+    // does not fail the fetch/cleanup. This test pins that contract so the fallback is a conscious
+    // choice, not an accident.
+    val controlPlane = mock(classOf[ControlPlane])
+    when(controlPlane.listOffsets(anyList())).thenThrow(new ControlPlaneException("boom"))
+    val cache = mock(classOf[CrossTierLogStartCache])
+    when(cache.get(any())).thenReturn(null.asInstanceOf[java.lang.Long])
+    val replicaManager = createReplicaManager(
+      List(disklessTopicPartition.topic()),
+      controlPlane = Some(controlPlane),
+      topicIdMapping = Map(disklessTopicPartition.topic() -> disklessTopicPartition.topicId()),
+      consolidatingDisklessTopics = Set(disklessTopicPartition.topic()),
+      crossTierLogStartCache = Some(cache),
+    )
+    try {
+      assertEquals(OptionalLong.empty(),
+        replicaManager.crossTierEarliestOffset(disklessTopicPartition.topicPartition()))
+      verify(cache, never()).put(any(), anyLong())
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
+  def testCrossTierEarliestOffsetReturnsEmptyWhenControlPlaneReturnsError(): Unit = {
+    // An error/negative control-plane response is treated as "unknown" (empty), not as offset -1, and
+    // must not poison the cache.
+    val controlPlane = mock(classOf[ControlPlane])
+    when(controlPlane.listOffsets(anyList()))
+      .thenReturn(util.List.of(CpListOffsetsResponse.unknownServerError(disklessTopicPartition)))
+    val cache = mock(classOf[CrossTierLogStartCache])
+    when(cache.get(any())).thenReturn(null.asInstanceOf[java.lang.Long])
+    val replicaManager = createReplicaManager(
+      List(disklessTopicPartition.topic()),
+      controlPlane = Some(controlPlane),
+      topicIdMapping = Map(disklessTopicPartition.topic() -> disklessTopicPartition.topicId()),
+      consolidatingDisklessTopics = Set(disklessTopicPartition.topic()),
+      crossTierLogStartCache = Some(cache),
+    )
+    try {
+      assertEquals(OptionalLong.empty(),
+        replicaManager.crossTierEarliestOffset(disklessTopicPartition.topicPartition()))
+      verify(cache, never()).put(any(), anyLong())
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
+  def testCrossTierEarliestOffsetReturnsEmptyForNonConsolidatingTopic(): Unit = {
+    // Metadata-propagation timing: if this broker's metadata view does not (yet) see the topic as
+    // consolidating, the accessor short-circuits to empty WITHOUT consulting the cache or the control
+    // plane, so callers keep the plain upstream behavior (local log start). This is also what keeps the
+    // accessor a no-op for classic / pure-diskless topics.
+    val controlPlane = mock(classOf[ControlPlane])
+    val cache = mock(classOf[CrossTierLogStartCache])
+    val replicaManager = createReplicaManager(
+      List(disklessTopicPartition.topic()),
+      controlPlane = Some(controlPlane),
+      topicIdMapping = Map(disklessTopicPartition.topic() -> disklessTopicPartition.topicId()),
+      consolidatingDisklessTopics = Set.empty, // not seen as consolidating on this broker
+      crossTierLogStartCache = Some(cache),
+    )
+    try {
+      assertEquals(OptionalLong.empty(),
+        replicaManager.crossTierEarliestOffset(disklessTopicPartition.topicPartition()))
+      verify(cache, never()).get(any())
+      verify(controlPlane, never()).listOffsets(anyList())
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
+  def testCrossTierEarliestOffsetReturnsEmptyWhenTopicIdUnknown(): Unit = {
+    // Another metadata-not-yet-propagated flavor: the topic is flagged consolidating but its id is not
+    // resolvable yet (ZERO_UUID). Without a topic id the control-plane key cannot be formed, so the
+    // accessor returns empty rather than querying with a bogus id.
+    val controlPlane = mock(classOf[ControlPlane])
+    val cache = mock(classOf[CrossTierLogStartCache])
+    val replicaManager = createReplicaManager(
+      List(disklessTopicPartition.topic()),
+      controlPlane = Some(controlPlane),
+      topicIdMapping = Map.empty, // getTopicId -> ZERO_UUID
+      consolidatingDisklessTopics = Set(disklessTopicPartition.topic()),
+      crossTierLogStartCache = Some(cache),
+    )
+    try {
+      assertEquals(OptionalLong.empty(),
+        replicaManager.crossTierEarliestOffset(disklessTopicPartition.topicPartition()))
+      verify(cache, never()).get(any())
+      verify(controlPlane, never()).listOffsets(anyList())
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
+  def testCrossTierEarliestOffsetIsPerPartitionIndependent(): Unit = {
+    // Multi-partition topology (delete-one-partition scenario): a DeleteRecords on ONE partition of a
+    // consolidating topic must not move a sibling partition's earliest. The cross-tier earliest is keyed
+    // by TopicIdPartition end to end (control-plane query and the write-through cache), so partition 0
+    // (advanced to the delete boundary 100) and partition 1 (untouched, still 0) resolve independently on
+    // the same broker -- there is no cross-partition leakage and each is cached under its own key.
+    val topic = disklessTopicPartition.topic()
+    val topicId = disklessTopicPartition.topicId()
+    val tp0 = new TopicPartition(topic, 0)
+    val tp1 = new TopicPartition(topic, 1)
+    val controlPlane = mock(classOf[ControlPlane])
+    when(controlPlane.listOffsets(anyList())).thenAnswer { invocation =>
+      val reqs = invocation.getArgument(0).asInstanceOf[util.List[CpListOffsetsRequest]]
+      val tidp = reqs.get(0).topicIdPartition()
+      val offset = if (tidp.partition() == 0) 100L else 0L
+      util.List.of(CpListOffsetsResponse.success(tidp, 0L, offset))
+    }
+    val cache = mock(classOf[CrossTierLogStartCache])
+    when(cache.get(any())).thenReturn(null.asInstanceOf[java.lang.Long])
+    val replicaManager = createReplicaManager(
+      List(topic),
+      controlPlane = Some(controlPlane),
+      topicIdMapping = Map(topic -> topicId),
+      consolidatingDisklessTopics = Set(topic),
+      crossTierLogStartCache = Some(cache),
+    )
+    try {
+      assertEquals(OptionalLong.of(100L), replicaManager.crossTierEarliestOffset(tp0),
+        "the deleted partition must resolve to its own advanced boundary")
+      assertEquals(OptionalLong.of(0L), replicaManager.crossTierEarliestOffset(tp1),
+        "an untouched sibling partition must keep its own earliest, not inherit the deleted one's")
+      // Each partition is written through under its own TopicIdPartition key.
+      verify(cache).put(ArgumentMatchers.eq(new TopicIdPartition(topicId, 0, topic)), ArgumentMatchers.eq(100L))
+      verify(cache).put(ArgumentMatchers.eq(new TopicIdPartition(topicId, 1, topic)), ArgumentMatchers.eq(0L))
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
+  def testIsConsolidatingDisklessPartitionReflectsMetadataView(): Unit = {
+    // The RLM reclaim-floor fail-safe keys off this accessor; it must be true exactly for consolidating
+    // diskless topics (so they never fall back to the local seal) and false for classic/pure-diskless.
+    val replicaManager = createReplicaManager(
+      List(disklessTopicPartition.topic()),
+      topicIdMapping = Map(disklessTopicPartition.topic() -> disklessTopicPartition.topicId()),
+      consolidatingDisklessTopics = Set(disklessTopicPartition.topic()),
+    )
+    try {
+      assertTrue(replicaManager.isConsolidatingDisklessPartition(disklessTopicPartition.topicPartition()))
+      assertFalse(replicaManager.isConsolidatingDisklessPartition(new TopicPartition("classic", 0)))
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
+  def testIsConsolidatingDisklessPartitionFalseWithoutSharedState(): Unit = {
+    // Without inkless shared state (non-inkless broker) the accessor must be false so the RLM keeps the
+    // plain upstream local-log-start reclaim floor.
+    val replicaManager = createReplicaManager(
+      List.empty,
+      consolidatingDisklessTopics = Set(disklessTopicPartition.topic()),
+      inklessSharedStateEnabled = false,
+    )
+    try {
+      assertFalse(replicaManager.isConsolidatingDisklessPartition(disklessTopicPartition.topicPartition()))
     } finally {
       replicaManager.shutdown(checkpointHW = false)
     }
@@ -6598,7 +6828,8 @@ class ReplicaManagerInklessTest {
     inklessSharedStateEnabled: Boolean = true,
     initDisklessLogManager: Option[InitDisklessLogManager] = None,
     delayedFetchPurgatory: Option[DelayedOperationPurgatory[DelayedFetch]] = None,
-    defaultLogConfig: Option[LogConfig] = None
+    defaultLogConfig: Option[LogConfig] = None,
+    crossTierLogStartCache: Option[CrossTierLogStartCache] = None
   ): ReplicaManager = {
     val props = TestUtils.createBrokerConfig(1, logDirCount = 2)
     if (disklessManagedReplicasEnabled || disklessRemoteStorageConsolidationEnabled) {
@@ -6628,6 +6859,7 @@ class ReplicaManagerInklessTest {
     when(sharedState.config()).thenReturn(new InklessConfig(inklessConfigMap))
     when(sharedState.controlPlane()).thenReturn(controlPlane.getOrElse(mock(classOf[ControlPlane])))
     when(sharedState.maybeLaggingFetchStorage()).thenReturn(Optional.empty())
+    crossTierLogStartCache.foreach(cache => when(sharedState.crossTierLogStartCache()).thenReturn(cache))
     val inklessMetadata = mock(classOf[InklessMetadataView])
     when(inklessMetadata.isDisklessTopic(any())).thenReturn(false)
     when(inklessMetadata.getClassicToDisklessStartOffset(any()))

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerInklessTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerInklessTest.scala
@@ -1047,7 +1047,7 @@ class ReplicaManagerInklessTest {
     // returns empty rather than propagating the exception. Callers (DisklessLeaderEndPoint whole-log
     // start, RemoteLogManager reclaim floor + become-leader report) then fall back to the broker-local
     // UnifiedLog.logStartOffset -- which on a freshly-rebuilt consolidating leader is the seal. So a
-    // control-plane outage in that window transiently reverts to the pre-fix (Problem B) behavior; it
+    // control-plane outage in that window transiently reverts to the pre-fix seal-based over-reclaim behavior; it
     // does not fail the fetch/cleanup. This test pins that contract so the fallback is a conscious
     // choice, not an accident.
     val controlPlane = mock(classOf[ControlPlane])

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerInklessTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerInklessTest.scala
@@ -1185,6 +1185,97 @@ class ReplicaManagerInklessTest {
   }
 
   @Test
+  def testCrossTierRemoteLogStartOffsetReturnsEmptyWhenRemoteStartUnreported(): Unit = {
+    // Data-loss guard (the whole point of the raw accessor): when remote_log_start_offset is NULL the
+    // dedicated control-plane read returns empty. The accessor must propagate that (NOT the WAL prune
+    // frontier that ListOffsets(EARLIEST) would COALESCE to), so the RLM reclaim floor / become-leader
+    // report fall back to the true remote earliest instead of over-reclaiming still-live remote segments.
+    val controlPlane = mock(classOf[ControlPlane])
+    when(controlPlane.getCrossTierLogStart(any())).thenReturn(OptionalLong.empty())
+    val cache = mock(classOf[CrossTierLogStartCache])
+    val replicaManager = createReplicaManager(
+      List(disklessTopicPartition.topic()),
+      controlPlane = Some(controlPlane),
+      topicIdMapping = Map(disklessTopicPartition.topic() -> disklessTopicPartition.topicId()),
+      consolidatingDisklessTopics = Set(disklessTopicPartition.topic()),
+      crossTierLogStartCache = Some(cache),
+    )
+    try {
+      assertEquals(OptionalLong.empty(),
+        replicaManager.crossTierRemoteLogStartOffset(disklessTopicPartition.topicPartition()))
+      // The raw accessor bypasses the shared cross-tier cache: that cache is also populated by
+      // ListOffsets(EARLIEST) read-throughs and can therefore hold a COALESCE'd frontier value.
+      verify(cache, never()).get(any())
+      verify(cache, never()).put(any(), anyLong())
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
+  def testCrossTierRemoteLogStartOffsetReturnsReportedValue(): Unit = {
+    // Once the classic leader has reported a remote start, the accessor returns it verbatim (still
+    // bypassing the shared cache).
+    val controlPlane = mock(classOf[ControlPlane])
+    when(controlPlane.getCrossTierLogStart(any())).thenReturn(OptionalLong.of(150L))
+    val cache = mock(classOf[CrossTierLogStartCache])
+    val replicaManager = createReplicaManager(
+      List(disklessTopicPartition.topic()),
+      controlPlane = Some(controlPlane),
+      topicIdMapping = Map(disklessTopicPartition.topic() -> disklessTopicPartition.topicId()),
+      consolidatingDisklessTopics = Set(disklessTopicPartition.topic()),
+      crossTierLogStartCache = Some(cache),
+    )
+    try {
+      assertEquals(OptionalLong.of(150L),
+        replicaManager.crossTierRemoteLogStartOffset(disklessTopicPartition.topicPartition()))
+      verify(cache, never()).get(any())
+      verify(cache, never()).put(any(), anyLong())
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
+  def testCrossTierRemoteLogStartOffsetReturnsEmptyForNonConsolidatingTopic(): Unit = {
+    // Short-circuits to empty without touching the control plane for classic / pure-diskless topics.
+    val controlPlane = mock(classOf[ControlPlane])
+    val replicaManager = createReplicaManager(
+      List(disklessTopicPartition.topic()),
+      controlPlane = Some(controlPlane),
+      topicIdMapping = Map(disklessTopicPartition.topic() -> disklessTopicPartition.topicId()),
+      consolidatingDisklessTopics = Set.empty,
+    )
+    try {
+      assertEquals(OptionalLong.empty(),
+        replicaManager.crossTierRemoteLogStartOffset(disklessTopicPartition.topicPartition()))
+      verify(controlPlane, never()).getCrossTierLogStart(any())
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
+  def testCrossTierRemoteLogStartOffsetReturnsEmptyWhenControlPlaneThrows(): Unit = {
+    // A control-plane outage in the reclaim window yields empty (not an exception); the RLM then fails
+    // safe to the true remote earliest rather than the local seal.
+    val controlPlane = mock(classOf[ControlPlane])
+    when(controlPlane.getCrossTierLogStart(any())).thenThrow(new ControlPlaneException("boom"))
+    val replicaManager = createReplicaManager(
+      List(disklessTopicPartition.topic()),
+      controlPlane = Some(controlPlane),
+      topicIdMapping = Map(disklessTopicPartition.topic() -> disklessTopicPartition.topicId()),
+      consolidatingDisklessTopics = Set(disklessTopicPartition.topic()),
+    )
+    try {
+      assertEquals(OptionalLong.empty(),
+        replicaManager.crossTierRemoteLogStartOffset(disklessTopicPartition.topicPartition()))
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
   def testIsConsolidatingDisklessPartitionReflectsMetadataView(): Unit = {
     // The RLM reclaim-floor fail-safe keys off this accessor; it must be true exactly for consolidating
     // diskless topics (so they never fall back to the local seal) and false for classic/pure-diskless.

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerInklessTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerInklessTest.scala
@@ -1276,6 +1276,27 @@ class ReplicaManagerInklessTest {
   }
 
   @Test
+  def testCrossTierRemoteLogStartOffsetReturnsEmptyWithoutSharedState(): Unit = {
+    // Without inkless shared state (non-inkless broker) the accessor short-circuits to empty without
+    // touching the control plane, so the RLM keeps the plain upstream local-log-start reclaim floor.
+    // Mirrors testIsConsolidatingDisklessPartitionFalseWithoutSharedState for symmetry.
+    val controlPlane = mock(classOf[ControlPlane])
+    val replicaManager = createReplicaManager(
+      List.empty,
+      controlPlane = Some(controlPlane),
+      consolidatingDisklessTopics = Set(disklessTopicPartition.topic()),
+      inklessSharedStateEnabled = false,
+    )
+    try {
+      assertEquals(OptionalLong.empty(),
+        replicaManager.crossTierRemoteLogStartOffset(disklessTopicPartition.topicPartition()))
+      verify(controlPlane, never()).getCrossTierLogStart(any())
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
   def testIsConsolidatingDisklessPartitionReflectsMetadataView(): Unit = {
     // The RLM reclaim-floor fail-safe keys off this accessor; it must be true exactly for consolidating
     // diskless topics (so they never fall back to the local seal) and false for classic/pure-diskless.

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerInklessTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerInklessTest.scala
@@ -1043,13 +1043,14 @@ class ReplicaManagerInklessTest {
 
   @Test
   def testCrossTierEarliestOffsetReturnsEmptyWhenControlPlaneThrows(): Unit = {
-    // Failure-mode characterization: if the control-plane query fails on a cache miss the accessor
-    // returns empty rather than propagating the exception. Callers (DisklessLeaderEndPoint whole-log
-    // start, RemoteLogManager reclaim floor + become-leader report) then fall back to the broker-local
-    // UnifiedLog.logStartOffset -- which on a freshly-rebuilt consolidating leader is the seal. So a
-    // control-plane outage in that window transiently reverts to the pre-fix seal-based over-reclaim behavior; it
-    // does not fail the fetch/cleanup. This test pins that contract so the fallback is a conscious
-    // choice, not an accident.
+    // A control-plane query that fails on a cache miss returns empty here; it does not throw. Only the
+    // read path (DisklessLeaderEndPoint, the whole-log start) reads this COALESCE'd accessor. On empty it
+    // uses the broker-local UnifiedLog.logStartOffset, which on a freshly-rebuilt consolidating leader is
+    // the seal, so a read of the surviving remote prefix [X, seal) fails as out-of-range until the control
+    // plane recovers. The fetch still completes; it just cannot see that prefix meanwhile. The reclaim
+    // floor and become-leader report never touch this accessor: they read the raw
+    // crossTierRemoteLogStartOffset and fall back to findLogStartOffset, the true remote earliest. This
+    // test locks in that read-path behavior.
     val controlPlane = mock(classOf[ControlPlane])
     when(controlPlane.listOffsets(anyList())).thenThrow(new ControlPlaneException("boom"))
     val cache = mock(classOf[CrossTierLogStartCache])

--- a/docs/inkless/metrics.rst
+++ b/docs/inkless/metrics.rst
@@ -293,6 +293,8 @@ FilesDeleteQueryRate                Total number of FilesDelete queries executed
 FilesDeleteQueryTime                Time spent executing the FilesDelete query in milliseconds             
 FindBatchesQueryRate                Total number of FindBatches queries executed                           
 FindBatchesQueryTime                Time spent executing the FindBatches query in milliseconds             
+GetCrossTierLogStartQueryRate       Total number of GetCrossTierLogStart queries executed                  
+GetCrossTierLogStartQueryTime       Time spent executing the GetCrossTierLogStart query in milliseconds    
 GetFilesToDeleteQueryRate           Total number of GetFilesToDelete queries executed                      
 GetFilesToDeleteQueryTime           Time spent executing the GetFilesToDelete query in milliseconds        
 GetLogInfoQueryRate                 Total number of GetLogInfo queries executed                            

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/ControlPlane.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/ControlPlane.java
@@ -18,6 +18,7 @@
 package io.aiven.inkless.control_plane;
 
 import org.apache.kafka.common.Configurable;
+import org.apache.kafka.common.TopicIdPartition;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.utils.Time;
 
@@ -25,6 +26,7 @@ import java.io.Closeable;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
+import java.util.OptionalLong;
 import java.util.Set;
 
 import io.aiven.inkless.common.ObjectFormat;
@@ -92,6 +94,20 @@ public interface ControlPlane extends Closeable, Configurable {
      * @return list of responses, one per request, in the same order as the requests.
      */
     List<AdvanceCrossTierLogStartOffsetResponse> advanceCrossTierLogStartOffset(List<AdvanceCrossTierLogStartOffsetRequest> requests);
+
+    /**
+     * The raw cross-tier (remote) log start offset stored for a partition, or empty when it has not
+     * been reported yet ({@code remote_log_start_offset IS NULL}) or the partition is unknown.
+     * <p>
+     * Unlike {@code ListOffsets(EARLIEST)} this deliberately does NOT fall back to
+     * {@code log_start_offset} (the diskless WAL prune frontier). That frontier can run ahead of the
+     * true remote start, so a caller using it as a reclaim floor would delete still-live remote
+     * segments. Returning empty lets such callers fail safe to the true remote earliest instead.
+     *
+     * @param topicIdPartition the partition to read
+     * @return the reported remote log start offset, or empty when unreported/unknown
+     */
+    OptionalLong getCrossTierLogStart(TopicIdPartition topicIdPartition);
 
     List<FileToDelete> getFilesToDelete();
 

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/InMemoryControlPlane.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/InMemoryControlPlane.java
@@ -36,6 +36,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicLong;
@@ -491,6 +492,19 @@ public class InMemoryControlPlane extends AbstractControlPlane {
             responses.add(AdvanceCrossTierLogStartOffsetResponse.success(logInfo.remoteLogStartOffset));
         }
         return responses;
+    }
+
+    @Override
+    public synchronized OptionalLong getCrossTierLogStart(final TopicIdPartition topicIdPartition) {
+        // Direct O(1) lookup like listOffset: the caller (ReplicaManager) passes a fully-formed
+        // TopicIdPartition. This differs from advanceCrossTierLogStartOffset, whose request has no topic
+        // name and so must fall back to the O(n) findTopicIdPartition scan.
+        final LogInfo logInfo = logs.get(topicIdPartition);
+        if (logInfo == null) {
+            return OptionalLong.empty();
+        }
+        // remoteLogStartOffset is -1 (the NULL sentinel) until the classic leader reports it.
+        return logInfo.remoteLogStartOffset < 0 ? OptionalLong.empty() : OptionalLong.of(logInfo.remoteLogStartOffset);
     }
 
     @Override

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/GetCrossTierLogStartJob.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/GetCrossTierLogStartJob.java
@@ -18,12 +18,14 @@
 package io.aiven.inkless.control_plane.postgres;
 
 import org.apache.kafka.common.TopicIdPartition;
+import org.apache.kafka.common.utils.Time;
 
 import org.jooq.Configuration;
 import org.jooq.DSLContext;
 
 import java.util.OptionalLong;
 import java.util.concurrent.Callable;
+import java.util.function.Consumer;
 
 import static org.jooq.generated.tables.Logs.LOGS;
 
@@ -34,17 +36,24 @@ import static org.jooq.generated.tables.Logs.LOGS;
  * (not yet reported by the classic leader). Deliberately does not fall back to {@code log_start_offset}.
  */
 public class GetCrossTierLogStartJob implements Callable<OptionalLong> {
+    private final Time time;
     private final DSLContext jooqCtx;
     private final TopicIdPartition topicIdPartition;
+    private final Consumer<Long> durationCallback;
 
-    public GetCrossTierLogStartJob(final DSLContext jooqCtx, final TopicIdPartition topicIdPartition) {
+    public GetCrossTierLogStartJob(final Time time,
+                                   final DSLContext jooqCtx,
+                                   final TopicIdPartition topicIdPartition,
+                                   final Consumer<Long> durationCallback) {
+        this.time = time;
         this.jooqCtx = jooqCtx;
         this.topicIdPartition = topicIdPartition;
+        this.durationCallback = durationCallback;
     }
 
     @Override
     public OptionalLong call() {
-        return JobUtils.run(this::runOnce);
+        return JobUtils.run(this::runOnce, time, durationCallback);
     }
 
     private OptionalLong runOnce() {

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/GetCrossTierLogStartJob.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/GetCrossTierLogStartJob.java
@@ -1,0 +1,61 @@
+/*
+ * Inkless
+ * Copyright (C) 2024 - 2026 Aiven OY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.aiven.inkless.control_plane.postgres;
+
+import org.apache.kafka.common.TopicIdPartition;
+
+import org.jooq.Configuration;
+import org.jooq.DSLContext;
+
+import java.util.OptionalLong;
+import java.util.concurrent.Callable;
+
+import static org.jooq.generated.tables.Logs.LOGS;
+
+/**
+ * Reads the raw cross-tier (remote) log start offset for a single partition, null-aware.
+ *
+ * <p>Returns empty when the partition is unknown or {@code remote_log_start_offset} is still NULL
+ * (not yet reported by the classic leader). Deliberately does not fall back to {@code log_start_offset}.
+ */
+public class GetCrossTierLogStartJob implements Callable<OptionalLong> {
+    private final DSLContext jooqCtx;
+    private final TopicIdPartition topicIdPartition;
+
+    public GetCrossTierLogStartJob(final DSLContext jooqCtx, final TopicIdPartition topicIdPartition) {
+        this.jooqCtx = jooqCtx;
+        this.topicIdPartition = topicIdPartition;
+    }
+
+    @Override
+    public OptionalLong call() {
+        return JobUtils.run(this::runOnce);
+    }
+
+    private OptionalLong runOnce() {
+        return jooqCtx.transactionResult((final Configuration conf) -> {
+            final Long value = conf.dsl()
+                .select(LOGS.REMOTE_LOG_START_OFFSET)
+                .from(LOGS)
+                .where(LOGS.TOPIC_ID.eq(topicIdPartition.topicId()))
+                .and(LOGS.PARTITION.eq(topicIdPartition.partition()))
+                .fetchOne(LOGS.REMOTE_LOG_START_OFFSET);
+            return value == null ? OptionalLong.empty() : OptionalLong.of(value);
+        });
+    }
+}

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/PostgresControlPlane.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/PostgresControlPlane.java
@@ -17,6 +17,7 @@
  */
 package io.aiven.inkless.control_plane.postgres;
 
+import org.apache.kafka.common.TopicIdPartition;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.server.metrics.KafkaMetricsGroup;
@@ -33,6 +34,7 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.OptionalLong;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -241,6 +243,15 @@ public class PostgresControlPlane extends AbstractControlPlane {
             return job.call();
         } catch (final Exception e) {
             throw new ControlPlaneException("Failed to advance cross-tier log start offset", e);
+        }
+    }
+
+    @Override
+    public OptionalLong getCrossTierLogStart(final TopicIdPartition topicIdPartition) {
+        try {
+            return new GetCrossTierLogStartJob(readJooqCtx, topicIdPartition).call();
+        } catch (final Exception e) {
+            throw new ControlPlaneException("Failed to get cross-tier log start offset", e);
         }
     }
 

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/PostgresControlPlane.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/PostgresControlPlane.java
@@ -249,7 +249,7 @@ public class PostgresControlPlane extends AbstractControlPlane {
     @Override
     public OptionalLong getCrossTierLogStart(final TopicIdPartition topicIdPartition) {
         try {
-            return new GetCrossTierLogStartJob(readJooqCtx, topicIdPartition).call();
+            return new GetCrossTierLogStartJob(time, readJooqCtx, topicIdPartition, pgMetrics::onGetCrossTierLogStartCompleted).call();
         } catch (final Exception e) {
             throw new ControlPlaneException("Failed to get cross-tier log start offset", e);
         }

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/PostgresControlPlaneMetrics.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/PostgresControlPlaneMetrics.java
@@ -39,7 +39,7 @@ public class PostgresControlPlaneMetrics implements Closeable {
         "DeleteRecords", "EnforceRetention", "GetFilesToDelete",
         "SafeDeleteFileCheck",
         "GetLogInfo", "InitDisklessLog", "GetProducerState",
-        "AdvanceCrossTierLogStart", "RepairDisklessLog"
+        "AdvanceCrossTierLogStart", "RepairDisklessLog", "GetCrossTierLogStart"
     );
 
     /**
@@ -78,6 +78,7 @@ public class PostgresControlPlaneMetrics implements Closeable {
     private final QueryMetrics getProducerStateMetrics = new QueryMetrics("GetProducerState");
     private final QueryMetrics pruneDisklessLogsMetrics = new QueryMetrics("PruneDisklessLogs");
     private final QueryMetrics advanceCrossTierLogStartMetrics = new QueryMetrics("AdvanceCrossTierLogStart");
+    private final QueryMetrics getCrossTierLogStartMetrics = new QueryMetrics("GetCrossTierLogStart");
 
     public PostgresControlPlaneMetrics(Time time) {
         this.time = Objects.requireNonNull(time, "time cannot be null");
@@ -151,6 +152,10 @@ public class PostgresControlPlaneMetrics implements Closeable {
         advanceCrossTierLogStartMetrics.record(duration);
     }
 
+    public void onGetCrossTierLogStartCompleted(Long duration) {
+        getCrossTierLogStartMetrics.record(duration);
+    }
+
     @Override
     public void close() {
         findBatchesMetrics.remove();
@@ -169,6 +174,7 @@ public class PostgresControlPlaneMetrics implements Closeable {
         getProducerStateMetrics.remove();
         pruneDisklessLogsMetrics.remove();
         advanceCrossTierLogStartMetrics.remove();
+        getCrossTierLogStartMetrics.remove();
     }
 
     private class QueryMetrics {

--- a/storage/inkless/src/test/java/io/aiven/inkless/control_plane/AbstractControlPlaneTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/control_plane/AbstractControlPlaneTest.java
@@ -1627,6 +1627,28 @@ public abstract class AbstractControlPlaneTest {
         }
 
         @Test
+        void getCrossTierLogStartIsNullAwareUnlikeEarliest() {
+            // Before any leader report, remote_log_start_offset is NULL. EARLIEST COALESCEs that to the log start (0),
+            // but the dedicated read must expose the NULL as empty so the RLM reclaim floor does not mistake the WAL
+            // frontier for the cross-tier earliest.
+            assertThat(controlPlane.getCrossTierLogStart(tidp)).isEmpty();
+            assertThat(controlPlane.listOffsets(List.of(new ListOffsetsRequest(tidp, EARLIEST_TIMESTAMP))))
+                .containsExactly(ListOffsetsResponse.success(tidp, NO_TIMESTAMP, 0));  // falls back to log start
+
+            // After a report the dedicated read returns the reported value.
+            controlPlane.advanceCrossTierLogStartOffset(List.of(
+                new AdvanceCrossTierLogStartOffsetRequest(topicId, 0, 50)
+            ));
+            assertThat(controlPlane.getCrossTierLogStart(tidp)).hasValue(50);
+        }
+
+        @Test
+        void getCrossTierLogStartIsEmptyForUnknownPartition() {
+            assertThat(controlPlane.getCrossTierLogStart(
+                new TopicIdPartition(NONEXISTENT_TOPIC_ID, 0, "nonexistent"))).isEmpty();
+        }
+
+        @Test
         void earliestReflectsCrossTierWhileEarliestLocalStaysAtLogStart() {
             controlPlane.advanceCrossTierLogStartOffset(List.of(
                 new AdvanceCrossTierLogStartOffsetRequest(topicId, 0, 50)

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogManager.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogManager.java
@@ -154,6 +154,19 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
     private final Time time;
     private final Function<TopicPartition, Optional<UnifiedLog>> fetchLog;
     private final BiConsumer<TopicPartition, Long> updateRemoteLogStartOffset;
+    // Inkless: overrides the log start offset used to drive remote-retention reclaim (and the
+    // become-leader log-start report) for consolidating diskless partitions. For such partitions the
+    // broker-local UnifiedLog.logStartOffset can be pinned at the classic-to-diskless seal on a
+    // freshly-rebuilt leader, which would over-reclaim the remote classic prefix and report the seal as
+    // the cross-tier earliest. This function returns the control-plane cross-tier earliest for those
+    // partitions and OptionalLong.empty() for everything else (classic topics / non-inkless), where the
+    // upstream behavior (log.logStartOffset()) is unchanged.
+    private final Function<TopicPartition, OptionalLong> logStartOffsetOverride;
+    // Inkless: tells whether a partition is a consolidating diskless topic. Used to pick the reclaim
+    // floor's fallback when {@link #logStartOffsetOverride} is empty: consolidating partitions must never
+    // fall back to the broker-local log start (the classic-to-diskless seal on a rebuilt leader), while
+    // classic topics keep the upstream local-log-start behavior. No-op predicate for non-Inkless callers.
+    private final Predicate<TopicPartition> isConsolidatingDisklessPartition;
     private final BrokerTopicStats brokerTopicStats;
     private final Metrics metrics;
 
@@ -208,7 +221,6 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
      * @param brokerTopicStats BrokerTopicStats instance to update the respective metrics.
      * @param metrics  Metrics instance
      */
-    @SuppressWarnings({"this-escape"})
     public RemoteLogManager(RemoteLogManagerConfig rlmConfig,
                             int brokerId,
                             String logDir,
@@ -219,6 +231,29 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
                             BrokerTopicStats brokerTopicStats,
                             Metrics metrics,
                             Optional<Endpoint> endpoint) throws IOException {
+        this(rlmConfig, brokerId, logDir, clusterId, time, fetchLog, updateRemoteLogStartOffset,
+                brokerTopicStats, metrics, endpoint, tp -> OptionalLong.empty(), tp -> false);
+    }
+
+    /**
+     * Creates a RemoteLogManager with an Inkless log-start-offset override (see
+     * {@link #logStartOffsetOverride}) and a consolidating-partition predicate (see
+     * {@link #isConsolidatingDisklessPartition}). Non-Inkless callers should use the other constructor,
+     * which defaults both to no-ops.
+     */
+    @SuppressWarnings({"this-escape"})
+    public RemoteLogManager(RemoteLogManagerConfig rlmConfig,
+                            int brokerId,
+                            String logDir,
+                            String clusterId,
+                            Time time,
+                            Function<TopicPartition, Optional<UnifiedLog>> fetchLog,
+                            BiConsumer<TopicPartition, Long> updateRemoteLogStartOffset,
+                            BrokerTopicStats brokerTopicStats,
+                            Metrics metrics,
+                            Optional<Endpoint> endpoint,
+                            Function<TopicPartition, OptionalLong> logStartOffsetOverride,
+                            Predicate<TopicPartition> isConsolidatingDisklessPartition) throws IOException {
         this.rlmConfig = rlmConfig;
         this.brokerId = brokerId;
         this.logDir = logDir;
@@ -226,6 +261,8 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
         this.time = time;
         this.fetchLog = fetchLog;
         this.updateRemoteLogStartOffset = updateRemoteLogStartOffset;
+        this.logStartOffsetOverride = logStartOffsetOverride;
+        this.isConsolidatingDisklessPartition = isConsolidatingDisklessPartition;
         this.brokerTopicStats = brokerTopicStats;
         this.metrics = metrics;
         this.endpoint = endpoint;
@@ -882,7 +919,13 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
 
         private void maybeUpdateLogStartOffsetOnBecomingLeader(UnifiedLog log) throws RemoteStorageException {
             if (!isLogStartOffsetUpdated) {
-                long logStartOffset = findLogStartOffset(topicIdPartition, log);
+                // For a consolidating diskless partition, prefer the control-plane cross-tier earliest so a
+                // freshly-elected leader does not report its local seal as the cross-tier earliest (which
+                // would push the broker-agnostic earliest up to the seal). No-op for classic topics.
+                OptionalLong override = logStartOffsetOverride.apply(topicIdPartition.topicPartition());
+                long logStartOffset = override.isPresent()
+                        ? override.getAsLong()
+                        : findLogStartOffset(topicIdPartition, log);
                 updateRemoteLogStartOffset.accept(topicIdPartition.topicPartition(), logStartOffset);
                 isLogStartOffsetUpdated = true;
                 logger.info("Found the logStartOffset: {} for partition: {} after becoming leader",
@@ -1250,6 +1293,33 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
             brokerTopicStats.recordRemoteDeleteLagBytes(topic, partition, sizeOfDeletableSegmentsBytes);
         }
 
+        /**
+         * The log start offset that drives the remote-retention log-start-offset reclaim floor.
+         *
+         * <p>Classic topics use the broker-local log start. A consolidating diskless partition instead uses
+         * the control-plane cross-tier earliest ({@link RemoteLogManager#logStartOffsetOverride}): on a
+         * rebuilt leader the local log start is pinned at the classic-to-diskless seal (and only increments),
+         * so it would delete the whole remote classic prefix {@code [earliest, seal)} though only
+         * {@code [0, earliest)} was removed.
+         *
+         * <p>If the override is empty for such a partition (control plane unreachable or metadata not yet
+         * propagated) we fail safe to the remote earliest
+         * ({@link RemoteLogManager#findLogStartOffset(TopicIdPartition, UnifiedLog)}), not the seal: nothing
+         * over-reclaims this cycle, time/size retention still applies, and the log-start reclaim retries once
+         * the cross-tier earliest resolves. Deferring is safe since remote deletes are irreversible.
+         */
+        private long reclaimFloorLogStartOffset(UnifiedLog log) throws RemoteStorageException {
+            final TopicPartition tp = topicIdPartition.topicPartition();
+            final OptionalLong crossTierEarliest = logStartOffsetOverride.apply(tp);
+            if (crossTierEarliest.isPresent()) {
+                return crossTierEarliest.getAsLong();
+            }
+            if (isConsolidatingDisklessPartition.test(tp)) {
+                return findLogStartOffset(topicIdPartition, log);
+            }
+            return log.logStartOffset();
+        }
+
         /** Cleanup expired and dangling remote log segments. */
         void cleanupExpiredRemoteLogSegments() throws RemoteStorageException, ExecutionException, InterruptedException {
             if (isCancelled()) {
@@ -1295,7 +1365,7 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
             // Build the leader epoch map by filtering the epochs that do not have any records.
             NavigableMap<Integer, Long> epochWithOffsets = buildFilteredLeaderEpochMap(leaderEpochCache.epochWithOffsets());
 
-            long logStartOffset = log.logStartOffset();
+            long logStartOffset = reclaimFloorLogStartOffset(log);
             long logEndOffset = log.logEndOffset();
             Optional<RetentionSizeData> retentionSizeData = buildRetentionSizeData(log.config().retentionSize,
                     log.onlyLocalLogSegmentsSize(), logEndOffset, epochWithOffsets);

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogManager.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogManager.java
@@ -920,9 +920,12 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
 
         private void maybeUpdateLogStartOffsetOnBecomingLeader(UnifiedLog log) throws RemoteStorageException {
             if (!isLogStartOffsetUpdated) {
-                // For a consolidating diskless partition, prefer the control-plane cross-tier earliest so a
+                // For a consolidating diskless partition, prefer the raw control-plane remote log start so a
                 // freshly-elected leader does not report its local seal as the cross-tier earliest (which
-                // would push the broker-agnostic earliest up to the seal). No-op for classic topics.
+                // would push the broker-agnostic earliest up to the seal). This is deliberately the raw
+                // remote start, not ListOffsets(EARLIEST): the latter COALESCEs to the WAL prune frontier
+                // when the remote start is unreported, which would lock the wrong value in via the
+                // forward-only advance. No-op for classic topics.
                 OptionalLong override = logStartOffsetOverride.apply(topicIdPartition.topicPartition());
                 long logStartOffset = override.isPresent()
                         ? override.getAsLong()
@@ -1298,22 +1301,25 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
          * The log start offset that drives the remote-retention log-start-offset reclaim floor.
          *
          * <p>Classic topics use the broker-local log start. A consolidating diskless partition instead uses
-         * the control-plane cross-tier earliest ({@link RemoteLogManager#logStartOffsetOverride}): on a
+         * the raw control-plane remote log start ({@link RemoteLogManager#logStartOffsetOverride}): on a
          * rebuilt leader the local log start is pinned at the classic-to-diskless seal (and only increments),
          * so it would delete the whole remote classic prefix {@code [earliest, seal)} though only
-         * {@code [0, earliest)} was removed.
+         * {@code [0, earliest)} was removed. This is deliberately the raw remote start, not
+         * {@code ListOffsets(EARLIEST)}: the latter COALESCEs to the WAL prune frontier when the remote
+         * start is unreported, which would itself over-reclaim still-live remote segments and lock the
+         * wrong value in via the forward-only control-plane advance.
          *
-         * <p>If the override is empty for such a partition (control plane unreachable or metadata not yet
-         * propagated) we fail safe to the remote earliest
+         * <p>If the override is empty for such a partition (control plane unreachable, metadata not yet
+         * propagated, or the remote start simply not reported yet) we fail safe to the remote earliest
          * ({@link RemoteLogManager#findLogStartOffset(TopicIdPartition, UnifiedLog)}), not the seal: nothing
-         * over-reclaims this cycle, time/size retention still applies, and the log-start reclaim retries once
-         * the cross-tier earliest resolves. Deferring is safe since remote deletes are irreversible.
+         * over-reclaims this cycle, time/size retention still applies, and the log-start reclaim retries
+         * once the remote start resolves. Deferring is safe since remote deletes are irreversible.
          */
         private long reclaimFloorLogStartOffset(UnifiedLog log) throws RemoteStorageException {
             final TopicPartition tp = topicIdPartition.topicPartition();
-            final OptionalLong crossTierEarliest = logStartOffsetOverride.apply(tp);
-            if (crossTierEarliest.isPresent()) {
-                return crossTierEarliest.getAsLong();
+            final OptionalLong crossTierRemoteStart = logStartOffsetOverride.apply(tp);
+            if (crossTierRemoteStart.isPresent()) {
+                return crossTierRemoteStart.getAsLong();
             }
             if (isConsolidatingDisklessPartition.test(tp)) {
                 return findLogStartOffset(topicIdPartition, log);

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogManager.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogManager.java
@@ -154,13 +154,14 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
     private final Time time;
     private final Function<TopicPartition, Optional<UnifiedLog>> fetchLog;
     private final BiConsumer<TopicPartition, Long> updateRemoteLogStartOffset;
-    // Inkless: overrides the log start offset used to drive remote-retention reclaim (and the
-    // become-leader log-start report) for consolidating diskless partitions. For such partitions the
-    // broker-local UnifiedLog.logStartOffset can be pinned at the classic-to-diskless seal on a
-    // freshly-rebuilt leader, which would over-reclaim the remote classic prefix and report the seal as
-    // the cross-tier earliest. This function returns the control-plane cross-tier earliest for those
-    // partitions and OptionalLong.empty() for everything else (classic topics / non-inkless), where the
-    // upstream behavior (log.logStartOffset()) is unchanged.
+    // Inkless: the reclaim floor (and become-leader log-start report) for consolidating diskless
+    // partitions. Their broker-local UnifiedLog.logStartOffset can be pinned at the classic-to-diskless
+    // seal on a rebuilt leader, so using it would over-reclaim the remote classic prefix and report the
+    // seal as the cross-tier earliest. Returns the raw control-plane remote log start, present only once
+    // the classic leader has reported it and not COALESCEd to the WAL prune frontier (which could also
+    // over-reclaim). Empty for classic/non-inkless partitions and for an unreported remote start; when
+    // empty the reclaim path uses the true remote earliest (findLogStartOffset), not the local seal.
+    // Non-consolidating partitions keep the upstream log.logStartOffset() behavior.
     private final Function<TopicPartition, OptionalLong> logStartOffsetOverride;
     // Inkless: tells whether a partition is a consolidating diskless topic. Used to pick the reclaim
     // floor's fallback when {@link #logStartOffsetOverride} is empty: consolidating partitions must never

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogManager.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteLogManager.java
@@ -1309,11 +1309,12 @@ public class RemoteLogManager implements Closeable, AsyncOffsetReader {
          * start is unreported, which would itself over-reclaim still-live remote segments and lock the
          * wrong value in via the forward-only control-plane advance.
          *
-         * <p>If the override is empty for such a partition (control plane unreachable, metadata not yet
-         * propagated, or the remote start simply not reported yet) we fail safe to the remote earliest
-         * ({@link RemoteLogManager#findLogStartOffset(TopicIdPartition, UnifiedLog)}), not the seal: nothing
-         * over-reclaims this cycle, time/size retention still applies, and the log-start reclaim retries
-         * once the remote start resolves. Deferring is safe since remote deletes are irreversible.
+         * <p>If the override is empty for such a partition (control plane unreachable, or metadata not yet
+         * propagated, or the remote start not reported yet) we fall back to
+         * {@link RemoteLogManager#findLogStartOffset(TopicIdPartition, UnifiedLog)}, which walks the
+         * cumulative remote epoch cache back to the true remote earliest. The classic prefix survives and
+         * time/size retention still applies. That floor is the true earliest and never the local seal, so
+         * the irreversible remote delete cannot over-reclaim.
          */
         private long reclaimFloorLogStartOffset(UnifiedLog log) throws RemoteStorageException {
             final TopicPartition tp = topicIdPartition.topicPartition();

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogManagerTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogManagerTest.java
@@ -107,6 +107,7 @@ import java.util.NavigableMap;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.OptionalLong;
 import java.util.Properties;
 import java.util.Set;
 import java.util.TreeMap;
@@ -2551,6 +2552,458 @@ public class RemoteLogManagerTest {
         // Verify aggregate metrics
         assertEquals(2, brokerTopicStats.allTopicsStats().remoteDeleteRequestRate().count());
         assertEquals(0, brokerTopicStats.allTopicsStats().failedRemoteDeleteRequestRate().count());
+    }
+
+    @Test
+    public void testConsolidatingLogStartOffsetOverrideDrivesRemoteReclaimFloor()
+            throws RemoteStorageException, ExecutionException, InterruptedException, IOException {
+        // Inkless: for a consolidating diskless partition the remote-retention reclaim floor must come
+        // from the control-plane cross-tier earliest (here 100), NOT the broker-local log start (200,
+        // which on a freshly-rebuilt leader is pinned at the classic-to-diskless seal). With retention
+        // disabled only a log-start-offset breach can delete, so the segment [0,99] (endOffset 99 < 100)
+        // is reclaimed while [100,199] survives -- even though the local seal (200) would breach it too.
+        Map<String, Long> logProps = new HashMap<>();
+        logProps.put("retention.bytes", -1L);
+        logProps.put("retention.ms", -1L);
+        LogConfig mockLogConfig = new LogConfig(logProps);
+        when(mockLog.config()).thenReturn(mockLogConfig);
+
+        List<EpochEntry> epochEntries = List.of(epochEntry0);
+        checkpoint.write(epochEntries);
+        LeaderEpochFileCache cache = new LeaderEpochFileCache(tp, checkpoint, scheduler);
+        when(mockLog.leaderEpochCache()).thenReturn(cache);
+        when(mockLog.topicPartition()).thenReturn(leaderTopicIdPartition.topicPartition());
+        when(mockLog.logEndOffset()).thenReturn(200L);
+        // Broker-local log start pinned at the seal; would delete BOTH segments if used as the floor.
+        when(mockLog.logStartOffset()).thenReturn(200L);
+
+        List<RemoteLogSegmentMetadata> metadataList =
+                listRemoteLogSegmentMetadata(leaderTopicIdPartition, 2, 100, 1024, epochEntries, RemoteLogSegmentState.COPY_SEGMENT_FINISHED);
+        when(remoteLogMetadataManager.listRemoteLogSegments(leaderTopicIdPartition))
+                .thenReturn(metadataList.iterator());
+        when(remoteLogMetadataManager.listRemoteLogSegments(leaderTopicIdPartition, 0))
+                .thenAnswer(ans -> metadataList.iterator());
+        when(remoteLogMetadataManager.updateRemoteLogSegmentMetadata(any(RemoteLogSegmentMetadataUpdate.class)))
+                .thenReturn(CompletableFuture.runAsync(() -> { }));
+        doNothing().when(remoteStorageManager).deleteLogSegmentData(any(RemoteLogSegmentMetadata.class));
+
+        try (RemoteLogManager rlmWithOverride = new RemoteLogManager(config, brokerId, logDir, clusterId, time,
+                tp -> Optional.of(mockLog),
+                (topicPartition, offset) -> currentLogStartOffset.set(offset),
+                brokerTopicStats, metrics, endPoint,
+                topicPartition -> OptionalLong.of(100L),
+                topicPartition -> true) {
+            @Override
+            public RemoteStorageManager createRemoteStorageManager() {
+                return remoteStorageManager;
+            }
+            @Override
+            public RemoteLogMetadataManager createRemoteLogMetadataManager() {
+                return remoteLogMetadataManager;
+            }
+            @Override
+            long findLogStartOffset(TopicIdPartition topicIdPartition, UnifiedLog log) {
+                return 0L;
+            }
+        }) {
+            doReturn(true).when(remoteLogMetadataManager).isReady(any(TopicIdPartition.class));
+            RemoteLogManager.RLMExpirationTask task = rlmWithOverride.new RLMExpirationTask(leaderTopicIdPartition);
+            task.cleanupExpiredRemoteLogSegments();
+        }
+
+        // Only the segment entirely below the cross-tier earliest (100) is reclaimed; the survivor stays.
+        verify(remoteStorageManager).deleteLogSegmentData(metadataList.get(0));
+        verify(remoteStorageManager, never()).deleteLogSegmentData(metadataList.get(1));
+    }
+
+    @Test
+    public void testConsolidatingReclaimFailsSafeWhenOverrideAbsent()
+            throws RemoteStorageException, ExecutionException, InterruptedException, IOException {
+        // Fail-safe (Problem B hardening): when the log-start-offset override yields empty for a
+        // CONSOLIDATING partition (control-plane outage or not-yet-propagated metadata on the RLM leader)
+        // the reclaim floor must NOT fall back to the broker-local log start -- on a freshly-rebuilt
+        // consolidating leader that is the seal (200) and would irreversibly delete the entire remote
+        // classic prefix. Instead it uses the remote earliest (findLogStartOffset -> 0), so no segment
+        // breaches the log-start-offset and NOTHING is reclaimed this cycle. Retention is disabled here,
+        // so both segments [0,99] and [100,199] survive; log-start reclaim retries once the control plane
+        // recovers.
+        Map<String, Long> logProps = new HashMap<>();
+        logProps.put("retention.bytes", -1L);
+        logProps.put("retention.ms", -1L);
+        LogConfig mockLogConfig = new LogConfig(logProps);
+        when(mockLog.config()).thenReturn(mockLogConfig);
+
+        List<EpochEntry> epochEntries = List.of(epochEntry0);
+        checkpoint.write(epochEntries);
+        LeaderEpochFileCache cache = new LeaderEpochFileCache(tp, checkpoint, scheduler);
+        when(mockLog.leaderEpochCache()).thenReturn(cache);
+        when(mockLog.topicPartition()).thenReturn(leaderTopicIdPartition.topicPartition());
+        when(mockLog.logEndOffset()).thenReturn(200L);
+        when(mockLog.logStartOffset()).thenReturn(200L); // local log start pinned at the seal (the trap)
+
+        List<RemoteLogSegmentMetadata> metadataList =
+                listRemoteLogSegmentMetadata(leaderTopicIdPartition, 2, 100, 1024, epochEntries, RemoteLogSegmentState.COPY_SEGMENT_FINISHED);
+        when(remoteLogMetadataManager.listRemoteLogSegments(leaderTopicIdPartition))
+                .thenReturn(metadataList.iterator());
+        when(remoteLogMetadataManager.listRemoteLogSegments(leaderTopicIdPartition, 0))
+                .thenAnswer(ans -> metadataList.iterator());
+        when(remoteLogMetadataManager.updateRemoteLogSegmentMetadata(any(RemoteLogSegmentMetadataUpdate.class)))
+                .thenReturn(CompletableFuture.runAsync(() -> { }));
+        doNothing().when(remoteStorageManager).deleteLogSegmentData(any(RemoteLogSegmentMetadata.class));
+
+        try (RemoteLogManager rlmWithEmptyOverride = new RemoteLogManager(config, brokerId, logDir, clusterId, time,
+                tp -> Optional.of(mockLog),
+                (topicPartition, offset) -> currentLogStartOffset.set(offset),
+                brokerTopicStats, metrics, endPoint,
+                topicPartition -> OptionalLong.empty(),
+                topicPartition -> true) { // consolidating -> fail safe, do not use the local seal
+            @Override
+            public RemoteStorageManager createRemoteStorageManager() {
+                return remoteStorageManager;
+            }
+            @Override
+            public RemoteLogMetadataManager createRemoteLogMetadataManager() {
+                return remoteLogMetadataManager;
+            }
+            @Override
+            long findLogStartOffset(TopicIdPartition topicIdPartition, UnifiedLog log) {
+                return 0L; // remote earliest
+            }
+        }) {
+            doReturn(true).when(remoteLogMetadataManager).isReady(any(TopicIdPartition.class));
+            RemoteLogManager.RLMExpirationTask task = rlmWithEmptyOverride.new RLMExpirationTask(leaderTopicIdPartition);
+            task.cleanupExpiredRemoteLogSegments();
+        }
+
+        // Neither segment is reclaimed: the fail-safe floor (remote earliest 0) breaches nothing, so the
+        // remote classic prefix is preserved rather than over-reclaimed to the seal.
+        verify(remoteStorageManager, never()).deleteLogSegmentData(metadataList.get(0));
+        verify(remoteStorageManager, never()).deleteLogSegmentData(metadataList.get(1));
+    }
+
+    @Test
+    public void testNonConsolidatingReclaimUsesLocalLogStartWhenOverrideAbsent()
+            throws RemoteStorageException, ExecutionException, InterruptedException, IOException {
+        // Regression guard: for a CLASSIC (non-consolidating) remote topic the fail-safe must NOT engage.
+        // With an empty override the reclaim floor keeps the upstream behavior of the broker-local log
+        // start (here 200, e.g. advanced by a user DeleteRecords), so both segments [0,99] and [100,199]
+        // breach the log-start-offset and are reclaimed as normal.
+        Map<String, Long> logProps = new HashMap<>();
+        logProps.put("retention.bytes", -1L);
+        logProps.put("retention.ms", -1L);
+        LogConfig mockLogConfig = new LogConfig(logProps);
+        when(mockLog.config()).thenReturn(mockLogConfig);
+
+        List<EpochEntry> epochEntries = List.of(epochEntry0);
+        checkpoint.write(epochEntries);
+        LeaderEpochFileCache cache = new LeaderEpochFileCache(tp, checkpoint, scheduler);
+        when(mockLog.leaderEpochCache()).thenReturn(cache);
+        when(mockLog.topicPartition()).thenReturn(leaderTopicIdPartition.topicPartition());
+        when(mockLog.logEndOffset()).thenReturn(200L);
+        when(mockLog.logStartOffset()).thenReturn(200L); // authoritative floor for a classic topic
+
+        List<RemoteLogSegmentMetadata> metadataList =
+                listRemoteLogSegmentMetadata(leaderTopicIdPartition, 2, 100, 1024, epochEntries, RemoteLogSegmentState.COPY_SEGMENT_FINISHED);
+        when(remoteLogMetadataManager.listRemoteLogSegments(leaderTopicIdPartition))
+                .thenReturn(metadataList.iterator());
+        when(remoteLogMetadataManager.listRemoteLogSegments(leaderTopicIdPartition, 0))
+                .thenAnswer(ans -> metadataList.iterator());
+        when(remoteLogMetadataManager.updateRemoteLogSegmentMetadata(any(RemoteLogSegmentMetadataUpdate.class)))
+                .thenReturn(CompletableFuture.runAsync(() -> { }));
+        doNothing().when(remoteStorageManager).deleteLogSegmentData(any(RemoteLogSegmentMetadata.class));
+
+        try (RemoteLogManager rlmClassic = new RemoteLogManager(config, brokerId, logDir, clusterId, time,
+                tp -> Optional.of(mockLog),
+                (topicPartition, offset) -> currentLogStartOffset.set(offset),
+                brokerTopicStats, metrics, endPoint,
+                topicPartition -> OptionalLong.empty(),
+                topicPartition -> false) { // not consolidating -> keep upstream local-log-start floor
+            @Override
+            public RemoteStorageManager createRemoteStorageManager() {
+                return remoteStorageManager;
+            }
+            @Override
+            public RemoteLogMetadataManager createRemoteLogMetadataManager() {
+                return remoteLogMetadataManager;
+            }
+            @Override
+            long findLogStartOffset(TopicIdPartition topicIdPartition, UnifiedLog log) {
+                return 0L; // must be ignored on the non-consolidating path
+            }
+        }) {
+            doReturn(true).when(remoteLogMetadataManager).isReady(any(TopicIdPartition.class));
+            RemoteLogManager.RLMExpirationTask task = rlmClassic.new RLMExpirationTask(leaderTopicIdPartition);
+            task.cleanupExpiredRemoteLogSegments();
+        }
+
+        // Both segments breach the local log start (200) and are reclaimed -- upstream behavior preserved.
+        verify(remoteStorageManager).deleteLogSegmentData(metadataList.get(0));
+        verify(remoteStorageManager).deleteLogSegmentData(metadataList.get(1));
+    }
+
+    @Test
+    public void testConsolidatingOverrideFloorHonoredWithActiveSizeRetention()
+            throws RemoteStorageException, ExecutionException, InterruptedException, IOException {
+        // Inkless (retention x DeleteRecords composition, size): an active retention.bytes breach in the
+        // SAME cleanup cycle must not drag the log-start reclaim floor to the broker-local seal. Three 1 KiB
+        // remote segments [0,99],[100,199],[200,299] plus 512 B local (total 3584). The consolidating
+        // override sets the log-start floor at X = 100 (NOT the seal at 300). retention.bytes = 2560 leaves
+        // one segment's worth (1024 B) of size budget, so:
+        //   - [0,99]   is reclaimed by the log-start floor (endOffset 99 < 100),
+        //   - [100,199] is reclaimed by the ACTIVE size breach (legitimate: over the byte budget), and
+        //   - [200,299] SURVIVES -- retention is satisfied and it is at/above the override floor.
+        // The seal (300) would additionally reclaim [200,299]; asserting it survives proves the override
+        // floor, not the seal, governs the log-start reclaim even with retention actively deleting.
+        int segmentSize = 1024;
+        long localLogSegmentsSize = 512L;
+        // total = 3*1024 + 512 = 3584; leave ~1 segment (1024) of size budget so exactly [100,199] breaches.
+        long retentionSize = 2560L;
+        Map<String, Long> logProps = new HashMap<>();
+        logProps.put("retention.bytes", retentionSize);
+        logProps.put("retention.ms", -1L);
+        LogConfig mockLogConfig = new LogConfig(logProps);
+        when(mockLog.config()).thenReturn(mockLogConfig);
+
+        List<EpochEntry> epochEntries = List.of(epochEntry0);
+        checkpoint.write(epochEntries);
+        LeaderEpochFileCache cache = new LeaderEpochFileCache(tp, checkpoint, scheduler);
+        when(mockLog.leaderEpochCache()).thenReturn(cache);
+        when(mockLog.topicPartition()).thenReturn(leaderTopicIdPartition.topicPartition());
+        when(mockLog.logEndOffset()).thenReturn(300L);
+        when(mockLog.logStartOffset()).thenReturn(300L);        // seal trap: would delete ALL if used
+        when(mockLog.localLogStartOffset()).thenReturn(300L);
+        when(mockLog.onlyLocalLogSegmentsSize()).thenReturn(localLogSegmentsSize);
+
+        List<RemoteLogSegmentMetadata> metadataList =
+                listRemoteLogSegmentMetadata(leaderTopicIdPartition, 3, 100, segmentSize, epochEntries, RemoteLogSegmentState.COPY_SEGMENT_FINISHED);
+        when(remoteLogMetadataManager.listRemoteLogSegments(leaderTopicIdPartition))
+                .thenAnswer(ans -> metadataList.iterator());
+        when(remoteLogMetadataManager.listRemoteLogSegments(leaderTopicIdPartition, 0))
+                .thenAnswer(ans -> metadataList.iterator());
+        when(remoteLogMetadataManager.updateRemoteLogSegmentMetadata(any(RemoteLogSegmentMetadataUpdate.class)))
+                .thenReturn(CompletableFuture.runAsync(() -> { }));
+        doNothing().when(remoteStorageManager).deleteLogSegmentData(any(RemoteLogSegmentMetadata.class));
+
+        try (RemoteLogManager rlmWithOverride = new RemoteLogManager(config, brokerId, logDir, clusterId, time,
+                tp -> Optional.of(mockLog),
+                (topicPartition, offset) -> currentLogStartOffset.set(offset),
+                brokerTopicStats, metrics, endPoint,
+                topicPartition -> OptionalLong.of(100L),
+                topicPartition -> true) {
+            @Override
+            public RemoteStorageManager createRemoteStorageManager() {
+                return remoteStorageManager;
+            }
+            @Override
+            public RemoteLogMetadataManager createRemoteLogMetadataManager() {
+                return remoteLogMetadataManager;
+            }
+            @Override
+            long findLogStartOffset(TopicIdPartition topicIdPartition, UnifiedLog log) {
+                return 0L;
+            }
+        }) {
+            doReturn(true).when(remoteLogMetadataManager).isReady(any(TopicIdPartition.class));
+            RemoteLogManager.RLMExpirationTask task = rlmWithOverride.new RLMExpirationTask(leaderTopicIdPartition);
+            task.cleanupExpiredRemoteLogSegments();
+        }
+
+        // Log-start floor (100) reclaimed [0,99]; the active size breach reclaimed [100,199]; the override
+        // floor (not the seal at 300) kept [200,299].
+        verify(remoteStorageManager).deleteLogSegmentData(metadataList.get(0));
+        verify(remoteStorageManager).deleteLogSegmentData(metadataList.get(1));
+        verify(remoteStorageManager, never()).deleteLogSegmentData(metadataList.get(2));
+    }
+
+    @Test
+    public void testConsolidatingOverrideFloorHonoredWithActiveTimeRetention()
+            throws RemoteStorageException, ExecutionException, InterruptedException, IOException {
+        // Inkless (retention x DeleteRecords composition, time): same guarantee as the size variant but the
+        // active breach is retention.ms. Only the oldest of the two segments is aged past retention.ms=1;
+        // the override X = 100 governs the log-start floor (not the seal at 200). [0,99] is deleted (time-
+        // and log-start-breached) and [100,199] survives -- the active time breach does not revert the
+        // floor to the seal.
+        int segmentSize = 1024;
+        long localLogSegmentsSize = 512L;
+        Map<String, Long> logProps = new HashMap<>();
+        logProps.put("retention.bytes", -1L);
+        logProps.put("retention.ms", 1L);
+        LogConfig mockLogConfig = new LogConfig(logProps);
+        when(mockLog.config()).thenReturn(mockLogConfig);
+
+        List<EpochEntry> epochEntries = List.of(epochEntry0);
+        checkpoint.write(epochEntries);
+        LeaderEpochFileCache cache = new LeaderEpochFileCache(tp, checkpoint, scheduler);
+        when(mockLog.leaderEpochCache()).thenReturn(cache);
+        when(mockLog.topicPartition()).thenReturn(leaderTopicIdPartition.topicPartition());
+        when(mockLog.logEndOffset()).thenReturn(200L);
+        when(mockLog.logStartOffset()).thenReturn(200L);        // seal trap
+        when(mockLog.localLogStartOffset()).thenReturn(200L);
+        when(mockLog.onlyLocalLogSegmentsSize()).thenReturn(localLogSegmentsSize);
+
+        // deletableSegmentCount=1 ages only the oldest segment past retention.ms.
+        List<RemoteLogSegmentMetadata> metadataList = listRemoteLogSegmentMetadataByTime(
+                leaderTopicIdPartition, 2, 1, 100, segmentSize, epochEntries, RemoteLogSegmentState.COPY_SEGMENT_FINISHED);
+        when(remoteLogMetadataManager.listRemoteLogSegments(leaderTopicIdPartition))
+                .thenAnswer(ans -> metadataList.iterator());
+        when(remoteLogMetadataManager.listRemoteLogSegments(leaderTopicIdPartition, 0))
+                .thenAnswer(ans -> metadataList.iterator());
+        when(remoteLogMetadataManager.updateRemoteLogSegmentMetadata(any(RemoteLogSegmentMetadataUpdate.class)))
+                .thenReturn(CompletableFuture.runAsync(() -> { }));
+        doNothing().when(remoteStorageManager).deleteLogSegmentData(any(RemoteLogSegmentMetadata.class));
+
+        try (RemoteLogManager rlmWithOverride = new RemoteLogManager(config, brokerId, logDir, clusterId, time,
+                tp -> Optional.of(mockLog),
+                (topicPartition, offset) -> currentLogStartOffset.set(offset),
+                brokerTopicStats, metrics, endPoint,
+                topicPartition -> OptionalLong.of(100L),
+                topicPartition -> true) {
+            @Override
+            public RemoteStorageManager createRemoteStorageManager() {
+                return remoteStorageManager;
+            }
+            @Override
+            public RemoteLogMetadataManager createRemoteLogMetadataManager() {
+                return remoteLogMetadataManager;
+            }
+            @Override
+            long findLogStartOffset(TopicIdPartition topicIdPartition, UnifiedLog log) {
+                return 0L;
+            }
+        }) {
+            doReturn(true).when(remoteLogMetadataManager).isReady(any(TopicIdPartition.class));
+            RemoteLogManager.RLMExpirationTask task = rlmWithOverride.new RLMExpirationTask(leaderTopicIdPartition);
+            task.cleanupExpiredRemoteLogSegments();
+        }
+
+        verify(remoteStorageManager).deleteLogSegmentData(metadataList.get(0));
+        verify(remoteStorageManager, never()).deleteLogSegmentData(metadataList.get(1));
+    }
+
+    @Test
+    public void testConsolidatingMidSegmentOverrideKeepsStraddlingSegment()
+            throws RemoteStorageException, ExecutionException, InterruptedException, IOException {
+        // Inkless (mid-segment delete_before): when the cross-tier earliest X lands INSIDE a segment, only
+        // whole segments strictly below X are physically reclaimed; the segment that straddles X is kept
+        // because its tail [X, segEnd] is still live. X = 150 with segments [0,99] and [100,199]: [0,99]
+        // (endOffset 99 < 150) is reclaimed, but [100,199] (which contains 150) is NOT over-reclaimed.
+        // The advertised earliest still advances to 150 -- served correctness is a broker/log concern
+        // exercised elsewhere; here we pin that the boundary segment is not physically deleted.
+        Map<String, Long> logProps = new HashMap<>();
+        logProps.put("retention.bytes", -1L);
+        logProps.put("retention.ms", -1L);
+        LogConfig mockLogConfig = new LogConfig(logProps);
+        when(mockLog.config()).thenReturn(mockLogConfig);
+
+        List<EpochEntry> epochEntries = List.of(epochEntry0);
+        checkpoint.write(epochEntries);
+        LeaderEpochFileCache cache = new LeaderEpochFileCache(tp, checkpoint, scheduler);
+        when(mockLog.leaderEpochCache()).thenReturn(cache);
+        when(mockLog.topicPartition()).thenReturn(leaderTopicIdPartition.topicPartition());
+        when(mockLog.logEndOffset()).thenReturn(200L);
+        when(mockLog.logStartOffset()).thenReturn(200L);
+
+        List<RemoteLogSegmentMetadata> metadataList =
+                listRemoteLogSegmentMetadata(leaderTopicIdPartition, 2, 100, 1024, epochEntries, RemoteLogSegmentState.COPY_SEGMENT_FINISHED);
+        when(remoteLogMetadataManager.listRemoteLogSegments(leaderTopicIdPartition))
+                .thenAnswer(ans -> metadataList.iterator());
+        when(remoteLogMetadataManager.listRemoteLogSegments(leaderTopicIdPartition, 0))
+                .thenAnswer(ans -> metadataList.iterator());
+        when(remoteLogMetadataManager.updateRemoteLogSegmentMetadata(any(RemoteLogSegmentMetadataUpdate.class)))
+                .thenReturn(CompletableFuture.runAsync(() -> { }));
+        doNothing().when(remoteStorageManager).deleteLogSegmentData(any(RemoteLogSegmentMetadata.class));
+
+        try (RemoteLogManager rlmWithOverride = new RemoteLogManager(config, brokerId, logDir, clusterId, time,
+                tp -> Optional.of(mockLog),
+                (topicPartition, offset) -> currentLogStartOffset.set(offset),
+                brokerTopicStats, metrics, endPoint,
+                topicPartition -> OptionalLong.of(150L),   // lands inside the second segment [100,199]
+                topicPartition -> true) {
+            @Override
+            public RemoteStorageManager createRemoteStorageManager() {
+                return remoteStorageManager;
+            }
+            @Override
+            public RemoteLogMetadataManager createRemoteLogMetadataManager() {
+                return remoteLogMetadataManager;
+            }
+            @Override
+            long findLogStartOffset(TopicIdPartition topicIdPartition, UnifiedLog log) {
+                return 0L;
+            }
+        }) {
+            doReturn(true).when(remoteLogMetadataManager).isReady(any(TopicIdPartition.class));
+            RemoteLogManager.RLMExpirationTask task = rlmWithOverride.new RLMExpirationTask(leaderTopicIdPartition);
+            task.cleanupExpiredRemoteLogSegments();
+        }
+
+        // Only the whole segment strictly below X is reclaimed; the segment straddling X survives.
+        verify(remoteStorageManager).deleteLogSegmentData(metadataList.get(0));
+        verify(remoteStorageManager, never()).deleteLogSegmentData(metadataList.get(1));
+    }
+
+    @Test
+    public void testConsolidatingReclaimFloorStableAcrossRepeatedLeaderCycles()
+            throws RemoteStorageException, ExecutionException, InterruptedException, IOException {
+        // Inkless (rapid/repeated failover): a consolidating partition can be rebuilt-as-leader and run the
+        // RLM expiration task repeatedly. Each cycle must recompute the floor from the override X (=100),
+        // never accumulating toward the seal (200), so the survivor [100,199] is not over-reclaimed no
+        // matter how many cleanup cycles run. Runs the task twice (two "become leader" cycles) and asserts
+        // the survivor is never touched across both.
+        Map<String, Long> logProps = new HashMap<>();
+        logProps.put("retention.bytes", -1L);
+        logProps.put("retention.ms", -1L);
+        LogConfig mockLogConfig = new LogConfig(logProps);
+        when(mockLog.config()).thenReturn(mockLogConfig);
+
+        List<EpochEntry> epochEntries = List.of(epochEntry0);
+        checkpoint.write(epochEntries);
+        LeaderEpochFileCache cache = new LeaderEpochFileCache(tp, checkpoint, scheduler);
+        when(mockLog.leaderEpochCache()).thenReturn(cache);
+        when(mockLog.topicPartition()).thenReturn(leaderTopicIdPartition.topicPartition());
+        when(mockLog.logEndOffset()).thenReturn(200L);
+        when(mockLog.logStartOffset()).thenReturn(200L); // seal trap on every rebuilt-leader cycle
+
+        List<RemoteLogSegmentMetadata> metadataList =
+                listRemoteLogSegmentMetadata(leaderTopicIdPartition, 2, 100, 1024, epochEntries, RemoteLogSegmentState.COPY_SEGMENT_FINISHED);
+        when(remoteLogMetadataManager.listRemoteLogSegments(leaderTopicIdPartition))
+                .thenAnswer(ans -> metadataList.iterator());
+        when(remoteLogMetadataManager.listRemoteLogSegments(leaderTopicIdPartition, 0))
+                .thenAnswer(ans -> metadataList.iterator());
+        when(remoteLogMetadataManager.updateRemoteLogSegmentMetadata(any(RemoteLogSegmentMetadataUpdate.class)))
+                .thenReturn(CompletableFuture.runAsync(() -> { }));
+        doNothing().when(remoteStorageManager).deleteLogSegmentData(any(RemoteLogSegmentMetadata.class));
+
+        try (RemoteLogManager rlmWithOverride = new RemoteLogManager(config, brokerId, logDir, clusterId, time,
+                tp -> Optional.of(mockLog),
+                (topicPartition, offset) -> currentLogStartOffset.set(offset),
+                brokerTopicStats, metrics, endPoint,
+                topicPartition -> OptionalLong.of(100L),
+                topicPartition -> true) {
+            @Override
+            public RemoteStorageManager createRemoteStorageManager() {
+                return remoteStorageManager;
+            }
+            @Override
+            public RemoteLogMetadataManager createRemoteLogMetadataManager() {
+                return remoteLogMetadataManager;
+            }
+            @Override
+            long findLogStartOffset(TopicIdPartition topicIdPartition, UnifiedLog log) {
+                return 0L;
+            }
+        }) {
+            doReturn(true).when(remoteLogMetadataManager).isReady(any(TopicIdPartition.class));
+            // Two consecutive become-leader / cleanup cycles.
+            rlmWithOverride.new RLMExpirationTask(leaderTopicIdPartition).cleanupExpiredRemoteLogSegments();
+            rlmWithOverride.new RLMExpirationTask(leaderTopicIdPartition).cleanupExpiredRemoteLogSegments();
+        }
+
+        // The survivor above the override floor is never reclaimed, no matter how many cycles run.
+        verify(remoteStorageManager, never()).deleteLogSegmentData(metadataList.get(1));
+        // The below-floor segment is reclaimed on each cycle (a mock artifact: in reality it is marked
+        // deleted after the first pass); the point is that it IS reclaimed and the survivor is not.
+        verify(remoteStorageManager, atLeastOnce()).deleteLogSegmentData(metadataList.get(0));
     }
 
     @ParameterizedTest(name = "testRemoteDeleteLagsOnRetentionBreachedSegments retentionSize={0} retentionMs={1}")

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogManagerTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogManagerTest.java
@@ -2742,6 +2742,191 @@ public class RemoteLogManagerTest {
     }
 
     @Test
+    public void testConsolidatingBecomeLeaderReportsRemoteEarliestWhenOverrideAbsent()
+            throws RemoteStorageException, IOException, InterruptedException {
+        // Become-leader report, over-reclaim + bootstrap hardening: when the cross-tier remote start
+        // override is empty for a CONSOLIDATING partition (reporter has not landed a value yet, control
+        // plane unreachable, or metadata not propagated), the report must resolve to the remote earliest
+        // (findLogStartOffset -> 0), never the broker-local seal (200) and never be skipped. Skipping it
+        // would leave remote_log_start_offset unset, so ListOffsets(EARLIEST) COALESCEs to the pruned WAL
+        // frontier and hides the still-live remote prefix; reporting the seal would push the broker-agnostic
+        // earliest up to the seal.
+        when(mockLog.topicPartition()).thenReturn(leaderTopicIdPartition.topicPartition());
+        // A rebuilt leader reassigns its leader-epoch cache from the cumulative remote checkpoint, so the
+        // cache carries the full history from offset 0 and findLogStartOffset can resolve the true earliest.
+        checkpoint.write(List.of(epochEntry0));
+        LeaderEpochFileCache cache = new LeaderEpochFileCache(leaderTopicIdPartition.topicPartition(), checkpoint, scheduler);
+        when(mockLog.leaderEpochCache()).thenReturn(cache);
+        when(mockLog.localLogStartOffset()).thenReturn(200L); // seal: the value that must NOT be reported
+
+        List<RemoteLogSegmentMetadata> metadataList =
+                listRemoteLogSegmentMetadata(leaderTopicIdPartition, 1, 100, 1024, List.of(epochEntry0), RemoteLogSegmentState.COPY_SEGMENT_FINISHED);
+        when(remoteLogMetadataManager.listRemoteLogSegments(eq(leaderTopicIdPartition), anyInt()))
+                .thenAnswer(inv -> {
+                    int epoch = inv.getArgument(1);
+                    return epoch == 0 ? metadataList.iterator() : Collections.emptyIterator();
+                });
+
+        AtomicLong reported = new AtomicLong(-1L);
+        try (RemoteLogManager rlm = new RemoteLogManager(config, brokerId, logDir, clusterId, time,
+                tp -> Optional.of(mockLog),
+                (topicPartition, offset) -> reported.set(offset),
+                brokerTopicStats, metrics, endPoint,
+                topicPartition -> OptionalLong.empty(),
+                topicPartition -> true) {
+            @Override
+            public RemoteLogMetadataManager createRemoteLogMetadataManager() {
+                return remoteLogMetadataManager;
+            }
+        }) {
+            RemoteLogManager.RLMCopyTask task = rlm.new RLMCopyTask(leaderTopicIdPartition, 128);
+            task.copyLogSegmentsToRemote(mockLog);
+        }
+
+        // The bootstrap report is the true remote earliest, not the seal.
+        assertEquals(0L, reported.get());
+    }
+
+    @Test
+    public void testConsolidatingBecomeLeaderReportsOverrideAndNeverSeal()
+            throws RemoteStorageException, IOException, InterruptedException {
+        // When the cross-tier remote start override IS present it is authoritative: the become-leader report
+        // uses it verbatim (100), never the broker-local seal (200) and never findLogStartOffset. The stubbed
+        // findLogStartOffset returns a trap value that must never surface.
+        when(mockLog.topicPartition()).thenReturn(leaderTopicIdPartition.topicPartition());
+        checkpoint.write(List.of(epochEntry0));
+        LeaderEpochFileCache cache = new LeaderEpochFileCache(leaderTopicIdPartition.topicPartition(), checkpoint, scheduler);
+        when(mockLog.leaderEpochCache()).thenReturn(cache);
+        when(mockLog.localLogStartOffset()).thenReturn(200L); // seal trap
+
+        AtomicLong reported = new AtomicLong(-1L);
+        try (RemoteLogManager rlm = new RemoteLogManager(config, brokerId, logDir, clusterId, time,
+                tp -> Optional.of(mockLog),
+                (topicPartition, offset) -> reported.set(offset),
+                brokerTopicStats, metrics, endPoint,
+                topicPartition -> OptionalLong.of(100L),
+                topicPartition -> true) {
+            @Override
+            public RemoteLogMetadataManager createRemoteLogMetadataManager() {
+                return remoteLogMetadataManager;
+            }
+            @Override
+            long findLogStartOffset(TopicIdPartition topicIdPartition, UnifiedLog log) {
+                return 500L; // trap: a present override must win, so this is never consulted
+            }
+        }) {
+            RemoteLogManager.RLMCopyTask task = rlm.new RLMCopyTask(leaderTopicIdPartition, 128);
+            task.copyLogSegmentsToRemote(mockLog);
+        }
+
+        assertEquals(100L, reported.get());
+    }
+
+    @Test
+    public void testFindLogStartOffsetReturnsRemoteEarliestDespiteSealPinnedLocalStart()
+            throws RemoteStorageException, IOException {
+        // On a rebuilt consolidating leader the local start is pinned at the classic-to-diskless seal (200),
+        // but the leader-epoch cache is reassigned from the cumulative remote checkpoint and so carries the
+        // full epoch history from offset 0. findLogStartOffset must walk that history and return the true
+        // remote earliest (0), NOT the seal-pinned localLogStartOffset. This is the invariant the reclaim
+        // floor and the become-leader report rely on when the override is empty; it is also why a
+        // defer-to-0 fail-safe was unnecessary.
+        checkpoint.write(List.of(epochEntry0));
+        LeaderEpochFileCache cache = new LeaderEpochFileCache(leaderTopicIdPartition.topicPartition(), checkpoint, scheduler);
+        when(mockLog.leaderEpochCache()).thenReturn(cache);
+        when(mockLog.localLogStartOffset()).thenReturn(200L); // seal: ignored while remote segments exist
+
+        List<RemoteLogSegmentMetadata> metadataList =
+                listRemoteLogSegmentMetadata(leaderTopicIdPartition, 2, 100, 1024, List.of(epochEntry0), RemoteLogSegmentState.COPY_SEGMENT_FINISHED);
+        when(remoteLogMetadataManager.listRemoteLogSegments(eq(leaderTopicIdPartition), anyInt()))
+                .thenAnswer(inv -> {
+                    int epoch = inv.getArgument(1);
+                    return epoch == 0 ? metadataList.iterator() : Collections.emptyIterator();
+                });
+
+        try (RemoteLogManager rlm = new RemoteLogManager(config, brokerId, logDir, clusterId, time,
+                tp -> Optional.of(mockLog),
+                (topicPartition, offset) -> { },
+                brokerTopicStats, metrics, endPoint) {
+            @Override
+            public RemoteLogMetadataManager createRemoteLogMetadataManager() {
+                return remoteLogMetadataManager;
+            }
+        }) {
+            assertEquals(0L, rlm.findLogStartOffset(leaderTopicIdPartition, mockLog));
+        }
+    }
+
+    @Test
+    public void testConsolidatingBootstrapReportsRemoteEarliestAndDoesNotOverReclaimWhenOverrideAbsent()
+            throws RemoteStorageException, ExecutionException, InterruptedException, IOException {
+        // End-to-end unit guard for a consolidating partition whose cross-tier remote start override is
+        // empty (reporter stuck or not yet propagated) and whose local start is pinned at the seal (200).
+        // On the same leader both halves must hold together:
+        //   1) become-leader reports the remote earliest (0), never the seal and never nothing, so
+        //      remote_log_start_offset heals to 0 instead of leaving EARLIEST to COALESCE to the WAL frontier;
+        //   2) with retention disabled the reclaim floor is that same remote earliest (0), so no remote
+        //      segment is deleted and the classic prefix survives.
+        Map<String, Long> logProps = new HashMap<>();
+        logProps.put("retention.bytes", -1L);
+        logProps.put("retention.ms", -1L);
+        LogConfig mockLogConfig = new LogConfig(logProps);
+        when(mockLog.config()).thenReturn(mockLogConfig);
+
+        checkpoint.write(List.of(epochEntry0));
+        LeaderEpochFileCache cache = new LeaderEpochFileCache(leaderTopicIdPartition.topicPartition(), checkpoint, scheduler);
+        when(mockLog.leaderEpochCache()).thenReturn(cache);
+        when(mockLog.topicPartition()).thenReturn(leaderTopicIdPartition.topicPartition());
+        when(mockLog.logEndOffset()).thenReturn(200L);
+        when(mockLog.logStartOffset()).thenReturn(200L);      // seal: reclaim-floor trap
+        when(mockLog.localLogStartOffset()).thenReturn(200L); // seal: findLogStartOffset fallback trap
+
+        List<RemoteLogSegmentMetadata> metadataList =
+                listRemoteLogSegmentMetadata(leaderTopicIdPartition, 2, 100, 1024, List.of(epochEntry0), RemoteLogSegmentState.COPY_SEGMENT_FINISHED);
+        when(remoteLogMetadataManager.listRemoteLogSegments(leaderTopicIdPartition))
+                .thenAnswer(ans -> metadataList.iterator());
+        when(remoteLogMetadataManager.listRemoteLogSegments(eq(leaderTopicIdPartition), anyInt()))
+                .thenAnswer(inv -> {
+                    int epoch = inv.getArgument(1);
+                    return epoch == 0 ? metadataList.iterator() : Collections.emptyIterator();
+                });
+        when(remoteLogMetadataManager.updateRemoteLogSegmentMetadata(any(RemoteLogSegmentMetadataUpdate.class)))
+                .thenReturn(CompletableFuture.runAsync(() -> { }));
+        doNothing().when(remoteStorageManager).deleteLogSegmentData(any(RemoteLogSegmentMetadata.class));
+
+        AtomicLong reported = new AtomicLong(-1L);
+        try (RemoteLogManager rlm = new RemoteLogManager(config, brokerId, logDir, clusterId, time,
+                tp -> Optional.of(mockLog),
+                (topicPartition, offset) -> reported.set(offset),
+                brokerTopicStats, metrics, endPoint,
+                topicPartition -> OptionalLong.empty(),
+                topicPartition -> true) {
+            @Override
+            public RemoteStorageManager createRemoteStorageManager() {
+                return remoteStorageManager;
+            }
+            @Override
+            public RemoteLogMetadataManager createRemoteLogMetadataManager() {
+                return remoteLogMetadataManager;
+            }
+        }) {
+            doReturn(true).when(remoteLogMetadataManager).isReady(any(TopicIdPartition.class));
+
+            RemoteLogManager.RLMCopyTask copyTask = rlm.new RLMCopyTask(leaderTopicIdPartition, 128);
+            copyTask.copyLogSegmentsToRemote(mockLog);
+            // The born-consolidated bootstrap reports the true remote earliest, not the seal and not nothing.
+            assertEquals(0L, reported.get());
+
+            RemoteLogManager.RLMExpirationTask expirationTask = rlm.new RLMExpirationTask(leaderTopicIdPartition);
+            expirationTask.cleanupExpiredRemoteLogSegments();
+        }
+
+        // Reclaim floor is the remote earliest (0), so the classic prefix is preserved, not over-reclaimed.
+        verify(remoteStorageManager, never()).deleteLogSegmentData(metadataList.get(0));
+        verify(remoteStorageManager, never()).deleteLogSegmentData(metadataList.get(1));
+    }
+
+    @Test
     public void testConsolidatingOverrideFloorHonoredWithActiveSizeRetention()
             throws RemoteStorageException, ExecutionException, InterruptedException, IOException {
         // Inkless (retention x DeleteRecords composition, size): an active retention.bytes breach in the

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogManagerTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogManagerTest.java
@@ -2619,14 +2619,14 @@ public class RemoteLogManagerTest {
     @Test
     public void testConsolidatingReclaimFailsSafeWhenOverrideAbsent()
             throws RemoteStorageException, ExecutionException, InterruptedException, IOException {
-        // Fail-safe (over-reclaim hardening): when the log-start-offset override yields empty for a
-        // CONSOLIDATING partition (control-plane outage or not-yet-propagated metadata on the RLM leader)
-        // the reclaim floor must NOT fall back to the broker-local log start -- on a freshly-rebuilt
-        // consolidating leader that is the seal (200) and would irreversibly delete the entire remote
-        // classic prefix. Instead it uses the remote earliest (findLogStartOffset -> 0), so no segment
-        // breaches the log-start-offset and NOTHING is reclaimed this cycle. Retention is disabled here,
-        // so both segments [0,99] and [100,199] survive; log-start reclaim retries once the control plane
-        // recovers.
+        // Fail-safe against over-reclaim: when the log-start override is empty for a CONSOLIDATING
+        // partition (control-plane outage, or metadata not yet propagated to the RLM leader) the reclaim
+        // floor must not fall back to the broker-local log start. On a freshly-rebuilt consolidating leader
+        // that start is the seal (200), which would irreversibly delete the whole remote classic prefix. It
+        // uses findLogStartOffset (-> 0) instead: the true cross-tier earliest, read back from the
+        // cumulative remote epoch cache. No segment breaches that floor, so nothing is over-reclaimed.
+        // Retention is off here, so both segments [0,99] and [100,199] survive; the floor advances to the
+        // override once it resolves.
         Map<String, Long> logProps = new HashMap<>();
         logProps.put("retention.bytes", -1L);
         logProps.put("retention.ms", -1L);

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogManagerTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogManagerTest.java
@@ -2619,7 +2619,7 @@ public class RemoteLogManagerTest {
     @Test
     public void testConsolidatingReclaimFailsSafeWhenOverrideAbsent()
             throws RemoteStorageException, ExecutionException, InterruptedException, IOException {
-        // Fail-safe (Problem B hardening): when the log-start-offset override yields empty for a
+        // Fail-safe (over-reclaim hardening): when the log-start-offset override yields empty for a
         // CONSOLIDATING partition (control-plane outage or not-yet-propagated metadata on the RLM leader)
         // the reclaim floor must NOT fall back to the broker-local log start -- on a freshly-rebuilt
         // consolidating leader that is the seal (200) and would irreversibly delete the entire remote


### PR DESCRIPTION
## Summary

Builds on the two merged consolidation fixes (#709 ListOffsets(EARLIEST) routing and #710 DeleteRecords forwarding). Those made the control plane the authoritative cross-tier earliest for reads and the DeleteRecords write path. This PR carries that same authority into remote-retention reclaim and the become-leader log-start report, so
a consolidating topic never deletes remote data that is still within the delete/retention boundary, and never reports a stale earliest.

## Background
After a classic topic switches to diskless, the classic prefix `[0, seal)` lives only in the remote tier. A broker that rebuilds the partition resumes its local log at the seal, so the whole-log `UnifiedLog.logStartOffset` is pinned at the seal by the tier-state rebuild and only ever increments. Two things then read that stale seal instead of the
true cross-tier earliest `X` that DeleteRecords/retention left in the control plane:
- the RemoteLogManager reclaim floor deleted the whole remote prefix `[X, seal)` and reported the seal as the earliest on becoming leader;
- a fetch in `[X, seal)` was rejected as out of range and the rebuild restarted at the seal. The reclaim leg is irreversible, so this is a data-loss path, not just a stale read.

## What changed
- **Whole-log start for the consolidation fetch/rebuild** (`DisklessLeaderEndPoint`): a consolidating partition now advertises `min(crossTierEarliest, localLog.logStartOffset)` as the whole-log start instead of the raw local seal, so a fetch in `[X, seal)` rebuilds from the remote tier and the rebuild restarts the log at `X`.
- **Reclaim floor and become-leader report** (`RemoteLogManager`, wired in `BrokerServer`): both now consult a control-plane override for consolidating partitions. On an empty override they fail safe to the remote earliest (`findLogStartOffset`), never the seal; classic/non-inkless topics keep the upstream broker-local behavior.
- **Raw remote-log-start accessor** (`ReplicaManager.crossTierRemoteLogStartOffset` + new `ControlPlane.getCrossTierLogStart`): the reclaim floor reads the raw `remote_log_start_offset`, null-aware, rather than `ListOffsets(EARLIEST)`. `EARLIEST` returns `COALESCE(remote_log_start_offset, log_start_offset)`, which falls back to the pruned WAL frontier when the remote start is unreported. Using that as the floor would delete still-live remote segments and lock the wrong value in through the forward-only advance. Returning empty here makes the RLM fail safe to the true remote earliest instead. `crossTierEarliestOffset` keeps the COALESCE fallback for reads, where the worst case is a transient, self-healing over-rejection.
- **New control-plane query and metric**: `GetCrossTierLogStartJob` (in-memory + Postgres) reads the raw column directly, with a `GetCrossTierLogStart` timer in `PostgresControlPlaneMetrics` and a `metrics.rst` entry.
- **Error handling**: the cross-tier accessors catch `Exception` rather than `Throwable`, so `Error`s propagate instead of silently failing open.

## Testing
- `RemoteLogManagerTest`: reclaim floor honored over the seal; fail-safe on empty override for consolidating vs. upstream behavior for classic; retention x DeleteRecords composition; and hardening tests proving the become-leader report resolves to the remote earliest (never the seal, never skipped), that `findLogStartOffset` returns the remote earliest despite a seal-pinned local start, and a combined bootstrap-plus-reclaim guard.
- `ReplicaManagerInklessTest` / `DisklessLeaderEndPointTest`: the accessors, the consolidating predicate, and the whole-log-start `min()` behavior.
- `AbstractControlPlaneTest`: `getCrossTierLogStart` is null-aware (returns empty for an unreported remote start) unlike `EARLIEST`.
- End-to-end coverage lives on the stacked e2e branch (`DeleteRecordsAcrossTiersTest`), which asserts the earliest settles at exactly the delete boundary on every broker with retention unset.

## Compatibility / risk
No behavior change for classic or non-inkless partitions: the override defaults to empty and the predicate to false, so the reclaim floor stays the broker-local log start. The control-plane advance is forward-only, and a stale cross-tier cache entry can only be too low, which under-reclaims and over-serves rather than losing data.
