### PR TITLE
feat(inkless:release): add changelog generator and backfill 0.33..0.46

### DIFF
--- a/.ai-agents/skills/inkless-changelog/SKILL.md
+++ b/.ai-agents/skills/inkless-changelog/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: inkless-changelog
+description: Generate or update the Inkless changelog and GitHub release notes for an Inkless release increment. Diffs conventional-commit history and the auto-generated configs.rst/metrics.rst between two inkless-release tags, categorizes changes, and produces a detailed changelog entry plus a curated release-notes summary. Use when cutting an Inkless release, refreshing docs/inkless/CHANGELOG.md, or preparing GitHub release notes for an inkless-release-<N> tag.
+---
+
+# Inkless Changelog & Release Notes
+
+Produce two artifacts for an Inkless increment (`inkless-release-<N-1>` -> `inkless-release-<N>`):
+
+1. A **detailed changelog entry** added to `docs/inkless/CHANGELOG.md` (newest first; see the placement step below).
+2. A **curated release-notes summary** for the GitHub Release of `inkless-release-<N>`.
+
+Both derive from the same sources; the summary is a filtered subset of the detailed entry.
+
+## Sources and their reliability
+
+| Source | Command | Reliability |
+| --- | --- | --- |
+| Commits | `git log --first-parent --no-merges` between the two tags | High. `--first-parent` excludes upstream commits dragged in by `apache/kafka` merge commits, leaving inkless PR squash-merges. |
+| Config changes | diff of `docs/inkless/configs.rst` between tags | High. Config keys are stable. |
+| Metric changes | diff of `docs/inkless/metrics.rst` between tags | Low. `metrics.rst` is produced by a hand-maintained registry list in `MetricsDocs.main()`, so a delta may be documentation catch-up, not a shipped metric (e.g. the 3->16 mbean jump at 0.39). ALWAYS curate. |
+| Upstream sync | `apache/kafka` merge commits in range + `gradle.properties` version delta | High. Emitted as a blockquote note under the heading when `main`'s Kafka base moves (e.g. 4.1.0 -> 4.2.0-SNAPSHOT at 0.35). |
+
+## Steps
+
+1. **Locate the repo and tags.** Run from the inkless worktree. Confirm the target tag exists:
+   ```bash
+   git tag | grep '^inkless-release-' | sort -V | tail -5
+   ```
+
+2. **Generate the draft** with the helper (run from repo root):
+   ```bash
+   .ai-agents/skills/inkless-changelog/gen-changelog.py --version <N>
+   ```
+   Options:
+   - `--version <N>` -> uses `inkless-release-<N-1>..inkless-release-<N>`.
+   - `--from <tag> --to <tag>` -> explicit range.
+   - no args -> latest two `inkless-release-*` tags.
+   - `--summary` -> emit only the curated release-notes summary (features + fixes + config changes).
+
+3. **Curate the metrics block.** The draft marks metric deltas with a
+   `<!-- REVIEW metrics ... -->` comment. Cross-check each entry against the
+   feature/fix commits in the same range. Keep metrics that a commit introduced;
+   collapse documentation catch-up into a short note (see the 0.39 entry in
+   `CHANGELOG.md` as the reference pattern). Remove the REVIEW comment before publishing.
+
+4. **Prepend the entry** to `docs/inkless/CHANGELOG.md` directly under the
+   `---` separator (newest first). Keep the Kafka-version list in the heading
+   accurate:
+   ```bash
+   git tag | grep -E "^inkless-4\.[0-9]+\.[0-9]+-<N>$"
+   ```
+
+5. **Produce the GitHub release notes** from `--summary` output. Drop
+   `chore`/`test`/`docs`/`refactor`; keep features, fixes, and config/metric
+   changes an operator cares about. Tighten wording; strip PR numbers only if
+   the release UI already links them.
+
+## Constraints
+
+- The only file this skill writes in the repo is `docs/inkless/CHANGELOG.md`.
+  Release notes are handed to the operator / GitHub Release UI, not committed.
+- Do not invent metric or config names; every entry must trace to a commit or a
+  `configs.rst`/`metrics.rst` diff.
+- Never publish raw metric deltas without the curation step.
+
+## Related
+
+- `docs/inkless/RELEASES.md` -- release process; the "Cutting a Release" section references this skill.
+- `docs/inkless/VERSIONING-STRATEGY.md` -- what an increment is.
+- `storage/inkless/src/main/java/io/aiven/inkless/doc/MetricsDocs.java` -- the
+  registry list behind `metrics.rst`; incomplete coverage here is the root cause
+  of noisy metric deltas.

--- a/.ai-agents/skills/inkless-changelog/gen-changelog.py
+++ b/.ai-agents/skills/inkless-changelog/gen-changelog.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+"""Generate an Inkless changelog draft between two inkless-release tags.
+
+Sources, in order of reliability:
+  1. Conventional-commit log (backbone) -- categorized by type/scope.
+  2. configs.rst delta                  -- RELIABLE (config keys are stable).
+  3. metrics.rst delta                  -- NOISY, marked REVIEW (see caveat below).
+
+Caveat on metrics: docs/inkless/metrics.rst is produced by MetricsDocs.main(),
+a hand-maintained list of metric registries. When a registry is added to that
+list, its metrics appear as "added" in the diff even though the code shipped
+earlier (e.g. the 3->16 mbean jump at 0.39 was backfilled tooling, not 13 new
+metrics). Always curate the metrics block before publishing.
+
+Usage:
+  gen-changelog.py                     # latest two inkless-release tags
+  gen-changelog.py --version 0.44      # 0.43 -> 0.44
+  gen-changelog.py --from inkless-release-0.43 --to inkless-release-0.44
+"""
+import argparse
+import re
+import subprocess
+import sys
+
+TYPE_LABELS = [
+    ("feat", "Features"),
+    ("fix", "Fixes"),
+    ("refactor", "Refactors"),
+    ("test", "Tests"),
+    ("docs", "Docs"),
+    ("chore", "Chores"),
+]
+# Types surfaced in the curated GH-release-notes summary (feat/fix only).
+SUMMARY_TYPES = {"feat", "fix"}
+
+
+def git(*args):
+    r = subprocess.run(["git", *args], capture_output=True, text=True)
+    if r.returncode != 0:
+        if r.stderr.strip():
+            print(f"warning: git {' '.join(args)}: {r.stderr.strip()}", file=sys.stderr)
+        return None
+    return r.stdout
+
+
+def release_tags():
+    out = git("tag") or ""
+    tags = [t for t in out.split() if re.match(r"^inkless-release-0\.\d+$", t)]
+    return sorted(tags, key=lambda t: int(t.rsplit(".", 1)[-1]))
+
+
+def kafka_base_tags(version):
+    out = git("tag") or ""
+    tags = [t for t in out.split()
+            if re.match(rf"^inkless-4\.\d+\.\d+-{re.escape(version)}$", t)]
+    # extract the kafka version portion "4.1.2"
+    return sorted({t[len("inkless-"):-(len(version) + 1)] for t in tags})
+
+
+def show(tag, path):
+    return git("show", f"{tag}:{path}")
+
+
+def gradle_version(tag):
+    """Return (kafka_base, scala) from gradle.properties at tag.
+
+    The version string is like `4.2.0-inkless-SNAPSHOT`; `-inkless` is stripped so
+    the Kafka base reads `4.2.0-SNAPSHOT`.
+    """
+    text = show(tag, "gradle.properties") or ""
+    ver = scala = None
+    for line in text.splitlines():
+        if line.startswith("version="):
+            ver = line[len("version="):].strip().replace("-inkless", "")
+        elif line.startswith("scalaVersion="):
+            scala = line[len("scalaVersion="):].strip()
+    return ver, scala
+
+
+def upstream_syncs(frm, to):
+    """Merge commits in range that merged apache/kafka trunk (an upstream sync)."""
+    out = git("log", "--merges", "--format=%s", f"{frm}..{to}") or ""
+    return [s.strip() for s in out.splitlines()
+            if re.search(r"apache/kafka|sync/upstream", s) or s.startswith("merge: apache")]
+
+
+def upstream_note(frm, to):
+    """One-line note on upstream syncs / main base version move in the range, or None."""
+    fv, fs = gradle_version(frm)
+    tv, ts = gradle_version(to)
+    synced = bool(upstream_syncs(frm, to))
+    if tv and fv and tv != fv:
+        note = f"Upstream sync: main development base moved to Kafka {tv} (from {fv})"
+        if ts and fs and ts != fs:
+            note += f", Scala {fs} -> {ts}"
+        return note + "."
+    if synced:
+        return "Upstream sync: merged apache/kafka trunk (no base version change)."
+    return None
+
+
+def parse_configs(text):
+    keys, prefix = set(), ""
+    if not text:
+        return keys
+    for line in text.splitlines():
+        m = re.match(r"^Under ``([^`]*)``", line)
+        if m:
+            prefix = m.group(1)
+            continue
+        m = re.match(r"^``([^`]+)``\s*$", line)
+        if m:
+            keys.add(prefix + m.group(1))
+    return keys
+
+
+def parse_metrics(text):
+    mbeans, attrs, cur = set(), set(), None
+    if not text:
+        return mbeans, attrs
+    for line in text.splitlines():
+        m = re.match(r"^(io\.aiven\.inkless[^\s]+)", line)
+        if m:
+            cur = m.group(1)
+            mbeans.add(cur)
+            continue
+        m = re.match(r"^([A-Za-z][a-zA-Z0-9\-\._]+)\s{2,}\S", line)
+        if m and cur:
+            attrs.add(f"{cur} :: {m.group(1)}")
+    return mbeans, attrs
+
+
+def parse_commit(subject):
+    """Return (type, scope, description) for a conventional commit, else None."""
+    m = re.match(r"^(\w+)(?:\(([^)]*)\))?!?:\s*(.+)$", subject)
+    if not m:
+        return None
+    return m.group(1).lower(), (m.group(2) or "").lower(), m.group(3).strip()
+
+
+def collect_commits(frm, to):
+    # --first-parent follows only the mainline of PR squash-merges, excluding the
+    # thousands of individual upstream commits pulled in by apache/kafka merge commits.
+    out = git("log", "--first-parent", "--no-merges", "--format=%s", f"{frm}..{to}") or ""
+    buckets = {t: [] for t, _ in TYPE_LABELS}
+    other = []
+    for line in out.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        parsed = parse_commit(line)
+        if not parsed:
+            continue  # skip Merge/KAFKA-/MINOR upstream noise
+        typ, scope, desc = parsed
+        # keep only inkless-relevant scopes; drop pure sync bookkeeping
+        if scope.startswith("sync") or scope == "sync":
+            continue
+        entry = (scope, desc)
+        if typ in buckets:
+            buckets[typ].append(entry)
+        else:
+            other.append(entry)
+    return buckets, other
+
+
+def fmt_entry(scope, desc):
+    return f"- {'(' + scope + ') ' if scope else ''}{desc}"
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--version")
+    ap.add_argument("--from", dest="frm")
+    ap.add_argument("--to")
+    ap.add_argument("--summary", action="store_true",
+                    help="emit only the curated GH-release-notes summary (feat/fix + config "
+                         "changes; metric deltas are omitted -- too noisy to auto-publish, see "
+                         "module docstring)")
+    args = ap.parse_args()
+
+    tags = release_tags()
+    if args.frm and args.to:
+        frm, to = args.frm, args.to
+    elif args.version:
+        to = f"inkless-release-{args.version}"
+        if to not in tags:
+            ap.error(f"tag {to} not found; known: {', '.join(tags) or '(none)'}")
+        idx = tags.index(to)
+        if idx == 0:
+            ap.error(f"{to} is the earliest inkless-release tag; nothing precedes it")
+        frm = tags[idx - 1]
+    else:
+        if len(tags) < 2:
+            ap.error(f"need at least two inkless-release tags, found {len(tags)}")
+        frm, to = tags[-2], tags[-1]
+
+    version = to.rsplit("-", 1)[-1]
+    kafka = kafka_base_tags(version)
+
+    ck_add = sorted(parse_configs(show(to, "docs/inkless/configs.rst"))
+                    - parse_configs(show(frm, "docs/inkless/configs.rst")))
+    ck_rm = sorted(parse_configs(show(frm, "docs/inkless/configs.rst"))
+                   - parse_configs(show(to, "docs/inkless/configs.rst")))
+    mb_to, ma_to = parse_metrics(show(to, "docs/inkless/metrics.rst"))
+    mb_fr, ma_fr = parse_metrics(show(frm, "docs/inkless/metrics.rst"))
+    mb_add, mb_rm = sorted(mb_to - mb_fr), sorted(mb_fr - mb_to)
+    ma_add, ma_rm = sorted(ma_to - ma_fr), sorted(ma_fr - ma_to)
+
+    buckets, other = collect_commits(frm, to)
+
+    p = print
+    header = f"## {version}"
+    if kafka:
+        header += f" (Kafka {', '.join(kafka)})"
+    p(header)
+    p("")
+
+    note = upstream_note(frm, to)
+    if note:
+        p(f"> {note}")
+        p("")
+
+    if args.summary:
+        for typ, label in TYPE_LABELS:
+            if typ not in SUMMARY_TYPES:
+                continue
+            if buckets[typ]:
+                p(f"### {label}")
+                for scope, desc in buckets[typ]:
+                    p(fmt_entry(scope, desc))
+                p("")
+        if ck_add or ck_rm:
+            p("### Configuration")
+            for c in ck_add:
+                p(f"- Added `{c}`")
+            for c in ck_rm:
+                p(f"- Removed `{c}`")
+            p("")
+        return
+
+    for typ, label in TYPE_LABELS:
+        if buckets[typ]:
+            p(f"### {label}")
+            for scope, desc in buckets[typ]:
+                p(fmt_entry(scope, desc))
+            p("")
+    if other:
+        p("### Other")
+        for scope, desc in other:
+            p(fmt_entry(scope, desc))
+        p("")
+
+    p("### Config & metric changes")
+    if ck_add or ck_rm:
+        for c in ck_add:
+            p(f"- config added: `{c}`")
+        for c in ck_rm:
+            p(f"- config removed: `{c}`")
+    else:
+        p("- no config changes")
+    if mb_add or mb_rm or ma_add or ma_rm:
+        p("")
+        p("<!-- REVIEW metrics: metrics.rst is a hand-maintained registry list;"
+          " a delta here may be tooling backfill, not a shipped metric. Curate before publishing. -->")
+        for m in mb_add:
+            p(f"- metric mbean added: `{m}`")
+        for m in mb_rm:
+            p(f"- metric mbean removed: `{m}`")
+        for a in ma_add:
+            p(f"- metric attr added: `{a}`")
+        for a in ma_rm:
+            p(f"- metric attr removed: `{a}`")
+    p("")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/inkless-publish.yml
+++ b/.github/workflows/inkless-publish.yml
@@ -311,6 +311,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: inkless-release-${{ needs.prepare.outputs.inkless_version }}
+          # Full history + tags so the changelog generator can diff this release
+          # tag against the previous inkless-release-* tag for the release notes.
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Setup Gradle
@@ -367,12 +370,38 @@ jobs:
           path: distributions
           merge-multiple: true
 
+      - name: Generate curated changelog summary
+        id: changelog
+        env:
+          INKLESS_VERSION: ${{ needs.prepare.outputs.inkless_version }}
+        run: |
+          # Best-effort: the curated summary is diffed from the previous
+          # inkless-release-* tag. If it can't be produced (e.g. first release,
+          # or the previous tag is missing), fall back to boilerplate-only notes
+          # rather than failing the release.
+          SUMMARY=""
+          if SUMMARY=$(python3 .ai-agents/skills/inkless-changelog/gen-changelog.py \
+                --version "$INKLESS_VERSION" --summary 2>/tmp/changelog.err); then
+            echo "Generated changelog summary ($(printf '%s' "$SUMMARY" | wc -l) lines)"
+          else
+            echo "::warning::Changelog summary generation failed; using boilerplate notes only."
+            cat /tmp/changelog.err || true
+            SUMMARY=""
+          fi
+          # Persist via multiline output for the next step.
+          {
+            echo "summary<<CHANGELOG_EOF"
+            printf '%s\n' "$SUMMARY"
+            echo "CHANGELOG_EOF"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Create or update GitHub Release
         env:
           GH_TOKEN:            ${{ secrets.GITHUB_TOKEN }}
           INKLESS_VERSION:     ${{ needs.prepare.outputs.inkless_version }}
           KAFKA_BASE_MATRIX:   ${{ needs.prepare.outputs.kafka_base_matrix }}
           GITHUB_REPOSITORY:   ${{ github.repository }}
+          CHANGELOG_SUMMARY:   ${{ steps.changelog.outputs.summary }}
         run: |
           set -eo pipefail
           RELEASE_TAG="inkless-release-${INKLESS_VERSION}"
@@ -402,6 +431,11 @@ jobs:
                   "$KAFKA_VER" "$tag" "$GITHUB_REPOSITORY" "$tag"
               fi
             done <<< "$TAGS"
+
+            # Append the curated changelog summary when available.
+            if [ -n "${CHANGELOG_SUMMARY//[$'\n\r\t ']/}" ]; then
+              printf '\n%s\n' "$CHANGELOG_SUMMARY"
+            fi
           } > "$NOTES_FILE"
 
           if ! gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" > /dev/null 2>&1; then

--- a/docs/inkless/CHANGELOG.md
+++ b/docs/inkless/CHANGELOG.md
@@ -1,0 +1,445 @@
+# Inkless Changelog
+
+Detailed, per-increment log of Inkless changes. Each section covers one Inkless
+iteration (`inkless-release-<N-1>` -> `inkless-release-<N>`) and lists the
+mainline commits plus operator-facing config and metric changes.
+
+- For release artifacts (Docker images, binaries), see [RELEASES.md](RELEASES.md).
+- For how versions work, see [VERSIONING-STRATEGY.md](VERSIONING-STRATEGY.md).
+- GitHub release notes are a **curated summary** of these entries (features and
+  fixes plus config/metric changes; chores, tests, and docs are dropped).
+
+## How this file is produced
+
+Entries are generated from git and the auto-generated docs, then curated:
+
+- **Commits** come from `git log --first-parent --no-merges` between the two
+  release tags, categorized by conventional-commit type. `--first-parent`
+  excludes the individual upstream commits pulled in by `apache/kafka` merge
+  commits.
+- **Config changes** are diffed from `docs/inkless/configs.rst` (reliable).
+- **Metric changes** are diffed from `docs/inkless/metrics.rst`. This file is
+  produced by a hand-maintained registry list in `MetricsDocs.main()`, so a
+  delta can reflect documentation catch-up rather than a newly shipped metric
+  (see the 0.39 note). Metric deltas are always curated before publishing.
+- **Upstream syncs** are detected from `apache/kafka` merge commits in the range
+  and a `gradle.properties` version delta; when `main`'s Kafka development base
+  moves, it is noted as a blockquote under the increment heading.
+
+Regenerate a draft with the `inkless-changelog` skill (or run it directly):
+
+```bash
+.ai-agents/skills/inkless-changelog/gen-changelog.py --version <N>            # detailed entry
+.ai-agents/skills/inkless-changelog/gen-changelog.py --version <N> --summary  # release-notes summary
+```
+
+---
+
+## 0.46 (Kafka 4.1.2, 4.2.1)
+
+### Features
+- (inkless) surface inkless tag at startup and in --version output (#717)
+- (inkless:consume) add diskless reader throughput metrics (#727)
+- (inkless:consolidation) separate ConsolidationFetchBytesInPerSec from replication metric (#723)
+- (inkless:consume) meter control-plane fetch errors separately from data-plane (#726)
+- (inkless:consolidation) delayed fetcher to honor minBytes/maxWaitMs (#685)
+
+### Fixes
+- (inkless:ci) green the upstream test suite (diskless test fixes + flaky quarantine) (#700)
+- (inkless:release) unblock the release workflow (#714)
+- (inkless) allow changing RF for diskless managed topics (#724)
+- (inkless:consolidation) reject follower reads below the cross-tier earliest [KC-332] (#720)
+- (inkless:retention) bound retention enforcement boundary scan to O(cap) (#722)
+- (inkless:consolidation) stop over-reclaiming the classic prefix on rebuilt leaders [KC-332] (#711)
+- (inkless:consolidation) route DeleteRecords to the real leader and report cross-tier low watermark [KC-332] (#710)
+- (inkless:consolidation) route ListOffsets(EARLIEST) to the control plane for consolidating topics [KC-332] (#709)
+- (inkless:switch) [KC-234] force-roll boundary segment at seal to enable tiering (#694)
+
+### Refactors
+- (inkless:delete) improve retention-enforcement observability (#725)
+
+### Config & metric changes
+- no config changes
+- metric attrs added: `InklessFetchMetrics :: DisklessBytesOutPerSec, StorageBytesInPerSec, StorageLaggingBytesInPerSec, CacheHitBytesPerSec` (diskless reader throughput metrics, #727)
+- metric attrs added: `InklessFetchMetrics :: PartitionControlPlaneErrorRate` (control-plane fetch errors metered separately, #726)
+- metric attrs added: `PostgresControlPlane :: GetCrossTierLogStartQueryRate, GetCrossTierLogStartQueryTime` (cross-tier consolidation, KC-332)
+- metric attrs added: `RetentionEnforcer :: RetentionEnforcementScheduleLagMs` (retention observability, #725)
+
+## 0.45 (Kafka 4.1.2, 4.2.1)
+
+### Features
+- (inkless:consume) coalesce per-batch buffers and isolate corrupt-batch failures [KC-279] (#706)
+- (inkless:retention) track earliest batch timestamp per log (#704)
+- (inkless:switch) implement `repair` tool for diskless switch (#686)
+- (inkless) add INKLESS_OWNERSHIP manifest as single source of truth (#693)
+
+### Fixes
+- (inkless:retention) decouple enforce_retention_v2 from the log lock (#705)
+- (inkless:consume) bound find_batches_v2 scan to the fetch budget (O(result), not O(read-depth)) [KC-327] (#701)
+- (inkless:ci) guard JUnit parsing against killed-test reports (#696)
+- (inkless:ts-unification) allow diskless+remote.storage on creation when allow-switch flag is on (#691)
+- (inkless:ci) fix RequestQuotaTest and make CI test failures visible (#692)
+
+### Tests
+- (inkless) give each broker an exclusive TS fetch chunk cache dir (#703)
+- (inkless) extract shared TopicConfigTestUtils from duplicated test helpers (#698)
+- (inkless) move diskless controller tests to InklessTest (#695)
+- (inkless:consolidation) [KC-298] add cross-tier retention reclaim system test (#681)
+
+### Chores
+- (inkless:ai) introduce vendor-neutral AI guardrails (#689)
+- (inkless:tools) Update cherry-pick guide, CI workflows, and release documentation (#690)
+
+### Config & metric changes
+- no config changes
+- metric attrs added: `InklessFetchMetrics :: FetchResponseSize, PartitionCorruptRecordRate, PartitionPartialFetchRate, PartitionStorageErrorRate` (corrupt-batch isolation, #706)
+- metric attrs added: `PostgresControlPlane :: RepairDisklessLogQueryRate, RepairDisklessLogQueryTime` (repair tool, #686)
+
+## 0.44 (Kafka 4.1.2, 4.2.1)
+
+### Features
+- (inkless:switch) auto-enable remote.storage atomically on diskless switch (#678)
+- (inkless:consolidation) [KC-298] add JMX metrics for the cross-tier log start offset (#682)
+- (inkless) [KC-298] track and serve the cross-tier earliest offset for consolidated topics (#670)
+- (inkless:switch) implement AlterDisklessSwitch and tooling [KC-97] (#665)
+- (inkless) resolve client AZ from listener map in metadata transformer (#684)
+- (inkless) add inkless.client.az.listener.map config (#683)
+- (inkless:consolidation) route consolidation fetcher through coldpath to avoid cache pollution [KC-171] (#679)
+- (inkless) coalesce contiguous batches into one row in commit_file_v2 (#671)
+- (inkless) add partition fan-in commit metrics (#675)
+
+### Fixes
+- (inkless:consolidation) serve cross-tier earliest offset promptly after startup (#688)
+- (inkless) find_batches rejects offset below log start offset (#666)
+- (inkless:consolidation) don't fence a consolidating leader below the seal (#677)
+- (inkless:controller) fix leader skew for managed diskless after rolling restart (#643)
+- (inkless:consolidation) recover a switched consolidated leader after local-log loss (#673)
+
+### Tests
+- (inkless:consolidation) add dependency-outage system test for consolidation pipeline (#669)
+- (inkless:consolidation) add read-from-remote system tests, harness support (#654)
+- (inkless:consolidation) add born-consolidated pipeline + WAL-prune system test (#674)
+
+### Docs
+- (inkless) document the interceptors introduced for CREATE_TOPIC (#680)
+
+### Config & metric changes
+- config added: `inkless.client.az.listener.map`
+- config added: `inkless.consume.cross.tier.log.start.cache.enabled`
+- config added: `inkless.consume.cross.tier.log.start.cache.ttl.ms`
+- config added: `inkless.control.plane.batch.coalescing.enabled`
+- config added: `inkless.cross.tier.log.start.report.interval.ms`
+- metric mbean added: `io.aiven.inkless.cache:type=CrossTierLogStartCache`
+- metric mbean added: `io.aiven.inkless.delete:type=CrossTierLogStartReporter`
+- metric attrs added: `CrossTierLogStartCache :: CacheHits, CacheMisses, CacheSize`
+- metric attrs added: `CrossTierLogStartReporter :: PartitionsReported, PendingPartitions, ReportErrors`
+- metric attrs added: `PostgresControlPlane :: AdvanceCrossTierLogStartQueryRate, AdvanceCrossTierLogStartQueryTime`
+- metric attrs added: `FileCommitter :: BatchesPerPartitionPerCommit, PartitionsPerCommit`
+
+## 0.43 (Kafka 4.1.2, 4.2.1)
+
+### Fixes
+- (inkless:consolidation) start consolidation when remote storage is enabled on a diskless topic (#672)
+- (inkless:consolidation) complete the classic-to-consolidated switch by always sealing and registering (#651)
+- (inkless) Add PostgreSQL socket timeouts for Inkless control plane (#668)
+- (inkless:metrics) exclude consolidating partitions from URP metrics (#640)
+- (inkless) truncate above the seal only if those messages are not consolidated (#667)
+
+### Config & metric changes
+- config added: `inkless.control.plane.connection.pool.timeout.ms`
+- config added: `inkless.control.plane.read.connection.pool.timeout.ms`
+- config added: `inkless.control.plane.read.socket.timeout.ms`
+- config added: `inkless.control.plane.read.tcp.connect.timeout.ms`
+- config added: `inkless.control.plane.socket.timeout.ms`
+- config added: `inkless.control.plane.tcp.connect.timeout.ms`
+- config added: `inkless.control.plane.write.connection.pool.timeout.ms`
+- config added: `inkless.control.plane.write.socket.timeout.ms`
+- config added: `inkless.control.plane.write.tcp.connect.timeout.ms`
+
+## 0.42 (Kafka 4.1.2, 4.2.1)
+
+### Features
+- (inkless:tools) add operator tooling for topic type switch [KC-97] (#661)
+- (inkless:consolidation) supplement local log with diskless data on fetch [KC-168] (#638)
+- (inkless:consolidation) serve consolidated reads from remote via OFFSET_MOVED_TO_TIERED_STORAGE (#650)
+- (inkless) ensure unclean leader election is disabled on classic-to-diskless switch [KC-129] (#647)
+- (inkless) KC-156 diskless leader epoch for consolidation truncation (#631)
+- (inkless) add controller guards for classic-to-diskless switch [POD-2464] (#634)
+- (inkless:test) implement system tests for classic to diskless switch (#581)
+- (inkless:consolidation) make fetch quota config dynamic (#637)
+- (inkless) add dedicated rate limit for consolidation fetch [KC-145] (#636)
+- (inkless:consolidation) add separate wiring for consolidation fetcher [KC-160] (#635)
+
+### Fixes
+- (inkless:switch) Fix stale HW on switched leader promotion (#660)
+- (inkless:systest) fix sigstop and slow consumer giving false negatives (#659)
+- (inkless) create tiered topic when diskless.enable=false and system is disabled (#641)
+- (inkless) reject topic creation with config conflicting with diskless regex (#642)
+- (inkless) Remove consolidating fetchers unconditionally (#629)
+
+### Refactors
+- (inkless) clarify fetch routing for consolidating partitions (#633)
+
+### Tests
+- (inkless:systest) run ducktape system tests against consolidated topics (#645)
+- (inkless) Integration test for diskless + consolidate separately (#639)
+
+### Docs
+- (inkless) Enrich documentation of classicToDisklessStartOffset (#658)
+- (inkless) fix rendering of release sync prompt (#648)
+- (inkless:switch) Document classic to diskless switch (#632)
+
+### Config & metric changes
+- no config changes
+
+## 0.41 (Kafka 4.1.2, 4.2.0)
+
+### Features
+- (inkless) KC-72 Reconcile stale records after diskless switch (#612)
+- (inkless:consume) Add request hedging for storage reads (#582)
+
+### Fixes
+- (inkless) initialize diskless switch for legacy alter configs (#630)
+- (inkless:consolidation) prevent ConsolidationFetcherThread crash on topic deletion (#627)
+- (inkless:switch) bump leader epoch on classic-to-diskless switch (#626)
+- (inkless:build) pass commitId to Gradle for worktree builds (#628)
+- (inkless) retry describeTopics in InklessManagedReplicasClusterTest for metadata propagation (#625)
+- (inkless) ensure ReplicaManager shutdown in Inkless tests (#623)
+
+### Refactors
+- (inkless) SharedState to own StorageBackend lifecycle (#562)
+- (inkless) extract Inkless tests from ReplicaManagerTest into standalone file (#624)
+
+### Tests
+- (inkless:switch) add consolidated diskless integration tests with transition matrix (#617)
+
+### Docs
+- (inkless) add system test documentation (#588)
+
+### Config & metric changes
+- config added: `inkless.fetch.hedge.total.time.threshold.ms`
+- config added: `inkless.fetch.hedge.ttfb.threshold.ms`
+- metric attrs added: `InklessFetchMetrics :: HedgeRequestRate, HedgeWonRate, HedgeTtfbTriggeredRate, HedgeTotalTimeTriggeredRate` (request hedging, #582)
+
+## 0.40 (Kafka 4.1.2, 4.2.0)
+
+### Features
+- (inkless) Introduce CREATE_TOPICS config interceptor framework and DisklessForceCreateTopicInterceptor (#614)
+- (inkless:switch) auto-enable remote.storage.enable on diskless topic creation (#619)
+- (inkless:switch) validate diskless requires remote storage when consolidation enabled (#616)
+- (inkless:switch) expose DisklessWithoutRemoteStorageCount metric for legacy topics (#618)
+- (inkless) Support OffsetsForLeaderEpoch for partitions switched to diskless (#613)
+- (inkless) POD-2395 Prune consolidated diskless offsets (#587)
+- (inkless:switch) support DELETE_RECORDS for hybrid partitions (#611)
+- (inkless) POD-2456 Enable offset fetch in consolidating partitions (#594)
+- (inkless) POD-2457 Allow transactional offset commits for Diskless sources (#596)
+
+### Fixes
+- (inkless) add KafkaConfigTest validation for diskless force topic regexes (#622)
+- (inkless) allow searching offsets in UnifiedLog only if switched topics are in sync (#620)
+- (inkless) correctly migrate all producer states after a diskless switch (#615)
+- (inkless:fetch) properly propagate exception back on failing FetchOffset (#608)
+- (inkless:switch) Advance HW past stale checkpoint for sealed leader after restart (#605)
+- (inkless:switch) Init Diskless Log on Control Plane on leader changes (#603)
+- (inkless:migration) reschedule fetcher on leader change during pending migration (#600)
+- (inkless) POD-1965 Use local log start in DisklessLeaderEndPoint (#591)
+- (inkless:migration) catch up replicas that are below the seal (#598)
+- (inkless) Ensure additional system topics created as classic when log.diskless.enable=true [POD-1312] (#586)
+
+### Refactors
+- (inkless:consolidation) rename and improve ConsolidationMetrics (#621)
+- (inkless:switch) drop sealing and registering from BrokerMetadataPublisher (#604)
+- (inkless) Rename diskless migration to diskless switch (#601)
+
+### Tests
+- (inkless:switch) Add invariant tests for sealed partition recovery (#609)
+- (inkless) add test for verifying consolidating partition reassignment (#599)
+
+### Chores
+- (inkless) remove FileMerger component and all related infrastructure (#607)
+
+### Config & metric changes
+- config added: `inkless.consolidation.cleanup.interval.ms`
+- config removed: `inkless.control.plane.file.merge.lock.period.ms`
+- config removed: `inkless.control.plane.file.merge.size.threshold.bytes`
+- config removed: `inkless.control.plane.read.file.merge.lock.period.ms`
+- config removed: `inkless.control.plane.read.file.merge.size.threshold.bytes`
+- config removed: `inkless.control.plane.write.file.merge.lock.period.ms`
+- config removed: `inkless.control.plane.write.file.merge.size.threshold.bytes`
+- config removed: `inkless.file.merger.interval.ms`
+- config removed: `inkless.file.merger.temp.dir`
+- metric mbean removed: `io.aiven.inkless.merge:type=FileMerger` (FileMerger component removed, #607)
+- metric attrs removed: `FileMerger :: FileMergeErrorRate, FileMergeFilesRate, FileMergeRate, FileMergeTotalTime, FileUploadTime` (#607)
+- metric attrs removed: `PostgresControlPlane :: {Commit,Get,Release}FileMergeWorkItemQuery{Rate,Time}` (#607)
+
+## 0.39 (Kafka 4.1.2)
+
+### Features
+- (inkless) fast fail producing during classic-to-diskless migration (#595)
+- (inkless) Always allow fetching from replicas for migrated partitions (#593)
+- (inkless) extended metrics for diskless migration states tracking (#589)
+- (inkless) add metrics for consolidated topic partitions (#590)
+
+### Config & metric changes
+- New metrics for diskless migration state tracking (#589) and consolidated
+  topic partitions (#590).
+- Documentation catch-up: `docs/inkless/metrics.rst` expanded from 3 to 16 mbeans
+  in this release (KC-1, #592). Most of the mbeans that appear "new" in the doc
+  diff (fetch, produce, delete, cache, control-plane, thread-pool, AZ-awareness)
+  were already shipping earlier; they became documented here. Do not read the
+  raw metrics diff for this release as newly introduced metrics.
+
+## 0.38 (Kafka 4.1.2)
+
+### Features
+- (inkless) Support ListOffsets for all cases of diskless partitions (#584)
+- (inkless) POD-2394 Implement read path for consolidated logs (#583)
+- (inkless) Support basic ListOffset for hybrid topics (#577)
+- (inkless) POD-2398 Integration test for consolidation produce path (#569)
+- (inkless) POD-2393 Add DisklessLeaderEndPoint to handle fetch requests (#568)
+- (inkless) Set migrating partitions in KRaft metadata (#580)
+- (inkless) Abort transactions on partition sealing (#573)
+- (inkless) POD-2392 Implement consolidating partition tracking (#567)
+- (inkless:consume) Add time-to-first-byte (TTFB) metric for storage reads (#575)
+- (inkless) Init diskless log on Control Plane (#563)
+- (inkless) Add TS Consolidation configs (#556)
+- (inkless:config) enforce diskless feature flag dependency chain (#560)
+- (inkless:docker) add diskless tiered storage unification demo (#559)
+- (inkless) allow reading from UnifiedLog for diskless topics (#553)
+- (inkless:metadata) Remove topic already diskless from InitDisklessLog Controller API (#547)
+- (inkless) Orchestrate classic-to-diskless migration (#536)
+- (inkless) Parse request and response of InitDisklessLog (#545)
+- (inkless:config) Enforce diskless.allow.from.classic.enable (#546)
+
+### Fixes
+- (inkless) Stop replicating after migration to diskless is completed (#585)
+- (cache) respect max-idle=-1 (disable idle eviction) (#470)
+- (inkless) Create Partition object even when diskless is enabled (#574)
+- (inkless:migration) Avoid deadlock in InitDisklessLogBatchQueue (#578)
+- (inkless) Add InitDisklessLog JSON conversion to RequestConvertToJson (#570)
+- (inkless:migration) Fix InitDisklessLogManager gaps during partition registration (#566)
+- (inkless:migration) fix classic-to-diskless migration validation and add LogConfigTest to CI (#558)
+- (inkless:migration) bypass diskless/remote-storage mutual exclusion for classic-to-diskless migration (#555)
+- (inkless:consume) handle error path in lastOffsetForLeaderEpoch for diskless topics (#554)
+- (inkless:metrics) Fix double-counting of diskless topic and partition metrics (#552)
+
+### Refactors
+- (inkless) Rename disklessStartOffset to classicToDisklessStartOffset (#572)
+- (inkless) Split InitDisklessLogManager logic into separate components (#561)
+- (inkless) Refactor InitDisklessLog flow and add integration tests (#549)
+
+### Other
+- Fix potential leak when closing resources (#565)
+- update Kafka version variables to 4.2.0-inkless-SNAPSHOT (#548)
+
+### Config & metric changes
+- config added: `inkless.consolidation.*` (TS Consolidation configs, #556)
+- `diskless.allow.from.classic.enable` feature flag enforced (#546, #560).
+
+## 0.37 (Kafka 4.0.2, 4.1.2)
+
+### Features
+- (inkless) add bytes limit to cache (#544)
+- (inkless) Expose InitDisklessLog controller API (#541)
+- (controller:diskless) add partitions support for diskless topics (#540)
+- (controller:diskless) enable immediate partition reassignment (#537)
+- (storage:inkless) add control plane method for getting the producer states (#530)
+- (inkless) Add metrics for sealed partitions (#534)
+- (inkless:sync) add upstream sync tooling and documentation (#498)
+- (diskless) add managed replicas routing to metadata transformer (#504)
+- (inkless) Seal the local log when a topic is migrated from classic to diskless (#533)
+- (inkless) implement InitDisklessLog Controller API (#531)
+- (metadata:diskless) add controller metrics for diskless topics (#503)
+- (metadata:diskless) implement managed replicas for diskless topics (#492)
+- (storage:inkless) InitDisklessLog Diskless Controller API (#528)
+- (produce) optimize AppendCompleter to complete futures first (#529)
+
+### Refactors
+- (inkless:consume) replace ByteRange.coalesce with BoundingRangeAlignment strategy (#532)
+- (inkless) improve thread pool lifecycle management (#475)
+- (metadata:diskless) preserve leader epoch in metadata transformer (#539)
+- (inkless) cache LogConfig in InklessMetadataView (#474)
+
+### Tests
+- (metadata:diskless) add integration tests for managed replicas (#542)
+
+### Docs
+- (inkless) add managed replicas documentation (#535)
+- (docker:inkless) add managed replicas demo with test procedure (#543)
+
+### Config & metric changes
+- config added: `inkless.consume.cache.max.bytes`
+
+## 0.36 (Kafka 4.0.0, 4.0.2, 4.1.1, 4.1.2)
+
+### Features
+- (inkless:config) disallow setting diskless.enable if diskless storage system is disabled (#520)
+
+### Fixes
+- (inkless:test) Fix KafkaConfigTest for CLASSIC_REMOTE_STORAGE_FORCE_EXCLUDE_TOPIC_REGEXES_CONFIG (#521)
+- (inkless) Fix error message when diskless.enable and remote.storage.enable are set (#516)
+
+### Chores
+- (build) Set Docker API version 1.44 in Gradle config (#519)
+
+### Config & metric changes
+- no config changes
+
+## 0.35 (Kafka 4.0.0, 4.1.1)
+
+> Upstream sync: main development base moved to Kafka 4.2.0-SNAPSHOT (from 4.1.0-SNAPSHOT), Scala 2.13.16 -> 2.13.17.
+
+### Features
+- (metadata) Introduce ClassicTopicRemoteStorageForcePolicy (#514)
+- Disallow setting remote.storage.enable when diskless.enable is set to true (#511)
+
+### Chores
+- (ci) use Docker API version 1.44 (#509)
+- (ci) replace usage of JDK 23 with 25 (#502)
+- (inkless) Update demo and documentation for GHCR images (#497)
+- (inkless:release) add gh workflows to release inkless artifacts (#489)
+
+### Other
+- storage: add metrics constructor to InMemoryStorage (#510)
+
+### Config & metric changes
+- no config changes
+
+## 0.34 (Kafka 4.0.0, 4.1.1)
+
+### Features
+- Allow switching diskless.enable from false to true (#486)
+
+### Fixes
+- (storage:metrics) eagerly initialize meters with only topicType tag (#493)
+
+### Refactors
+- (metadata:diskless) fail on topic creation with replica assignment (#488)
+
+### Docs
+- (inkless) update architecture diagram (#487)
+- (inkless) update readme with new sections and glossary (#483)
+- (inkless) fix performance docs (#482)
+- (inkless) fix relation with kips on client-az awareness (#485)
+- (inkless) add az-alignment feature documentation (#481)
+
+### Chores
+- (storage:inkless) add jooq classes (#490)
+
+### Config & metric changes
+- no config changes
+
+## 0.33 (Kafka 4.0.0, 4.1.1)
+
+First release under the global Inkless iteration counter (previously
+`inkless-4.0.0-rc32` / `inkless-4.1.1-rc1`; see
+[VERSIONING-STRATEGY.md](VERSIONING-STRATEGY.md)).
+
+### Refactors
+- (inkless:metrics) only add topic-type tag on all topic stats (#472)
+
+### Docs
+- (inkless) add versioning strategy (#479)
+
+### Config & metric changes
+- no config changes

--- a/docs/inkless/README.md
+++ b/docs/inkless/README.md
@@ -47,6 +47,7 @@ See [Releases](RELEASES.md) for active versions and release history.
 ### Reference
 - [Versioning Strategy](VERSIONING-STRATEGY.md) - Version format and release workflow
 - [Releases](RELEASES.md) - Artifacts released (binaries and docker images)
+- [Changelog](CHANGELOG.md) - Per-increment changes (features, fixes, config and metric changes)
 - [Glossary](GLOSSARY.md) - Definitions of Inkless-specific terms and concepts
 
 ### Development & Maintenance

--- a/docs/inkless/RELEASES.md
+++ b/docs/inkless/RELEASES.md
@@ -186,9 +186,34 @@ for pair in "inkless-4.1.2-0.45 4.1.2" "inkless-4.2.1-0.45 4.2.1"; do
 done
 ```
 
-Attach the `.tgz` distributions and publish the Release with `gh release create`/`edit`
+Attach the `.tgz` distributions and publish the Release as in the changelog section below
 (the workflow's `finalize-release` normally does this). Prefer `resume=true` over this whenever
 the workflow is available.
+
+### Changelog and release notes
+
+Every release increment gets an entry in [CHANGELOG.md](CHANGELOG.md) and a curated GitHub
+release-notes summary. Both are generated from the commit history plus the auto-generated
+`configs.rst`/`metrics.rst` diffs between the previous and new `inkless-release-*` tags, then curated
+(metric deltas in particular need review -- see the changelog header for why).
+
+The **curated summary is injected into the GitHub Release body automatically** by the release
+workflow's `finalize-release` job (it runs the generator against the freshly created tag; if
+generation fails it falls back to boilerplate notes). You do **not** need to paste it by hand,
+and re-running publish reproduces the same notes rather than clobbering them.
+
+The **detailed CHANGELOG.md entry is a manual commit to `main` via a normal PR** (there is no
+automation and no auto-PR). Because it is diffed from the new `inkless-release-<N>` tag, it can
+only be produced **after** the release workflow creates that tag -- in practice at the start of
+the next increment's prep. Generate it and prepend to `docs/inkless/CHANGELOG.md`:
+
+```bash
+# Detailed CHANGELOG entry for inkless-release-<N> (prepend to CHANGELOG.md, then PR to main)
+.ai-agents/skills/inkless-changelog/gen-changelog.py --version <N>
+
+# Curated summary (same text the workflow injects) -- for preview/manual override
+.ai-agents/skills/inkless-changelog/gen-changelog.py --version <N> --summary
+```
 
 ### Onboarding a new release branch
 


### PR DESCRIPTION
Adds Inkless changelog generation and wires it into the release notes. Stacks on #714 (which owns `inkless-publish.yml`).

## Changes

- `gen-changelog.py` + the `inkless-changelog` skill: diff conventional-commit history and `configs.rst`/`metrics.rst` between two `inkless-release-*` tags to produce a detailed `CHANGELOG.md` entry and a curated release-notes summary. Detects upstream syncs (apache/kafka merges + gradle version delta).
- Backfill `docs/inkless/CHANGELOG.md` for increments 0.33..0.46 and link it from the docs index.
- `finalize-release` now runs the generator against the freshly created tag and injects the curated summary into the GitHub Release body (best-effort: falls back to boilerplate notes if generation fails). Documents the changelog/release-notes flow in RELEASES.md.
