### PR TITLE
fix(inkless:release): run finalize-release on the workflow_call path

### DIFF
--- a/.github/workflows/inkless-publish.yml
+++ b/.github/workflows/inkless-publish.yml
@@ -296,7 +296,12 @@ jobs:
   # inkless-release-<N> tag on main.
   finalize-release:
     needs: [prepare, build-kafka-base, manifest-kafka-base]
-    if: ${{ always() && github.event_name == 'workflow_call' && !cancelled() }}
+    # Run only on the workflow_call path (coordinated release), not on the
+    # push-tag trigger. `github.event_name` can't be used here: in a reusable
+    # workflow it reflects the caller's top-level event (workflow_dispatch),
+    # never 'workflow_call'. `inputs.inkless_version` is set only on the
+    # workflow_call path and empty on push, so it's the reliable signal.
+    if: ${{ always() && !cancelled() && inputs.inkless_version != '' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
The finalize-release job (which creates the GitHub Release, attaches the .tgz binaries, and publishes the :<version> and :latest Docker images) was gated on `github.event_name == 'workflow_call'`. In a reusable workflow `github.event_name` reflects the caller's top-level event — which is `workflow_dispatch` when invoked from inkless-release.yml — so the condition was never true and the job was silently skipped. Every coordinated release created tags and images but no GitHub Release.
Gate on `inputs.inkless_version` instead, which is set only on the workflow_call path and empty on the push-tag trigger, so finalize-release runs for coordinated releases and stays skipped on single-tag pushes.