### PR TITLE
fix(inkless:storage): bound bulk-delete failure logging [KC-430]

### DIFF
--- a/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/azure/AzureBlobStorage.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/azure/AzureBlobStorage.java
@@ -23,6 +23,7 @@ import org.apache.kafka.common.metrics.Metrics;
 import com.azure.identity.DefaultAzureCredentialBuilder;
 import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.BlobServiceClientBuilder;
+import com.azure.storage.blob.models.BlobErrorCode;
 import com.azure.storage.blob.models.BlobRange;
 import com.azure.storage.blob.models.BlobStorageException;
 import com.azure.storage.blob.models.ParallelTransferOptions;
@@ -45,6 +46,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.TreeMap;
 
 import io.aiven.inkless.common.ByteRange;
 import io.aiven.inkless.common.ObjectKey;
@@ -57,6 +59,11 @@ import reactor.core.Exceptions;
 @CoverageIgnore // tested on integration level
 public final class AzureBlobStorage extends StorageBackend {
     private static final Logger LOGGER = LoggerFactory.getLogger(AzureBlobStorage.class);
+
+    // Azure error codes that indicate throttling rather than a hard failure. The set only picks the log
+    // level: the next FileCleaner cycle retries either kind. INTERNAL_ERROR and OPERATION_TIMED_OUT stay
+    // out because a transient server error doesn't self-heal like backpressure, so they keep the WARN.
+    private static final Set<String> THROTTLE_ERROR_CODES = Set.of(BlobErrorCode.SERVER_BUSY.toString());
 
     private AzureBlobStorageConfig config;
     private BlobContainerClient blobContainerClient;
@@ -207,16 +214,34 @@ public final class AzureBlobStorage extends StorageBackend {
         // failed ones as not deleted. deleteIfExists() returns true if the blob was deleted and false
         // if it was already absent; both mean the key is gone (idempotent).
         final Set<ObjectKey> deleted = new HashSet<>();
+        // Count the failures by error code instead of logging one line per key: a pass that fails for
+        // every key repeats on every FileCleaner cycle, so per-key lines grow with the worklist.
+        final Map<String, Integer> failuresByCode = new TreeMap<>();
         for (final ObjectKey key : keys) {
             try {
                 blobContainerClient.getBlobClient(key.value()).deleteIfExists();
                 deleted.add(key);
             } catch (final BlobStorageException e) {
-                LOGGER.warn("Failed to delete {}; leaving it for the next cycle", key, e);
+                failuresByCode.merge(String.valueOf(e.getErrorCode()), 1, Integer::sum);
             } catch (final RuntimeException e) {
-                LOGGER.warn("Failed to delete {}; leaving it for the next cycle", key, Exceptions.unwrap(e));
+                // Not a service response, so there is no error code to count, and nothing says the next key
+                // fares better: the client itself is likely unusable. Report it in full and stop the pass,
+                // since deletion is idempotent and the remaining keys retry on the next FileCleaner cycle.
+                LOGGER.warn("Deleting {} failed unexpectedly, stopping the pass", key, Exceptions.unwrap(e));
+                break;
             }
         }
+
+        if (!failuresByCode.isEmpty()) {
+            // Throttling is backpressure the next FileCleaner cycle retries; any other code needs an
+            // operator, so it must not sit at INFO while the worklist stops draining.
+            if (THROTTLE_ERROR_CODES.containsAll(failuresByCode.keySet())) {
+                LOGGER.info("Delete failures by error code {}", failuresByCode);
+            } else {
+                LOGGER.warn("Delete failures by error code {}", failuresByCode);
+            }
+        }
+
         return deleted;
     }
 

--- a/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/gcs/GcsStorage.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/gcs/GcsStorage.java
@@ -138,7 +138,7 @@ public class GcsStorage extends StorageBackend {
             storage.delete(ids);
             return Set.copyOf(keys);
         } catch (final BaseServiceException e) {
-            throw new StorageBackendException("Failed to delete " + keys, e);
+            throw new StorageBackendException("Failed to delete " + keys.size() + " keys", e);
         }
     }
 

--- a/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/s3/S3Storage.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/s3/S3Storage.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
 
 import io.aiven.inkless.common.ByteRange;
@@ -58,7 +59,6 @@ import software.amazon.awssdk.services.s3.model.DeleteObjectsResponse;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
-import software.amazon.awssdk.services.s3.model.S3Error;
 
 @CoverageIgnore  // tested on integration level
 public final class S3Storage extends StorageBackend {
@@ -67,10 +67,13 @@ public final class S3Storage extends StorageBackend {
 
     public static final int MAX_DELETE_KEYS_LIMIT = 1000;
 
-    // Per-key S3 error codes that indicate throttling rather than a hard, non-transient failure. Used
-    // only to log throttling distinctly; neither kind is retried in-call.
-    private static final Set<String> THROTTLE_ERROR_CODES =
-        Set.of("SlowDown", "ServiceUnavailable", "RequestLimitExceeded");
+    // Per-key S3 error codes that indicate throttling rather than a hard failure. Matched by name because
+    // a per-key error is not an exception, so the SDK's own check (RetryUtils.isThrottlingException) does
+    // not apply; both names appear in the SDK's throttling list, AwsErrorCode.THROTTLING_ERROR_CODES,
+    // which is internal API and so not referenced here. ServiceUnavailable stays out: AWS classifies it as
+    // a retryable 503 rather than throttling, and a transient server error doesn't self-heal the way
+    // backpressure does, so it keeps the WARN.
+    private static final Set<String> THROTTLE_ERROR_CODES = Set.of("SlowDown", "RequestLimitExceeded");
 
     private S3Client s3Client;
     private String bucketName;
@@ -171,6 +174,10 @@ public final class S3Storage extends StorageBackend {
     public Set<ObjectKey> delete(final Set<ObjectKey> keys) throws StorageBackendException {
         final List<ObjectKey> objectKeys = new ArrayList<>(keys);
         final Set<ObjectKey> deleted = new HashSet<>();
+        // Count the failures by error code instead of logging one line per key: a pass that fails for
+        // every key repeats on every FileCleaner cycle, so per-key lines grow with the worklist.
+        final Map<String, Integer> failuresByCode = new TreeMap<>();
+
         for (int i = 0; i < objectKeys.size(); i += MAX_DELETE_KEYS_LIMIT) {
             final Set<ObjectKey> batch = new HashSet<>(objectKeys.subList(
                 i,
@@ -182,11 +189,9 @@ public final class S3Storage extends StorageBackend {
             try {
                 response = deleteObjectsOnce(batch);
             } catch (final SdkException e) {
-                // Whole-request failure, including a 503 the SDK's adaptive retry already exhausted and
-                // timeouts. Stop this pass and report the remaining keys as not deleted; deletion is
-                // idempotent, so re-attempting them later is safe.
-                LOGGER.warn("DeleteObjects request failed; {} keys not deleted",
-                    objectKeys.size() - deleted.size(), e);
+                // Nothing in this batch was attempted. Stop the pass; deletion is idempotent, so
+                // retrying the keys later is safe.
+                LOGGER.warn("DeleteObjects request failed, stopping the pass", e);
                 break;
             }
 
@@ -196,30 +201,22 @@ public final class S3Storage extends StorageBackend {
                     deleted.add(key);
                 }
             }
-            logDeleteErrors(response.errors());
-        }
-        return deleted;
-    }
-
-    /**
-     * Logs per-key delete errors, distinguishing throttling (expected under load, aggregated) from
-     * hard errors (logged individually). No retry happens here: keys that were not deleted stay marked
-     * for deletion and are retried on the next FileCleaner cycle, while request-rate backoff is left to
-     * the S3 client's adaptive retry strategy.
-     */
-    private void logDeleteErrors(final List<S3Error> errors) {
-        int throttled = 0;
-        for (final var error : errors) {
-            if (THROTTLE_ERROR_CODES.contains(error.code())) {
-                throttled++;
-            } else {
-                LOGGER.warn("Failed to delete {}: {} ({}); leaving it for the next cycle",
-                    error.key(), error.message(), error.code());
+            for (final var error : response.errors()) {
+                failuresByCode.merge(error.code(), 1, Integer::sum);
             }
         }
-        if (throttled > 0) {
-            LOGGER.info("{} keys throttled by S3; leaving them for the next cycle", throttled);
+
+        if (!failuresByCode.isEmpty()) {
+            // Throttling is backpressure the next FileCleaner cycle retries; any other code needs an
+            // operator, so it must not sit at INFO while the worklist stops draining.
+            if (THROTTLE_ERROR_CODES.containsAll(failuresByCode.keySet())) {
+                LOGGER.info("Delete failures by error code {}", failuresByCode);
+            } else {
+                LOGGER.warn("Delete failures by error code {}", failuresByCode);
+            }
         }
+
+        return deleted;
     }
 
     private DeleteObjectsResponse deleteObjectsOnce(final Set<ObjectKey> keys) {


### PR DESCRIPTION
A delete pass that fails for every key it submitted logs one line per key, with a stack trace each on Azure, and repeats that on every cleanup cycle, since undeleted keys stay marked for deletion. GCS interpolates the whole key set into the exception message, which is the bug #733 fixed for S3.

Count the failures of a pass by error code and log them once, at INFO when every code is a throttle and at WARN otherwise, so the output is bounded by the distinct codes rather than by the worklist. Report an exception that carries no service code in full instead, since the stack trace is then the only diagnosis: a whole-request `SdkException` on S3, any non-`BlobStorageException` on Azure. Both stop the pass, because neither is attributable to a single key and the rest retry on the next cycle. GCS logs only the key count, since it can't report per-key results.

The counts describe one pass and never the worklist: `FileCleaner` reports how many candidates it deleted and derives `FileCleanerFilesFailedRate` from the same numbers.

Both throttle sets keep only the codes the provider calls throttling, since the set picks the log level and a transient server error doesn't self-heal like backpressure. S3 drops `ServiceUnavailable`, which AWS classifies as a retryable 503. Azure keeps `ServerBusy` alone, sourced from `BlobErrorCode`.

[KC-430]


[KC-430]: https://aiven.atlassian.net/browse/KC-430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ