### PR TITLE
control_plane: retry transient postgres errors in control plane jobs

### DIFF
--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/EnforceRetentionJob.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/EnforceRetentionJob.java
@@ -62,7 +62,8 @@ public class EnforceRetentionJob implements Callable<List<EnforceRetentionRespon
         if (requests.isEmpty()) {
             return List.of();
         }
-        return JobUtils.run(this::runOnce);
+        // JobUtils must not record duration: runOnce already reports each partition separately.
+        return JobUtils.run(this::runOnce, time, ignored -> { });
     }
 
     private List<EnforceRetentionResponse> runOnce() throws Exception {

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/JobUtils.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/JobUtils.java
@@ -45,34 +45,14 @@ public class JobUtils {
     static final int BACKOFF_MULTIPLIER = 2;
     static final double BACKOFF_JITTER = 0.2;
 
-    /**
-     * Backoff between retries. Uses jitter (a randomized factor in {@code [1 - jitter, 1 + jitter]})
-     * so that many jobs failing against the same struggling standby at once do not retry in lockstep
-     * (thundering herd) and re-collide on the same recovery-conflict window.
-     */
+    // Jittered so concurrent retries against the same standby do not collide in lockstep.
     private static final ExponentialBackoff BACKOFF =
         new ExponentialBackoff(INITIAL_BACKOFF_MS, BACKOFF_MULTIPLIER, MAX_BACKOFF_MS, BACKOFF_JITTER);
 
     /**
-     * PostgreSQL {@code SQLState}s that are safe to retry because they guarantee the transaction did
-     * <em>not</em> commit (the server rolled it back), so replaying the whole transaction cannot
-     * double-apply a write.
-     *
-     * <ul>
-     *   <li>{@code 40001} — {@code serialization_failure}. PostgreSQL also raises this
-     *       ({@code ERRCODE_T_R_SERIALIZATION_FAILURE}) for hot-standby recovery conflicts, in both
-     *       observed forms: the statement cancellation
-     *       ("canceling statement due to conflict with recovery") <em>and</em> the connection
-     *       termination ("terminating connection due to conflict with recovery"). The latter closes
-     *       the JDBC connection, but because {@code readJooqCtx}/{@code writeJooqCtx} are backed by a
-     *       connection pool, the retry transparently obtains a fresh connection.</li>
-     *   <li>{@code 40P01} — {@code deadlock_detected}. The victim transaction is rolled back.</li>
-     * </ul>
-     *
-     * <p>We deliberately do <b>not</b> retry generic connection-loss states (class {@code 08*},
-     * {@code 57P01}) here: a connection dropped <em>during commit</em> leaves the transaction
-     * in-doubt, so blindly replaying a write job could apply it twice. The recovery-conflict family
-     * that motivated this retry logic is fully covered by the rollback-guaranteed states above.
+     * PostgreSQL failures that guarantee transaction rollback and are safe to retry:
+     * {@code 40001} for serialization or recovery conflicts, and {@code 40P01} for deadlocks.
+     * Connection-loss states are excluded because the commit outcome may be unknown.
      */
     private static final Set<String> RETRIABLE_SQL_STATES = Set.of("40001", "40P01");
 
@@ -95,58 +75,39 @@ public class JobUtils {
         }
     }
 
-    /**
-     * Execute {@code callable}, retrying with jittered exponential backoff on transient PostgreSQL
-     * failures (see {@link #RETRIABLE_SQL_STATES}). On exhaustion, or for any non-retriable failure,
-     * the original exception is rethrown so callers observe the unchanged error contract.
-     *
-     * <p>Only the <em>decisive</em> attempt (the one that succeeds, or the final failure) is reported
-     * to {@code durationCallback}. Intermediate retried attempts are timed internally but not
-     * forwarded, so failed-attempt durations do not inflate the latency/rate metrics — exactly when
-     * an operator relies on them during a conflict storm.
-     */
     private static <T> T runWithRetry(final Callable<T> callable, final Time time, final Consumer<Long> durationCallback) throws Exception {
-        // measureDurationMs records the just-finished attempt's duration into this holder (via its
-        // finally block, so it fires on failure too); we forward it to durationCallback only once,
-        // when we stop retrying.
-        final long[] lastAttemptDurationMs = {0L};
-        final Consumer<Long> captureDuration = d -> lastAttemptDurationMs[0] = d;
-
-        for (int attempt = 1; ; attempt++) {
-            try {
-                final T result = TimeUtils.measureDurationMs(time, callable, captureDuration);
-                durationCallback.accept(lastAttemptDurationMs[0]);
-                return result;
-            } catch (final Exception e) {
-                if (attempt >= MAX_ATTEMPTS || !isRetriable(e)) {
-                    // Decisive failure: record its duration once, then propagate unchanged.
-                    durationCallback.accept(lastAttemptDurationMs[0]);
-                    if (attempt > 1) {
-                        LOGGER.warn("Giving up after {} attempts on transient database error", attempt, e);
+        // One sample per run(), covering attempts and backoff, so QueryTime matches client-visible
+        // latency and QueryRate stays one increment per job.
+        return TimeUtils.measureDurationMs(time, () -> {
+            for (int attempt = 1; ; attempt++) {
+                try {
+                    return callable.call();
+                } catch (final Exception e) {
+                    if (attempt >= MAX_ATTEMPTS || !isRetriable(e)) {
+                        if (attempt >= MAX_ATTEMPTS) {
+                            LOGGER.warn("Giving up after {} attempts on transient database error", attempt, e);
+                        }
+                        throw e;
                     }
-                    throw e;
-                }
-                final long backoffMs = BACKOFF.backoff(attempt - 1);
-                LOGGER.warn("Transient database error on attempt {}/{}, retrying in {} ms",
-                    attempt, MAX_ATTEMPTS, backoffMs, e);
-                time.sleep(backoffMs);
-                if (Thread.currentThread().isInterrupted()) {
-                    // Interrupted during backoff (e.g. broker shutdown). Utils.sleep restores the
-                    // interrupt flag but returns normally, so we must check it explicitly: stop
-                    // retrying, keep the flag set, and surface the last error rather than spinning
-                    // through the remaining attempts and delaying shutdown.
-                    durationCallback.accept(lastAttemptDurationMs[0]);
-                    throw e;
+                    final long backoffMs = BACKOFF.backoff(attempt - 1);
+                    LOGGER.debug("Transient database error on attempt {}/{}, retrying in {} ms",
+                        attempt, MAX_ATTEMPTS, backoffMs, e);
+                    time.sleep(backoffMs);
+                    if (Thread.currentThread().isInterrupted()) {
+                        // SystemTime.sleep restores the interrupt flag but returns normally, so
+                        // check it here or the loop would keep retrying through broker shutdown.
+                        throw e;
+                    }
                 }
             }
-        }
+        }, durationCallback);
     }
 
     /**
-     * Returns {@code true} if any throwable in the cause chain (including suppressed throwables) is a
-     * {@link SQLException} whose {@code SQLState} is in {@link #RETRIABLE_SQL_STATES}. The retriable
-     * cause is typically wrapped several layers deep (e.g. {@code ControlPlaneException} ->
-     * {@code DataAccessException} -> {@code PSQLException}), so the whole tree is scanned.
+     * True if any {@link SQLException} in the cause chain, JDBC {@code nextException} chain, or
+     * suppressed throwables has a SQLState in {@link #RETRIABLE_SQL_STATES}. Jobs wrap the JDBC
+     * failure (e.g. {@code ControlPlaneException} -> {@code DataAccessException} ->
+     * {@code PSQLException}), so the argument stays {@link Throwable}.
      */
     static boolean isRetriable(final Throwable throwable) {
         // Identity-based visited set guards against self-referential cause chains.
@@ -158,8 +119,12 @@ public class JobUtils {
             return false;
         }
         if (throwable instanceof SQLException) {
-            final String sqlState = ((SQLException) throwable).getSQLState();
+            final SQLException sqlException = (SQLException) throwable;
+            final String sqlState = sqlException.getSQLState();
             if (sqlState != null && RETRIABLE_SQL_STATES.contains(sqlState)) {
+                return true;
+            }
+            if (hasRetriableCause(sqlException.getNextException(), seen)) {
                 return true;
             }
         }

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/JobUtils.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/JobUtils.java
@@ -17,8 +17,16 @@
  */
 package io.aiven.inkless.control_plane.postgres;
 
+import org.apache.kafka.common.utils.ExponentialBackoff;
 import org.apache.kafka.common.utils.Time;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.SQLException;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.function.Consumer;
 
@@ -26,55 +34,143 @@ import io.aiven.inkless.TimeUtils;
 import io.aiven.inkless.control_plane.ControlPlaneException;
 
 public class JobUtils {
-    public static void run(final Runnable runnable) {
-        try {
-            runnable.run();
-        } catch (final Exception e) {
-            // TODO add retry with backoff
-            if (e instanceof ControlPlaneException) {
-                throw (ControlPlaneException) e;
-            } else {
-                throw new RuntimeException(e);
-            }
-        }
-    }
+    private static final Logger LOGGER = LoggerFactory.getLogger(JobUtils.class);
+
+    /**
+     * Total number of attempts (initial try + retries) for a transient database failure.
+     */
+    static final int MAX_ATTEMPTS = 3;
+    static final long INITIAL_BACKOFF_MS = 50;
+    static final long MAX_BACKOFF_MS = 1_000;
+    static final int BACKOFF_MULTIPLIER = 2;
+    static final double BACKOFF_JITTER = 0.2;
+
+    /**
+     * Backoff between retries. Uses jitter (a randomized factor in {@code [1 - jitter, 1 + jitter]})
+     * so that many jobs failing against the same struggling standby at once do not retry in lockstep
+     * (thundering herd) and re-collide on the same recovery-conflict window.
+     */
+    private static final ExponentialBackoff BACKOFF =
+        new ExponentialBackoff(INITIAL_BACKOFF_MS, BACKOFF_MULTIPLIER, MAX_BACKOFF_MS, BACKOFF_JITTER);
+
+    /**
+     * PostgreSQL {@code SQLState}s that are safe to retry because they guarantee the transaction did
+     * <em>not</em> commit (the server rolled it back), so replaying the whole transaction cannot
+     * double-apply a write.
+     *
+     * <ul>
+     *   <li>{@code 40001} — {@code serialization_failure}. PostgreSQL also raises this
+     *       ({@code ERRCODE_T_R_SERIALIZATION_FAILURE}) for hot-standby recovery conflicts, in both
+     *       observed forms: the statement cancellation
+     *       ("canceling statement due to conflict with recovery") <em>and</em> the connection
+     *       termination ("terminating connection due to conflict with recovery"). The latter closes
+     *       the JDBC connection, but because {@code readJooqCtx}/{@code writeJooqCtx} are backed by a
+     *       connection pool, the retry transparently obtains a fresh connection.</li>
+     *   <li>{@code 40P01} — {@code deadlock_detected}. The victim transaction is rolled back.</li>
+     * </ul>
+     *
+     * <p>We deliberately do <b>not</b> retry generic connection-loss states (class {@code 08*},
+     * {@code 57P01}) here: a connection dropped <em>during commit</em> leaves the transaction
+     * in-doubt, so blindly replaying a write job could apply it twice. The recovery-conflict family
+     * that motivated this retry logic is fully covered by the rollback-guaranteed states above.
+     */
+    private static final Set<String> RETRIABLE_SQL_STATES = Set.of("40001", "40P01");
 
     public static void run(final Runnable runnable, final Time time, final Consumer<Long> durationCallback) {
-        try {
-            TimeUtils.measureDurationMs(time, runnable, durationCallback);
-        } catch (final Exception e) {
-            // TODO add retry with backoff
-            if (e instanceof ControlPlaneException) {
-                throw (ControlPlaneException) e;
-            } else {
-                throw new RuntimeException(e);
-            }
-        }
-    }
-
-    public static <T> T run(final Callable<T> callable) {
-        try {
-            return callable.call();
-        } catch (final Exception e) {
-            // TODO add retry with backoff
-            if (e instanceof ControlPlaneException) {
-                throw (ControlPlaneException) e;
-            } else {
-                throw new RuntimeException(e);
-            }
-        }
+        run(() -> {
+            runnable.run();
+            return null;
+        }, time, durationCallback);
     }
 
     public static <T> T run(final Callable<T> callable, final Time time, final Consumer<Long> durationCallback) {
         try {
-            return TimeUtils.measureDurationMs(time, callable, durationCallback);
+            return runWithRetry(callable, time, durationCallback);
         } catch (final Exception e) {
-            // TODO add retry with backoff
             if (e instanceof ControlPlaneException) {
                 throw (ControlPlaneException) e;
             } else {
                 throw new RuntimeException(e);
             }
         }
+    }
+
+    /**
+     * Execute {@code callable}, retrying with jittered exponential backoff on transient PostgreSQL
+     * failures (see {@link #RETRIABLE_SQL_STATES}). On exhaustion, or for any non-retriable failure,
+     * the original exception is rethrown so callers observe the unchanged error contract.
+     *
+     * <p>Only the <em>decisive</em> attempt (the one that succeeds, or the final failure) is reported
+     * to {@code durationCallback}. Intermediate retried attempts are timed internally but not
+     * forwarded, so failed-attempt durations do not inflate the latency/rate metrics — exactly when
+     * an operator relies on them during a conflict storm.
+     */
+    private static <T> T runWithRetry(final Callable<T> callable, final Time time, final Consumer<Long> durationCallback) throws Exception {
+        // measureDurationMs records the just-finished attempt's duration into this holder (via its
+        // finally block, so it fires on failure too); we forward it to durationCallback only once,
+        // when we stop retrying.
+        final long[] lastAttemptDurationMs = {0L};
+        final Consumer<Long> captureDuration = d -> lastAttemptDurationMs[0] = d;
+
+        for (int attempt = 1; ; attempt++) {
+            try {
+                final T result = TimeUtils.measureDurationMs(time, callable, captureDuration);
+                durationCallback.accept(lastAttemptDurationMs[0]);
+                return result;
+            } catch (final Exception e) {
+                if (attempt >= MAX_ATTEMPTS || !isRetriable(e)) {
+                    // Decisive failure: record its duration once, then propagate unchanged.
+                    durationCallback.accept(lastAttemptDurationMs[0]);
+                    if (attempt > 1) {
+                        LOGGER.warn("Giving up after {} attempts on transient database error", attempt, e);
+                    }
+                    throw e;
+                }
+                final long backoffMs = BACKOFF.backoff(attempt - 1);
+                LOGGER.warn("Transient database error on attempt {}/{}, retrying in {} ms",
+                    attempt, MAX_ATTEMPTS, backoffMs, e);
+                time.sleep(backoffMs);
+                if (Thread.currentThread().isInterrupted()) {
+                    // Interrupted during backoff (e.g. broker shutdown). Utils.sleep restores the
+                    // interrupt flag but returns normally, so we must check it explicitly: stop
+                    // retrying, keep the flag set, and surface the last error rather than spinning
+                    // through the remaining attempts and delaying shutdown.
+                    durationCallback.accept(lastAttemptDurationMs[0]);
+                    throw e;
+                }
+            }
+        }
+    }
+
+    /**
+     * Returns {@code true} if any throwable in the cause chain (including suppressed throwables) is a
+     * {@link SQLException} whose {@code SQLState} is in {@link #RETRIABLE_SQL_STATES}. The retriable
+     * cause is typically wrapped several layers deep (e.g. {@code ControlPlaneException} ->
+     * {@code DataAccessException} -> {@code PSQLException}), so the whole tree is scanned.
+     */
+    static boolean isRetriable(final Throwable throwable) {
+        // Identity-based visited set guards against self-referential cause chains.
+        return hasRetriableCause(throwable, Collections.newSetFromMap(new IdentityHashMap<>()));
+    }
+
+    private static boolean hasRetriableCause(final Throwable throwable, final Set<Throwable> seen) {
+        if (throwable == null || !seen.add(throwable)) {
+            return false;
+        }
+        if (throwable instanceof SQLException) {
+            final String sqlState = ((SQLException) throwable).getSQLState();
+            if (sqlState != null && RETRIABLE_SQL_STATES.contains(sqlState)) {
+                return true;
+            }
+        }
+        if (hasRetriableCause(throwable.getCause(), seen)) {
+            return true;
+        }
+        for (final Throwable suppressed : throwable.getSuppressed()) {
+            if (hasRetriableCause(suppressed, seen)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/JobUtilsTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/JobUtilsTest.java
@@ -1,0 +1,248 @@
+/*
+ * Inkless
+ * Copyright (C) 2024 - 2025 Aiven OY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.aiven.inkless.control_plane.postgres;
+
+import org.apache.kafka.common.utils.MockTime;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.sql.SQLException;
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.aiven.inkless.control_plane.ControlPlaneException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for {@link JobUtils} retry behavior. These use {@link MockTime}, so the backoff
+ * {@code sleep} advances virtual time only and the tests never block on wall-clock.
+ */
+@Timeout(10)
+class JobUtilsTest {
+
+    /** Serialization failure / recovery conflict — PostgreSQL uses 40001 for both. */
+    private static SQLException recoveryConflict() {
+        return new SQLException("canceling statement due to conflict with recovery", "40001");
+    }
+
+    private static SQLException deadlock() {
+        return new SQLException("deadlock detected", "40P01");
+    }
+
+    @Test
+    void succeedsWithoutRetryWhenNoError() {
+        final MockTime time = new MockTime();
+        final AtomicInteger attempts = new AtomicInteger();
+        final AtomicInteger durationCallbacks = new AtomicInteger();
+        final long startMs = time.milliseconds();
+
+        final String result = JobUtils.run(() -> {
+            attempts.incrementAndGet();
+            return "ok";
+        }, time, ignored -> durationCallbacks.incrementAndGet());
+
+        assertThat(result).isEqualTo("ok");
+        assertThat(attempts).hasValue(1);
+        // Exactly one metric sample, no backoff on the happy path.
+        assertThat(durationCallbacks).hasValue(1);
+        assertThat(time.milliseconds()).isEqualTo(startMs);
+    }
+
+    @Test
+    void retriesRecoveryConflictThenSucceeds() {
+        final MockTime time = new MockTime();
+        final AtomicInteger attempts = new AtomicInteger();
+        final AtomicInteger durationCallbacks = new AtomicInteger();
+
+        // Reproduces the production incident: the read replica cancels the first attempts with a
+        // recovery conflict (SQLState 40001), wrapped exactly as the control plane wraps it, then a
+        // later attempt on a fresh pooled connection succeeds.
+        final Callable<String> flaky = () -> {
+            if (attempts.incrementAndGet() < 3) {
+                throw new ControlPlaneException("Error finding batches",
+                    new RuntimeException("Cannot commit transaction", recoveryConflict()));
+            }
+            return "recovered";
+        };
+
+        final String result = JobUtils.run(flaky, time, ignored -> durationCallbacks.incrementAndGet());
+
+        assertThat(result).isEqualTo("recovered");
+        assertThat(attempts).hasValue(3);
+        // Guards against metric double-counting (finding #1): even though the job ran 3 times, only
+        // the decisive attempt is reported to the duration callback.
+        assertThat(durationCallbacks).hasValue(1);
+    }
+
+    @Test
+    void backsOffWithExponentialJitterBetweenRetries() {
+        final MockTime time = new MockTime();
+        final AtomicInteger attempts = new AtomicInteger();
+        final long startMs = time.milliseconds();
+
+        // Fails on the first two attempts, succeeds on the third, so two backoff sleeps happen.
+        JobUtils.run(() -> {
+            if (attempts.incrementAndGet() < 3) {
+                throw new RuntimeException(recoveryConflict());
+            }
+            return "ok";
+        }, time, ignored -> { });
+
+        // Jittered exponential backoff: attempt 1 sleeps ~50ms, attempt 2 sleeps ~100ms, each
+        // scaled by a factor in [1 - JITTER, 1 + JITTER]. Assert the total elapsed virtual time
+        // falls within those combined bounds (this also proves a sleep actually happened).
+        final long elapsed = time.milliseconds() - startMs;
+        final long nominal = JobUtils.INITIAL_BACKOFF_MS
+            + JobUtils.INITIAL_BACKOFF_MS * JobUtils.BACKOFF_MULTIPLIER;
+        final long minExpected = (long) (nominal * (1 - JobUtils.BACKOFF_JITTER));
+        final long maxExpected = (long) (nominal * (1 + JobUtils.BACKOFF_JITTER));
+        assertThat(elapsed).isBetween(minExpected, maxExpected);
+    }
+
+    @Test
+    void retriesDeadlock() {
+        final MockTime time = new MockTime();
+        final AtomicInteger attempts = new AtomicInteger();
+
+        final String result = JobUtils.run(() -> {
+            if (attempts.incrementAndGet() < 2) {
+                throw new RuntimeException(deadlock());
+            }
+            return "ok";
+        }, time, ignored -> { });
+
+        assertThat(result).isEqualTo("ok");
+        assertThat(attempts).hasValue(2);
+    }
+
+    @Test
+    void stopsAfterMaxAttemptsAndRethrowsOriginal() {
+        final MockTime time = new MockTime();
+        final AtomicInteger attempts = new AtomicInteger();
+        final AtomicInteger durationCallbacks = new AtomicInteger();
+
+        // Always fails with a retriable error: the caller must observe the unchanged
+        // ControlPlaneException contract after retries are exhausted.
+        assertThatThrownBy(() -> JobUtils.run((Callable<String>) () -> {
+            attempts.incrementAndGet();
+            throw new ControlPlaneException("Error finding batches",
+                new RuntimeException(recoveryConflict()));
+        }, time, ignored -> durationCallbacks.incrementAndGet()))
+            .isInstanceOf(ControlPlaneException.class)
+            .hasMessage("Error finding batches");
+
+        assertThat(attempts).hasValue(JobUtils.MAX_ATTEMPTS);
+        // Even on exhaustion the decisive (final) failure is reported exactly once.
+        assertThat(durationCallbacks).hasValue(1);
+    }
+
+    @Test
+    void doesNotRetryNonRetriableSqlState() {
+        final MockTime time = new MockTime();
+        final AtomicInteger attempts = new AtomicInteger();
+        final long startMs = time.milliseconds();
+
+        // 23505 (unique_violation) is a deterministic error; retrying would just fail again.
+        assertThatThrownBy(() -> JobUtils.run((Callable<String>) () -> {
+            attempts.incrementAndGet();
+            throw new RuntimeException(new SQLException("duplicate key", "23505"));
+        }, time, ignored -> { }))
+            .isInstanceOf(RuntimeException.class);
+
+        assertThat(attempts).hasValue(1);
+        // A deterministic failure must fail fast: no backoff sleep before giving up.
+        assertThat(time.milliseconds()).isEqualTo(startMs);
+    }
+
+    @Test
+    void doesNotRetryPlainRuntimeException() {
+        final MockTime time = new MockTime();
+        final AtomicInteger attempts = new AtomicInteger();
+        final long startMs = time.milliseconds();
+
+        assertThatThrownBy(() -> JobUtils.run((Callable<String>) () -> {
+            attempts.incrementAndGet();
+            throw new IllegalStateException("bug, not transient");
+        }, time, ignored -> { }))
+            .isInstanceOf(RuntimeException.class);
+
+        assertThat(attempts).hasValue(1);
+        assertThat(time.milliseconds()).isEqualTo(startMs);
+    }
+
+    @Test
+    void abandonsRetriesWhenInterruptedDuringBackoff() {
+        final MockTime time = new MockTime();
+        final AtomicInteger attempts = new AtomicInteger();
+
+        // Set the interrupt flag so that after the first backoff the loop observes an interrupted
+        // thread (mirrors a broker shutdown interrupting the retry) and stops immediately instead
+        // of exhausting all attempts.
+        Thread.currentThread().interrupt();
+        try {
+            assertThatThrownBy(() -> JobUtils.run((Callable<String>) () -> {
+                attempts.incrementAndGet();
+                throw new RuntimeException(recoveryConflict());
+            }, time, ignored -> { }))
+                .isInstanceOf(RuntimeException.class);
+
+            // Only the first attempt ran; the interrupt aborted the retry loop before a second try.
+            assertThat(attempts).hasValue(1);
+            // The interrupt status is preserved for cooperative shutdown downstream.
+            assertThat(Thread.currentThread().isInterrupted()).isTrue();
+        } finally {
+            // Clear the flag so it does not leak into other tests.
+            Thread.interrupted();
+        }
+    }
+
+    @Test
+    void wrapsNonControlPlaneExceptionInRuntimeException() {
+        final MockTime time = new MockTime();
+
+        assertThatThrownBy(() -> JobUtils.run((Callable<String>) () -> {
+            throw new SQLException("non-retriable", "08006");
+        }, time, ignored -> { }))
+            .isInstanceOf(RuntimeException.class)
+            .hasCauseInstanceOf(SQLException.class);
+    }
+
+    @Test
+    void isRetriableScansSuppressedThrowables() {
+        // The connection-terminated form surfaces the retriable cause as a suppressed throwable
+        // (the failed rollback), not on the main cause chain.
+        final RuntimeException top = new RuntimeException("Cannot commit transaction");
+        top.addSuppressed(new SQLException("terminating connection due to conflict with recovery", "40001"));
+
+        assertThat(JobUtils.isRetriable(top)).isTrue();
+    }
+
+    @Test
+    void isRetriableHandlesSelfReferentialCauseChain() {
+        final SQLException a = new SQLException("a", "23505");
+        final SQLException b = new SQLException("b", "23505");
+        a.initCause(b);
+        b.initCause(a);
+
+        // Must terminate, not StackOverflow, and report no retriable state.
+        assertThat(JobUtils.isRetriable(a)).isFalse();
+    }
+}

--- a/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/JobUtilsTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/JobUtilsTest.java
@@ -38,7 +38,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 @Timeout(10)
 class JobUtilsTest {
 
-    /** Serialization failure / recovery conflict — PostgreSQL uses 40001 for both. */
+    /** Serialization failure / recovery conflict. PostgreSQL uses 40001 for both. */
     private static SQLException recoveryConflict() {
         return new SQLException("canceling statement due to conflict with recovery", "40001");
     }
@@ -52,17 +52,21 @@ class JobUtilsTest {
         final MockTime time = new MockTime();
         final AtomicInteger attempts = new AtomicInteger();
         final AtomicInteger durationCallbacks = new AtomicInteger();
+        final AtomicInteger reportedDurationMs = new AtomicInteger(-1);
         final long startMs = time.milliseconds();
 
         final String result = JobUtils.run(() -> {
             attempts.incrementAndGet();
             return "ok";
-        }, time, ignored -> durationCallbacks.incrementAndGet());
+        }, time, d -> {
+            durationCallbacks.incrementAndGet();
+            reportedDurationMs.set(d.intValue());
+        });
 
         assertThat(result).isEqualTo("ok");
         assertThat(attempts).hasValue(1);
-        // Exactly one metric sample, no backoff on the happy path.
         assertThat(durationCallbacks).hasValue(1);
+        assertThat(reportedDurationMs).hasValue(0);
         assertThat(time.milliseconds()).isEqualTo(startMs);
     }
 
@@ -71,6 +75,8 @@ class JobUtilsTest {
         final MockTime time = new MockTime();
         final AtomicInteger attempts = new AtomicInteger();
         final AtomicInteger durationCallbacks = new AtomicInteger();
+        final AtomicInteger reportedDurationMs = new AtomicInteger(-1);
+        final long startMs = time.milliseconds();
 
         // Reproduces the production incident: the read replica cancels the first attempts with a
         // recovery conflict (SQLState 40001), wrapped exactly as the control plane wraps it, then a
@@ -83,13 +89,17 @@ class JobUtilsTest {
             return "recovered";
         };
 
-        final String result = JobUtils.run(flaky, time, ignored -> durationCallbacks.incrementAndGet());
+        final String result = JobUtils.run(flaky, time, d -> {
+            durationCallbacks.incrementAndGet();
+            reportedDurationMs.set(d.intValue());
+        });
 
         assertThat(result).isEqualTo("recovered");
         assertThat(attempts).hasValue(3);
-        // Guards against metric double-counting (finding #1): even though the job ran 3 times, only
-        // the decisive attempt is reported to the duration callback.
         assertThat(durationCallbacks).hasValue(1);
+        // QueryTime is the whole run, including backoff, so a retry storm shows up as latency.
+        assertThat(reportedDurationMs).hasValue((int) (time.milliseconds() - startMs));
+        assertThat(reportedDurationMs.get()).isGreaterThan(0);
     }
 
     @Test
@@ -138,6 +148,8 @@ class JobUtilsTest {
         final MockTime time = new MockTime();
         final AtomicInteger attempts = new AtomicInteger();
         final AtomicInteger durationCallbacks = new AtomicInteger();
+        final AtomicInteger reportedDurationMs = new AtomicInteger(-1);
+        final long startMs = time.milliseconds();
 
         // Always fails with a retriable error: the caller must observe the unchanged
         // ControlPlaneException contract after retries are exhausted.
@@ -145,13 +157,17 @@ class JobUtilsTest {
             attempts.incrementAndGet();
             throw new ControlPlaneException("Error finding batches",
                 new RuntimeException(recoveryConflict()));
-        }, time, ignored -> durationCallbacks.incrementAndGet()))
+        }, time, d -> {
+            durationCallbacks.incrementAndGet();
+            reportedDurationMs.set(d.intValue());
+        }))
             .isInstanceOf(ControlPlaneException.class)
             .hasMessage("Error finding batches");
 
         assertThat(attempts).hasValue(JobUtils.MAX_ATTEMPTS);
-        // Even on exhaustion the decisive (final) failure is reported exactly once.
         assertThat(durationCallbacks).hasValue(1);
+        assertThat(reportedDurationMs).hasValue((int) (time.milliseconds() - startMs));
+        assertThat(reportedDurationMs.get()).isGreaterThan(0);
     }
 
     @Test
@@ -236,6 +252,16 @@ class JobUtilsTest {
     }
 
     @Test
+    void isRetriableScansSqlExceptionNextException() {
+        // JDBC chains related errors via getNextException(), separate from getCause().
+        final SQLException head = new SQLException("connection closed", "08006");
+        head.setNextException(recoveryConflict());
+
+        assertThat(JobUtils.isRetriable(head)).isTrue();
+        assertThat(JobUtils.isRetriable(new RuntimeException(head))).isTrue();
+    }
+
+    @Test
     void isRetriableHandlesSelfReferentialCauseChain() {
         final SQLException a = new SQLException("a", "23505");
         final SQLException b = new SQLException("b", "23505");
@@ -243,6 +269,16 @@ class JobUtilsTest {
         b.initCause(a);
 
         // Must terminate, not StackOverflow, and report no retriable state.
+        assertThat(JobUtils.isRetriable(a)).isFalse();
+    }
+
+    @Test
+    void isRetriableHandlesSelfReferentialNextExceptionChain() {
+        final SQLException a = new SQLException("a", "23505");
+        final SQLException b = new SQLException("b", "23505");
+        a.setNextException(b);
+        b.setNextException(a);
+
         assertThat(JobUtils.isRetriable(a)).isFalse();
     }
 }


### PR DESCRIPTION
## Problem

A production cluster (`cdip-diskless-prod-spoke-*`) threw a burst of `FetchError` / `Read future failed` exceptions. Every trace bottoms out in the same PostgreSQL condition on the **read replica** that serves `find_batches_v2`, in two escalating forms:

1. **Statement cancellation**
   ```
   org.postgresql.util.PSQLException: ERROR: canceling statement due to conflict with recovery
     Detail: User was holding shared buffer pin for too long.
   ```
2. **Connection termination** (escalation of the same conflict)
   ```
   org.postgresql.util.PSQLException: FATAL: terminating connection due to conflict with recovery
     Detail: User was holding shared buffer pin for too long.
   ```
   which then surfaces downstream as `server conn crashed?`, `Cannot commit transaction`, and a suppressed `Connection is closed` / `Cannot get autoCommit`.

Both are **hot-standby recovery conflicts**: a read query holds a shared buffer pin while WAL replay needs the same page. They are transient and the server rolls the transaction back — but `JobUtils` had no retry (only a `// TODO add retry with backoff`), so a single conflict propagated all the way up as `ControlPlaneException("Error finding batches")` → `FindBatchesException` and `FetchHandler` returned `UNKNOWN_SERVER_ERROR` for every partition in the fetch.

> Note: the DB-side mitigations (`hot_standby_feedback = on`, raised `max_standby_streaming_delay`) are already enabled on this cluster. This PR is the application-side resilience for the conflicts that still occur under replay pressure.

## Change

Implement the missing retry in `JobUtils`: retry the whole job with jittered exponential backoff (3 attempts, ~50 ms → ~100 ms with 0.2 jitter, capped at 1 s; via the injected `Time` so it is fully virtual in tests).

**Exceptions handled** — retry is keyed on rollback-guaranteed PostgreSQL `SQLState`s:

| SQLState | Meaning | Why retriable |
|----------|---------|---------------|
| `40001` | `serialization_failure` | PostgreSQL raises this (`ERRCODE_T_R_SERIALIZATION_FAILURE`) for **both** recovery-conflict forms above — the statement cancellation *and* the connection termination. Server guarantees rollback. |
| `40P01` | `deadlock_detected` | Victim transaction is rolled back. |

Key design points:

- **Retry wraps the whole transaction**, not the inner lambda. Because the control-plane `DSLContext`s are Hikari-pool-backed, a retry pulls a **fresh connection** — this is what recovers from the connection-terminated form where the previous connection is dead.
- **Full cause chain + suppressed throwables are scanned.** The retriable `PSQLException` is buried under `ControlPlaneException` → `DataAccessException`; in the connection-killed form it appears as a **suppressed** throwable (the failed rollback), exactly as in the traces.
- **Generic connection-loss states (`08*`, `57P01`) are intentionally NOT retried** — a drop *during commit* leaves a write in-doubt, so blindly replaying could double-apply. The recovery-conflict family that caused this incident is fully covered by the rollback-guaranteed states, so the retry is safe for both read and write jobs and can live in the shared helper.
- **Error contract unchanged**: on exhaustion or a non-retriable failure, the original exception is rethrown and mapped to `ControlPlaneException` / wrapped `RuntimeException` as before.

### Hot-path safety

This retry sits on the fetch hot path shared by all 16 control-plane jobs, so it is designed to stay safe under a conflict storm rather than amplify one:

- **Metrics stay accurate.** `measureDurationMs` fires the duration callback in a `finally`, so timing each attempt directly would record N samples per run and pollute the latency/rate percentiles with failed-attempt durations. Only the **decisive** attempt (success, or the final failure) is reported to the callback → exactly one sample per `run()`.
- **Jittered backoff** (`ExponentialBackoff`, reused from `clients`) prevents many jobs failing against the same struggling standby from retrying in lockstep and re-colliding on the same recovery-conflict window.
- **Interrupt-aware.** `Utils.sleep` restores the interrupt flag but returns normally; the loop checks `Thread.isInterrupted()` after backoff and aborts (keeping the flag set) rather than spinning through remaining attempts and delaying broker shutdown.
- **One terminal log** on exhaustion, so the final user-visible failure is greppable instead of appearing only as intermediate "retrying" warnings.

## Tests

`JobUtilsTest` (pure unit — no DB container, uses `MockTime`): happy path, recovery-conflict-then-succeed (reproduces the incident with the exact wrapping from the traces), deadlock retry, max-attempts exhaustion preserving `ControlPlaneException`, non-retriable SQLState (`23505`) and plain runtime exceptions not retried, suppressed-throwable scanning, self-referential cause chain (terminates, no `StackOverflow`), plus: jittered backoff timing asserted via `MockTime` deltas, a single duration-callback per run (guards the metrics contract), no sleep on non-retriable failures, and interrupt-driven abort.

## Follow-up (not in this PR)

- When retries are exhausted the client still gets `UNKNOWN_SERVER_ERROR`. Surfacing exhausted transient failures as a *retriable* Kafka error would be a separate change in the `FetchHandler` error-mapping path.
- The connection-terminated form relies on pgjdbc surfacing SQLState `40001`; there is a residual driver-level race where a socket EOF beating the FATAL message could downgrade to `08006`. Confirming this end-to-end warrants a hot-standby integration test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)