### PR TITLE
feat(inkless:retention): shorten the file-cleaner interval to 2 minutes [KC-404]

### DIFF
--- a/docs/inkless/configs.rst
+++ b/docs/inkless/configs.rst
@@ -109,7 +109,7 @@ Under ``inkless.``
   * Importance: low
 
 ``consume.batch.coordinate.cache.ttl.ms``
-  Time to live in milliseconds for an entry in the Batch Coordinate cache. The time to live must be <= than half of the value of of file.cleaner.interval.ms.
+  Time to live in milliseconds for an entry in the Batch Coordinate cache. The time to live must be <= half of the value of file.cleaner.retention.period.ms.
 
   * Type: int
   * Default: 5000 (5 seconds)
@@ -227,10 +227,10 @@ Under ``inkless.``
   * Importance: low
 
 ``file.cleaner.interval.ms``
-  The interval with which to clean up files marked for deletion.
+  The interval with which to clean up files marked for deletion. Together with file.cleaner.max.files.per.cycle, this interval sets the rate at which files marked for deletion drain.
 
   * Type: int
-  * Default: 300000 (5 minutes)
+  * Default: 120000 (2 minutes)
   * Valid Values: [1,...]
   * Importance: low
 

--- a/storage/inkless/src/main/java/io/aiven/inkless/config/InklessConfig.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/config/InklessConfig.java
@@ -107,7 +107,7 @@ public class InklessConfig extends AbstractConfig {
 
     public static final String CONSUME_BATCH_COORDINATE_CACHE_TTL_MS_CONFIG = CONSUME_PREFIX + "batch.coordinate.cache.ttl.ms";
     public static final String CONSUME_BATCH_COORDINATE_CACHE_TTL_MS_DOC = "Time to live in milliseconds for an entry in the Batch Coordinate cache. " +
-        "The time to live must be <= than half of the value of of file.cleaner.interval.ms.";
+        "The time to live must be <= half of the value of file.cleaner.retention.period.ms.";
     private static final int CONSUME_BATCH_COORDINATE_CACHE_TTL_MS_DEFAULT = 5000;
 
     public static final String CONSUME_CROSS_TIER_LOG_START_CACHE_ENABLED_CONFIG = CONSUME_PREFIX + "cross.tier.log.start.cache.enabled";
@@ -132,8 +132,10 @@ public class InklessConfig extends AbstractConfig {
     private static final int CONSOLIDATION_CLEANUP_INTERVAL_MS_DEFAULT = RETENTION_ENFORCEMENT_INTERVAL_MS_DEFAULT;
 
     public static final String FILE_CLEANER_INTERVAL_MS_CONFIG = "file.cleaner.interval.ms";
-    private static final String FILE_CLEANER_INTERVAL_MS_DOC = "The interval with which to clean up files marked for deletion.";
-    private static final int FILE_CLEANER_INTERVAL_MS_DEFAULT = 5 * 60 * 1000;  // 5 minutes
+    private static final String FILE_CLEANER_INTERVAL_MS_DOC = "The interval with which to clean up files marked for deletion. "
+        + "Together with file.cleaner.max.files.per.cycle, this interval sets the rate at which "
+        + "files marked for deletion drain.";
+    private static final int FILE_CLEANER_INTERVAL_MS_DEFAULT = 2 * 60 * 1000;  // 2 minutes
 
     public static final String CROSS_TIER_LOG_START_REPORT_INTERVAL_MS_CONFIG = "cross.tier.log.start.report.interval.ms";
     private static final String CROSS_TIER_LOG_START_REPORT_INTERVAL_MS_DOC = "The interval with which the leader reports " +

--- a/storage/inkless/src/test/java/io/aiven/inkless/config/InklessConfigTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/config/InklessConfigTest.java
@@ -100,7 +100,7 @@ class InklessConfigTest {
         assertThat(config.produceMaxUploadAttempts()).isEqualTo(3);
         assertThat(config.produceUploadBackoff()).isEqualTo(Duration.ofMillis(10));
         assertThat(config.storage(storageMetrics)).isInstanceOf(ConfigTestStorageBackend.class);
-        assertThat(config.fileCleanerInterval()).isEqualTo(Duration.ofMinutes(5));
+        assertThat(config.fileCleanerInterval()).isEqualTo(Duration.ofMinutes(2));
         assertThat(config.fileCleanerRetentionPeriod()).isEqualTo(Duration.ofMinutes(1));
         assertThat(config.fileCleanerMaxFilesPerCycle()).isEqualTo(20_000);
         assertThat(config.cacheMaxCount()).isEqualTo(1000);


### PR DESCRIPTION
A cycle used to fetch the whole deletion backlog, so running it less often was the only brake on query cost, and 5 minutes bought that brake. `file.cleaner.max.files.per.cycle` now bounds the fetch, which caps per-cycle cost and frees the interval to serve drain rate instead.

The old cadence has less headroom than it looks. Steady-state marking tracks file creation: a broker rotates a file every `produce.commit.interval.ms` (250 ms), or sooner when `produce.buffer.max.bytes` (8 MiB) fills. The timer sets a floor of 4 files/s per broker. Above roughly 32 MiB/s of ingest per broker the size trigger dominates at ingest / 8 MiB, about 12 files/s at 100 MiB/s.

Cluster drain is harder to pin down than a single cycle. The bounded query is deterministic and there is no leasing, so cycles that overlap on different brokers select the same rows and delete the same objects. Cluster drain therefore lands between 1x and Nx the cap per interval, and only the 1x end is safe to assume.

On that pessimistic assumption, 20000 files per 5 minutes drains 67 files/s. Six timer-bound brokers create 24 files/s, and six brokers at 100 MiB/s each create 75 files/s, so the old default goes underwater exactly when ingest is highest. 20000 files per 2 minutes drains 167 files/s.

Shortening the interval beats raising the cap for the same throughput. It holds the per-cycle burst at 20 `DeleteObjects` calls instead of 50, and S3 request-rate throttling responds to the burst. It also keeps the transient worklist smaller and shortens the jobs-pool connection hold time. A cycle holds that worklist about four times over, across the fetch, the key sets, and the confirmed-deleted set.

`FileCleanerCycleSaturatedRate` is the feedback signal. If it stays flat in production, the cap is over-provisioned and the interval can go back up.

## Config changes

- `inkless.file.cleaner.interval.ms` default: 300000 (5 minutes) -> 120000 (2 minutes). Clusters that pinned the old value keep it.
- `inkless.consume.batch.coordinate.cache.ttl.ms` doc string: pointed at `file.cleaner.interval.ms`, which made the shorter interval look like it tightens the cache bound. `SharedState.initialize` enforces a ceiling of half of `file.cleaner.retention.period.ms` and rejects the broker config at startup otherwise. The retention period stays at 1 minute here, so the ceiling stays at 30 s and the interval change doesn't touch it. The doc string now names that config, and drops a duplicated word.

## Operator impact

File-cleaner cycles run 2.5x more often, so per-cycle counters and rates re-baseline. Total deleted objects per unit of ingest doesn't change. Expect `FileCleanerCycleSaturatedRate` to drop wherever the cap was binding at the old cadence.

## Testing

`InklessConfigTest` asserts the new default, and `docs/inkless/configs.rst` carries the new default and doc strings.
