### PR TITLE
fix(inkless:release): gate finalize-release on event_name != push

### DIFF
--- a/.github/workflows/inkless-publish.yml
+++ b/.github/workflows/inkless-publish.yml
@@ -296,7 +296,7 @@ jobs:
   # inkless-release-<N> tag on main.
   finalize-release:
     needs: [prepare, build-kafka-base, manifest-kafka-base]
-    if: ${{ always() && github.event_name == 'workflow_call' && !cancelled() }}
+    if: ${{ always() && github.event_name != 'push' && !cancelled() }}
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
finalize-release skipped on every workflow_call from inkless-release.yml, so no GitHub Release was created (run 30553955976, v0.46). Its guard tested github.event_name == 'workflow_call', but a reusable workflow inherits the caller's event name (workflow_dispatch here), never 'workflow_call'. Gate on event_name != 'push' instead, matching the prepare job's push/call split.
