### PR TITLE
test(inkless:consume): de-flake recentDataUsesRecentExecutorWithoutRateLimit

### DIFF
--- a/storage/inkless/src/test/java/io/aiven/inkless/consume/FetchPlannerTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/consume/FetchPlannerTest.java
@@ -826,9 +826,11 @@ public class FetchPlannerTest {
                     verify(metrics, never()).recordLaggingConsumerRequest();
                     verify(metrics, never()).recordRateLimitWaitTime(any(Long.class));
 
-                    // Verify throughput metrics: cache miss records storage bytes in + bytes out, no cache hit
+                    // Verify throughput metrics: cache miss records storage bytes in + bytes out, no cache hit.
+                    // recordDisklessBytesOut runs in a thenAccept dependent stage off the awaited future, so
+                    // wait for it to avoid racing the executor thread that fires the callback.
                     verify(metrics).recordStorageBytesIn(expectedData.length);
-                    verify(metrics).recordDisklessBytesOut(expectedData.length);
+                    verify(metrics, timeout(1000)).recordDisklessBytesOut(expectedData.length);
                     verify(metrics, never()).recordCacheHitBytes(any(Long.class));
                     verify(metrics, never()).recordStorageLaggingBytesIn(any(Long.class));
                 }


### PR DESCRIPTION
On a hot-path cache miss, recordDisklessBytesOut is recorded in a thenAccept dependent stage that runs off the future the test awaits. The test thread and the executor thread firing the callback have no happens-before edge, so the verify could run before the metric was recorded. Wait for it with timeout(), following the same async-verify pattern already used for the hedge assertions in this file (e.g. verify(metrics, timeout(1000)).recordHedgeWon()).
