### PR TITLE
chore(inkless:ai): replace probabilistic rule loading with context injection

### DIFF
--- a/.ai-agents/rules/comments.md
+++ b/.ai-agents/rules/comments.md
@@ -1,5 +1,0 @@
-# Comments
-
-Write self-documenting code. Comments should be rare and explain **why** (a
-non-obvious constraint, workaround, or deliberate deviation), never **what** the
-code does. Match the surrounding comment density and never restate the code.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,9 +59,10 @@ Upstream Kafka build, test, and tooling commands are in the root
 
 ### Engineering Rules
 
-**MUST**-follow defaults. All docs are under
-[`.ai-agents/rules/`](.ai-agents/rules/).
+**MUST**-follow rules and guidelines for development.
 
-| Topic    | Doc           | When to Load               |
-| -------- | ------------- | -------------------------- |
-| Comments | `comments.md` | Writing or reviewing code. |
+#### Comments
+
+Write self-documenting code. Comments should be rare and explain **why** (a
+non-obvious constraint, workaround, or deliberate deviation), never **what** the
+code does. Match the surrounding comment density and never restate the code.


### PR DESCRIPTION
Prior to this commit, the AGENTS.md file included a table of rules and when to load them. This did not work due to the probabilistic nature of LLMs. Instead, we now include those rules in the AGENTS.md file itself, so they are always available in the context.