### PR TITLE
feat(inkless): surface inkless version at startup and in --version output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,13 @@
 .PHONY: all
 all: clean fmt test pitest build_release
 
-VERSION := 4.2.0-inkless-SNAPSHOT
+# Kafka distribution version. Source of truth is gradle.properties (project.version),
+# so build_release/docker targets are correct on any checkout (main, a release
+# branch, or a release tag) without manual overrides. Override with `make VERSION=...`
+# if needed.
+ifndef VERSION
+VERSION := $(shell sed -n 's/^version=//p' gradle.properties)
+endif
 
 # Docker image settings (aligned with .github/workflows/inkless-release.yml)
 REGISTRY := ghcr.io

--- a/build.gradle
+++ b/build.gradle
@@ -117,6 +117,7 @@ ext {
   repo = file("$rootDir/.git").isDirectory() ? Grgit.open(currentDir: project.getRootDir()) : null
 
   commitId = determineCommitId()
+  inklessTag = determineInklessTag()
 
   configureJavaCompiler = { name, options, projectPath ->
     // -parameters generates arguments with parameter names in TestInfo#getDisplayName.
@@ -242,6 +243,27 @@ def determineCommitId() {
   } else {
     "unknown"
   }
+}
+
+// Inkless: describe the nearest inkless-* tag (e.g. "inkless-4.2.1-0.45" at a tag,
+// or "inkless-4.2.1-0.45-3-g9c3cf45" a few commits past it). This surfaces the
+// git tag and the inkless increment in the baked-in version file. The increment
+// lives only in tags (never in gradle.properties), so this is the only build-time
+// source for it.
+//
+// Returned as a lazy Provider using providers.exec (the configuration-cache-safe
+// API) rather than a config-time exec, and evaluated when createVersionFile runs.
+// Uses the git CLI (worktree-aware) so it works in linked worktrees where Grgit's
+// `repo` is null. Falls back to "unknown" on any error or missing tag.
+def determineInklessTag() {
+  if (project.hasProperty('inklessTag')) {
+    return providers.provider { project.property('inklessTag').toString() }
+  }
+  def described = providers.exec {
+    commandLine 'git', 'describe', '--tags', '--match', 'inkless-*', '--always', '--dirty'
+    workingDir project.rootDir
+  }.standardOutput.asText.map { it.trim() }
+  return described.map { it.isEmpty() ? "unknown" : it }.orElse("unknown")
 }
 
 /**
@@ -1013,6 +1035,7 @@ project(':server') {
     def receiptFile = file("${layout.buildDirectory.get().asFile.path}/kafka/$buildVersionFileName")
     inputs.property "commitId", commitId
     inputs.property "version", version
+    inputs.property "inklessTag", inklessTag
     outputs.file receiptFile
     outputs.cacheIf { true }
 
@@ -1020,6 +1043,7 @@ project(':server') {
       def data = [
         commitId: commitId,
         version: version,
+        inklessTag: inklessTag.get(),
       ]
 
       receiptFile.parentFile.mkdirs()
@@ -1475,6 +1499,7 @@ project(':group-coordinator:group-coordinator-api') {
     def receiptFile = file("${layout.buildDirectory.get().asFile.path}/kafka/$buildVersionFileName")
     inputs.property "commitId", commitId
     inputs.property "version", version
+    inputs.property "inklessTag", inklessTag
     outputs.file receiptFile
     outputs.cacheIf { true }
 
@@ -1482,6 +1507,7 @@ project(':group-coordinator:group-coordinator-api') {
       def data = [
               commitId: commitId,
               version: version,
+              inklessTag: inklessTag.get(),
       ]
 
       receiptFile.parentFile.mkdirs()
@@ -1948,6 +1974,7 @@ project(':clients') {
     def receiptFile = file("${layout.buildDirectory.get().asFile.path}/kafka/$buildVersionFileName")
     inputs.property "commitId", commitId
     inputs.property "version", version
+    inputs.property "inklessTag", inklessTag
     outputs.file receiptFile
     outputs.cacheIf { true }
 
@@ -1955,6 +1982,7 @@ project(':clients') {
       def data = [
         commitId: commitId,
         version: version,
+        inklessTag: inklessTag.get(),
       ]
 
       receiptFile.parentFile.mkdirs()
@@ -2148,6 +2176,7 @@ project(':raft') {
     def receiptFile = file("${layout.buildDirectory.get().asFile.path}/kafka/$buildVersionFileName")
     inputs.property "commitId", commitId
     inputs.property "version", version
+    inputs.property "inklessTag", inklessTag
     outputs.file receiptFile
     outputs.cacheIf { true }
 
@@ -2155,6 +2184,7 @@ project(':raft') {
       def data = [
         commitId: commitId,
         version: version,
+        inklessTag: inklessTag.get(),
       ]
 
       receiptFile.parentFile.mkdirs()
@@ -2242,6 +2272,7 @@ project(':server-common') {
     def receiptFile = file("${layout.buildDirectory.get().asFile.path}/kafka/$buildVersionFileName")
     inputs.property "commitId", commitId
     inputs.property "version", version
+    inputs.property "inklessTag", inklessTag
     outputs.file receiptFile
     outputs.cacheIf { true }
 
@@ -2249,6 +2280,7 @@ project(':server-common') {
       def data = [
               commitId: commitId,
               version: version,
+              inklessTag: inklessTag.get(),
       ]
 
       receiptFile.parentFile.mkdirs()
@@ -2301,6 +2333,7 @@ project(':storage:storage-api') {
     def receiptFile = file("${layout.buildDirectory.get().asFile.path}/kafka/$buildVersionFileName")
     inputs.property "commitId", commitId
     inputs.property "version", version
+    inputs.property "inklessTag", inklessTag
     outputs.file receiptFile
     outputs.cacheIf { true }
 
@@ -2308,6 +2341,7 @@ project(':storage:storage-api') {
       def data = [
               commitId: commitId,
               version: version,
+              inklessTag: inklessTag.get(),
       ]
 
       receiptFile.parentFile.mkdirs()
@@ -2397,6 +2431,7 @@ project(':storage') {
     def receiptFile = file("${layout.buildDirectory.get().asFile.path}/kafka/$buildVersionFileName")
     inputs.property "commitId", commitId
     inputs.property "version", version
+    inputs.property "inklessTag", inklessTag
     outputs.file receiptFile
     outputs.cacheIf { true }
 
@@ -2404,6 +2439,7 @@ project(':storage') {
       def data = [
               commitId: commitId,
               version: version,
+              inklessTag: inklessTag.get(),
       ]
 
       receiptFile.parentFile.mkdirs()
@@ -2761,6 +2797,7 @@ project(':tools:tools-api') {
     def receiptFile = file("${layout.buildDirectory.get().asFile.path}/kafka/$buildVersionFileName")
     inputs.property "commitId", commitId
     inputs.property "version", version
+    inputs.property "inklessTag", inklessTag
     outputs.file receiptFile
     outputs.cacheIf { true }
 
@@ -2768,6 +2805,7 @@ project(':tools:tools-api') {
       def data = [
               commitId: commitId,
               version: version,
+              inklessTag: inklessTag.get(),
       ]
 
       receiptFile.parentFile.mkdirs()
@@ -3090,12 +3128,14 @@ project(':streams') {
     def receiptFile = file("${layout.buildDirectory.get().asFile.path}/kafka/$buildStreamsVersionFileName")
     inputs.property "commitId", commitId
     inputs.property "version", version
+    inputs.property "inklessTag", inklessTag
     outputs.file receiptFile
 
     doLast {
       def data = [
               commitId: commitId,
               version: version,
+              inklessTag: inklessTag.get(),
       ]
 
       receiptFile.parentFile.mkdirs()

--- a/clients/src/main/java/org/apache/kafka/common/utils/AppInfoParser.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/AppInfoParser.java
@@ -36,6 +36,8 @@ public class AppInfoParser {
     private static final Logger log = LoggerFactory.getLogger(AppInfoParser.class);
     private static final String VERSION;
     private static final String COMMIT_ID;
+    // INKLESS: git-describe of the nearest inkless-* tag (tag + increment), baked in by build.gradle.
+    private static final String INKLESS_TAG;
 
     protected static final String DEFAULT_VALUE = "unknown";
 
@@ -48,6 +50,7 @@ public class AppInfoParser {
         }
         VERSION = props.getProperty("version", DEFAULT_VALUE).trim();
         COMMIT_ID = props.getProperty("commitId", DEFAULT_VALUE).trim();
+        INKLESS_TAG = props.getProperty("inklessTag", DEFAULT_VALUE).trim();
     }
 
     public static String getVersion() {
@@ -56,6 +59,22 @@ public class AppInfoParser {
 
     public static String getCommitId() {
         return COMMIT_ID;
+    }
+
+    // INKLESS: the inkless release tag description (e.g. "inkless-4.2.1-0.45"), from git describe.
+    public static String getInklessTag() {
+        return INKLESS_TAG;
+    }
+
+    // INKLESS: true when an inkless tag was baked in (release build), false otherwise.
+    private static boolean hasInklessTag() {
+        return !INKLESS_TAG.isEmpty() && !DEFAULT_VALUE.equals(INKLESS_TAG);
+    }
+
+    // INKLESS: " (Inkless:<tag>)" suffix for --version output, or "" when the inkless
+    // tag was not baked in (keeps upstream output/tests intact off a release build).
+    public static String getInklessTagSuffix() {
+        return hasInklessTag() ? " (Inkless:" + INKLESS_TAG + ")" : "";
     }
 
     public static synchronized void registerAppInfo(String prefix, String id, Metrics metrics, long nowMs) {
@@ -137,6 +156,10 @@ public class AppInfoParser {
             this.startTimeMs = startTimeMs;
             log.info("Kafka version: {}", AppInfoParser.getVersion());
             log.info("Kafka commitId: {}", AppInfoParser.getCommitId());
+            // INKLESS: log the inkless tag/increment at startup when baked in (see build.gradle).
+            if (hasInklessTag()) {
+                log.info("Inkless tag: {}", INKLESS_TAG);
+            }
             log.info("Kafka startTimeMs: {}", startTimeMs);
         }
 

--- a/clients/src/test/java/org/apache/kafka/common/utils/AppInfoParserTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/AppInfoParserTest.java
@@ -85,6 +85,14 @@ public class AppInfoParserTest {
         }
     }
 
+    // INKLESS: without a baked kafka-version.properties on the test classpath the inkless
+    // tag defaults to "unknown" and the --version suffix is suppressed.
+    @Test
+    public void testInklessTagDefaultsToUnknownAndSuppressesSuffix() {
+        assertEquals(AppInfoParser.DEFAULT_VALUE, AppInfoParser.getInklessTag());
+        assertEquals("", AppInfoParser.getInklessTagSuffix());
+    }
+
     private void registerAppInfo(Metrics metrics) throws JMException {
         assertEquals(EXPECTED_COMMIT_VERSION, AppInfoParser.getCommitId());
         assertEquals(EXPECTED_VERSION, AppInfoParser.getVersion());

--- a/server-common/src/main/java/org/apache/kafka/server/util/CommandLineUtils.java
+++ b/server-common/src/main/java/org/apache/kafka/server/util/CommandLineUtils.java
@@ -171,7 +171,8 @@ public class CommandLineUtils {
     }
 
     public static void printVersionAndExit() {
-        System.out.println(AppInfoParser.getVersion());
+        // INKLESS: append the inkless tag/increment (e.g. "inkless-4.2.1-0.45") when baked in.
+        System.out.println(AppInfoParser.getVersion() + AppInfoParser.getInklessTagSuffix());
         Exit.exit(0);
     }
 

--- a/tools/src/main/java/org/apache/kafka/tools/PrintVersionAndExitAction.java
+++ b/tools/src/main/java/org/apache/kafka/tools/PrintVersionAndExitAction.java
@@ -37,7 +37,8 @@ class PrintVersionAndExitAction implements ArgumentAction {
     ) {
         String version = AppInfoParser.getVersion();
         String commitId = AppInfoParser.getCommitId();
-        System.out.println(version + " (Commit:" + commitId + ")");
+        // INKLESS: also print the inkless tag/increment (e.g. "inkless-4.2.1-0.45") when baked in.
+        System.out.println(version + " (Commit:" + commitId + ")" + AppInfoParser.getInklessTagSuffix());
         Exit.exit(0);
     }
 

--- a/tools/src/test/java/org/apache/kafka/tools/GetOffsetShellTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/GetOffsetShellTest.java
@@ -484,7 +484,7 @@ public class GetOffsetShellTest {
     @ClusterTest
     public void testPrintVersion() {
         String out = ToolsTestUtils.captureStandardOut(() -> GetOffsetShell.mainNoExit("--version"));
-        assertEquals(AppInfoParser.getVersion(), out);
+        assertEquals(AppInfoParser.getVersion() + AppInfoParser.getInklessTagSuffix(), out);
     }
 
     private void assertExitCodeIsOne(String... args) {

--- a/tools/src/test/java/org/apache/kafka/tools/consumer/group/DescribeConsumerGroupTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/consumer/group/DescribeConsumerGroupTest.java
@@ -1164,7 +1164,7 @@ public class DescribeConsumerGroupTest {
         try {
             String out = ToolsTestUtils.captureStandardOut(() -> ConsumerGroupCommandOptions.fromArgs(new String[]{"--version"}));
             assertEquals(0, exitProcedure.statusCode());
-            assertEquals(AppInfoParser.getVersion(), out);
+            assertEquals(AppInfoParser.getVersion() + AppInfoParser.getInklessTagSuffix(), out);
         } finally {
             Exit.resetExitProcedure();
         }


### PR DESCRIPTION
Bake git describe --tags --match 'inkless-*' into kafka-version.properties as inklessTag (via providers.exec, worktree-aware) and expose it through AppInfoParser.getInklessTag(). Log it at broker/client startup ("Inkless tag: <describe>") alongside the existing Kafka version/commitId lines, and append it as a " (Inkless:<tag>)" suffix to the broker/tools --version output. Both are gated on the tag being baked in (non-empty and not "unknown"), so upstream output/logs are unchanged when it is absent (e.g. off a non-release build).

Also derive Makefile VERSION from gradle.properties instead of hardcoding 4.2.0-inkless-SNAPSHOT, so build_release/docker are correct on any checkout (inkless-4.1 hardcoded 4.1.0 while its gradle.properties said 4.1.2).
