### PR TITLE
fix(inkless:release): unblock the release workflow

### DIFF
--- a/.github/workflows/inkless-publish.yml
+++ b/.github/workflows/inkless-publish.yml
@@ -369,37 +369,45 @@ jobs:
           KAFKA_BASE_MATRIX:   ${{ needs.prepare.outputs.kafka_base_matrix }}
           GITHUB_REPOSITORY:   ${{ github.repository }}
         run: |
+          set -eo pipefail
           RELEASE_TAG="inkless-release-${INKLESS_VERSION}"
 
-          RELEASE_NOTES="Inkless version ${INKLESS_VERSION}
+          # Build the notes in a file to avoid the YAML block-scalar indentation
+          # leaking into the markdown (leading spaces would render headings and
+          # bullets as an indented code block).
+          NOTES_FILE="$(mktemp)"
+          trap 'rm -f "$NOTES_FILE"' EXIT
+          {
+            printf 'Inkless version %s\n\n' "$INKLESS_VERSION"
+            printf '## Docker Images\n\n'
+            printf '```bash\n'
+            printf 'docker pull ghcr.io/aiven/inkless:%s\n' "$INKLESS_VERSION"
+            printf 'docker pull ghcr.io/aiven/inkless:latest\n'
+            printf '```\n\n'
+            printf '## Kafka Versions\n'
 
-          ## Docker Images
-
-          \`\`\`bash
-          docker pull ghcr.io/aiven/inkless:${INKLESS_VERSION}
-          docker pull ghcr.io/aiven/inkless:latest
-          \`\`\`
-
-          ## Kafka Versions"
-
-          TAGS=$(echo "$KAFKA_BASE_MATRIX" | jq -r '.include[].tag // empty' 2>/dev/null | sort -V | uniq)
-          while IFS= read -r tag; do
-            if [[ "$tag" =~ ^inkless-([0-9]+\.[0-9]+\.[0-9]+)-(.+)$ ]]; then
-              KAFKA_VER="${BASH_REMATCH[1]}"
-              RELEASE_NOTES="${RELEASE_NOTES}
-          - Kafka ${KAFKA_VER}: [\`${tag}\`](https://github.com/${GITHUB_REPOSITORY}/tree/${tag})"
+            if ! TAGS=$(echo "$KAFKA_BASE_MATRIX" | jq -r '.include[].tag // empty' | sort -V | uniq); then
+              echo "::error::Could not parse kafka_base_matrix as JSON: $KAFKA_BASE_MATRIX" >&2
+              exit 1
             fi
-          done <<< "$TAGS"
+            while IFS= read -r tag; do
+              if [[ "$tag" =~ ^inkless-([0-9]+\.[0-9]+\.[0-9]+)-(.+)$ ]]; then
+                KAFKA_VER="${BASH_REMATCH[1]}"
+                printf -- '- Kafka %s: [`%s`](https://github.com/%s/tree/%s)\n' \
+                  "$KAFKA_VER" "$tag" "$GITHUB_REPOSITORY" "$tag"
+              fi
+            done <<< "$TAGS"
+          } > "$NOTES_FILE"
 
           if ! gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" > /dev/null 2>&1; then
             gh release create "$RELEASE_TAG" \
               --repo "$GITHUB_REPOSITORY" \
               --title "Inkless ${INKLESS_VERSION}" \
-              --notes "$RELEASE_NOTES"
+              --notes-file "$NOTES_FILE"
           else
             gh release edit "$RELEASE_TAG" \
               --repo "$GITHUB_REPOSITORY" \
-              --notes "$RELEASE_NOTES"
+              --notes-file "$NOTES_FILE"
           fi
 
           if [ -d distributions ] && [ "$(ls -A distributions/ 2>/dev/null)" ]; then

--- a/.github/workflows/inkless-release.yml
+++ b/.github/workflows/inkless-release.yml
@@ -36,6 +36,11 @@ on:
         description: 'Space-separated list of additional release branches to include (e.g. "inkless-4.3"). Used when onboarding a new branch for the first time.'
         required: false
         type: string
+      resume:
+        description: 'Resume a partially-completed release whose tags already exist but whose GitHub Release was never published. Skips tag creation and re-runs build+publish. Requires inkless_version to be set explicitly.'
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: inkless-release
@@ -56,6 +61,7 @@ jobs:
       main_commit:       ${{ steps.resolve.outputs.main_commit }}
       release_tag:       ${{ steps.resolve.outputs.release_tag }}
       active_branches:   ${{ steps.resolve.outputs.active_branches }}
+      resume:            ${{ steps.resolve.outputs.resume }}
       kafka_versions:    ${{ steps.resolve-kafka.outputs.kafka_versions }}
       build_matrix:      ${{ steps.resolve-kafka.outputs.build_matrix }}
       kafka_base_matrix: ${{ steps.resolve-kafka.outputs.kafka_base_matrix }}
@@ -73,9 +79,19 @@ jobs:
           INPUT_VERSION:        ${{ inputs.inkless_version }}
           INPUT_COMMIT:         ${{ inputs.main_commit }}
           INPUT_EXTRA_BRANCHES: ${{ inputs.extra_branches }}
+          INPUT_RESUME:         ${{ inputs.resume }}
         run: |
+          RESUME="${INPUT_RESUME:-false}"
+
           # --- Inkless version ---
-          if [ -z "$INPUT_VERSION" ]; then
+          if [ "$RESUME" = "true" ]; then
+            # Resume reuses an EXISTING version; auto-increment would be wrong.
+            if [ -z "$INPUT_VERSION" ]; then
+              echo "::error::resume=true requires inkless_version to be set explicitly (the version whose tags already exist)."
+              exit 1
+            fi
+            INKLESS_VERSION="$INPUT_VERSION"
+          elif [ -z "$INPUT_VERSION" ]; then
             LATEST=$(git tag -l "inkless-release-*" | sort -V | tail -n1)
             if [ -z "$LATEST" ]; then
               echo "::error::No existing inkless-release-* tags found; specify inkless_version explicitly"
@@ -91,10 +107,19 @@ jobs:
 
           RELEASE_TAG="inkless-release-${INKLESS_VERSION}"
 
-          # Ensure the version doesn't already exist
-          if git rev-parse "$RELEASE_TAG" >/dev/null 2>&1; then
-            echo "::error::Tag $RELEASE_TAG already exists. If the release was never finalized (no GitHub Release published), delete the tag and retry. Otherwise use a higher version number."
-            exit 1
+          # --- Tag existence guard (inverted under resume) ---
+          if [ "$RESUME" = "true" ]; then
+            # Resuming: the release tag MUST already exist (tagging is skipped).
+            if ! git rev-parse --verify --quiet "refs/tags/$RELEASE_TAG" >/dev/null; then
+              echo "::error::resume=true but $RELEASE_TAG does not exist. Run a normal release (resume=false) to create tags."
+              exit 1
+            fi
+            echo "Resuming release $RELEASE_TAG (tags already exist; will skip tagging, re-run build+publish)."
+          else
+            if git rev-parse --verify --quiet "refs/tags/$RELEASE_TAG" >/dev/null; then
+              echo "::error::Tag $RELEASE_TAG already exists. To finish a release whose tags exist but was never published, re-run with resume=true. Otherwise use a higher version number."
+              exit 1
+            fi
           fi
 
           # --- Main commit ---
@@ -107,19 +132,25 @@ jobs:
           fi
 
           # --- Active release branches ---
-          # Discover from the previous release's Kafka-base tags.
-          PREV_VERSION=$(git tag -l "inkless-release-*" | sort -V | tail -n1)
-          PREV_VERSION="${PREV_VERSION#inkless-release-}"
+          # Discover active branches from Kafka-base tags. Normally these come
+          # from the PREVIOUS release; when resuming, the target version's own
+          # tags already exist, so discover from those.
+          if [ "$RESUME" = "true" ]; then
+            DISCOVER_VERSION="$INKLESS_VERSION"
+          else
+            DISCOVER_VERSION=$(git tag -l "inkless-release-*" | sort -V | tail -n1)
+            DISCOVER_VERSION="${DISCOVER_VERSION#inkless-release-}"
+          fi
           DISCOVERED=""
-          if [ -n "$PREV_VERSION" ]; then
-            DISCOVERED=$(git tag -l "inkless-*-${PREV_VERSION}" \
+          if [ -n "$DISCOVER_VERSION" ]; then
+            DISCOVERED=$(git tag -l "inkless-*-${DISCOVER_VERSION}" \
               | grep -E '^inkless-[0-9]+\.[0-9]+\.[0-9]+-' \
               | while read -r tag; do
                   if [[ "$tag" =~ ^inkless-([0-9]+\.[0-9]+)\.[0-9]+-(.+)$ ]]; then
                     echo "inkless-${BASH_REMATCH[1]}"
                   fi
                 done | sort -u)
-            echo "Discovered active branches from ${PREV_VERSION} tags: $(echo "$DISCOVERED" | tr '\n' ' ')"
+            echo "Discovered active branches from ${DISCOVER_VERSION} tags: $(echo "$DISCOVERED" | tr '\n' ' ')"
           fi
 
           # Merge with extra_branches input
@@ -135,6 +166,7 @@ jobs:
           echo "inkless_version=$INKLESS_VERSION"                   >> $GITHUB_OUTPUT
           echo "main_commit=$MAIN_COMMIT"                           >> $GITHUB_OUTPUT
           echo "release_tag=$RELEASE_TAG"                           >> $GITHUB_OUTPUT
+          echo "resume=$RESUME"                                     >> $GITHUB_OUTPUT
           echo "active_branches=$(echo "$ALL_BRANCHES" | tr '\n' ' ' | sed 's/ $//')" >> $GITHUB_OUTPUT
 
       - name: Resolve Kafka versions for active branches
@@ -142,8 +174,13 @@ jobs:
         env:
           ACTIVE_BRANCHES: ${{ steps.resolve.outputs.active_branches }}
           INKLESS_VERSION: ${{ steps.resolve.outputs.inkless_version }}
+          RESUME:          ${{ steps.resolve.outputs.resume }}
         run: |
-          # For each active branch, determine its current Kafka version from gradle.properties
+          # For each active branch, determine its Kafka version from gradle.properties.
+          # Normal release reads the branch HEAD (about to be tagged). On resume the
+          # tags already exist and the branch HEAD may have moved on, so read the
+          # gradle.properties captured at the existing kafka-base tag instead by
+          # discovering the tag directly.
           BUILD_MATRIX_ENTRIES=""
           KAFKA_MATRIX_ENTRIES=""
           LATEST_TAGS_JSON="{"
@@ -151,8 +188,23 @@ jobs:
           KAFKA_VERSIONS=""
 
           for BRANCH in $ACTIVE_BRANCHES; do
-            KAFKA_VER=$(git show "origin/${BRANCH}:gradle.properties" \
-              | grep '^version=' | head -1 | sed 's/version=\(.*\)-inkless.*/\1/')
+            if [ "$RESUME" = "true" ]; then
+              # Find the existing kafka-base tag for this branch+version and use it
+              # as-is: on resume the tag is authoritative (it was validated at cut
+              # time). Do NOT recompute the tag name from gradle.properties -- that
+              # would assume the embedded Kafka version still matches the tag.
+              KAFKA_MINOR="${BRANCH#inkless-}"
+              TAG=$(git tag -l "inkless-${KAFKA_MINOR}.*-${INKLESS_VERSION}" | sort -V | tail -n1)
+              if [ -z "$TAG" ]; then
+                echo "::error::resume: no existing tag inkless-${KAFKA_MINOR}.*-${INKLESS_VERSION} for branch $BRANCH"
+                exit 1
+              fi
+              KAFKA_VER=$(git show "${TAG}:gradle.properties" \
+                | grep '^version=' | head -1 | sed 's/version=\(.*\)-inkless.*/\1/')
+            else
+              KAFKA_VER=$(git show "origin/${BRANCH}:gradle.properties" \
+                | grep '^version=' | head -1 | sed 's/version=\(.*\)-inkless.*/\1/')
+            fi
 
             if [ -z "$KAFKA_VER" ]; then
               echo "::error::Cannot determine Kafka version for branch $BRANCH (gradle.properties version= not found)"
@@ -160,7 +212,11 @@ jobs:
             fi
 
             KAFKA_MAJOR_MINOR=$(echo "$KAFKA_VER" | cut -d. -f1-2)
-            TAG="inkless-${KAFKA_VER}-${INKLESS_VERSION}"
+            # On resume TAG is the discovered tag (kept above); on a normal release
+            # it is the tag about to be created for this branch's HEAD.
+            if [ "$RESUME" != "true" ]; then
+              TAG="inkless-${KAFKA_VER}-${INKLESS_VERSION}"
+            fi
 
             echo "$BRANCH -> Kafka $KAFKA_VER -> tag $TAG"
             KAFKA_VERSIONS="${KAFKA_VERSIONS} ${TAG}"
@@ -185,11 +241,17 @@ jobs:
           echo "kafka_base_matrix={\"include\":[${KAFKA_MATRIX_ENTRIES}]}" >> $GITHUB_OUTPUT
           echo "latest_tags=${LATEST_TAGS_JSON}"                          >> $GITHUB_OUTPUT
 
-  # Assert that each active release branch is ready to release:
-  #   - the target main commit is present on the branch
-  #   - branch-consistency.sh reports zero missing commits
+  # Assert that each active release branch is ready to release: it contains every
+  # actionable inkless commit from main (by PR presence, via branch-consistency.sh
+  # --check). We do NOT assert the exact main commit SHA is an ancestor: release
+  # branches are built by CHERRY-PICKING from main, so the commits are present
+  # under different SHAs. Skip-listed and old commits do not fail the check.
   validate:
     needs: prepare
+    # On resume the tags already exist and were validated when first cut; the
+    # branches (and main) may have moved on since, so re-checking against current
+    # main would spuriously fail. Skip validation when resuming.
+    if: needs.prepare.outputs.resume != 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -205,34 +267,34 @@ jobs:
         run: |
           FAILED=0
           for BRANCH in $ACTIVE_BRANCHES; do
-            git fetch origin "$BRANCH"
+            # Populate the remote-tracking refs the check reads. Pin origin/main to
+            # the RESOLVED main_commit (not the live remote HEAD) so validation
+            # matches the exact release target, even if main advanced since prepare
+            # or an older main_commit was requested. branch-consistency.sh --check
+            # does no fetch of its own, so these refs are authoritative. The
+            # main_commit object is already present (checkout used fetch-depth: 0).
+            git fetch origin "+refs/heads/$BRANCH:refs/remotes/origin/$BRANCH"
+            git update-ref refs/remotes/origin/main "$MAIN_COMMIT"
 
-            # Assert main commit is present
-            if ! git merge-base --is-ancestor "$MAIN_COMMIT" "origin/$BRANCH"; then
-              echo "::error::Commit $MAIN_COMMIT is NOT present on $BRANCH. Cherry-pick it first."
+            # branch-consistency.sh --check exits non-zero when the branch has
+            # actionable missing inkless commits. It matches by PR number, which
+            # is correct for cherry-picked history (SHAs differ from main).
+            if ./inkless-sync/branch-consistency.sh "$BRANCH" --check; then
+              echo "✓ $BRANCH is in sync with main"
+            else
+              echo "::error::$BRANCH is missing actionable inkless commits from main. Run cherry-pick sync first."
               FAILED=1
-              continue
             fi
-            echo "✓ $MAIN_COMMIT is present on $BRANCH"
-
-            # Assert no missing inkless commits
-            MISSING=$(./inkless-sync/branch-consistency.sh "$BRANCH" --missing 2>&1 \
-              | grep -E '^- [0-9a-f]{10}' | wc -l | tr -d ' ')
-            if [ "$MISSING" -gt 0 ]; then
-              echo "::error::$BRANCH has $MISSING missing inkless commit(s) from main. Run cherry-pick sync first."
-              ./inkless-sync/branch-consistency.sh "$BRANCH" --missing
-              FAILED=1
-              continue
-            fi
-            echo "✓ $BRANCH is in sync with main"
           done
           exit $FAILED
 
   # Create and push all tags:
   #   - inkless-release-<N> on the resolved main commit
   #   - inkless-<kafka-version>-<N> on the HEAD of each active release branch
+  # Skipped when resuming a release whose tags already exist.
   tag:
     needs: [prepare, validate]
+    if: needs.prepare.outputs.resume != 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -278,8 +340,11 @@ jobs:
 
   # Build Docker images and binary distributions for all Kafka-base tags,
   # then finalize the GitHub Release with all artifacts.
+  # Runs after tagging on a normal release, or directly after validate when
+  # resuming (the tag job is skipped because tags already exist).
   publish:
-    needs: [prepare, tag]
+    needs: [prepare, validate, tag]
+    if: ${{ always() && !cancelled() && needs.prepare.result == 'success' && (needs.validate.result == 'success' || needs.validate.result == 'skipped') && (needs.tag.result == 'success' || needs.tag.result == 'skipped') }}
     uses: ./.github/workflows/inkless-publish.yml
     with:
       inkless_version:   ${{ needs.prepare.outputs.inkless_version }}

--- a/docs/inkless/RELEASES.md
+++ b/docs/inkless/RELEASES.md
@@ -133,17 +133,62 @@ Go to **GitHub Actions → Inkless Release → Run workflow** and fill in:
 | `inkless_version` | Version to release (e.g. `0.44`) | Auto-increments from latest tag |
 | `main_commit` | Commit on `main` to release | `main` HEAD |
 | `extra_branches` | Space-separated branches to add (e.g. `inkless-4.3`) | Empty — use for new branches only |
+| `resume` | Finish a release whose tags already exist but was never published. Skips tagging, re-runs build+publish. Requires `inkless_version`. | `false` |
 
 The workflow then:
 
 1. **Resolves** the version and discovers active branches from the previous release's tags
-2. **Validates** each branch — asserts the target commit is present and no inkless commits are missing
-3. **Creates and pushes tags** — `inkless-release-<N>` on main and `inkless-<kafka-version>-<N>` on each branch
+   (from the target version's own tags when resuming)
+2. **Validates** each branch — asserts every actionable inkless commit is present (by PR
+   number, via `branch-consistency.sh --check`; cherry-picked commits have different SHAs
+   than main, so presence is matched by PR, not by SHA ancestry). **Skipped when `resume=true`**
+   (the tags were already validated when first cut, and branches may have moved on since).
+3. **Creates and pushes tags** — `inkless-release-<N>` on main and `inkless-<kafka-version>-<N>` on each branch (**skipped when `resume=true`**)
 4. **Builds** Docker images (amd64 + arm64) and binary distributions for each Kafka version in parallel
 5. **Finalizes** — creates the GitHub Release, attaches all artifacts, publishes `latest` and `X.Y-latest` Docker aliases
 
 If validation fails (a branch is missing commits), the workflow aborts before touching any tags. Fix the
 branch with cherry-pick sync and re-trigger.
+
+**Resuming a partial release:** if a run created the tags but never published the GitHub Release
+(e.g. it failed after step 3), re-run with the same `inkless_version` and `resume=true`. It skips
+validation and tag creation, and re-runs build + finalize. Do not delete tags or bump the version.
+
+### Break-glass: build and publish by hand
+
+Only if the workflow is unavailable. This reproduces steps 4-5 using the same `make` targets the
+workflow calls (`inkless-publish.yml`). Do it per **Kafka-base tag** (one per active branch), building
+each architecture. `VERSION`/`DIST_VERSION` are derived from `gradle.properties` at the checked-out
+tag, so no version override is needed. The image tag is `<kafka-version>-<increment>-<arch>`
+(e.g. `4.1.2-0.45-amd64`) -- NOT `<increment>-<arch>`.
+
+```bash
+# Example for 0.45: tags inkless-4.1.2-0.45 and inkless-4.2.1-0.45.
+# Run each from a checkout of that tag (a worktree is convenient).
+export IMAGE=ghcr.io/aiven/inkless
+
+for pair in "inkless-4.1.2-0.45 4.1.2" "inkless-4.2.1-0.45 4.2.1"; do
+  set -- $pair; TAG="$1"; KVER="$2"; INC="0.45"
+  git -C ../inkless-work checkout "$TAG"          # detached checkout at the kafka-base tag
+  ( cd ../inkless-work && make build_release )    # VERSION comes from gradle.properties at the tag
+
+  # Per-arch build + push (loads/pushes the arch-suffixed tag)
+  for ARCH in amd64 arm64; do
+    ( cd ../inkless-work && make docker_build \
+        PLATFORM="linux/${ARCH}" \
+        DOCKER_TAGS="${IMAGE}:${KVER}-${INC}-${ARCH}" \
+        PUSH=true )
+  done
+
+  # Multi-arch manifest for the version tag (and the X.Y-latest alias for the highest patch)
+  docker buildx imagetools create -t "${IMAGE}:${KVER}-${INC}" \
+    "${IMAGE}:${KVER}-${INC}-amd64" "${IMAGE}:${KVER}-${INC}-arm64"
+done
+```
+
+Attach the `.tgz` distributions and publish the Release with `gh release create`/`edit`
+(the workflow's `finalize-release` normally does this). Prefer `resume=true` over this whenever
+the workflow is available.
 
 ### Onboarding a new release branch
 
@@ -154,6 +199,9 @@ in future runs.
 ## Versioning
 
 For details on how Inkless versions work, see [Versioning Strategy](VERSIONING-STRATEGY.md).
+
+The increment number is carried only by tags, never by `gradle.properties`, so a release involves
+no per-branch version bump commit.
 
 **Quick summary:**
 - Same Inkless version (e.g., `0.33`) across Kafka versions = same Inkless features

--- a/inkless-sync/branch-consistency.sh
+++ b/inkless-sync/branch-consistency.sh
@@ -16,6 +16,12 @@ RELEASE_BRANCH=""
 VERBOSE=false
 SHOW_MISSING=false
 SHOW_ALL=false
+CHECK=false
+
+# Set by check_consistency: number of actionable missing commits (newer than the
+# last cherry-pick; old below-window commits do not count). Used by --check to
+# derive the process exit code.
+ACTIONABLE_COUNT=0
 
 usage() {
     cat <<EOF
@@ -30,6 +36,8 @@ Options:
   --missing         Show only missing commits (not yet cherry-picked)
   --all             Show ALL missing commits (including old ones)
                     By default, only shows commits newer than last cherry-picked
+  --check           Exit non-zero if there are actionable missing commits
+                    (old below-window commits do not count). For CI gates.
   --verbose         Show detailed commit information
   -h, --help        Show this help
 
@@ -39,6 +47,9 @@ Examples:
 
   # Show only missing commits
   $(basename "$0") inkless-4.0 --missing
+
+  # CI gate: nonzero exit when the branch is behind
+  $(basename "$0") inkless-4.0 --check
 
   # Verbose output with commit details
   $(basename "$0") inkless-4.0 --verbose
@@ -57,6 +68,10 @@ parse_args() {
                 ;;
             --all)
                 SHOW_ALL=true
+                shift
+                ;;
+            --check)
+                CHECK=true
                 shift
                 ;;
             --verbose)
@@ -245,6 +260,9 @@ check_consistency() {
     local actionable_count=${#actionable_commits[@]}
     local old_count=${#old_commits[@]}
 
+    # Publish the actionable count for --check (process exit code).
+    ACTIONABLE_COUNT=$actionable_count
+
     # Summary
     echo ""
     echo "## Summary"
@@ -330,10 +348,30 @@ main() {
     parse_args "$@"
 
     require_git_repo
-    fetch_upstream
-    git fetch origin --prune
+    # --check only compares origin/main against origin/<branch> and is meant for CI
+    # gates that populate those refs themselves (pinned to the release target). Skip
+    # BOTH fetches in that mode: fetch_upstream needs an apache/upstream remote that
+    # CI checkouts lack, and `git fetch origin --prune` would reset refs/remotes/origin/*
+    # to the live remote HEAD, clobbering the caller's pinned comparison base.
+    if [[ "$CHECK" != "true" ]]; then
+        fetch_upstream
+        git fetch origin --prune
+    fi
 
     check_consistency "$RELEASE_BRANCH"
+
+    # --check turns the actionable-missing count into a process exit code so CI
+    # can gate on it without parsing the human-readable output. Old (below-window)
+    # commits are NOT actionable and do not fail the check.
+    if [[ "$CHECK" == "true" ]]; then
+        if [[ "$ACTIONABLE_COUNT" -gt 0 ]]; then
+            echo ""
+            echo "CHECK FAILED: $RELEASE_BRANCH has $ACTIONABLE_COUNT actionable missing commit(s)."
+            exit 1
+        fi
+        echo ""
+        echo "CHECK OK: $RELEASE_BRANCH has no actionable missing commits."
+    fi
 }
 
 main "$@"


### PR DESCRIPTION
Makes the Inkless release workflow usable and resumable. Self-contained: everything the workflow calls at runtime is included, so it is safe to merge alone.

## Changes

- Validate by PR-presence: `validate` now runs `branch-consistency.sh --check` (matches inkless commits by PR number, correct for cherry-picked branches) instead of a SHA ancestry check that could never pass.
- `--check` flag added to `branch-consistency.sh`: turns the actionable-missing count into an exit code for CI. Skips the upstream (apache) fetch so it works in an origin-only CI checkout.
- Resume support: `resume=true` finishes an already-tagged release that was never published. It skips tagging and validation (the tags were valid at cut time) and re-runs publish.
- Release-notes rendering: notes are written to a file and passed via `--notes-file`, so YAML block-scalar indentation no longer leaks into the markdown. A malformed matrix now fails loudly instead of aborting silently.

## Not included

Curated-changelog injection is deferred; its generator lives with the `inkless-changelog` skill (separate PR) and is not on `main` yet. Until then the Release publishes with boilerplate notes.
