### PR TITLE
test(inkless): retry describeTopics in produceAndConsumeWithClientAZ

### DIFF
--- a/core/src/test/java/kafka/server/InklessManagedReplicasClusterTest.java
+++ b/core/src/test/java/kafka/server/InklessManagedReplicasClusterTest.java
@@ -267,8 +267,7 @@ public class InklessManagedReplicasClusterTest {
             result.all().get(30, TimeUnit.SECONDS);
 
             // Verify managed replicas: RF=2 with replicas on both brokers
-            TopicDescription description = admin.describeTopics(Collections.singletonList(topicName))
-                .allTopicNames().get(30, TimeUnit.SECONDS).get(topicName);
+            TopicDescription description = waitForTopicDescription(admin, topicName);
             TopicPartitionInfo partition = description.partitions().get(0);
             assertEquals(2, partition.replicas().size(),
                 "Expected RF=2 for managed replicas with 2 racks");


### PR DESCRIPTION
createTopics completes when the controller commits the record, so a describeTopics that lands on a broker which has not yet applied the metadata delta fails with UnknownTopicOrPartitionException. Seen on CI in run 32010702566 (Java 25), where the test failed 3s in on the clientId=connector-producer-orders-0 parameter.

The retry helper for this already exists in the class (added in #625 for the same reason) and is used by the other two describeTopics call sites; produceAndConsumeWithClientAZ was added later in #684 and called the Admin API directly.
