### PR TITLE
fix(inkless:consume): stop counting a fast cache load as a cache hit

### DIFF
--- a/storage/inkless/src/main/java/io/aiven/inkless/cache/CaffeineCache.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/cache/CaffeineCache.java
@@ -80,7 +80,8 @@ public final class CaffeineCache implements ObjectCache {
     public CompletableFuture<FileExtent> computeIfAbsent(
         final CacheKey key,
         final Function<CacheKey, FileExtent> load,
-        final Executor loadExecutor
+        final Executor loadExecutor,
+        final Runnable onLoadStarted
     ) {
         // Caffeine's AsyncCache.get() provides atomic cache population per key.
         // When multiple threads concurrently request the same uncached key, the mapping function
@@ -88,6 +89,9 @@ public final class CaffeineCache implements ObjectCache {
         // This guarantees that the load function is called at most once per key for successful operations,
         // preventing duplicate fetch operations from object storage. Failed loads are invalidated and may be retried.
         return cache.get(key, (k, defaultExecutor) -> {
+            // Caffeine invokes this mapping function on the calling thread, and only on a miss, so the
+            // callback runs before get() returns and cannot race with the load thread.
+            onLoadStarted.run();
             // Use the provided executor instead of Caffeine's default executor.
             // This allows us to control which thread pool handles the fetch and blocks there,
             // while Caffeine's internal threads remain unblocked, so cache operations can continue to be served.

--- a/storage/inkless/src/main/java/io/aiven/inkless/cache/ObjectCache.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/cache/ObjectCache.java
@@ -38,11 +38,15 @@ public interface ObjectCache extends Cache<CacheKey, FileExtent>, Closeable {
      * @param key the cache key
      * @param load the function to compute the value if absent
      * @param loadExecutor the executor to use for async computation on cache miss
+     * @param onLoadStarted run on the calling thread before this method returns, only when this caller's load
+     *                      was registered. Not run when an entry was present, including when coalescing onto
+     *                      another caller's in-flight load.
      * @return a CompletableFuture that will complete with the cached or computed value
      */
     CompletableFuture<FileExtent> computeIfAbsent(
         CacheKey key,
         Function<CacheKey, FileExtent> load,
-        Executor loadExecutor
+        Executor loadExecutor,
+        Runnable onLoadStarted
     );
 }

--- a/storage/inkless/src/main/java/io/aiven/inkless/consume/FetchPlanner.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/consume/FetchPlanner.java
@@ -259,20 +259,21 @@ public class FetchPlanner implements Supplier<List<FetchPlanner.FetchRequestWith
             // doesn't run, so this flag stays false — but with per-key hedge dedup (hedgeGuards),
             // at most one hedge fires per primary regardless of how many callers have stale TTFB flags.
             final AtomicBoolean firstByteReceived = new AtomicBoolean(false);
+            final AtomicBoolean loadRan = new AtomicBoolean(false);
             final CompletableFuture<FileExtent> primary = cache.computeIfAbsent(
                 request.toCacheKey(),
                 k -> {
+                    loadRan.set(true);
                     final FileExtent fileExtent = fetchFileExtent(objectFetcher, request, firstByteReceived);
                     metrics.recordStorageBytesIn(fileExtent.data().length);
                     return fileExtent;
                 },
                 fetchDataExecutor
             );
-            // A true cache hit returns an already-completed future; the loader runs asynchronously on
-            // fetchDataExecutor, so a cache miss (whether this caller ran the loader or coalesced onto an
-            // in-flight load) is never done at this point. Deciding the hit from isDone() here avoids
-            // counting a coalesced in-flight miss as cache-hit bytes.
-            final boolean alreadyCached = primary.isDone();
+            // This caller running the load means a miss whatever isDone() reports by now: the load may already
+            // have finished on the fetch executor. Only when it did not run does isDone() separate a value that
+            // was already cached from coalescing onto another caller's in-flight load.
+            final boolean alreadyCached = !loadRan.get() && primary.isDone();
             primary.thenAccept(fileExtent -> {
                 metrics.recordDisklessBytesOut(fileExtent.data().length);
                 if (alreadyCached) {

--- a/storage/inkless/src/main/java/io/aiven/inkless/consume/FetchPlanner.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/consume/FetchPlanner.java
@@ -259,21 +259,23 @@ public class FetchPlanner implements Supplier<List<FetchPlanner.FetchRequestWith
             // doesn't run, so this flag stays false — but with per-key hedge dedup (hedgeGuards),
             // at most one hedge fires per primary regardless of how many callers have stale TTFB flags.
             final AtomicBoolean firstByteReceived = new AtomicBoolean(false);
-            final AtomicBoolean loadRan = new AtomicBoolean(false);
+            // Set by the cache on the calling thread before computeIfAbsent returns when this caller's load
+            // was registered, so it cannot be observed stale the way the load body itself can.
+            final AtomicBoolean loadStarted = new AtomicBoolean(false);
             final CompletableFuture<FileExtent> primary = cache.computeIfAbsent(
                 request.toCacheKey(),
                 k -> {
-                    loadRan.set(true);
                     final FileExtent fileExtent = fetchFileExtent(objectFetcher, request, firstByteReceived);
                     metrics.recordStorageBytesIn(fileExtent.data().length);
                     return fileExtent;
                 },
-                fetchDataExecutor
+                fetchDataExecutor,
+                () -> loadStarted.set(true)
             );
-            // This caller running the load means a miss whatever isDone() reports by now: the load may already
-            // have finished on the fetch executor. Only when it did not run does isDone() separate a value that
+            // This caller starting the load means a miss whatever isDone() reports by now: the load may already
+            // have finished on the fetch executor. Only when it did not start does isDone() separate a value that
             // was already cached from coalescing onto another caller's in-flight load.
-            final boolean alreadyCached = !loadRan.get() && primary.isDone();
+            final boolean alreadyCached = !loadStarted.get() && primary.isDone();
             primary.thenAccept(fileExtent -> {
                 metrics.recordDisklessBytesOut(fileExtent.data().length);
                 if (alreadyCached) {

--- a/storage/inkless/src/test/java/io/aiven/inkless/cache/CaffeineCacheTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/cache/CaffeineCacheTest.java
@@ -20,6 +20,11 @@ package io.aiven.inkless.cache;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import io.aiven.inkless.generated.CacheKey;
 import io.aiven.inkless.generated.FileExtent;
@@ -84,6 +89,72 @@ class CaffeineCacheTest {
 
             // Count limit (1) is ignored because bytes limit is configured
             assertThat(cache.size()).isGreaterThan(1);
+        }
+    }
+
+    /**
+     * The hot path classifies a fetch as a cache hit from what {@code computeIfAbsent} reports, so the
+     * miss signal must be visible to the caller as soon as the call returns. Signalling it from the load
+     * body would not be: the load runs on the load executor and may not have started yet, or may already
+     * have completed the future.
+     */
+    @Test
+    void loadStartedCallbackRunsOnTheCallingThreadBeforeReturning() throws Exception {
+        try (CaffeineCache cache = new CaffeineCache(10, 0, 3600, 180)) {
+            final Queue<Runnable> pending = new ConcurrentLinkedQueue<>();
+            final AtomicBoolean loadStarted = new AtomicBoolean(false);
+            final List<Thread> callbackThread = new ArrayList<>();
+
+            final var future = cache.computeIfAbsent(
+                key("a"),
+                k -> extent(10),
+                pending::add,
+                () -> {
+                    callbackThread.add(Thread.currentThread());
+                    loadStarted.set(true);
+                }
+            );
+
+            // The load has not run at all yet, so only a callback invoked by computeIfAbsent itself can
+            // have set the flag.
+            assertThat(loadStarted).isTrue();
+            assertThat(callbackThread).containsExactly(Thread.currentThread());
+            assertThat(future).isNotDone();
+            assertThat(pending).hasSize(1);
+
+            pending.poll().run();
+            assertThat(future.get()).isEqualTo(extent(10));
+        }
+    }
+
+    /**
+     * Coalescing onto an in-flight load must not signal a load start: the caller did not start a load, so
+     * the hot path can tell it apart from an already-cached value by the future not being done.
+     */
+    @Test
+    void loadStartedCallbackDoesNotRunForACoalescedOrCachedLookup() throws Exception {
+        try (CaffeineCache cache = new CaffeineCache(10, 0, 3600, 180)) {
+            final Queue<Runnable> pending = new ConcurrentLinkedQueue<>();
+            final var first = cache.computeIfAbsent(key("a"), k -> extent(10), pending::add, () -> { });
+
+            final AtomicBoolean coalescedLoadStarted = new AtomicBoolean(false);
+            final var coalesced = cache.computeIfAbsent(
+                key("a"), k -> extent(10), pending::add, () -> coalescedLoadStarted.set(true));
+
+            assertThat(coalescedLoadStarted).isFalse();
+            assertThat(coalesced).isSameAs(first).isNotDone();
+            assertThat(pending).hasSize(1);
+
+            pending.poll().run();
+            assertThat(first.get()).isEqualTo(extent(10));
+
+            final AtomicBoolean cachedLoadStarted = new AtomicBoolean(false);
+            final var cached = cache.computeIfAbsent(
+                key("a"), k -> extent(10), pending::add, () -> cachedLoadStarted.set(true));
+
+            assertThat(cachedLoadStarted).isFalse();
+            assertThat(cached).isDone();
+            assertThat(pending).isEmpty();
         }
     }
 

--- a/storage/inkless/src/test/java/io/aiven/inkless/cache/NullCache.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/cache/NullCache.java
@@ -42,9 +42,11 @@ public class NullCache implements ObjectCache {
     public CompletableFuture<FileExtent> computeIfAbsent(
         CacheKey key,
         Function<CacheKey, FileExtent> load,
-        Executor loadExecutor
+        Executor loadExecutor,
+        Runnable onLoadStarted
     ) {
         // Always a cache miss, compute on executor
+        onLoadStarted.run();
         return CompletableFuture.supplyAsync(() -> load.apply(key), loadExecutor);
     }
 

--- a/storage/inkless/src/test/java/io/aiven/inkless/consume/FetchPlannerTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/consume/FetchPlannerTest.java
@@ -38,6 +38,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.AbstractExecutorService;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
@@ -2772,6 +2773,187 @@ public class FetchPlannerTest {
                 true, // isConsolidationFetch
                 metrics
             );
+        }
+    }
+
+    /**
+     * Cache-hit accounting on the hot path. A fetch must count cache-hit bytes only when the range was
+     * already in the cache - never when this caller ran the load, and never when it coalesced onto a load
+     * that another caller had already started.
+     */
+    @Nested
+    class CacheHitAccountingTests {
+        private final byte[] data = "recent-data".getBytes();
+
+        private Map<TopicIdPartition, FindBatchResponse> coordinatesForA() {
+            return Map.of(partition0, FindBatchResponse.success(List.of(
+                new BatchInfo(1L, OBJECT_KEY_A.value(),
+                    BatchMetadata.of(partition0, 0, data.length, 0, 0, 10, time.milliseconds(),
+                        TimestampType.CREATE_TIME))
+            ), 0, 1));
+        }
+
+        private FileExtent awaitSingleFetch(final FetchPlanner planner) throws Exception {
+            final List<CompletableFuture<FileExtent>> futures = planner.get().stream()
+                .map(FetchPlanner.FetchRequestWithFuture::future)
+                .toList();
+            assertThat(futures).hasSize(1);
+            return futures.get(0).get();
+        }
+
+        /**
+         * The load runs on the fetch executor while the caller decides hit vs miss. A same-thread executor
+         * makes the load finish before the caller can look at the future, which is the ordering a loaded
+         * broker (or CI machine) reaches by chance: a first load must still be a miss.
+         */
+        @Test
+        public void firstLoadIsNotACacheHitWhenTheLoadFinishesBeforeTheCallerObservesTheFuture() throws Exception {
+            try (CaffeineCache caffeineCache = new CaffeineCache(100, 0, 3600, 180);
+                 SameThreadExecutorService sameThread = new SameThreadExecutorService()) {
+                when(fetcher.fetch(eq(OBJECT_KEY_A), any(ByteRange.class))).thenReturn(mock(ReadableByteChannel.class));
+                when(fetcher.readToByteBuffer(any())).thenReturn(ByteBuffer.wrap(data));
+
+                final FetchPlanner planner = createHotPathPlannerWithFetchExecutor(
+                    caffeineCache, coordinatesForA(), sameThread);
+
+                assertThat(awaitSingleFetch(planner).data()).isEqualTo(data);
+
+                verify(metrics).recordStorageBytesIn(data.length);
+                verify(metrics).recordDisklessBytesOut(data.length);
+                verify(metrics, never()).recordCacheHitBytes(any(Long.class));
+            }
+        }
+
+        /** The metric must still fire for a genuine hit: second fetch of the same range, one load. */
+        @Test
+        public void anAlreadyCachedRangeIsCountedAsACacheHitOnce() throws Exception {
+            try (CaffeineCache caffeineCache = new CaffeineCache(100, 0, 3600, 180);
+                 SameThreadExecutorService sameThread = new SameThreadExecutorService()) {
+                when(fetcher.fetch(eq(OBJECT_KEY_A), any(ByteRange.class))).thenReturn(mock(ReadableByteChannel.class));
+                when(fetcher.readToByteBuffer(any())).thenReturn(ByteBuffer.wrap(data));
+
+                awaitSingleFetch(createHotPathPlannerWithFetchExecutor(caffeineCache, coordinatesForA(), sameThread));
+                awaitSingleFetch(createHotPathPlannerWithFetchExecutor(caffeineCache, coordinatesForA(), sameThread));
+
+                verify(metrics, times(1)).recordStorageBytesIn(data.length);
+                verify(metrics, times(2)).recordDisklessBytesOut(data.length);
+                verify(metrics, times(1)).recordCacheHitBytes(data.length);
+            }
+        }
+
+        /**
+         * Coalescing onto another caller's in-flight load is a miss, not a hit: no bytes were served from
+         * the cache. This is the case a "did the loader run?" check alone would misclassify.
+         */
+        @Test
+        public void coalescingOntoAnInFlightLoadIsNotACacheHit() throws Exception {
+            try (CaffeineCache caffeineCache = new CaffeineCache(100, 0, 3600, 180)) {
+                final CountDownLatch loadStarted = new CountDownLatch(1);
+                final CountDownLatch releaseLoad = new CountDownLatch(1);
+                when(fetcher.fetch(eq(OBJECT_KEY_A), any(ByteRange.class))).thenReturn(mock(ReadableByteChannel.class));
+                when(fetcher.readToByteBuffer(any())).thenAnswer(invocation -> {
+                    loadStarted.countDown();
+                    assertThat(releaseLoad.await(10, TimeUnit.SECONDS)).isTrue();
+                    return ByteBuffer.wrap(data);
+                });
+
+                final FetchPlanner first = createHotPathPlannerWithFetchExecutor(
+                    caffeineCache, coordinatesForA(), fetchDataExecutor);
+                final List<CompletableFuture<FileExtent>> firstFutures = first.get().stream()
+                    .map(FetchPlanner.FetchRequestWithFuture::future)
+                    .toList();
+                assertThat(loadStarted.await(10, TimeUnit.SECONDS)).isTrue();
+
+                // Second caller finds the in-flight future rather than a cached value.
+                final FetchPlanner second = createHotPathPlannerWithFetchExecutor(
+                    caffeineCache, coordinatesForA(), fetchDataExecutor);
+                final List<CompletableFuture<FileExtent>> secondFutures = second.get().stream()
+                    .map(FetchPlanner.FetchRequestWithFuture::future)
+                    .toList();
+
+                releaseLoad.countDown();
+                assertThat(firstFutures.get(0).get().data()).isEqualTo(data);
+                assertThat(secondFutures.get(0).get().data()).isEqualTo(data);
+
+                verify(metrics, times(1)).recordStorageBytesIn(data.length);
+                verify(metrics, timeout(1000).times(2)).recordDisklessBytesOut(data.length);
+                verify(metrics, never()).recordCacheHitBytes(any(Long.class));
+            }
+        }
+    }
+
+    /**
+     * Hot path only (lagging feature disabled, so every request takes it), with the fetch executor under
+     * the test's control: it decides whether a load completes before or after the caller observes the
+     * future, which is what cache-hit accounting turns on.
+     */
+    private FetchPlanner createHotPathPlannerWithFetchExecutor(
+        final ObjectCache cache,
+        final Map<TopicIdPartition, FindBatchResponse> batchCoordinates,
+        final ExecutorService hotPathFetchExecutor
+    ) {
+        return new FetchPlanner(
+            time,
+            FetchPlannerTest.OBJECT_KEY_CREATOR,
+            keyAlignmentStrategy,
+            cache,
+            fetcher,
+            hotPathFetchExecutor,
+            fetcher,
+            60 * 1000L,
+            null, // no rate limiter
+            null, // lagging feature disabled: always hot path
+            null, // no hedge scheduler
+            0, // TTFB hedging disabled
+            0, // total-time hedging disabled
+            new ConcurrentHashMap<>(),
+            batchCoordinates,
+            false,
+            metrics
+        );
+    }
+
+    /** Runs submitted tasks on the calling thread, so a cache load completes within computeIfAbsent. */
+    private static final class SameThreadExecutorService extends AbstractExecutorService implements AutoCloseable {
+        private volatile boolean shutdown;
+
+        @Override
+        public void execute(final Runnable command) {
+            if (shutdown) {
+                throw new RejectedExecutionException("executor is shut down");
+            }
+            command.run();
+        }
+
+        @Override
+        public void shutdown() {
+            shutdown = true;
+        }
+
+        @Override
+        public List<Runnable> shutdownNow() {
+            shutdown = true;
+            return List.of();
+        }
+
+        @Override
+        public boolean isShutdown() {
+            return shutdown;
+        }
+
+        @Override
+        public boolean isTerminated() {
+            return shutdown;
+        }
+
+        @Override
+        public boolean awaitTermination(final long timeout, final TimeUnit unit) {
+            return true;
+        }
+
+        @Override
+        public void close() {
+            shutdown();
         }
     }
 }


### PR DESCRIPTION
The hot path decided cache hit vs miss from primary.isDone() right after computeIfAbsent, on the premise that a miss cannot be done yet because the load runs on the fetch executor. The premise does not hold: the load is a supplyAsync on that executor and can finish before the calling thread reaches isDone(), which is likelier the smaller the range, the faster the object store, and the busier the broker. Those misses were counted as cache hits, so CacheHitBytes overstated cache effectiveness on exactly the fetches that are cheapest to serve.

Track whether this caller ran the load instead. Running it means a miss whatever isDone() reports by then; only when it did not run does isDone() separate an already-cached value from coalescing onto another caller's in-flight load, which stays a miss.

This is also what was failing `recentDataUsesRecentExecutorWithoutRateLimit` on CI. Since #732 that test waits for the asynchronous byte accounting, so it observes the mislabeled hit reliably instead of racing past it; the de-flake exposed this bug rather than causing it.

The new tests pin the classification deterministically by running the load on a same-thread executor, so a first load always completes before the caller observes the future - the ordering CI reached by chance. One of them asserts that coalescing onto an in-flight load is still a miss, which is what fails if the fix drops the isDone() check.
