### PR TITLE
refactor(inkless:delete): improve retention-enforcement observability

### DIFF
--- a/docs/inkless/metrics.rst
+++ b/docs/inkless/metrics.rst
@@ -228,15 +228,16 @@ RetentionEnforcer metrics
 io.aiven.inkless.delete:type=RetentionEnforcer
 ----------------------------------------------
 
-========================================  =================================================================
-Attribute name                            Description                                                      
-========================================  =================================================================
-RetentionEnforcementErrorRate             Total number of retention enforcement errors                     
-RetentionEnforcementRate                  Total number of retention enforcement cycles started             
-RetentionEnforcementTotalBatchesDeleted   Total number of batches deleted by retention enforcement         
-RetentionEnforcementTotalBytesDeleted     Total number of bytes deleted by retention enforcement           
-RetentionEnforcementTotalTime             Total time spent on a retention enforcement cycle in milliseconds
-========================================  =================================================================
+========================================  ==================================================================================================================================================================
+Attribute name                            Description                                                                                                                                                       
+========================================  ==================================================================================================================================================================
+RetentionEnforcementErrorRate             Total number of retention enforcement errors                                                                                                                      
+RetentionEnforcementRate                  Total number of retention enforcement cycles started                                                                                                              
+RetentionEnforcementScheduleLagMs         Milliseconds the most overdue diskless partition is past its scheduled retention enforcement time; 0 when on schedule or when no diskless partitions are scheduled
+RetentionEnforcementTotalBatchesDeleted   Total number of batches deleted by retention enforcement                                                                                                          
+RetentionEnforcementTotalBytesDeleted     Total number of bytes deleted by retention enforcement                                                                                                            
+RetentionEnforcementTotalTime             Total time spent on a retention enforcement cycle in milliseconds                                                                                                 
+========================================  ==================================================================================================================================================================
 
 
 CrossTierLogStartReporter metrics

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/EnforceRetentionJob.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/EnforceRetentionJob.java
@@ -62,14 +62,17 @@ public class EnforceRetentionJob implements Callable<List<EnforceRetentionRespon
         if (requests.isEmpty()) {
             return List.of();
         }
-        return JobUtils.run(this::runOnce, time, durationCallback);
+        return JobUtils.run(this::runOnce);
     }
 
-    private List<EnforceRetentionResponse> runOnce() {
+    private List<EnforceRetentionResponse> runOnce() throws Exception {
         final Instant now = TimeUtils.now(time);
         final List<EnforceRetentionResponse> responses = new ArrayList<>(requests.size());
         for (final EnforceRetentionRequest request : requests) {
-            responses.add(enforceOne(now, request));
+            // enforceOne is one transaction per partition,
+            // so EnforceRetentionQueryTime/QueryRate are recorded per partition
+            // (the whole-wave total is the broker-side RetentionEnforcementTotalTime).
+            responses.add(TimeUtils.measureDurationMs(time, () -> enforceOne(now, request), durationCallback));
         }
         return responses;
     }

--- a/storage/inkless/src/main/java/io/aiven/inkless/delete/FileCleaner.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/delete/FileCleaner.java
@@ -93,7 +93,6 @@ public class FileCleaner implements Runnable, Closeable {
     public void run() {
         try {
             final var now = TimeUtils.now(time);
-            LOGGER.info("Running file cleaner at {}", now);
 
             // find all files that are marked for deletion
             final List<FileToDelete> filesToDelete = controlPlane.getFilesToDelete();
@@ -107,7 +106,11 @@ public class FileCleaner implements Runnable, Closeable {
                 LOGGER.info("No files to delete, sleeping for {}", sleepDuration);
                 time.sleep(sleepMillis);
             } else {
+                LOGGER.info("Running file cleaner: deleting {} of {} marked files", objectKeyPaths.size(), filesToDelete.size());
                 metrics.recordFileCleanerStart();
+                // 1-element holder to carry the duration out of the (synchronous, same-thread) callback
+                // for the log line below; a plain local cannot be assigned from the lambda.
+                final long[] durationMs = {0};
                 TimeUtils.measureDurationMs(time, () -> {
                     try {
                         cleanFiles(objectKeyPaths);
@@ -115,8 +118,12 @@ public class FileCleaner implements Runnable, Closeable {
                         LOGGER.error("Error while cleaning files", e);
                         throw new RuntimeException(e);
                     }
-                }, metrics::recordFileCleanerTotalTime);
+                }, duration -> {
+                    durationMs[0] = duration;
+                    metrics.recordFileCleanerTotalTime(duration);
+                });
                 metrics.recordFileCleanerCompleted(objectKeyPaths.size());
+                LOGGER.info("File cleaner deleted {} files in {} ms", objectKeyPaths.size(), durationMs[0]);
             }
 
             attempts.set(0);
@@ -137,8 +144,6 @@ public class FileCleaner implements Runnable, Closeable {
         // update control plane
         final DeleteFilesRequest request = new DeleteFilesRequest(objectKeyPaths);
         controlPlane.deleteFiles(request);
-
-        LOGGER.info("Deleted {} files", objectKeyPaths.size());
     }
 
     @Override

--- a/storage/inkless/src/main/java/io/aiven/inkless/delete/RetentionEnforcementScheduler.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/delete/RetentionEnforcementScheduler.java
@@ -65,6 +65,10 @@ class RetentionEnforcementScheduler {
     private Instant lastKnownPartitionsUpdate = Instant.MIN;
     private Set<TopicIdPartition> knownPartitions = new HashSet<>();
 
+    // Guards partitionsByNextEnforcementTime: mutated on the enforcement thread (getReadyPartitions),
+    // read by the metrics thread (scheduleLagMillis); PriorityQueue is not thread-safe.
+    private final Object queueLock = new Object();
+
     private final PriorityQueue<TopicIdPartitionWithNextEnforcementTime> partitionsByNextEnforcementTime = new PriorityQueue<>(
         TopicIdPartitionWithNextEnforcementTime.timeComparator()
     );
@@ -86,25 +90,44 @@ class RetentionEnforcementScheduler {
 
         final List<TopicIdPartition> result = new ArrayList<>();
         TopicIdPartitionWithNextEnforcementTime tidpwt;
-        // These peek() and poll() are guaranteed to work with the same item
-        // if there's no concurrent modification (which should be the case).
-        while ((tidpwt = partitionsByNextEnforcementTime.peek()) != null && tidpwt.nextEnforcementTime().isBefore(now)) {
-            partitionsByNextEnforcementTime.poll();
-            final TopicIdPartition partition = tidpwt.topicIdPartition();
-            // Filter out previously deleted partitions.
-            if (knownPartitions.contains(partition)) {
-                result.add(partition);
-            } else {
-                LOGGER.debug("Partition removed: {}", partition);
+        // Under queueLock nothing else mutates the queue, so peek() and the following poll()
+        // act on the same head element.
+        synchronized (queueLock) {
+            while ((tidpwt = partitionsByNextEnforcementTime.peek()) != null && tidpwt.nextEnforcementTime().isBefore(now)) {
+                partitionsByNextEnforcementTime.poll();
+                final TopicIdPartition partition = tidpwt.topicIdPartition();
+                // Filter out previously deleted partitions.
+                if (knownPartitions.contains(partition)) {
+                    result.add(partition);
+                } else {
+                    LOGGER.debug("Partition removed: {}", partition);
+                }
+            }
+
+            // We need to reschedule the taken partitions.
+            for (final TopicIdPartition partition : result) {
+                schedulePartition(now, partition);
             }
         }
 
-        // We need to reschedule the taken partitions.
-        for (final TopicIdPartition partition : result) {
-            schedulePartition(now, partition);
-        }
-
         return result;
+    }
+
+    /**
+     * Milliseconds by which the most overdue partition is past its scheduled enforcement time, or 0 when
+     * nothing in the queue is past due. A sustained nonzero value means enforcement is falling behind its
+     * cadence (a stalled or blocked enforcer loop), which is otherwise indistinguishable from an idle trough.
+     */
+    long scheduleLagMillis() {
+        final Instant now = TimeUtils.now(time);
+        synchronized (queueLock) {
+            final TopicIdPartitionWithNextEnforcementTime head = partitionsByNextEnforcementTime.peek();
+            if (head == null) {
+                return 0L;
+            }
+            final long lagMs = Duration.between(head.nextEnforcementTime(), now).toMillis();
+            return Math.max(0L, lagMs);
+        }
     }
 
     private void updateKnownPartitionsIfNeeded(final Instant now) {
@@ -123,9 +146,11 @@ class RetentionEnforcementScheduler {
     }
 
     private void schedulePartition(final Instant now, final TopicIdPartition partition) {
-        partitionsByNextEnforcementTime.add(
-            new TopicIdPartitionWithNextEnforcementTime(partition, nextCheck(now)
-        ));
+        synchronized (queueLock) {
+            partitionsByNextEnforcementTime.add(
+                new TopicIdPartitionWithNextEnforcementTime(partition, nextCheck(now)
+            ));
+        }
     }
 
     private Instant nextCheck(final Instant now) {
@@ -155,8 +180,13 @@ class RetentionEnforcementScheduler {
         }
     }
 
-    // Visible for testing.
+    // Visible for testing. Returns a snapshot ordered by nextEnforcementTime (PriorityQueue iteration
+    // is not sorted), so assertions don't depend on the internal heap layout.
     List<TopicIdPartitionWithNextEnforcementTime> dumpQueue() {
-        return partitionsByNextEnforcementTime.stream().toList();
+        synchronized (queueLock) {
+            return partitionsByNextEnforcementTime.stream()
+                .sorted(TopicIdPartitionWithNextEnforcementTime.timeComparator())
+                .toList();
+        }
     }
 }

--- a/storage/inkless/src/main/java/io/aiven/inkless/delete/RetentionEnforcer.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/delete/RetentionEnforcer.java
@@ -92,6 +92,9 @@ public class RetentionEnforcer implements Runnable, Closeable {
 
     private synchronized void runUnsafe() {
         final List<EnforceRetentionRequest> requests = new ArrayList<>();
+        // Kept aligned 1:1 with requests (and thus responses) so per-partition logs are attributed correctly
+        // even when readyPartitions contains partitions filtered out below.
+        final List<TopicIdPartition> enforcedPartitions = new ArrayList<>();
         final List<TopicIdPartition> readyPartitions = retentionEnforcementScheduler.getReadyPartitions();
         final Map<String, LogConfig> topicConfigs = new HashMap<>();
         for (final TopicIdPartition partition : readyPartitions) {
@@ -105,6 +108,7 @@ public class RetentionEnforcer implements Runnable, Closeable {
                     topicConfig.retentionSize,
                     topicConfig.retentionMs
                 ));
+                enforcedPartitions.add(partition);
             }
         }
 
@@ -113,6 +117,8 @@ public class RetentionEnforcer implements Runnable, Closeable {
         }
 
         metrics.recordRetentionEnforcementStarted();
+
+        LOGGER.info("Enforcing retention for {} partitions", requests.size());
 
         final Instant start = TimeUtils.durationMeasurementNow(time);
         final List<EnforceRetentionResponse> responses;
@@ -126,12 +132,10 @@ public class RetentionEnforcer implements Runnable, Closeable {
         final Instant ended = TimeUtils.durationMeasurementNow(time);
         final long durationMs = Duration.between(start, ended).toMillis();
 
-        LOGGER.debug("Enforcing retention for {} partitions took {} ms", requests.size(), durationMs);
-
         long totalBatchesDeleted = 0;
         long totalBytesDeleted = 0;
         for (int i = 0; i < responses.size(); i++) {
-            final TopicIdPartition readyPartition = readyPartitions.get(i);
+            final TopicIdPartition enforcedPartition = enforcedPartitions.get(i);
             final var request = requests.get(i);
             final var response = responses.get(i);
 
@@ -139,7 +143,7 @@ public class RetentionEnforcer implements Runnable, Closeable {
                 case NONE -> {
                     LOGGER.trace("Enforcing retention for {} with retentionBytes={}, retentionMs={} completed successfully. " +
                             "{} batches and {} bytes deleted, new log start offset: {}",
-                        readyPartition.topicPartition(), request.retentionBytes(), request.retentionMs(),
+                        enforcedPartition.topicPartition(), request.retentionBytes(), request.retentionMs(),
                         response.batchesDeleted(), response.bytesDeleted(), response.logStartOffset());
                     totalBatchesDeleted += response.batchesDeleted();
                     totalBytesDeleted += response.bytesDeleted();
@@ -149,15 +153,18 @@ public class RetentionEnforcer implements Runnable, Closeable {
                     // When a topic is deleted, each partition may still be attempted once.
                     // Use debug logging to not pollute the log with this normal behavior.
                     LOGGER.debug("Enforcing retention for {} with retentionBytes={}, retentionMs={} completed with error: {}",
-                        readyPartition.topicPartition(), request.retentionBytes(), request.retentionMs(), response.errors());
+                        enforcedPartition.topicPartition(), request.retentionBytes(), request.retentionMs(), response.errors());
 
                 default ->
                     LOGGER.error("Enforcing retention for {} with retentionBytes={}, retentionMs={} completed with error: {}",
-                        readyPartition.topicPartition(), request.retentionBytes(), request.retentionMs(), response.errors());
+                        enforcedPartition.topicPartition(), request.retentionBytes(), request.retentionMs(), response.errors());
             }
         }
 
         metrics.recordRetentionEnforcementFinishedSuccessfully(durationMs, totalBatchesDeleted, totalBytesDeleted);
+
+        LOGGER.info("Enforced retention for {} partitions in {} ms: {} batches, {} bytes deleted",
+            requests.size(), durationMs, totalBatchesDeleted, totalBytesDeleted);
     }
 
     @Override

--- a/storage/inkless/src/main/java/io/aiven/inkless/delete/RetentionEnforcer.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/delete/RetentionEnforcer.java
@@ -51,7 +51,7 @@ public class RetentionEnforcer implements Runnable, Closeable {
     private final RetentionEnforcementScheduler retentionEnforcementScheduler;
     private final int maxBatchesPerRequest;
 
-    private final RetentionEnforcerMetrics metrics = new RetentionEnforcerMetrics();
+    private final RetentionEnforcerMetrics metrics;
 
     public RetentionEnforcer(final SharedState sharedState) {
         this(Objects.requireNonNull(sharedState, "sharedState cannot be null").time(),
@@ -78,6 +78,7 @@ public class RetentionEnforcer implements Runnable, Closeable {
         this.controlPlane = controlPlane;
         this.retentionEnforcementScheduler = retentionEnforcementScheduler;
         this.maxBatchesPerRequest = maxBatchesPerRequest;
+        this.metrics = new RetentionEnforcerMetrics(retentionEnforcementScheduler::scheduleLagMillis);
     }
 
     @Override

--- a/storage/inkless/src/main/java/io/aiven/inkless/delete/RetentionEnforcerMetrics.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/delete/RetentionEnforcerMetrics.java
@@ -26,6 +26,7 @@ import java.io.Closeable;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.LongAdder;
+import java.util.function.Supplier;
 
 public class RetentionEnforcerMetrics implements Closeable {
     private static final String GROUP = RetentionEnforcer.class.getSimpleName();
@@ -40,6 +41,8 @@ public class RetentionEnforcerMetrics implements Closeable {
     private static final String RETENTION_ENFORCEMENT_TOTAL_BYTES_DELETED_DOC = "Total number of bytes deleted by retention enforcement";
     static final String RETENTION_ENFORCEMENT_ERROR_RATE = "RetentionEnforcementErrorRate";
     private static final String RETENTION_ENFORCEMENT_ERROR_RATE_DOC = "Total number of retention enforcement errors";
+    static final String RETENTION_ENFORCEMENT_SCHEDULE_LAG_MS = "RetentionEnforcementScheduleLagMs";
+    private static final String RETENTION_ENFORCEMENT_SCHEDULE_LAG_MS_DOC = "Milliseconds the most overdue diskless partition is past its scheduled retention enforcement time; 0 when on schedule or when no diskless partitions are scheduled";
 
     /**
      * This method returns a list of all the metric name templates for the RetentionEnforcerMetrics class.
@@ -51,7 +54,8 @@ public class RetentionEnforcerMetrics implements Closeable {
             new MetricNameTemplate(RETENTION_ENFORCEMENT_RATE, GROUP, RETENTION_ENFORCEMENT_RATE_DOC),
             new MetricNameTemplate(RETENTION_ENFORCEMENT_TOTAL_BATCHES_DELETED, GROUP, RETENTION_ENFORCEMENT_TOTAL_BATCHES_DELETED_DOC),
             new MetricNameTemplate(RETENTION_ENFORCEMENT_TOTAL_BYTES_DELETED, GROUP, RETENTION_ENFORCEMENT_TOTAL_BYTES_DELETED_DOC),
-            new MetricNameTemplate(RETENTION_ENFORCEMENT_ERROR_RATE, GROUP, RETENTION_ENFORCEMENT_ERROR_RATE_DOC)
+            new MetricNameTemplate(RETENTION_ENFORCEMENT_ERROR_RATE, GROUP, RETENTION_ENFORCEMENT_ERROR_RATE_DOC),
+            new MetricNameTemplate(RETENTION_ENFORCEMENT_SCHEDULE_LAG_MS, GROUP, RETENTION_ENFORCEMENT_SCHEDULE_LAG_MS_DOC)
         );
     }
 
@@ -63,12 +67,13 @@ public class RetentionEnforcerMetrics implements Closeable {
     private final LongAdder retentionEnforcementTotalBytesDeleted = new LongAdder();
     private final LongAdder retentionEnforcementErrorRate = new LongAdder();
 
-    public RetentionEnforcerMetrics() {
+    public RetentionEnforcerMetrics(final Supplier<Long> scheduleLagMsSupplier) {
         retentionEnforcementTotalTime = metricsGroup.newHistogram(RETENTION_ENFORCEMENT_TOTAL_TIME, true, Map.of());
         metricsGroup.newGauge(RETENTION_ENFORCEMENT_RATE, retentionEnforcementRate::intValue);
         metricsGroup.newGauge(RETENTION_ENFORCEMENT_TOTAL_BATCHES_DELETED, retentionEnforcementTotalBatchesDeleted::intValue);
         metricsGroup.newGauge(RETENTION_ENFORCEMENT_TOTAL_BYTES_DELETED, retentionEnforcementTotalBytesDeleted::intValue);
         metricsGroup.newGauge(RETENTION_ENFORCEMENT_ERROR_RATE, retentionEnforcementErrorRate::intValue);
+        metricsGroup.newGauge(RETENTION_ENFORCEMENT_SCHEDULE_LAG_MS, scheduleLagMsSupplier);
     }
 
     public void recordRetentionEnforcementStarted() {
@@ -94,5 +99,6 @@ public class RetentionEnforcerMetrics implements Closeable {
         metricsGroup.removeMetric(RETENTION_ENFORCEMENT_TOTAL_BATCHES_DELETED);
         metricsGroup.removeMetric(RETENTION_ENFORCEMENT_TOTAL_BYTES_DELETED);
         metricsGroup.removeMetric(RETENTION_ENFORCEMENT_ERROR_RATE);
+        metricsGroup.removeMetric(RETENTION_ENFORCEMENT_SCHEDULE_LAG_MS);
     }
 }

--- a/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/EnforceRetentionJobTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/EnforceRetentionJobTest.java
@@ -43,6 +43,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
 import io.aiven.inkless.TimeUtils;
@@ -130,6 +131,27 @@ class EnforceRetentionJobTest {
             EnforceRetentionResponse.success(0, 0, 0),
             EnforceRetentionResponse.success(0, 0, 0)
         );
+    }
+
+    @Test
+    void durationCallbackFiresOncePerPartition() throws Exception {
+        final AtomicInteger count = new AtomicInteger();
+        final EnforceRetentionJob job = new EnforceRetentionJob(
+            time,
+            pgContainer.getJooqCtx(),
+            List.of(
+                new EnforceRetentionRequest(TOPIC_ID_0, 0, 1, 1),
+                new EnforceRetentionRequest(TOPIC_ID_1, 0, 1, 1),
+                new EnforceRetentionRequest(TOPIC_ID_0, 1000, 1, 1)  // non-existent still counts as one exec
+            ),
+            0,
+            duration -> count.incrementAndGet());
+
+        job.call();
+
+        // EnforceRetentionQueryTime/QueryRate are recorded per partition (one enforce_retention_v2 call each),
+        // including the unknown one; the whole-wave total lives in the broker's RetentionEnforcementTotalTime.
+        assertThat(count.get()).isEqualTo(3);
     }
 
     /**

--- a/storage/inkless/src/test/java/io/aiven/inkless/delete/RetentionEnforcementSchedulerTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/delete/RetentionEnforcementSchedulerTest.java
@@ -145,7 +145,7 @@ class RetentionEnforcementSchedulerTest {
 
         final Instant expectedNextTime = Instant.ofEpochMilli(time.milliseconds() + ENFORCEMENT_INTERVAL_MS);
         assertThat(scheduler.dumpQueue())
-            .containsExactly(
+            .containsExactlyInAnyOrder(
                 new RetentionEnforcementScheduler.TopicIdPartitionWithNextEnforcementTime(T0P1, expectedNextTime),
                 new RetentionEnforcementScheduler.TopicIdPartitionWithNextEnforcementTime(T0P0, expectedNextTime)
             );
@@ -166,11 +166,33 @@ class RetentionEnforcementSchedulerTest {
         when(metadataView.getDisklessTopicPartitions()).thenReturn(Set.of(T0P1));
 
         assertThat(scheduler.getReadyPartitions()).containsExactlyInAnyOrder(T0P1);
-        
+
         final Instant expectedNextTime = Instant.ofEpochMilli(time.milliseconds() + ENFORCEMENT_INTERVAL_MS);
         assertThat(scheduler.dumpQueue())
             .containsExactly(
                 new RetentionEnforcementScheduler.TopicIdPartitionWithNextEnforcementTime(T0P1, expectedNextTime)
             );
+    }
+
+    @Test
+    void scheduleLagTracksOverduePartition() {
+        final var scheduler = new RetentionEnforcementScheduler(time, metadataView, ENFORCEMENT_INTERVAL, random);
+
+        when(metadataView.getDisklessTopicPartitions()).thenReturn(Set.of(T0P0));
+        when(metadataView.getBrokerCount()).thenReturn(1);
+
+        // Empty queue: nothing scheduled yet, so no lag.
+        assertThat(scheduler.scheduleLagMillis()).isZero();
+
+        // Initial scheduling: T0P0 scheduled at now + ENFORCEMENT_INTERVAL (deterministic random).
+        scheduler.getReadyPartitions();
+
+        // Head is in the future, so nothing is overdue.
+        assertThat(scheduler.scheduleLagMillis()).isZero();
+
+        // Advance past the scheduled time without draining the queue (simulates a stalled/blocked enforcer).
+        time.sleep(ENFORCEMENT_INTERVAL_MS + 2_000);
+
+        assertThat(scheduler.scheduleLagMillis()).isEqualTo(2_000L);
     }
 }


### PR DESCRIPTION
Improves observability of diskless retention enforcement and file cleanup. No change to enforcement or cleanup behavior. Three focused commits, all in the `io.aiven.inkless.delete` / control-plane area.

## What changed

- **Schedule-lag gauge** — new `RetentionEnforcementScheduleLagMs` gauge: milliseconds the most overdue diskless partition is past its scheduled enforcement time (0 when on schedule; a sustained positive value means enforcement is falling behind its per-partition cadence). Fed by the scheduler's oldest past-due queue entry, read under a lock so the metrics/JMX thread and the enforcement thread don't race the `PriorityQueue`.
- **Per-partition enforce latency** — `EnforceRetentionJob` runs one transaction per partition (post-#705), so `EnforceRetentionQueryTime`/`QueryRate` are now recorded per partition instead of once per wave. No new metric.
- **Intent/result run logs** — enforcer and file cleaner now log a "starting" intent line before the potentially-blocking work and a "done" line after, so a stuck operation shows as intent-without-completion.

## Metrics

New:
- `RetentionEnforcer.RetentionEnforcementScheduleLagMs` — gauge (ms).

Redefined (operator impact — re-baseline any dashboards/alerts on these): `PostgresControlPlane.EnforceRetentionQueryTime` and `EnforceRetentionQueryRate` now measure a single `enforce_retention_v2` call (one partition) rather than the whole wave. `QueryRate` rises by roughly partitions-per-wave with no config change; `QueryTime` percentiles become per-partition latencies. Nothing is lost — the whole-wave duration remains `RetentionEnforcer.RetentionEnforcementTotalTime` and the wave count remains `RetentionEnforcementRate`. Per-transaction latency is the more accurate thing to measure since each partition is its own transaction.

## Logs

- Enforcer: per-cycle summary promoted DEBUG -> INFO and paired with an intent line — `Enforcing retention for {n} partitions` / `Enforced retention for {n} partitions in {ms} ms: {b} batches, {y} bytes deleted`. One pair per non-empty cycle; empty cycles stay silent (no per-tick heartbeat, since the enforcer ticks every 500ms).
- File cleaner: replaced the per-run `Running file cleaner at {now}` heartbeat (redundant with the log framework timestamp and the outcome line) with a work-gated pair — `Running file cleaner: deleting {n} of {m} marked files` / `File cleaner deleted {n} files in {ms} ms` (the `m - n` files are still within the retention grace period).
- Also fixes a latent partition misattribution in the enforcer's per-partition log lines (they indexed `readyPartitions` while responses align with the delete-policy-filtered `requests`); now uses a list kept aligned 1:1 with `requests`/`responses`. Latent today (diskless doesn't support compaction, so the lists don't diverge) but made correct.

## Operator notes

- Re-baseline dashboards/alerts on `EnforceRetentionQueryTime`/`EnforceRetentionQueryRate` (semantics changed as above).
- The enforcer now emits an INFO intent+result pair per non-empty cycle; if that volume is a concern on high-delete clusters, the pair can be gated on deletions later.
- `RetentionEnforcementScheduleLagMs` returns 0 for both "on schedule" and "empty queue" (no diskless delete-policy partitions yet, or during startup); pair it with queue activity if that distinction matters.
- Partition/size counts are intentionally absent from the file-cleaner logs: `FileToDelete` carries only the object key, and batches are already deleted by cleanup time.

## Testing

- `scheduleLagTracksOverduePartition` (empty -> 0, future head -> 0, advance past due -> exact lag).
- `durationCallbackFiresOncePerPartition` (3 callbacks for 3 requests, including a non-existent partition).
- File-cleaner mocked + integration tests.
- `metrics.rst` regenerated; checkstyle (main + test) clean.