### PR TITLE
feat(inkless:retention): add LastSuccessfulFileCleanupAgeMs [KC-412]

### DIFF
--- a/docs/inkless/metrics.rst
+++ b/docs/inkless/metrics.rst
@@ -236,15 +236,16 @@ FileCleaner metrics
 io.aiven.inkless.delete:type=FileCleaner
 ----------------------------------------
 
-===========================  =================================================================================================================================
-Attribute name               Description                                                                                                                      
-===========================  =================================================================================================================================
-FileCleanerErrorRate         Total number of file cleaning errors                                                                                             
-FileCleanerFilesFailedRate   Total number of files the storage backend did not confirm deleted; they stay marked for deletion and are retried on a later cycle
-FileCleanerFilesRate         Total number of files cleaned                                                                                                    
-FileCleanerRate              Total number of file cleaning cycles started                                                                                     
-FileCleanerTotalTime         Total time spent on a file cleaning cycle in milliseconds                                                                        
-===========================  =================================================================================================================================
+===============================  ==================================================================================================================================================================
+Attribute name                   Description                                                                                                                                                       
+===============================  ==================================================================================================================================================================
+FileCleanerErrorRate             Total number of file cleaning errors                                                                                                                              
+FileCleanerFilesFailedRate       Total number of files the storage backend did not confirm deleted; they stay marked for deletion and are retried on a later cycle                                 
+FileCleanerFilesRate             Total number of files cleaned                                                                                                                                     
+FileCleanerRate                  Total number of file cleaning cycles started                                                                                                                      
+FileCleanerTotalTime             Total time spent on a file cleaning cycle in milliseconds                                                                                                         
+LastSuccessfulFileCleanupAgeMs   Milliseconds since the last file cleaning cycle completed without error, including cycles that found nothing to delete; -1 if no cycle has completed since startup
+===============================  ==================================================================================================================================================================
 
 
 RetentionEnforcer metrics

--- a/storage/inkless/src/main/java/io/aiven/inkless/delete/FileCleaner.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/delete/FileCleaner.java
@@ -80,7 +80,7 @@ public class FileCleaner implements Runnable, Closeable {
         this.storage = storage;
         this.objectKeyCreator = objectKeyCreator;
         this.retentionPeriod = retentionPeriod;
-        this.metrics = new FileCleanerMetrics();
+        this.metrics = new FileCleanerMetrics(time);
 
         // This backoff is needed only for jitter, there's no exponent in it.
         final int noWorkBackoffDuration = 10 * 1000;
@@ -115,6 +115,7 @@ public class FileCleaner implements Runnable, Closeable {
             }
 
             attempts.set(0);
+            metrics.recordFileCleanerCycleSucceeded();
         } catch (final Exception e) {
             metrics.recordFileCleanerError();
             final long backoff = errorBackoff.backoff(attempts.incrementAndGet());

--- a/storage/inkless/src/main/java/io/aiven/inkless/delete/FileCleanerMetrics.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/delete/FileCleanerMetrics.java
@@ -18,12 +18,15 @@
 package io.aiven.inkless.delete;
 
 import org.apache.kafka.common.MetricNameTemplate;
+import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.server.metrics.KafkaMetricsGroup;
 
 import com.yammer.metrics.core.Histogram;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.LongAdder;
 
 public class FileCleanerMetrics {
@@ -40,6 +43,10 @@ public class FileCleanerMetrics {
     static final String FILE_CLEANER_FILES_FAILED_RATE = "FileCleanerFilesFailedRate";
     private static final String FILE_CLEANER_FILES_FAILED_RATE_DOC = "Total number of files the storage backend did "
         + "not confirm deleted; they stay marked for deletion and are retried on a later cycle";
+    static final String LAST_SUCCESSFUL_FILE_CLEANUP_AGE_MS = "LastSuccessfulFileCleanupAgeMs";
+    private static final String LAST_SUCCESSFUL_FILE_CLEANUP_AGE_MS_DOC = "Milliseconds since the last file cleaning "
+        + "cycle completed without error, including cycles that found nothing to delete; -1 if no cycle has "
+        + "completed since startup";
 
     /**
      * This method returns a list of all the metric name templates for the FileCleanerMetrics class.
@@ -51,25 +58,34 @@ public class FileCleanerMetrics {
             new MetricNameTemplate(FILE_CLEANER_RATE, GROUP, FILE_CLEANER_RATE_DOC),
             new MetricNameTemplate(FILE_CLEANER_FILES_RATE, GROUP, FILE_CLEANER_FILES_RATE_DOC),
             new MetricNameTemplate(FILE_CLEANER_ERROR_RATE, GROUP, FILE_CLEANER_ERROR_RATE_DOC),
-            new MetricNameTemplate(FILE_CLEANER_FILES_FAILED_RATE, GROUP, FILE_CLEANER_FILES_FAILED_RATE_DOC)
+            new MetricNameTemplate(FILE_CLEANER_FILES_FAILED_RATE, GROUP, FILE_CLEANER_FILES_FAILED_RATE_DOC),
+            new MetricNameTemplate(LAST_SUCCESSFUL_FILE_CLEANUP_AGE_MS, GROUP, LAST_SUCCESSFUL_FILE_CLEANUP_AGE_MS_DOC)
         );
     }
 
     private final KafkaMetricsGroup metricsGroup = new KafkaMetricsGroup(
         FileCleaner.class.getPackageName(), FileCleaner.class.getSimpleName());
+    private final Time time;
     private final Histogram fileCleanerTotalTime;
     private final LongAdder fileCleanerRate = new LongAdder();
     private final LongAdder fileCleanerFiles = new LongAdder();
     private final LongAdder fileCleanerErrorRate = new LongAdder();
     // package-private for tests, following ClientAzAwarenessMetrics
     final LongAdder fileCleanerFilesFailed = new LongAdder();
+    // package-private for tests, following FileCommitterMetrics
+    final AtomicLong lastSuccessfulCleanupTimeMs = new AtomicLong(-1);
 
-    public FileCleanerMetrics() {
+    public FileCleanerMetrics(final Time time) {
+        this.time = Objects.requireNonNull(time, "time cannot be null");
         fileCleanerTotalTime = metricsGroup.newHistogram(FILE_CLEANER_TOTAL_TIME, true, Map.of());
         metricsGroup.newGauge(FILE_CLEANER_RATE, fileCleanerRate::intValue);
         metricsGroup.newGauge(FILE_CLEANER_FILES_RATE, fileCleanerFiles::intValue);
         metricsGroup.newGauge(FILE_CLEANER_ERROR_RATE, fileCleanerErrorRate::intValue);
         metricsGroup.newGauge(FILE_CLEANER_FILES_FAILED_RATE, fileCleanerFilesFailed::intValue);
+        metricsGroup.newGauge(LAST_SUCCESSFUL_FILE_CLEANUP_AGE_MS, () -> {
+            final long last = lastSuccessfulCleanupTimeMs.get();
+            return last == -1 ? -1L : time.milliseconds() - last;
+        });
     }
 
     public void recordFileCleanerStart() {
@@ -92,11 +108,20 @@ public class FileCleanerMetrics {
         fileCleanerFilesFailed.add(filesSize);
     }
 
+    /**
+     * Marks a cycle as having completed without error. Called for every such cycle, including ones with
+     * no work, so the gauge tracks liveness rather than delete volume.
+     */
+    public void recordFileCleanerCycleSucceeded() {
+        lastSuccessfulCleanupTimeMs.set(time.milliseconds());
+    }
+
     public void close() {
         metricsGroup.removeMetric(FILE_CLEANER_TOTAL_TIME);
         metricsGroup.removeMetric(FILE_CLEANER_RATE);
         metricsGroup.removeMetric(FILE_CLEANER_FILES_RATE);
         metricsGroup.removeMetric(FILE_CLEANER_ERROR_RATE);
         metricsGroup.removeMetric(FILE_CLEANER_FILES_FAILED_RATE);
+        metricsGroup.removeMetric(LAST_SUCCESSFUL_FILE_CLEANUP_AGE_MS);
     }
 }

--- a/storage/inkless/src/test/java/io/aiven/inkless/delete/FileCleanerMockedTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/delete/FileCleanerMockedTest.java
@@ -169,4 +169,27 @@ class FileCleanerMockedTest {
 
         verify(controlPlane, times(0)).deleteFiles(any());
     }
+
+    @Test
+    void tracksLastSuccessfulCycle() throws Exception {
+        final var cleaner = new FileCleaner(time, controlPlane, storageBackend, OBJECT_KEY_CREATOR, RETENTION_PERIOD);
+        when(controlPlane.getFilesToDelete()).thenReturn(List.of());
+
+        assertEquals(-1, cleaner.metrics.lastSuccessfulCleanupTimeMs.get());
+
+        cleaner.run();
+
+        // A cycle with no work still counts: the gauge answers "is the cleaner running", not "is it deleting".
+        assertEquals(time.milliseconds(), cleaner.metrics.lastSuccessfulCleanupTimeMs.get());
+    }
+
+    @Test
+    void doesNotTrackFailedCycleAsSuccessful() throws Exception {
+        final var cleaner = new FileCleaner(time, controlPlane, storageBackend, OBJECT_KEY_CREATOR, RETENTION_PERIOD);
+        when(controlPlane.getFilesToDelete()).thenThrow(new RuntimeException("boom"));
+
+        cleaner.run();
+
+        assertEquals(-1, cleaner.metrics.lastSuccessfulCleanupTimeMs.get());
+    }
 }


### PR DESCRIPTION
#735 added age-of-last-success gauges so a stuck operation surfaces before a customer reports it, but FileCleaner did not get one. Its counters are all cumulative, so a cleaner that has stopped cycling looks exactly like one with nothing to delete.

Follow the same pattern as LastSuccessfulFileCommitAgeMs: record the clock at the end of every cycle that completes without error and expose the age, returning -1 until the first completion so "never ran" is distinguishable from "just ran".

Cycles with no work count as successful. The gauge answers whether the cleaner is running, not whether it is deleting; delete volume is already covered by FileCleanerFilesRate.

This overlaps with GetFilesToDeleteLastSuccessfulQueryAgeMs, which #735 generated for every control-plane query and which also goes stale when the cleaner stops cycling. The difference is what happens when a cycle starts but never finishes - an S3 delete stalling under throttling keeps the query gauge fresh while no cleanup completes. That case is the reason to scope this to the cycle rather than rely on the query gauge.
