### PR TITLE
inkless: add last-successful-operation age gauges [KC-316]

### DIFF
--- a/docs/inkless/metrics.rst
+++ b/docs/inkless/metrics.rst
@@ -186,29 +186,30 @@ FileCommitter metrics
 io.aiven.inkless.produce:type=FileCommitter
 -------------------------------------------
 
-=============================  ==================================================================================================
-Attribute name                 Description                                                                                       
-=============================  ==================================================================================================
-BatchesCommitRate              Rate of batches committed per second                                                              
-BatchesCount                   Number of batches per committed file                                                              
-BatchesPerPartitionPerCommit   Number of batches a single topic-partition contributes to a committed file (per-partition fan-in).
-CacheStoreTime                 Time spent storing file data in the cache after commit in milliseconds                            
-CommitQueueBytes               Current total bytes of files waiting to be committed                                              
-CommitQueueFiles               Current number of files waiting to be committed                                                   
-FileCommitErrorRate            Rate of failed file commits per second                                                            
-FileCommitRate                 Rate of successful file commits per second                                                        
-FileCommitTime                 Time spent committing a file to the control plane in milliseconds                                 
-FileCommitWaitTime             Time a file waits before commit starts in milliseconds                                            
-FileSize                       Size of committed files in bytes                                                                  
-FileTotalLifeTime              Total lifetime of a file from creation to commit completion in milliseconds                       
-FileUploadAndCommitTime        Time spent uploading and committing a file in milliseconds                                        
-FileUploadErrorRate            Rate of failed file uploads per second                                                            
-FileUploadRate                 Rate of successful file uploads per second                                                        
-FileUploadTime                 Time spent uploading a file to object storage in milliseconds                                     
-PartitionsPerCommit            Number of distinct topic-partitions in a committed file                                           
-WriteErrorRate                 Rate of failed write operations per second                                                        
-WriteRate                      Rate of successful write operations per second                                                    
-=============================  ==================================================================================================
+==============================  =========================================================================================================
+Attribute name                  Description                                                                                              
+==============================  =========================================================================================================
+BatchesCommitRate               Rate of batches committed per second                                                                     
+BatchesCount                    Number of batches per committed file                                                                     
+BatchesPerPartitionPerCommit    Number of batches a single topic-partition contributes to a committed file (per-partition fan-in).       
+CacheStoreTime                  Time spent storing file data in the cache after commit in milliseconds                                   
+CommitQueueBytes                Current total bytes of files waiting to be committed                                                     
+CommitQueueFiles                Current number of files waiting to be committed                                                          
+FileCommitErrorRate             Rate of failed file commits per second                                                                   
+FileCommitRate                  Rate of successful file commits per second                                                               
+FileCommitTime                  Time spent committing a file to the control plane in milliseconds                                        
+FileCommitWaitTime              Time a file waits before commit starts in milliseconds                                                   
+FileSize                        Size of committed files in bytes                                                                         
+FileTotalLifeTime               Total lifetime of a file from creation to commit completion in milliseconds                              
+FileUploadAndCommitTime         Time spent uploading and committing a file in milliseconds                                               
+FileUploadErrorRate             Rate of failed file uploads per second                                                                   
+FileUploadRate                  Rate of successful file uploads per second                                                               
+FileUploadTime                  Time spent uploading a file to object storage in milliseconds                                            
+LastSuccessfulFileCommitAgeMs   Milliseconds since the last successful file commit completed; -1 if no commit has succeeded since startup
+PartitionsPerCommit             Number of distinct topic-partitions in a committed file                                                  
+WriteErrorRate                  Rate of failed write operations per second                                                               
+WriteRate                       Rate of successful write operations per second                                                           
+==============================  =========================================================================================================
 
 
 FileCleaner metrics
@@ -284,44 +285,61 @@ PostgresControlPlane metrics
 io.aiven.inkless.control_plane.postgres:type=PostgresControlPlane
 -----------------------------------------------------------------
 
-==================================  =======================================================================
-Attribute name                      Description                                                            
-==================================  =======================================================================
-AdvanceCrossTierLogStartQueryRate   Total number of AdvanceCrossTierLogStart queries executed              
-AdvanceCrossTierLogStartQueryTime   Time spent executing the AdvanceCrossTierLogStart query in milliseconds
-CommitFileQueryRate                 Total number of CommitFile queries executed                            
-CommitFileQueryTime                 Time spent executing the CommitFile query in milliseconds              
-DeleteRecordsQueryRate              Total number of DeleteRecords queries executed                         
-DeleteRecordsQueryTime              Time spent executing the DeleteRecords query in milliseconds           
-EnforceRetentionQueryRate           Total number of EnforceRetention queries executed                      
-EnforceRetentionQueryTime           Time spent executing the EnforceRetention query in milliseconds        
-FilesDeleteQueryRate                Total number of FilesDelete queries executed                           
-FilesDeleteQueryTime                Time spent executing the FilesDelete query in milliseconds             
-FindBatchesQueryRate                Total number of FindBatches queries executed                           
-FindBatchesQueryTime                Time spent executing the FindBatches query in milliseconds             
-GetCrossTierLogStartQueryRate       Total number of GetCrossTierLogStart queries executed                  
-GetCrossTierLogStartQueryTime       Time spent executing the GetCrossTierLogStart query in milliseconds    
-GetFilesToDeleteQueryRate           Total number of GetFilesToDelete queries executed                      
-GetFilesToDeleteQueryTime           Time spent executing the GetFilesToDelete query in milliseconds        
-GetLogInfoQueryRate                 Total number of GetLogInfo queries executed                            
-GetLogInfoQueryTime                 Time spent executing the GetLogInfo query in milliseconds              
-GetLogsQueryRate                    Total number of GetLogs queries executed                               
-GetLogsQueryTime                    Time spent executing the GetLogs query in milliseconds                 
-GetProducerStateQueryRate           Total number of GetProducerState queries executed                      
-GetProducerStateQueryTime           Time spent executing the GetProducerState query in milliseconds        
-InitDisklessLogQueryRate            Total number of InitDisklessLog queries executed                       
-InitDisklessLogQueryTime            Time spent executing the InitDisklessLog query in milliseconds         
-ListOffsetsQueryRate                Total number of ListOffsets queries executed                           
-ListOffsetsQueryTime                Time spent executing the ListOffsets query in milliseconds             
-RepairDisklessLogQueryRate          Total number of RepairDisklessLog queries executed                     
-RepairDisklessLogQueryTime          Time spent executing the RepairDisklessLog query in milliseconds       
-SafeDeleteFileCheckQueryRate        Total number of SafeDeleteFileCheck queries executed                   
-SafeDeleteFileCheckQueryTime        Time spent executing the SafeDeleteFileCheck query in milliseconds     
-TopicCreateQueryRate                Total number of TopicCreate queries executed                           
-TopicCreateQueryTime                Time spent executing the TopicCreate query in milliseconds             
-TopicDeleteQueryRate                Total number of TopicDelete queries executed                           
-TopicDeleteQueryTime                Time spent executing the TopicDelete query in milliseconds             
-==================================  =======================================================================
+=================================================  ===========================================================================================================================
+Attribute name                                     Description                                                                                                                
+=================================================  ===========================================================================================================================
+AdvanceCrossTierLogStartLastSuccessfulQueryAgeMs   Milliseconds since the last successful AdvanceCrossTierLogStart query completed; -1 if no query has succeeded since startup
+AdvanceCrossTierLogStartQueryRate                  Total number of AdvanceCrossTierLogStart queries executed                                                                  
+AdvanceCrossTierLogStartQueryTime                  Time spent executing the AdvanceCrossTierLogStart query in milliseconds                                                    
+CommitFileLastSuccessfulQueryAgeMs                 Milliseconds since the last successful CommitFile query completed; -1 if no query has succeeded since startup              
+CommitFileQueryRate                                Total number of CommitFile queries executed                                                                                
+CommitFileQueryTime                                Time spent executing the CommitFile query in milliseconds                                                                  
+DeleteRecordsLastSuccessfulQueryAgeMs              Milliseconds since the last successful DeleteRecords query completed; -1 if no query has succeeded since startup           
+DeleteRecordsQueryRate                             Total number of DeleteRecords queries executed                                                                             
+DeleteRecordsQueryTime                             Time spent executing the DeleteRecords query in milliseconds                                                               
+EnforceRetentionLastSuccessfulQueryAgeMs           Milliseconds since the last successful EnforceRetention query completed; -1 if no query has succeeded since startup        
+EnforceRetentionQueryRate                          Total number of EnforceRetention queries executed                                                                          
+EnforceRetentionQueryTime                          Time spent executing the EnforceRetention query in milliseconds                                                            
+FilesDeleteLastSuccessfulQueryAgeMs                Milliseconds since the last successful FilesDelete query completed; -1 if no query has succeeded since startup             
+FilesDeleteQueryRate                               Total number of FilesDelete queries executed                                                                               
+FilesDeleteQueryTime                               Time spent executing the FilesDelete query in milliseconds                                                                 
+FindBatchesLastSuccessfulQueryAgeMs                Milliseconds since the last successful FindBatches query completed; -1 if no query has succeeded since startup             
+FindBatchesQueryRate                               Total number of FindBatches queries executed                                                                               
+FindBatchesQueryTime                               Time spent executing the FindBatches query in milliseconds                                                                 
+GetCrossTierLogStartLastSuccessfulQueryAgeMs       Milliseconds since the last successful GetCrossTierLogStart query completed; -1 if no query has succeeded since startup    
+GetCrossTierLogStartQueryRate                      Total number of GetCrossTierLogStart queries executed                                                                      
+GetCrossTierLogStartQueryTime                      Time spent executing the GetCrossTierLogStart query in milliseconds                                                        
+GetFilesToDeleteLastSuccessfulQueryAgeMs           Milliseconds since the last successful GetFilesToDelete query completed; -1 if no query has succeeded since startup        
+GetFilesToDeleteQueryRate                          Total number of GetFilesToDelete queries executed                                                                          
+GetFilesToDeleteQueryTime                          Time spent executing the GetFilesToDelete query in milliseconds                                                            
+GetLogInfoLastSuccessfulQueryAgeMs                 Milliseconds since the last successful GetLogInfo query completed; -1 if no query has succeeded since startup              
+GetLogInfoQueryRate                                Total number of GetLogInfo queries executed                                                                                
+GetLogInfoQueryTime                                Time spent executing the GetLogInfo query in milliseconds                                                                  
+GetLogsLastSuccessfulQueryAgeMs                    Milliseconds since the last successful GetLogs query completed; -1 if no query has succeeded since startup                 
+GetLogsQueryRate                                   Total number of GetLogs queries executed                                                                                   
+GetLogsQueryTime                                   Time spent executing the GetLogs query in milliseconds                                                                     
+GetProducerStateLastSuccessfulQueryAgeMs           Milliseconds since the last successful GetProducerState query completed; -1 if no query has succeeded since startup        
+GetProducerStateQueryRate                          Total number of GetProducerState queries executed                                                                          
+GetProducerStateQueryTime                          Time spent executing the GetProducerState query in milliseconds                                                            
+InitDisklessLogLastSuccessfulQueryAgeMs            Milliseconds since the last successful InitDisklessLog query completed; -1 if no query has succeeded since startup         
+InitDisklessLogQueryRate                           Total number of InitDisklessLog queries executed                                                                           
+InitDisklessLogQueryTime                           Time spent executing the InitDisklessLog query in milliseconds                                                             
+ListOffsetsLastSuccessfulQueryAgeMs                Milliseconds since the last successful ListOffsets query completed; -1 if no query has succeeded since startup             
+ListOffsetsQueryRate                               Total number of ListOffsets queries executed                                                                               
+ListOffsetsQueryTime                               Time spent executing the ListOffsets query in milliseconds                                                                 
+RepairDisklessLogLastSuccessfulQueryAgeMs          Milliseconds since the last successful RepairDisklessLog query completed; -1 if no query has succeeded since startup       
+RepairDisklessLogQueryRate                         Total number of RepairDisklessLog queries executed                                                                         
+RepairDisklessLogQueryTime                         Time spent executing the RepairDisklessLog query in milliseconds                                                           
+SafeDeleteFileCheckLastSuccessfulQueryAgeMs        Milliseconds since the last successful SafeDeleteFileCheck query completed; -1 if no query has succeeded since startup     
+SafeDeleteFileCheckQueryRate                       Total number of SafeDeleteFileCheck queries executed                                                                       
+SafeDeleteFileCheckQueryTime                       Time spent executing the SafeDeleteFileCheck query in milliseconds                                                         
+TopicCreateLastSuccessfulQueryAgeMs                Milliseconds since the last successful TopicCreate query completed; -1 if no query has succeeded since startup             
+TopicCreateQueryRate                               Total number of TopicCreate queries executed                                                                               
+TopicCreateQueryTime                               Time spent executing the TopicCreate query in milliseconds                                                                 
+TopicDeleteLastSuccessfulQueryAgeMs                Milliseconds since the last successful TopicDelete query completed; -1 if no query has succeeded since startup             
+TopicDeleteQueryRate                               Total number of TopicDelete queries executed                                                                               
+TopicDeleteQueryTime                               Time spent executing the TopicDelete query in milliseconds                                                                 
+=================================================  ===========================================================================================================================
 
 
 PostgresConnectionPool metrics

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/PostgresControlPlaneMetrics.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/PostgresControlPlaneMetrics.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.LongAdder;
 
 public class PostgresControlPlaneMetrics implements Closeable {
@@ -53,6 +54,8 @@ public class PostgresControlPlaneMetrics implements Closeable {
                 "Time spent executing the " + name + " query in milliseconds"));
             templates.add(new MetricNameTemplate(name + "QueryRate", GROUP,
                 "Total number of " + name + " queries executed"));
+            templates.add(new MetricNameTemplate(name + "LastSuccessfulQueryAgeMs", GROUP,
+                "Milliseconds since the last successful " + name + " query completed; -1 if no query has succeeded since startup"));
         }
         return templates;
     }
@@ -61,9 +64,11 @@ public class PostgresControlPlaneMetrics implements Closeable {
 
     private final KafkaMetricsGroup metricsGroup = new KafkaMetricsGroup(
         PostgresControlPlane.class.getPackageName(), PostgresControlPlane.class.getSimpleName());
-    private final QueryMetrics findBatchesMetrics = new QueryMetrics("FindBatches");
+    // Visible for testing.
+    final QueryMetrics findBatchesMetrics = new QueryMetrics("FindBatches");
     private final QueryMetrics getLogsMetrics = new QueryMetrics("GetLogs");
-    private final QueryMetrics commitFileMetrics = new QueryMetrics("CommitFile");
+    // Visible for testing.
+    final QueryMetrics commitFileMetrics = new QueryMetrics("CommitFile");
     private final QueryMetrics topicCreateMetrics = new QueryMetrics("TopicCreate");
     private final QueryMetrics topicDeleteMetrics = new QueryMetrics("TopicDelete");
     private final QueryMetrics fileDeleteMetrics = new QueryMetrics("FilesDelete");
@@ -171,33 +176,46 @@ public class PostgresControlPlaneMetrics implements Closeable {
         safeDeleteFileCheckMetrics.remove();
         getLogInfoMetrics.remove();
         initDisklessLogMetrics.remove();
+        repairDisklessLogMetrics.remove();
         getProducerStateMetrics.remove();
         pruneDisklessLogsMetrics.remove();
         advanceCrossTierLogStartMetrics.remove();
         getCrossTierLogStartMetrics.remove();
     }
 
-    private class QueryMetrics {
+    // Visible for testing.
+    class QueryMetrics {
         private final String queryTimeMetricName;
         private final String queryRateMetricName;
+        private final String lastSuccessfulQueryAgeMsMetricName;
         private final Histogram queryTimeHistogram;
         private final LongAdder queryRate = new LongAdder();
+        // -1 means no successful query has occurred since startup.
+        // Visible for testing.
+        final AtomicLong lastSuccessfulQueryTimeMs = new AtomicLong(-1);
 
         private QueryMetrics(final String name) {
             this.queryTimeMetricName = name + "QueryTime";
             this.queryRateMetricName = name + "QueryRate";
+            this.lastSuccessfulQueryAgeMsMetricName = name + "LastSuccessfulQueryAgeMs";
             this.queryTimeHistogram = metricsGroup.newHistogram(queryTimeMetricName, true, Map.of());
             metricsGroup.newGauge(queryRateMetricName, queryRate::intValue);
+            metricsGroup.newGauge(lastSuccessfulQueryAgeMsMetricName, () -> {
+                final long last = lastSuccessfulQueryTimeMs.get();
+                return last == -1 ? -1L : time.milliseconds() - last;
+            });
         }
 
         private void record(final long duration) {
             queryTimeHistogram.update(duration);
             queryRate.increment();
+            lastSuccessfulQueryTimeMs.set(time.milliseconds());
         }
 
         private void remove() {
             metricsGroup.removeMetric(this.queryTimeMetricName);
             metricsGroup.removeMetric(this.queryRateMetricName);
+            metricsGroup.removeMetric(this.lastSuccessfulQueryAgeMsMetricName);
         }
     }
 }

--- a/storage/inkless/src/main/java/io/aiven/inkless/produce/FileCommitterMetrics.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/produce/FileCommitterMetrics.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 
 import io.aiven.inkless.TimeUtils;
@@ -81,6 +82,8 @@ public class FileCommitterMetrics implements Closeable {
     private static final String WRITE_RATE_DOC = "Rate of successful write operations per second";
     private static final String WRITE_ERROR_RATE = "WriteErrorRate";
     private static final String WRITE_ERROR_RATE_DOC = "Rate of failed write operations per second";
+    private static final String LAST_SUCCESSFUL_FILE_COMMIT_AGE_MS = "LastSuccessfulFileCommitAgeMs";
+    private static final String LAST_SUCCESSFUL_FILE_COMMIT_AGE_MS_DOC = "Milliseconds since the last successful file commit completed; -1 if no commit has succeeded since startup";
 
     /**
      * This method returns a list of all the metric name templates for the FileCommitterMetrics class.
@@ -106,7 +109,8 @@ public class FileCommitterMetrics implements Closeable {
             new MetricNameTemplate(WRITE_RATE, GROUP, WRITE_RATE_DOC),
             new MetricNameTemplate(WRITE_ERROR_RATE, GROUP, WRITE_ERROR_RATE_DOC),
             new MetricNameTemplate(COMMIT_QUEUE_FILES, GROUP, COMMIT_QUEUE_FILES_DOC),
-            new MetricNameTemplate(COMMIT_QUEUE_BYTES, GROUP, COMMIT_QUEUE_BYTES_DOC)
+            new MetricNameTemplate(COMMIT_QUEUE_BYTES, GROUP, COMMIT_QUEUE_BYTES_DOC),
+            new MetricNameTemplate(LAST_SUCCESSFUL_FILE_COMMIT_AGE_MS, GROUP, LAST_SUCCESSFUL_FILE_COMMIT_AGE_MS_DOC)
         );
     }
 
@@ -132,6 +136,9 @@ public class FileCommitterMetrics implements Closeable {
     private final Meter batchesCommitRate;
     private final Meter writeRate;
     private final Meter writeErrorRate;
+    // -1 means no successful commit has occurred since startup.
+    // Visible for testing.
+    final AtomicLong lastSuccessfulFileCommitTimeMs = new AtomicLong(-1);
 
     FileCommitterMetrics(final Time time) {
         this.time = Objects.requireNonNull(time, "time cannot be null");
@@ -152,6 +159,10 @@ public class FileCommitterMetrics implements Closeable {
         cacheStoreTimeHistogram = metricsGroup.newHistogram(CACHE_STORE_TIME, true, Map.of());
         writeRate = metricsGroup.newMeter(WRITE_RATE, "writes", TimeUnit.SECONDS, Map.of());
         writeErrorRate = metricsGroup.newMeter(WRITE_ERROR_RATE, "errors", TimeUnit.SECONDS, Map.of());
+        metricsGroup.newGauge(LAST_SUCCESSFUL_FILE_COMMIT_AGE_MS, () -> {
+            final long last = lastSuccessfulFileCommitTimeMs.get();
+            return last == -1 ? -1L : time.milliseconds() - last;
+        });
     }
 
     void initTotalFilesInProgressMetric(final Supplier<Integer> supplier) {
@@ -230,6 +241,7 @@ public class FileCommitterMetrics implements Closeable {
         final Instant now = TimeUtils.durationMeasurementNow(time);
         fileTotalLifeTimeHistogram.update(Duration.between(fileStart, now).toMillis());
         fileUploadAndCommitTimeHistogram.update(Duration.between(uploadAndCommitStart, now).toMillis());
+        lastSuccessfulFileCommitTimeMs.set(time.milliseconds());
     }
 
     void writeCompleted() {
@@ -265,5 +277,6 @@ public class FileCommitterMetrics implements Closeable {
         metricsGroup.removeMetric(BATCHES_PER_PARTITION_PER_COMMIT);
         metricsGroup.removeMetric(WRITE_RATE);
         metricsGroup.removeMetric(WRITE_ERROR_RATE);
+        metricsGroup.removeMetric(LAST_SUCCESSFUL_FILE_COMMIT_AGE_MS);
     }
 }

--- a/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/PostgresControlPlaneMetricsTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/PostgresControlPlaneMetricsTest.java
@@ -1,0 +1,77 @@
+/*
+ * Inkless
+ * Copyright (C) 2024 - 2026 Aiven OY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.aiven.inkless.control_plane.postgres;
+
+import org.apache.kafka.common.utils.MockTime;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PostgresControlPlaneMetricsTest {
+
+    MockTime time;
+    PostgresControlPlaneMetrics metrics;
+
+    @BeforeEach
+    void setUp() {
+        time = new MockTime(0, 0, 0);
+        metrics = new PostgresControlPlaneMetrics(time);
+    }
+
+    @AfterEach
+    void tearDown() {
+        metrics.close();
+    }
+
+    @Test
+    void lastSuccessfulQueryAgeMs_isMinusOneBeforeFirstQuery() {
+        assertThat(metrics.commitFileMetrics.lastSuccessfulQueryTimeMs.get()).isEqualTo(-1L);
+    }
+
+    @Test
+    void lastSuccessfulQueryAgeMs_recordedOnQueryCompletion() {
+        time.setCurrentTimeMs(1_000L);
+        metrics.onCommitFileCompleted(50L);
+
+        assertThat(metrics.commitFileMetrics.lastSuccessfulQueryTimeMs.get()).isEqualTo(1_000L);
+    }
+
+    @Test
+    void lastSuccessfulQueryAgeMs_updatesOnSubsequentQueries() {
+        time.setCurrentTimeMs(1_000L);
+        metrics.onCommitFileCompleted(50L);
+
+        time.setCurrentTimeMs(3_000L);
+        metrics.onCommitFileCompleted(30L);
+
+        assertThat(metrics.commitFileMetrics.lastSuccessfulQueryTimeMs.get()).isEqualTo(3_000L);
+    }
+
+    @Test
+    void lastSuccessfulQueryAgeMs_independentPerQueryType() {
+        time.setCurrentTimeMs(1_000L);
+        metrics.onCommitFileCompleted(50L);
+
+        // FindBatches has not been called — its timestamp should still be -1.
+        assertThat(metrics.commitFileMetrics.lastSuccessfulQueryTimeMs.get()).isEqualTo(1_000L);
+        assertThat(metrics.findBatchesMetrics.lastSuccessfulQueryTimeMs.get()).isEqualTo(-1L);
+    }
+}

--- a/storage/inkless/src/test/java/io/aiven/inkless/produce/FileCommitterMetricsTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/produce/FileCommitterMetricsTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -40,11 +41,13 @@ class FileCommitterMetricsTest {
     static final TopicIdPartition T1 = new TopicIdPartition(TOPIC_ID, 1, "t");
     static final TopicIdPartition T2 = new TopicIdPartition(TOPIC_ID, 2, "t");
 
+    MockTime time;
     FileCommitterMetrics metrics;
 
     @BeforeEach
     void setUp() {
-        metrics = new FileCommitterMetrics(new MockTime());
+        time = new MockTime(0, 0, 0);
+        metrics = new FileCommitterMetrics(time);
     }
 
     @AfterEach
@@ -126,5 +129,37 @@ class FileCommitterMetricsTest {
         assertThat(metrics.batchesPerPartitionPerCommitHistogram.count()).isEqualTo(4);
         assertThat(metrics.batchesPerPartitionPerCommitHistogram.max()).isEqualTo(2.0);
         assertThat(metrics.batchesPerPartitionPerCommitHistogram.min()).isEqualTo(1.0);
+    }
+
+    @Test
+    void lastSuccessfulFileCommitAgeMs_isMinusOneBeforeFirstCommit() {
+        assertThat(metrics.lastSuccessfulFileCommitTimeMs.get()).isEqualTo(-1L);
+    }
+
+    @Test
+    void lastSuccessfulFileCommitAgeMs_recordedOnFileFinished() {
+        time.setCurrentTimeMs(1_000L);
+        metrics.fileFinished(Instant.EPOCH, Instant.EPOCH);
+
+        assertThat(metrics.lastSuccessfulFileCommitTimeMs.get()).isEqualTo(1_000L);
+    }
+
+    @Test
+    void lastSuccessfulFileCommitAgeMs_updatesOnSubsequentCommits() {
+        time.setCurrentTimeMs(1_000L);
+        metrics.fileFinished(Instant.EPOCH, Instant.EPOCH);
+
+        time.setCurrentTimeMs(3_000L);
+        metrics.fileFinished(Instant.EPOCH, Instant.EPOCH);
+
+        assertThat(metrics.lastSuccessfulFileCommitTimeMs.get()).isEqualTo(3_000L);
+    }
+
+    @Test
+    void lastSuccessfulFileCommitAgeMs_notUpdatedOnCommitFailure() {
+        time.setCurrentTimeMs(1_000L);
+        metrics.fileCommitFailed();
+
+        assertThat(metrics.lastSuccessfulFileCommitTimeMs.get()).isEqualTo(-1L);
     }
 }


### PR DESCRIPTION
Commit 9389b7a fixed a stuck write-path thread caused by a connection to a deleted PG node. The issue was only surfaced by the customer — no internal metric revealed the hang.

Add age-of-last-success gauges so a stuck operation becomes visible before a customer reports it:

- FileCommitter.LastSuccessfulFileCommitAgeMs: milliseconds since the last file commit completed successfully.

- PostgresControlPlane.{QueryName}LastSuccessfulQueryAgeMs: same pattern, one gauge per query type (CommitFile, FindBatches, etc.).

Both gauges return -1 before the first success, making "never ran" distinguishable from "ran very recently".

Also fix missing removal of RepairDisklessLog QueryMetrics alongside all other query metrics removals.

[KC-316]

[KC-316]: https://aiven.atlassian.net/browse/KC-316?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ