### PR TITLE
feat(inkless:consolidation): separate ConsolidationFetchBytesInPerSec from replication metric [KC-276]

### DIFF
--- a/core/src/main/scala/io/aiven/inkless/consolidation/ConsolidationFetcherThread.scala
+++ b/core/src/main/scala/io/aiven/inkless/consolidation/ConsolidationFetcherThread.scala
@@ -48,6 +48,8 @@ class ConsolidationFetcherThread(name: String,
 
   override protected def shouldEvictFullySwitchedDisklessPartitions: Boolean = false
 
+  override protected def shouldRecordReplicationBytesIn: Boolean = false
+
   override def processPartitionData(
     topicPartition: TopicPartition,
     fetchOffset: Long,
@@ -75,6 +77,12 @@ class ConsolidationFetcherThread(name: String,
           throw new ConsolidationSegmentOverflowException(
             s"Consolidation block for $topicPartition exceeds segment.bytes ($segmentSize)", e)
       }
+
+    result.foreach { logAppendInfo =>
+      if (logAppendInfo.validBytes > 0) {
+        replicaMgr.recordConsolidationFetchBytesIn(logAppendInfo.validBytes.toLong)
+      }
+    }
 
     consolidationMetrics.foreach { metrics =>
       val logOpt = Try(replicaMgr.getPartitionOrException(topicPartition).localLogOrException).toOption

--- a/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
@@ -111,6 +111,11 @@ class ReplicaFetcherThread(name: String,
 
   protected def shouldEvictFullySwitchedDisklessPartitions: Boolean = true
 
+  // Overridden to false by ConsolidationFetcherThread so consolidation throughput is reported via the
+  // ConsolidationFetchBytesInPerSec meter (JMX: kafka.server:type=ReplicaManager,name=ConsolidationFetchBytesInPerSec)
+  // instead of inflating the inter-broker ReplicationBytesInPerSec metric.
+  protected def shouldRecordReplicationBytesIn: Boolean = true
+
   // process fetched data
   override def processPartitionData(
     topicPartition: TopicPartition,
@@ -160,7 +165,8 @@ class ReplicaFetcherThread(name: String,
     if (partition.isReassigning && partition.isAddingLocalReplica)
       brokerTopicStats.updateReassignmentBytesIn(records.sizeInBytes)
 
-    brokerTopicStats.updateReplicationBytesIn(records.sizeInBytes)
+    if (shouldRecordReplicationBytesIn)
+      brokerTopicStats.updateReplicationBytesIn(records.sizeInBytes)
 
     // Stop fetching after the switch from classic to diskless is completed: once the controller
     // has committed a classicToDisklessStartOffset for this partition AND our local LEO has reached it,

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -28,7 +28,7 @@ import kafka.cluster.Partition
 import kafka.log.LogManager
 import kafka.server.HostedPartition.Online
 import kafka.server.QuotaFactory.QuotaManagers
-import kafka.server.ReplicaManager.{AtMinIsrPartitionCountMetricName, FailedIsrUpdatesPerSecMetricName, IsrExpandsPerSecMetricName, IsrShrinksPerSecMetricName, LeaderCountMetricName, OfflineReplicaCountMetricName, PartitionCountMetricName, PartitionsWithLateTransactionsCountMetricName, ProducerIdCountMetricName, ReassigningPartitionsMetricName, SealedPartitionsCountMetricName, UnderMinIsrPartitionCountMetricName, UnderReplicatedPartitionsMetricName, createLogReadResult, isListOffsetsTimestampUnsupported}
+import kafka.server.ReplicaManager.{AtMinIsrPartitionCountMetricName, ConsolidationFetchBytesInPerSecMetricName, FailedIsrUpdatesPerSecMetricName, IsrExpandsPerSecMetricName, IsrShrinksPerSecMetricName, LeaderCountMetricName, OfflineReplicaCountMetricName, PartitionCountMetricName, PartitionsWithLateTransactionsCountMetricName, ProducerIdCountMetricName, ReassigningPartitionsMetricName, SealedPartitionsCountMetricName, UnderMinIsrPartitionCountMetricName, UnderReplicatedPartitionsMetricName, createLogReadResult, isListOffsetsTimestampUnsupported}
 import kafka.server.metadata.{InklessMetadataView, KRaftMetadataCache}
 import kafka.server.share.DelayedShareFetch
 import kafka.utils._
@@ -159,6 +159,7 @@ object ReplicaManager {
   private val IsrExpandsPerSecMetricName = "IsrExpandsPerSec"
   private val IsrShrinksPerSecMetricName = "IsrShrinksPerSec"
   private val FailedIsrUpdatesPerSecMetricName = "FailedIsrUpdatesPerSec"
+  private val ConsolidationFetchBytesInPerSecMetricName = "ConsolidationFetchBytesInPerSec"
 
   private[server] val GaugeMetricNames = Set(
     LeaderCountMetricName,
@@ -176,7 +177,8 @@ object ReplicaManager {
   private[server] val MeterMetricNames = Set(
     IsrExpandsPerSecMetricName,
     IsrShrinksPerSecMetricName,
-    FailedIsrUpdatesPerSecMetricName
+    FailedIsrUpdatesPerSecMetricName,
+    ConsolidationFetchBytesInPerSecMetricName
   )
 
   private[server] val MetricNames = GaugeMetricNames.union(MeterMetricNames)
@@ -446,9 +448,12 @@ class ReplicaManager(val config: KafkaConfig,
   val isrExpandRate: Meter = metricsGroup.newMeter(IsrExpandsPerSecMetricName, "expands", TimeUnit.SECONDS)
   val isrShrinkRate: Meter = metricsGroup.newMeter(IsrShrinksPerSecMetricName, "shrinks", TimeUnit.SECONDS)
   val failedIsrUpdatesRate: Meter = metricsGroup.newMeter(FailedIsrUpdatesPerSecMetricName, "failedUpdates", TimeUnit.SECONDS)
+  private val consolidationFetchBytesInPerSec: Meter = metricsGroup.newMeter(ConsolidationFetchBytesInPerSecMetricName, "bytes", TimeUnit.SECONDS)
 
   private def isConsolidatingPartition(partition: Partition): Boolean =
     config.disklessRemoteStorageConsolidationEnabled && _inklessMetadataView.isConsolidatingDisklessTopic(partition.topic)
+
+  def recordConsolidationFetchBytesIn(bytes: Long): Unit = consolidationFetchBytesInPerSec.mark(bytes)
 
   def underReplicatedPartitionCount: Int = leaderPartitionsIterator.count { partition =>
     partition.isUnderReplicated && !isConsolidatingPartition(partition)

--- a/core/src/test/scala/io/aiven/inkless/consolidation/ConsolidationFetcherThreadTest.scala
+++ b/core/src/test/scala/io/aiven/inkless/consolidation/ConsolidationFetcherThreadTest.scala
@@ -40,7 +40,7 @@ import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.{any, anyLong}
-import org.mockito.Mockito.{RETURNS_DEEP_STUBS, doNothing, mock, verify, when}
+import org.mockito.Mockito.{RETURNS_DEEP_STUBS, doNothing, mock, never, verify, when}
 
 import java.nio.charset.StandardCharsets
 import java.util.Optional
@@ -104,7 +104,8 @@ class ConsolidationFetcherThreadTest {
   private def mockPartitionWithLog(
     logEndOffset: Long,
     highestOffsetInRemoteStorage: Long,
-    localLogStartOffset: Long = 0L
+    localLogStartOffset: Long = 0L,
+    appendedValidBytes: Int = 0
   ): Partition = {
     val log = mock(classOf[UnifiedLog])
     when(log.logEndOffset).thenReturn(logEndOffset)
@@ -112,10 +113,12 @@ class ConsolidationFetcherThreadTest {
     when(log.localLogStartOffset()).thenReturn(localLogStartOffset)
     when(log.maybeUpdateHighWatermark(anyLong())).thenReturn(Optional.empty)
 
+    val appendInfo = mock(classOf[LogAppendInfo])
+    when(appendInfo.validBytes).thenReturn(appendedValidBytes)
     val partition = mock(classOf[Partition])
     when(partition.localLogOrException).thenReturn(log)
     when(partition.appendRecordsToFollowerOrFutureReplica(any[MemoryRecords], any[Boolean], any[Int]))
-      .thenReturn(Some(mock(classOf[LogAppendInfo])))
+      .thenReturn(Some(appendInfo))
     partition
   }
 
@@ -311,6 +314,34 @@ class ConsolidationFetcherThreadTest {
     assertEquals(40L, findGaugeValue("ConsolidationTotalLag", topicPartition))
     assertEquals(20L, findGaugeValue("ConsolidationLocalLag", topicPartition))
     assertEquals(50L, findGaugeValue("ConsolidationDeletableMessages", topicPartition))
+  }
+
+  @Test
+  def testRecordsConsolidationFetchBytesInAndSkipsReplicationBytesIn(): Unit = {
+    val validBytes = 512
+    val partition = mockPartitionWithLog(logEndOffset = 80L, highestOffsetInRemoteStorage = 60L,
+      appendedValidBytes = validBytes)
+    val replicaManager = mockReplicaManager(partition)
+    val brokerTopicStats = replicaManager.brokerTopicStats
+    val thread = createConsolidationFetcherThread(replicaManager, None)
+
+    thread.processPartitionData(topicPartition, 80L, Int.MaxValue, buildPartitionData(100L))
+
+    verify(replicaManager).recordConsolidationFetchBytesIn(validBytes.toLong)
+    // Consolidation throughput must not leak into the inter-broker ReplicationBytesInPerSec meter.
+    assertEquals(0L, brokerTopicStats.allTopicsStats.replicationBytesInRate().get.count())
+  }
+
+  @Test
+  def testDoesNotRecordConsolidationFetchBytesInWhenNoValidBytes(): Unit = {
+    val partition = mockPartitionWithLog(logEndOffset = 80L, highestOffsetInRemoteStorage = 60L,
+      appendedValidBytes = 0)
+    val replicaManager = mockReplicaManager(partition)
+    val thread = createConsolidationFetcherThread(replicaManager, None)
+
+    thread.processPartitionData(topicPartition, 80L, Int.MaxValue, buildPartitionData(100L))
+
+    verify(replicaManager, never()).recordConsolidationFetchBytesIn(anyLong())
   }
 
   @Test


### PR DESCRIPTION
ReplicationBytesInPerSec previously summed inter-broker replication AND consolidation fetcher appends, since both go through the AbstractFetcherThread processPartitionData path. That conflation made the metric meaningless on consolidation-heavy brokers and required operators to subtract the consolidation throughput to recover the inter-broker number.

Add a shouldRecordReplicationBytesIn hook in ReplicaFetcherThread (default true) and override to false in ConsolidationFetcherThread. Add a new ConsolidationFetchBytesInPerSec meter on ReplicaManager, marked from ConsolidationFetcherThread.processPartitionData when validBytes > 0.

Effect on existing dashboards: ReplicationBytesInPerSec on consolidation brokers will drop by the consolidation throughput (now reported separately). This is the corrected baseline.

[KC-276]

[KC-276]: https://aiven.atlassian.net/browse/KC-276?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ