### PR TITLE
fix(inkless:retention): Limit the size of AWS delete error messages

### DIFF
--- a/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/s3/S3Storage.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/s3/S3Storage.java
@@ -157,9 +157,10 @@ public final class S3Storage extends StorageBackend {
     @Override
     public void delete(final Set<ObjectKey> keys) throws StorageBackendException {
         final List<ObjectKey> objectKeys = new ArrayList<>(keys);
+        List<ObjectKey> batch = null;
         try {
             for (int i = 0; i < objectKeys.size(); i += MAX_DELETE_KEYS_LIMIT) {
-                final var batch = objectKeys.subList(
+                batch = objectKeys.subList(
                     i,
                     Math.min(i + MAX_DELETE_KEYS_LIMIT, objectKeys.size())
                 );
@@ -178,13 +179,13 @@ public final class S3Storage extends StorageBackend {
                     final var errors = response.errors().stream()
                         .map(e -> String.format("Error %s: %s (%s)", e.key(), e.message(), e.code()))
                         .collect(Collectors.joining(", "));
-                    throw new StorageBackendException("Failed to delete keys " + keys + ": " + errors);
+                    throw new StorageBackendException("Failed to delete keys " + batch + ": " + errors);
                 }
             }
         } catch (final ApiCallTimeoutException | ApiCallAttemptTimeoutException e) {
-            throw new StorageBackendTimeoutException("Failed to delete keys " + keys, e);
+            throw new StorageBackendTimeoutException("Failed to delete keys " + batch, e);
         } catch (final SdkException e) {
-            throw new StorageBackendException("Failed to delete keys " + keys, e);
+            throw new StorageBackendException("Failed to delete keys " + batch, e);
         }
     }
 


### PR DESCRIPTION
The number of keys passed to the ObjectDeleter:delete method may be extremely large. If any key fails to delete, an error message including every key is assembled. This error message may be several megabytes in size, putting excessive memory pressure on the broker node.

Instead, the error message should be scoped to just the batch of keys that has just been deleted. This is limited by MAX_DELETE_KEYS_LIMIT (1000) which should keep the size of the message bounded.

This same failure mode appears in the other cloud implementations, those bugs/fixes are out of scope but will be addressed in an immediate follow-up. We will also investigate limiting the number of keys distributed to nodes by the control plane.
