### PR TITLE
fix(inkless): refresh cached topic config for diskless topics with a local log [KC-388]

### DIFF
--- a/core/src/main/scala/kafka/server/ConfigHandler.scala
+++ b/core/src/main/scala/kafka/server/ConfigHandler.scala
@@ -58,10 +58,7 @@ class TopicConfigHandler(private val replicaManager: ReplicaManager,
       wasRemoteLogEnabled)
     maybeUpdateRemoteLogComponents(topic, logs, wasRemoteLogEnabled, wasCopyDisabled)
 
-    if (logs.isEmpty) {
-      // Update cached LogConfig only for diskless topics (topics without local logs) to preserve lazy population.
-      replicaManager.inklessMetadataView().updateTopicConfig(topic, topicConfig)
-    }
+    replicaManager.inklessMetadataView().updateTopicConfig(topic, topicConfig)
   }
 
   private[server] def maybeUpdateRemoteLogComponents(topic: String,

--- a/core/src/test/java/kafka/server/InklessConsolidatedDisklessTopicsTest.java
+++ b/core/src/test/java/kafka/server/InklessConsolidatedDisklessTopicsTest.java
@@ -40,6 +40,7 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.TopicPartitionInfo;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.config.ConfigResource;
+import org.apache.kafka.common.errors.RecordTooLargeException;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
@@ -102,6 +103,7 @@ import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
 import static org.apache.kafka.common.config.TopicConfig.CLEANUP_POLICY_CONFIG;
 import static org.apache.kafka.common.config.TopicConfig.CLEANUP_POLICY_DELETE;
 import static org.apache.kafka.common.config.TopicConfig.DISKLESS_ENABLE_CONFIG;
+import static org.apache.kafka.common.config.TopicConfig.MAX_MESSAGE_BYTES_CONFIG;
 import static org.apache.kafka.common.config.TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG;
 import static org.apache.kafka.common.config.TopicConfig.SEGMENT_BYTES_CONFIG;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -495,6 +497,83 @@ public class InklessConsolidatedDisklessTopicsTest {
         // The survivors [7, seal) on each partition are still readable and contiguous across the cut.
         final int survivorsPerPartition = (int) (sealPerPartition - 7);
         consumeAndVerify(commonConfigs, survivorsPerPartition * numPartitions);
+    }
+
+    /**
+     * A raised {@code max.message.bytes} must take effect on a consolidated diskless topic that has already
+     * been produced to.
+     *
+     * <p>The diskless append path validates against a per-broker cached {@code LogConfig} populated on the
+     * first produce. A consolidated topic always has a local log on its replicas, so a config-change refresh
+     * gated on "no local log" never reaches it and produces above the previously cached limit keep failing
+     * with {@code MESSAGE_TOO_LARGE}.
+     */
+    @Test
+    public void testRaisedMaxMessageBytesIsHonouredOnConsolidatedDisklessTopic() throws Exception {
+        topicName = "raised-max-message-bytes";
+        numPartitions = 1;
+        final int initialMaxMessageBytes = 262_144;
+        final int raisedMaxMessageBytes = 6_291_456;
+        // Over the initial limit, under the raised one.
+        final int largeValueSize = 1_048_576;
+
+        final Map<String, Object> commonConfigs = new HashMap<>();
+        commonConfigs.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers());
+
+        try (Admin admin = AdminClient.create(commonConfigs)) {
+            final Map<String, String> topicConfigs = Map.of(
+                DISKLESS_ENABLE_CONFIG, "true",
+                REMOTE_LOG_STORAGE_ENABLE_CONFIG, "true",
+                CLEANUP_POLICY_CONFIG, CLEANUP_POLICY_DELETE,
+                SEGMENT_BYTES_CONFIG, "1048576",
+                MAX_MESSAGE_BYTES_CONFIG, Integer.toString(initialMaxMessageBytes)
+            );
+            final NewTopic topic = new NewTopic(topicName, numPartitions, (short) -1).configs(topicConfigs);
+            admin.createTopics(Collections.singletonList(topic)).all().get(30, TimeUnit.SECONDS);
+            TopicMetadataProbe.awaitValue(admin, topicName, MAX_MESSAGE_BYTES_CONFIG,
+                Integer.toString(initialMaxMessageBytes));
+
+            // The first produce is what populates the leader's cached LogConfig.
+            produceRecords(commonConfigs, 1,
+                i -> new ProducerRecord<>(topicName, 0, null, TestUtils.randomString(1024)));
+
+            assertFalse(tryProduceValueOfSize(commonConfigs, largeValueSize),
+                "A record above the initial max.message.bytes must be rejected before the config is raised");
+
+            incrementalAlterTopicConfigs(admin,
+                Map.of(MAX_MESSAGE_BYTES_CONFIG, Integer.toString(raisedMaxMessageBytes)));
+            TopicMetadataProbe.awaitValue(admin, topicName, MAX_MESSAGE_BYTES_CONFIG,
+                Integer.toString(raisedMaxMessageBytes));
+
+            // Polled rather than asserted once: brokers apply the published config change asynchronously.
+            TestUtils.waitForCondition(() -> tryProduceValueOfSize(commonConfigs, largeValueSize),
+                60_000,
+                () -> "A " + largeValueSize + " byte record must be accepted after max.message.bytes was raised to "
+                    + raisedMaxMessageBytes + "; the diskless append path is still validating against the stale "
+                    + "cached limit (" + initialMaxMessageBytes + ")");
+        }
+    }
+
+    /**
+     * Sends one record with a value of {@code valueSize} bytes and reports whether the broker accepted it.
+     * {@code false} means it was rejected as too large; any other failure propagates.
+     */
+    private boolean tryProduceValueOfSize(Map<String, Object> commonConfigs, int valueSize) throws Exception {
+        final Map<String, Object> producerConfigs = new HashMap<>(commonConfigs);
+        producerConfigs.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        producerConfigs.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        // Keep the client-side limit out of the way; the broker-side limit is what is under test.
+        producerConfigs.put(ProducerConfig.MAX_REQUEST_SIZE_CONFIG, 8 * 1024 * 1024);
+        try (Producer<String, String> producer = new KafkaProducer<>(producerConfigs)) {
+            producer.send(new ProducerRecord<>(topicName, 0, null, TestUtils.randomString(valueSize)))
+                .get(30, TimeUnit.SECONDS);
+            return true;
+        } catch (ExecutionException e) {
+            if (e.getCause() instanceof RecordTooLargeException) {
+                return false;
+            }
+            throw e;
+        }
     }
 
     /**

--- a/core/src/test/scala/unit/kafka/server/DynamicConfigChangeTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DynamicConfigChangeTest.scala
@@ -18,6 +18,7 @@ package kafka.server
 
 import kafka.cluster.Partition
 import kafka.integration.KafkaServerTestHarness
+import kafka.server.metadata.{InklessMetadataView, KRaftMetadataCache}
 import kafka.utils.TestUtils.random
 import kafka.utils._
 import org.apache.kafka.clients.CommonClientConfigs
@@ -40,6 +41,8 @@ import org.apache.kafka.storage.internals.log.{LogConfig, UnifiedLog}
 import org.apache.kafka.test.TestUtils.assertFutureThrows
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{Test, Timeout}
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
@@ -614,36 +617,140 @@ class DynamicConfigChangeUnitTest {
     verify(inklessMetadataView).updateTopicConfig(topic, topicConfig)
   }
 
-  @Test
-  def testClassicTopicConfigUpdateDoesNotCallInklessMetadataView(): Unit = {
-    val topic = "classic-topic"
+  /**
+   * Drives TopicConfigHandler against a real InklessMetadataView (not a mock) so the assertions are on
+   * the config the diskless produce and retention paths would read, rather than on the handler's calls.
+   *
+   * @param localLogs logs this broker holds for the topic; a non-empty value is what every consolidated
+   *                  topic and every switched topic with a classic prefix looks like on a replica broker.
+   */
+  private def topicConfigHandlerWithInklessView(
+    topic: String,
+    publishedTopicConfig: Properties,
+    localLogs: Seq[UnifiedLog],
+    brokerDefaults: util.Map[String, Object]
+  ): (TopicConfigHandler, InklessMetadataView) = {
+    val metadataCache = mock(classOf[KRaftMetadataCache])
+    when(metadataCache.topicConfig(topic)).thenReturn(publishedTopicConfig)
+    val inklessMetadataView = new InklessMetadataView(metadataCache, () => brokerDefaults)
+
     val logManager = mock(classOf[kafka.log.LogManager])
+    when(logManager.logsByTopic(topic)).thenReturn(localLogs)
     val replicaManager: ReplicaManager = mock(classOf[ReplicaManager])
-    val inklessMetadataView = mock(classOf[kafka.server.metadata.InklessMetadataView])
     when(replicaManager.logManager).thenReturn(logManager)
     when(replicaManager.inklessMetadataView()).thenReturn(inklessMetadataView)
+    when(replicaManager.metadataCache).thenReturn(metadataCache)
     when(replicaManager.remoteLogManager).thenReturn(None)
-    // Has local logs — classic topic
-    val tp0 = new TopicPartition(topic, 0)
-    val log = mock(classOf[UnifiedLog])
-    when(log.topicPartition).thenReturn(tp0)
-    when(log.remoteLogEnabled()).thenReturn(false)
-    when(log.config).thenReturn(new LogConfig(Collections.emptyMap()))
-    when(logManager.logsByTopic(topic)).thenReturn(Seq(log))
-    when(replicaManager.onlinePartition(tp0)).thenReturn(None)
+    localLogs.foreach(log => when(replicaManager.onlinePartition(log.topicPartition)).thenReturn(None))
 
     val quotas = mock(classOf[QuotaFactory.QuotaManagers])
     when(quotas.leader).thenReturn(mock(classOf[ReplicationQuotaManager]))
     when(quotas.follower).thenReturn(mock(classOf[ReplicationQuotaManager]))
 
-    val topicConfig = new Properties()
-    topicConfig.put(TopicConfig.RETENTION_MS_CONFIG, "3600000")
-
     val kafkaConfig = KafkaConfig.fromProps(TestUtils.createBrokerConfig(0, port = 9092))
-    val configHandler = new TopicConfigHandler(replicaManager, kafkaConfig, quotas)
-    configHandler.processConfigChanges(topic, topicConfig)
+    (new TopicConfigHandler(replicaManager, kafkaConfig, quotas), inklessMetadataView)
+  }
 
-    verify(inklessMetadataView, never()).updateTopicConfig(any(), any())
+  private def localLog(topic: String, remoteLogEnabled: Boolean): UnifiedLog = {
+    val log = mock(classOf[UnifiedLog])
+    when(log.topicPartition).thenReturn(new TopicPartition(topic, 0))
+    when(log.remoteLogEnabled()).thenReturn(remoteLogEnabled)
+    when(log.config).thenReturn(new LogConfig(Collections.emptyMap()))
+    log
+  }
+
+  private def disklessTopicProps(remoteStorageEnabled: Boolean, overrides: (String, String)*): Properties = {
+    val props = new Properties()
+    props.put(TopicConfig.DISKLESS_ENABLE_CONFIG, "true")
+    if (remoteStorageEnabled) props.put(TopicConfig.REMOTE_LOG_STORAGE_ENABLE_CONFIG, "true")
+    overrides.foreach { case (k, v) => props.put(k, v) }
+    props
+  }
+
+  /**
+   * Both diskless topic kinds that hold a local log on this broker: a consolidated topic
+   * (remoteStorageEnabled = true) and a topic switched from classic without consolidation.
+   */
+  @ParameterizedTest(name = "remoteStorageEnabled={0}")
+  @ValueSource(booleans = Array(true, false))
+  def testDisklessTopicWithLocalLogConfigUpdateReachesInklessMetadataView(remoteStorageEnabled: Boolean): Unit = {
+    val topic = if (remoteStorageEnabled) "consolidating-diskless-topic" else "switched-diskless-topic"
+    val initialMaxMessageBytes = "1048588"
+    val raisedMaxMessageBytes = "6291456"
+    val (configHandler, inklessMetadataView) = topicConfigHandlerWithInklessView(
+      topic,
+      disklessTopicProps(remoteStorageEnabled, TopicConfig.MAX_MESSAGE_BYTES_CONFIG -> initialMaxMessageBytes),
+      // Consolidated: ReplicaManager takes the classic makeLeader branch, so every replica has a local log.
+      // Switched without consolidation: the pre-switch data stays on local disk, so the log exists too.
+      // Which of the two it is does not reach TopicConfigHandler, hence the local log is injected here.
+      Seq(localLog(topic, remoteLogEnabled = remoteStorageEnabled)),
+      Collections.singletonMap(TopicConfig.MAX_MESSAGE_BYTES_CONFIG, initialMaxMessageBytes)
+    )
+
+    // Seeds the leader's cached LogConfig at the initial limit; with no entry there is nothing to go stale.
+    assertEquals(initialMaxMessageBytes.toInt, inklessMetadataView.getTopicConfig(topic).maxMessageSize)
+
+    // The switched case is modelled after the switch: post-switch config, classic prefix still on disk.
+    configHandler.processConfigChanges(
+      topic,
+      disklessTopicProps(remoteStorageEnabled, TopicConfig.MAX_MESSAGE_BYTES_CONFIG -> raisedMaxMessageBytes)
+    )
+
+    assertEquals(raisedMaxMessageBytes.toInt, inklessMetadataView.getTopicConfig(topic).maxMessageSize,
+      "A raised max.message.bytes must reach the diskless append path on a broker holding a local log " +
+        "for the topic, otherwise produces are rejected with MESSAGE_TOO_LARGE against the old limit")
+  }
+
+  @Test
+  def testRetentionConfigUpdateReachesInklessMetadataViewForConsolidatingTopic(): Unit = {
+    val topic = "consolidating-diskless-topic-retention"
+    val (configHandler, inklessMetadataView) = topicConfigHandlerWithInklessView(
+      topic,
+      disklessTopicProps(remoteStorageEnabled = true,
+        TopicConfig.RETENTION_MS_CONFIG -> "604800000",
+        TopicConfig.RETENTION_BYTES_CONFIG -> "-1",
+        TopicConfig.CLEANUP_POLICY_CONFIG -> TopicConfig.CLEANUP_POLICY_DELETE),
+      Seq(localLog(topic, remoteLogEnabled = true)),
+      Collections.emptyMap[String, Object]()
+    )
+
+    val seeded = inklessMetadataView.getTopicConfig(topic)
+    assertEquals(604800000L, seeded.retentionMs)
+    assertEquals(-1L, seeded.retentionSize)
+
+    configHandler.processConfigChanges(topic, disklessTopicProps(remoteStorageEnabled = true,
+      TopicConfig.RETENTION_MS_CONFIG -> "3600000",
+      TopicConfig.RETENTION_BYTES_CONFIG -> "1048576",
+      TopicConfig.CLEANUP_POLICY_CONFIG -> TopicConfig.CLEANUP_POLICY_DELETE))
+
+    // RetentionEnforcer re-reads these three per cycle through getTopicConfig, so a stale entry keeps
+    // enforcing the old retention indefinitely (silently, and it governs deletion).
+    val updated = inklessMetadataView.getTopicConfig(topic)
+    assertEquals(3600000L, updated.retentionMs, "Shortened retention.ms must reach diskless retention enforcement")
+    assertEquals(1048576L, updated.retentionSize, "Changed retention.bytes must reach diskless retention enforcement")
+    assertTrue(updated.delete, "cleanup.policy must still be read from the refreshed entry")
+  }
+
+  @Test
+  def testClassicTopicConfigUpdateDoesNotPopulateInklessMetadataView(): Unit = {
+    val topic = "classic-topic"
+    val publishedTopicConfig = new Properties()
+    publishedTopicConfig.put(TopicConfig.RETENTION_MS_CONFIG, "7200000")
+    val (configHandler, inklessMetadataView) = topicConfigHandlerWithInklessView(
+      topic,
+      publishedTopicConfig,
+      Seq(localLog(topic, remoteLogEnabled = false)),
+      Collections.emptyMap[String, Object]()
+    )
+
+    val alteredTopicConfig = new Properties()
+    alteredTopicConfig.put(TopicConfig.RETENTION_MS_CONFIG, "3600000")
+    configHandler.processConfigChanges(topic, alteredTopicConfig)
+
+    // Lazy population is preserved by updateTopicConfig's computeIfPresent, not by the caller: a topic
+    // never read by a diskless path must still resolve from the metadata cache on first access.
+    assertEquals(7200000L, inklessMetadataView.getTopicConfig(topic).retentionMs)
+    verify(inklessMetadataView.metadataCache, times(1)).topicConfig(topic)
   }
 
   /**


### PR DESCRIPTION
Left over from pre-consolidation Diskless topics. `TopicConfigHandler` refreshed InklessMetadataView's cached LogConfig only when this broker held no local log for the topic, using "no local log" as a proxy for "diskless topic". 
Consolidation broke the proxy: a consolidated topic is diskless and remote-storage backed, so it takes the classic `makeLeader` branch and every replica has a local log; a topic switched from classic keeps its pre-switch data on disk and has one too. On those topics the diskless produce and retention paths kept serving whatever config was resolved on first access, so a raised max.message.bytes had no effect (produces rejected with MESSAGE_TOO_LARGE against the old limit) and `retention.ms`/`retention.bytes`/`cleanup.policy` changes were silently ignored.

The guard did not buy what it claimed: `updateTopicConfig` is `computeIfPresent`, so lazy population is preserved without it. Call it unconditionally.

Observed in aiven-core CI kafka-service #26252 (ts-unification integration run), where raising a consolidated topic's `max.message.bytes` had no effect on produces.

The unit tests now drive `TopicConfigHandler` against a real `InklessMetadataView`, so they assert on the config the diskless paths would read rather than on the handler's calls. 
`testClassicTopicConfigUpdateDoesNotCallInklessMetadataView` asserted the opposite of the fixed behavior and is replaced by one asserting what matters: no cache entry is created for a topic no diskless path has read.