### PR TITLE
fix(inkless): bound error-message size on fetch/commit failure paths [KC-410]

### DIFF
--- a/storage/inkless/src/main/java/io/aiven/inkless/consume/FetchCompleter.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/consume/FetchCompleter.java
@@ -95,7 +95,9 @@ public class FetchCompleter implements Supplier<Map<TopicIdPartition, FetchParti
             metrics.recordFetchResponseSize(totalBytes);
             return result;
         } catch (Exception e) {
-            throw new FetchException("Failed to complete fetch for partitions " + fetchInfos.keySet(), e);
+            // Only the partition count: fetchInfos can span thousands of client-requested
+            // partitions, so interpolating the full key set here would build an unbounded string.
+            throw new FetchException("Failed to complete fetch for " + fetchInfos.size() + " partitions", e);
         }
     }
 

--- a/storage/inkless/src/main/java/io/aiven/inkless/produce/FileCommitter.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/produce/FileCommitter.java
@@ -219,7 +219,10 @@ class FileCommitter implements Closeable {
                             totalBytesInProgress.addAndGet(-file.size());
                             if (error != null) {
                                 // at this point the commit has failed and need to check whether it failed on upload or commit
-                                LOGGER.error("Failed to commit diskless file {}", file, error);
+                                // Log a bounded summary: ClosedFile.toString() would dump every aggregated
+                                // request/batch, an unbounded string on this error path.
+                                LOGGER.error("Failed to commit diskless file (start={}, requests={}, batches={}, bytes={})",
+                                        file.start(), file.originalRequests().size(), file.commitBatchRequests().size(), file.size(), error);
                                 if (error.getCause() instanceof FileUploadException) {
                                     metrics.fileUploadFailed();
                                 } else {


### PR DESCRIPTION
Two error paths interpolated an unbounded value into the message, the same class of bug as the S3 bulk-delete fix (https://github.com/aiven/inkless/pull/733):

- FetchCompleter: the catch-all wrapped the failure with the full fetchInfos.keySet(), which spans every client-requested partition (up to thousands). Report only the partition count.
- FileCommitter: logged the whole ClosedFile record, whose toString dumps every aggregated produce request and commit batch. Log a bounded summary (start, request count, batch count, bytes).