### PR TITLE
fix(inkless:build): resolve the inkless release tag without git [KC-384]

### DIFF
--- a/.github/scripts/test-inkless-tag.sh
+++ b/.github/scripts/test-inkless-tag.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Aiven, Helsinki, Finland. https://aiven.io/
+#
+# Checks how the inkless release tag baked into kafka-version.properties resolves.
+#
+# Two regressions this guards against:
+#   1. a source tree without .git must resolve to "unknown", not fail the build
+#      (release packaging builds from a tarball, where git describe exits 128);
+#   2. -PinklessTag must be honoured verbatim (it lands in the project's `ext`
+#      namespace, which the ext block then shadows with the provider itself).
+#
+# Usage: .github/scripts/test-inkless-tag.sh
+# Run from the repository root of a git checkout.
+
+set -euo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd "$REPO_ROOT"
+
+EXPORT_DIR=$(mktemp -d)
+trap 'rm -rf "$EXPORT_DIR"' EXIT
+
+failures=0
+
+# Resolves the tag by running the real build logic. Extra args are passed to gradle.
+resolve_tag() {
+  local dir=$1
+  shift
+  local log
+  log=$(mktemp)
+  if ! (cd "$dir" && ./gradlew --console=plain --no-daemon "$@" printInklessTag) >"$log" 2>&1; then
+    echo "gradle failed in $dir:" >&2
+    cat "$log" >&2
+    rm -f "$log"
+    return 0
+  fi
+  sed -n 's/^INKLESS_TAG=//p' "$log" | tail -n1
+  rm -f "$log"
+}
+
+expect_eq() {
+  local name=$1 expected=$2 actual=$3
+  if [[ "$actual" == "$expected" ]]; then
+    echo "ok   - $name (got '$actual')"
+  else
+    echo "FAIL - $name: expected '$expected', got '$actual'"
+    failures=$((failures + 1))
+  fi
+}
+
+expect_resolved() {
+  local name=$1 actual=$2
+  if [[ -n "$actual" && "$actual" != *CIRCULAR* ]]; then
+    echo "ok   - $name (got '$actual')"
+  else
+    echo "FAIL - $name: expected a resolved tag, got '$actual'"
+    failures=$((failures + 1))
+  fi
+}
+
+echo "== git-less source tree (release packaging) =="
+# Copy the tracked working tree (not `git archive HEAD`, so uncommitted changes to
+# the resolution logic are exercised too), leaving out .git.
+git ls-files -z | rsync -a --files-from=- --from0 ./ "$EXPORT_DIR"
+expect_eq "no .git and no property falls back to unknown" \
+  "unknown" "$(resolve_tag "$EXPORT_DIR")"
+expect_eq "no .git honours -PinklessTag" \
+  "inkless-release-9.99" "$(resolve_tag "$EXPORT_DIR" -PinklessTag=inkless-release-9.99)"
+
+echo "== git checkout =="
+expect_resolved "git checkout resolves from git describe" \
+  "$(resolve_tag "$REPO_ROOT")"
+expect_eq "-PinklessTag overrides git describe" \
+  "inkless-release-9.99" "$(resolve_tag "$REPO_ROOT" -PinklessTag=inkless-release-9.99)"
+
+if ((failures > 0)); then
+  echo "$failures check(s) failed"
+  exit 1
+fi
+echo "all checks passed"

--- a/.github/workflows/inkless.yml
+++ b/.github/workflows/inkless.yml
@@ -114,6 +114,24 @@ jobs:
       #   env:
       #     GITHUB_WORKSPACE: ${{ github.workspace }}
 
+  inkless-version-tag:
+    runs-on: ubuntu-latest
+    name: Inkless version tag resolution
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Setup Gradle
+        uses: ./.github/actions/setup-gradle
+        with:
+          java-version: 17
+          gradle-cache-read-only: true
+      # Guards the tag baked into kafka-version.properties: a git-less source tree
+      # must not fail the build, and -PinklessTag must be honoured verbatim.
+      - name: Check inkless tag resolution
+        run: ./.github/scripts/test-inkless-tag.sh
+
   test:
     needs: validate
     runs-on: ubuntu-latest

--- a/build.gradle
+++ b/build.gradle
@@ -248,22 +248,34 @@ def determineCommitId() {
 // Inkless: describe the nearest inkless-* tag (e.g. "inkless-4.2.1-0.45" at a tag,
 // or "inkless-4.2.1-0.45-3-g9c3cf45" a few commits past it). This surfaces the
 // git tag and the inkless increment in the baked-in version file. The increment
-// lives only in tags (never in gradle.properties), so this is the only build-time
-// source for it.
+// lives only in tags (never in gradle.properties), so git (or an explicit
+// -PinklessTag) is the only build-time source for it.
+//
+// An explicit `inklessTag` gradle property wins, so builds without a git checkout
+// (release packaging from a source tarball) can supply it. It must be read through
+// providers.gradleProperty: `-PinklessTag` lands in the project's `ext` namespace,
+// which `ext { inklessTag = ... }` then overwrites with this very provider, so
+// project.property('inklessTag') would resolve back to the provider itself.
 //
 // Returned as a lazy Provider using providers.exec (the configuration-cache-safe
 // API) rather than a config-time exec, and evaluated when createVersionFile runs.
 // Uses the git CLI (worktree-aware) so it works in linked worktrees where Grgit's
-// `repo` is null. Falls back to "unknown" on any error or missing tag.
+// `repo` is null. Falls back to "unknown" when there is no checkout and when git
+// fails (e.g. no tags and no HEAD): a missing version must not fail the build.
 def determineInklessTag() {
-  if (project.hasProperty('inklessTag')) {
-    return providers.provider { project.property('inklessTag').toString() }
+  def fromProperty = providers.gradleProperty('inklessTag').map { it.trim() }
+  if (!file("$rootDir/.git").exists()) {
+    return fromProperty.orElse("unknown")
   }
   def described = providers.exec {
     commandLine 'git', 'describe', '--tags', '--match', 'inkless-*', '--always', '--dirty'
     workingDir project.rootDir
-  }.standardOutput.asText.map { it.trim() }
-  return described.map { it.isEmpty() ? "unknown" : it }.orElse("unknown")
+    ignoreExitValue = true
+  }
+  def fromGit = described.standardOutput.asText.zip(described.result) { output, result ->
+    result.exitValue == 0 ? output.trim() : ""
+  }
+  return fromProperty.orElse(fromGit).map { it.isEmpty() ? "unknown" : it }.orElse("unknown")
 }
 
 /**
@@ -285,6 +297,16 @@ static def projectToJUnitXmlPath(project) {
 
 
 apply from: file('wrapper.gradle')
+
+// Inkless: resolve and print the tag baked into kafka-version.properties, without
+// running a build. Used by .github/scripts/test-inkless-tag.sh and by release
+// packaging to check what -PinklessTag resolves to.
+tasks.register('printInklessTag') {
+  def tag = inklessTag
+  doLast {
+    println "INKLESS_TAG=${tag.get()}"
+  }
+}
 
 if (repo != null) {
   rat {
@@ -328,6 +350,7 @@ if (repo != null) {
         'config/inkless/**',
         'checkstyle/import-control-storage-inkless.xml',
         '.github/workflows/inkless*',
+        '.github/scripts/test-inkless-tag.sh',
         'docker/extra',
         'docs/inkless/**',
         'dump-schema-compose.yml',


### PR DESCRIPTION
Two defects in determineInklessTag() made the baked-in inkless version unusable outside a git checkout:

1. providers.exec checks the exit value by default, so `git describe` returning 128 (no repository, or no HEAD to describe) failed the build instead of falling back to "unknown". This is what breaks builds on BuildKite workers, where git is not available.

2. `-PinklessTag=<version>` resolved to "<CIRCULAR REFERENCE>". Gradle injects -P properties into the project's `ext` namespace, which `ext { inklessTag = determineInklessTag() }` then overwrites with the provider itself, so `project.property('inklessTag')` inside that provider returned the provider and stringified to a placeholder. Reading through providers.gradleProperty bypasses `ext`, and also picks up an `inklessTag` set in gradle.properties.

With both fixed, release packaging can pass the version explicitly and the aiven-core workaround patch that renamed the property is no longer needed.

Adds printInklessTag to resolve the value without running a build, and .github/scripts/test-inkless-tag.sh which exercises the four cases (with/without a checkout, with/without the property) against a copy of the tracked tree; wired into the Inkless CI workflow.