### PR TITLE
fix(inkless:switch): keep switched partitions eligible for ISR shrink

### DIFF
--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -1220,17 +1220,27 @@ class Partition(val topicPartition: TopicPartition,
     delayedOperations.checkAndCompleteAll()
   }
 
-  def maybeShrinkIsr(): Unit = {
+  /**
+   * @param leaderEndOffsetCap highest offset a follower is expected to reach by fetching from this
+   *                           leader, or -1 for the leader's log end offset. Set below the LEO when
+   *                           part of the local log is replicated out of band and the leader therefore
+   *                           holds no fetch evidence of a healthy follower's progress past that point.
+   *                           Inkless (diskless tiered-storage consolidation): `ReplicaManager` passes
+   *                           the classic-to-diskless seal for a switched partition, because past the
+   *                           seal every replica appends the consolidated suffix from object storage
+   *                           instead of fetching it from this leader.
+   */
+  def maybeShrinkIsr(leaderEndOffsetCap: Long = -1L): Unit = {
     def needsIsrUpdate: Boolean = {
       !partitionState.isInflight && inReadLock(leaderIsrUpdateLock) {
-        needsShrinkIsr()
+        needsShrinkIsr(leaderEndOffsetCap)
       }
     }
 
     if (needsIsrUpdate) {
       val alterIsrUpdateOpt = inWriteLock(leaderIsrUpdateLock) {
         leaderLogIfLocal.flatMap { leaderLog =>
-          val outOfSyncReplicaIds = getOutOfSyncReplicas(replicaLagTimeMaxMs)
+          val outOfSyncReplicaIds = getOutOfSyncReplicas(replicaLagTimeMaxMs, leaderEndOffsetCap)
           partitionState match {
             case currentState: CommittedPartitionState if outOfSyncReplicaIds.nonEmpty =>
               val outOfSyncReplicaLog = outOfSyncReplicaIds.map { replicaId =>
@@ -1260,8 +1270,8 @@ class Partition(val topicPartition: TopicPartition,
     }
   }
 
-  private def needsShrinkIsr(): Boolean = {
-    leaderLogIfLocal.exists { _ => getOutOfSyncReplicas(replicaLagTimeMaxMs).nonEmpty }
+  private def needsShrinkIsr(leaderEndOffsetCap: Long): Boolean = {
+    leaderLogIfLocal.exists { _ => getOutOfSyncReplicas(replicaLagTimeMaxMs, leaderEndOffsetCap).nonEmpty }
   }
 
   private def isFollowerOutOfSync(replicaId: Int,
@@ -1285,13 +1295,17 @@ class Partition(val topicPartition: TopicPartition,
    * is violated, that replica is considered to be out of sync
    *
    * If an ISR update is in-flight, we will return an empty set here
+   *
+   * @param leaderEndOffsetCap see [[maybeShrinkIsr]]
    **/
-  def getOutOfSyncReplicas(maxLagMs: Long): Set[Int] = {
+  def getOutOfSyncReplicas(maxLagMs: Long, leaderEndOffsetCap: Long = -1L): Set[Int] = {
     val current = partitionState
     if (!current.isInflight) {
       val candidateReplicaIds = (current.isr.asScala.map(_.toInt) - localBrokerId).toSet
       val currentTimeMs = time.milliseconds()
-      val leaderEndOffset = localLogOrException.logEndOffset
+      val logEndOffset = localLogOrException.logEndOffset
+      val leaderEndOffset =
+        if (leaderEndOffsetCap >= 0) math.min(logEndOffset, leaderEndOffsetCap) else logEndOffset
       candidateReplicaIds.filter(replicaId => isFollowerOutOfSync(replicaId, leaderEndOffset, currentTimeMs, maxLagMs))
     } else {
       Set.empty

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -1276,10 +1276,15 @@ class Partition(val topicPartition: TopicPartition,
 
   private def isFollowerOutOfSync(replicaId: Int,
                                   leaderEndOffset: Long,
+                                  leaderEndOffsetCap: Long,
                                   currentTimeMs: Long,
                                   maxLagMs: Long): Boolean = {
     getReplica(replicaId).fold(true) { followerReplica =>
-      !followerReplica.stateSnapshot.isCaughtUp(leaderEndOffset, currentTimeMs, maxLagMs)
+      val followerState = followerReplica.stateSnapshot
+      // A follower recorded at or beyond the ceiling holds everything this leader supplies, so it
+      // cannot lag regardless of when it last fetched.
+      if (leaderEndOffsetCap >= 0 && followerState.logEndOffset >= leaderEndOffsetCap) false
+      else !followerState.isCaughtUp(leaderEndOffset, currentTimeMs, maxLagMs)
     }
   }
 
@@ -1306,7 +1311,8 @@ class Partition(val topicPartition: TopicPartition,
       val logEndOffset = localLogOrException.logEndOffset
       val leaderEndOffset =
         if (leaderEndOffsetCap >= 0) math.min(logEndOffset, leaderEndOffsetCap) else logEndOffset
-      candidateReplicaIds.filter(replicaId => isFollowerOutOfSync(replicaId, leaderEndOffset, currentTimeMs, maxLagMs))
+      candidateReplicaIds.filter(replicaId =>
+        isFollowerOutOfSync(replicaId, leaderEndOffset, leaderEndOffsetCap, currentTimeMs, maxLagMs))
     } else {
       Set.empty
     }

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -3239,13 +3239,29 @@ class ReplicaManager(val config: KafkaConfig,
       log.highWatermark
   }
 
-  private def maybeShrinkIsr(): Unit = {
+  // private[server] for testing: otherwise only reachable via the scheduled "isr-expiration" task.
+  private[server] def maybeShrinkIsr(): Unit = {
     trace("Evaluating ISR list of partitions to see which replicas can be removed from the ISR")
 
     // Shrink ISRs for non offline partitions
     allPartitions.forEach { (topicPartition, _) =>
-      if (!_inklessMetadataView.isDisklessTopic(topicPartition.topic()))
+      if (_inklessMetadataView.isDisklessTopic(topicPartition.topic())) {
+        val seal = _inklessMetadataView.getClassicToDisklessStartOffset(topicPartition)
+        // -1 means "no committed seal": born-diskless, or a switch aborted through
+        // AlterDisklessSwitch. Neither has a classic prefix replicated from this leader, so there
+        // is nothing to fall behind on.
+        if (seal != PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET) {
+          // Past a committed seal the local log only grows by consolidation, which every replica does
+          // from object storage without fetching from this leader (DisklessLeaderEndPoint), so the
+          // leader's recorded state for a healthy follower stops at the seal. Cap the lag comparison
+          // there, or the whole ISR is shrunk out as the consolidated suffix advances. Nothing
+          // re-expands it either, because expansion also needs a follower fetch.
+          val leaderEndOffsetCap = if (seal >= 0) seal else -1L
+          onlinePartition(topicPartition).foreach(_.maybeShrinkIsr(leaderEndOffsetCap))
+        }
+      } else {
         onlinePartition(topicPartition).foreach(_.maybeShrinkIsr())
+      }
     }
   }
 
@@ -4139,14 +4155,19 @@ class ReplicaManager(val config: KafkaConfig,
           getOrCreatePartition(tp, delta, info.topicId).foreach { case (partition, isNew) =>
             try {
               val partitionAssignedDirectoryId = directoryIds.find(_._1.topicPartition() == tp).map(_._2)
+              val previousLeaderId = partition.leaderReplicaIdOpt
               val isNewLeaderEpoch = partition.makeFollower(info.partition, isNew, offsetCheckpoints, Some(info.topicId), partitionAssignedDirectoryId)
               partition.seal()
               changedPartitions.add(partition)
               val isOutOfIsr = !info.partition.isr.contains(config.brokerId)
+              // A new leader resets our recorded fetch state to UNKNOWN (Replica.resetReplicaState),
+              // so without a fetch to re-establish it the lastCaughtUpTimeMs grace period expires and
+              // the leader shrinks us out of ISR.
+              val leaderChanged = previousLeaderId.exists(_ != info.partition.leader)
               // Skip during controlled shutdown: the leader will not expand ISR for a shutting-down
               // broker (isReplicaIsrEligible), and this replica is about to stop serving.
               if (seal >= 0 && !isInControlledShutdown &&
-                (partition.localLogOrException.highWatermark < seal || isOutOfIsr)) {
+                (partition.localLogOrException.highWatermark < seal || isOutOfIsr || leaderChanged)) {
                 // Schedule a catch-up fetch when the local HW is below the seal -- either
                 // because we restarted with a stale HW (unclean shutdown) or because we
                 // were just added as a replica and have an empty local log.

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -4131,6 +4131,9 @@ class ReplicaManager(val config: KafkaConfig,
       "local followers.")
     val partitionsToStartFetching = new mutable.HashMap[TopicPartition, Partition]
     val partitionsToStopFetching = new mutable.HashMap[TopicPartition, Boolean]
+    // Consolidating followers that need one classic fetch to re-establish the new leader's record of
+    // their position. See the diversion below.
+    val consolidationLeaderEvidenceFetch = new mutable.HashSet[TopicPartition]
     val followerTopicSet = new mutable.HashSet[String]
     localFollowers.foreachEntry { (tp, info) =>
       val isConsolidatingDisklessTopic =
@@ -4204,6 +4207,7 @@ class ReplicaManager(val config: KafkaConfig,
             //   is unavailable. This is required to ensure that we include the partition's
             //   high watermark in the checkpoint file (see KAFKA-1647).
             val partitionAssignedDirectoryId = directoryIds.find(_._1.topicPartition() == tp).map(_._2)
+            val previousLeaderId = partition.leaderReplicaIdOpt
             val isNewLeaderEpoch = partition.makeFollower(info.partition, isNew, offsetCheckpoints, Some(info.topicId), partitionAssignedDirectoryId)
 
             if (isInControlledShutdown && (info.partition.leader == NO_LEADER ||
@@ -4216,6 +4220,9 @@ class ReplicaManager(val config: KafkaConfig,
               partition.invokeOnBecomingFollowerListeners()
               // Otherwise, fetcher is restarted if the leader epoch has changed.
               partitionsToStartFetching.put(tp, partition)
+              if (isConsolidatingDisklessTopic && previousLeaderId.exists(_ != info.partition.leader)) {
+                consolidationLeaderEvidenceFetch.add(tp)
+              }
             }
 
             changedPartitions.add(partition)
@@ -4264,11 +4271,20 @@ class ReplicaManager(val config: KafkaConfig,
       // to the consolidation reconciler (startConsolidationFetchersForCaughtUpClassicPartitions).
       // Routing a below-seal/pending partition straight to the reconciler would strand it: the
       // reconciler returns Retry and no classic fetcher would ever bring it up to the seal.
+      // A consolidation-ready follower is also diverted to the classic fetcher for one round when the
+      // leader changed. Consolidation reads from object storage, so the new leader never sees a fetch
+      // from this replica and keeps the UNKNOWN state that makeLeader installed, which maybeShrinkIsr
+      // removes from ISR once the lag timeout passes. One classic fetch records the position; the
+      // fetcher then self-evicts at the seal and hands the partition back to consolidation.
       val (consolidatingDisklessPartitionsToStartFetching, classicPartitionsToStartFetching) = partitionsToStartFetching.partition { case (tp, partition) =>
-        isReadyForConsolidation(tp, partition)
+        isReadyForConsolidation(tp, partition) && !consolidationLeaderEvidenceFetch.contains(tp)
       }
       replicaFetcherManager.removeFetcherForPartitions(classicPartitionsToStartFetching.keySet)
-      consolidationFetcherManager.foreach(_.removeFetcherForPartitions(consolidatingDisklessPartitionsToStartFetching.keySet))
+      // Diverted partitions keep a consolidation fetcher from the previous leader epoch. Evict it as
+      // well, or both fetchers append to the same log and processPartitionData fails the
+      // fetchOffset == logEndOffset check.
+      consolidationFetcherManager.foreach(_.removeFetcherForPartitions(
+        consolidatingDisklessPartitionsToStartFetching.keySet ++ consolidationLeaderEvidenceFetch))
       stateChangeLogger.info(s"Stopped fetchers as part of become-follower for ${partitionsToStartFetching.size} partitions")
 
       val listenerName = config.interBrokerListenerName.value

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerInklessTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerInklessTest.scala
@@ -6585,8 +6585,9 @@ class ReplicaManagerInklessTest {
     val topicId = Uuid.randomUuid()
     val tp = new TopicPartition(topicName, 0)
     val brokerId = 1
-    val firstLeaderId = 2
-    val secondLeaderId = 3
+    val previousLeaderId = 0
+    val newLeaderId = 2
+    val sealOffset = 10L
 
     val mockFetcherManager = mock(classOf[ReplicaFetcherManager])
     when(mockFetcherManager.removeFetcherForPartitions(any())).thenReturn(Map.empty[TopicPartition, PartitionFetchState])
@@ -6598,20 +6599,26 @@ class ReplicaManagerInklessTest {
     try {
       // Caught up to the seal and in ISR, so steady state needs no fetcher.
       val log = replicaManager.logManager.getOrCreateLog(tp, isNew = true, topicId = Optional.of(topicId))
-      populateLocalLogAtLeoAndCheckpointedHwm(replicaManager, tp, log, leo = 10L, hw = 10L)
-      when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(tp)).thenReturn(10L)
+      populateLocalLogAtLeoAndCheckpointedHwm(replicaManager, tp, log, leo = sealOffset, hw = sealOffset)
+      when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(tp)).thenReturn(sealOffset)
 
-      val firstDelta = disklessFollowerDelta(topicName, topicId, brokerId, firstLeaderId)
-      replicaManager.applyDelta(firstDelta, imageFromTopics(firstDelta.apply()))
+      val previousLeaderDelta = disklessFollowerDelta(topicName, topicId, brokerId, previousLeaderId)
+      replicaManager.applyDelta(previousLeaderDelta, imageFromTopics(previousLeaderDelta.apply()))
       verify(mockFetcherManager, never()).addFetcherForPartitions(any())
 
       // The leader moves. The new leader reset our recorded fetch state to UNKNOWN, so it holds no
       // evidence we reached the seal; without a fetch it would shrink us out once the lag timeout
       // elapses. A catch-up fetch must be scheduled even though we are caught up and in ISR.
-      val secondDelta = disklessFollowerDelta(topicName, topicId, brokerId, secondLeaderId)
-      replicaManager.applyDelta(secondDelta, imageFromTopics(secondDelta.apply()))
+      val newLeaderDelta = disklessFollowerDelta(topicName, topicId, brokerId, newLeaderId)
+      replicaManager.applyDelta(newLeaderDelta, imageFromTopics(newLeaderDelta.apply()))
 
-      verify(mockFetcherManager, times(1)).addFetcherForPartitions(any())
+      val newLeaderEndpoint = ClusterImageTest.IMAGE1.broker(newLeaderId).listeners().get("PLAINTEXT")
+      verify(mockFetcherManager).addFetcherForPartitions(Map(tp -> InitialFetchState(
+        topicId = Some(topicId),
+        leader = new BrokerEndPoint(newLeaderId, newLeaderEndpoint.host(), newLeaderEndpoint.port()),
+        currentLeaderEpoch = 0,
+        initOffset = sealOffset
+      )))
     } finally {
       replicaManager.shutdown(checkpointHW = false)
     }

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerInklessTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerInklessTest.scala
@@ -7855,6 +7855,72 @@ class ReplicaManagerInklessTest {
   }
 
   @Test
+  def testApplyDeltaDivertsConsolidatingFollowerToClassicFetcherOnLeaderChange(): Unit = {
+    val topicName = "switched-consolidating"
+    val topicId = Uuid.randomUuid()
+    val tp = new TopicPartition(topicName, 0)
+    val brokerId = 1
+    val previousLeaderId = 2
+    val newLeaderId = 0
+    val seal = 10L
+
+    val mockFetcherManager = mock(classOf[ReplicaFetcherManager])
+    when(mockFetcherManager.removeFetcherForPartitions(any())).thenReturn(Map.empty[TopicPartition, PartitionFetchState])
+    val ctorInit: MockedConstruction.MockInitializer[ConsolidationFetcherManager] = {
+      case (mock, _) =>
+        when(mock.removeFetcherForPartitions(any())).thenReturn(Map.empty[TopicPartition, PartitionFetchState])
+    }
+    val consolidationCtor = mockConstruction(classOf[ConsolidationFetcherManager], ctorInit)
+    try {
+      val replicaManager = spy(createReplicaManager(
+        List(topicName),
+        topicIdMapping = Map(topicName -> topicId),
+        disklessRemoteStorageConsolidationEnabled = true,
+        consolidatingDisklessTopics = Set(topicName),
+        mockReplicaFetcherManager = Some(mockFetcherManager),
+      ))
+      try {
+        val mockCfm = consolidationCtor.constructed().get(0)
+        // Local log past the seal: the classic prefix is replicated and consolidation has appended
+        // part of the suffix, so the partition is ready for consolidation.
+        val log = replicaManager.logManager.getOrCreateLog(tp, isNew = true, topicId = Optional.of(topicId))
+        populateLocalLogAtLeoAndCheckpointedHwm(replicaManager, tp, log, leo = 12L, hw = 12L)
+        when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(tp)).thenReturn(seal)
+
+        val firstDelta = createFollowerDelta(topicId, tp, brokerId, previousLeaderId)
+        replicaManager.applyDelta(firstDelta, imageFromTopics(firstDelta.apply()))
+        verify(mockCfm).addFetcherForPartitions(any())
+        // The unconditional call at the end of applyLocalFollowersDelta passes an empty map, so match
+        // on content rather than on the call.
+        verify(mockFetcherManager, never()).addFetcherForPartitions(
+          argThat[Map[TopicPartition, InitialFetchState]](_.nonEmpty))
+        clearInvocations(mockCfm, mockFetcherManager)
+
+        val secondDelta = createFollowerDelta(topicId, tp, brokerId, newLeaderId, leaderEpoch = 1)
+        replicaManager.applyDelta(secondDelta, imageFromTopics(secondDelta.apply()))
+
+        // The new leader holds no record of this follower's position, so it takes one classic fetch
+        // from that leader instead of going straight back to consolidation.
+        val endpoint = ClusterImageTest.IMAGE1.broker(newLeaderId).listeners().get("PLAINTEXT")
+        verify(mockFetcherManager).addFetcherForPartitions(Map(tp -> InitialFetchState(
+          topicId = Some(topicId),
+          leader = new BrokerEndPoint(newLeaderId, endpoint.host(), endpoint.port()),
+          currentLeaderEpoch = 1,
+          initOffset = 12L
+        )))
+        // The consolidation fetcher from the previous leader epoch is evicted, so only one fetcher
+        // appends to the local log.
+        verify(mockCfm).removeFetcherForPartitions(Set(tp))
+        verify(mockCfm, never()).addFetcherForPartitions(any())
+      } finally {
+        replicaManager.shutdown(checkpointHW = false)
+      }
+    } finally {
+      consolidationCtor.close()
+    }
+  }
+
+  @Test
   def testMaybeShrinkIsrKeepsConsolidatingFollowerAtSealInIsr(): Unit = {
     val followerId = 2
     val switched = new TopicIdPartition(Uuid.randomUuid(), 0, "switched-consolidating")
@@ -7894,6 +7960,48 @@ class ReplicaManagerInklessTest {
       // Lag is judged against the seal, not the advancing LEO, so a follower that reached the seal
       // stays in ISR. Judging it against the LEO would shrink every consolidating follower out and
       // nothing would re-expand: expansion also needs a fetch that never comes.
+      verify(alterPartitionManager, never()).submit(any(), any())
+      assertTrue(partition.inSyncReplicaIds.contains(followerId))
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
+  def testMaybeShrinkIsrKeepsConsolidatingFollowerRecordedBeyondSealInIsr(): Unit = {
+    val followerId = 2
+    val switched = new TopicIdPartition(Uuid.randomUuid(), 0, "switched-consolidating")
+    val seal = 5L
+    val replicaManager = spy(createReplicaManager(
+      List(switched.topic()),
+      topicIdMapping = Map(switched.topic() -> switched.topicId()),
+      disklessRemoteStorageConsolidationEnabled = true,
+      consolidatingDisklessTopics = Set(switched.topic()),
+    ))
+    try {
+      doReturn(new CompletableFuture[Any]())
+        .when(alterPartitionManager).submit(any(), any())
+
+      val partition = setupDisklessLeaderWithLaggingFollowerInIsr(
+        replicaManager, switched, followerId, logEndOffset = 12L, seal = seal)
+
+      // A follower diverted to the classic fetcher on a leader change reports its real position,
+      // which consolidation has already carried past the seal.
+      val followerReplica = partition.getReplica(followerId).get
+      partition.updateFollowerFetchState(
+        followerReplica,
+        followerFetchOffsetMetadata = new LogOffsetMetadata(8L),
+        followerStartOffset = 0L,
+        followerFetchTimeMs = time.milliseconds(),
+        leaderEndOffset = 12L,
+        brokerEpoch = -1L)
+      clearInvocations(alterPartitionManager)
+
+      time.sleep(replicaManager.config.replicaLagTimeMaxMs * 2)
+      replicaManager.maybeShrinkIsr()
+
+      // The ceiling caps both sides of the comparison, so a follower recorded beyond the seal counts
+      // as caught up even though the leader's log end offset is higher still.
       verify(alterPartitionManager, never()).submit(any(), any())
       assertTrue(partition.inSyncReplicaIds.contains(followerId))
     } finally {

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerInklessTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerInklessTest.scala
@@ -6580,6 +6580,44 @@ class ReplicaManagerInklessTest {
   }
 
   @Test
+  def testApplyDeltaStartsCatchUpFetcherForDisklessFollowerAtSealOnLeaderChange(): Unit = {
+    val topicName = "switched-topic"
+    val topicId = Uuid.randomUuid()
+    val tp = new TopicPartition(topicName, 0)
+    val brokerId = 1
+    val firstLeaderId = 2
+    val secondLeaderId = 3
+
+    val mockFetcherManager = mock(classOf[ReplicaFetcherManager])
+    when(mockFetcherManager.removeFetcherForPartitions(any())).thenReturn(Map.empty[TopicPartition, PartitionFetchState])
+
+    val replicaManager = spy(createReplicaManager(
+      List(topicName),
+      mockReplicaFetcherManager = Some(mockFetcherManager)
+    ))
+    try {
+      // Caught up to the seal and in ISR, so steady state needs no fetcher.
+      val log = replicaManager.logManager.getOrCreateLog(tp, isNew = true, topicId = Optional.of(topicId))
+      populateLocalLogAtLeoAndCheckpointedHwm(replicaManager, tp, log, leo = 10L, hw = 10L)
+      when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(tp)).thenReturn(10L)
+
+      val firstDelta = disklessFollowerDelta(topicName, topicId, brokerId, firstLeaderId)
+      replicaManager.applyDelta(firstDelta, imageFromTopics(firstDelta.apply()))
+      verify(mockFetcherManager, never()).addFetcherForPartitions(any())
+
+      // The leader moves. The new leader reset our recorded fetch state to UNKNOWN, so it holds no
+      // evidence we reached the seal; without a fetch it would shrink us out once the lag timeout
+      // elapses. A catch-up fetch must be scheduled even though we are caught up and in ISR.
+      val secondDelta = disklessFollowerDelta(topicName, topicId, brokerId, secondLeaderId)
+      replicaManager.applyDelta(secondDelta, imageFromTopics(secondDelta.apply()))
+
+      verify(mockFetcherManager, times(1)).addFetcherForPartitions(any())
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
   def testApplyDeltaStartsCatchUpFetcherWhenDisklessFollowerAtSealButOutOfIsr(): Unit = {
     val topicName = "switched-topic"
     val topicId = Uuid.randomUuid()
@@ -7761,6 +7799,150 @@ class ReplicaManagerInklessTest {
     assertEquals(UnifiedLog.UNKNOWN_OFFSET, data.highWatermark)
     assertEquals(UnifiedLog.UNKNOWN_OFFSET, data.logStartOffset)
     verify(alterPartitionManager, never()).submit(any(), any())
+  }
+
+  @Test
+  def testMaybeShrinkIsrAppliesToSwitchedPartitionsButNotBornDiskless(): Unit = {
+    val followerId = 2
+    val switched = new TopicIdPartition(Uuid.randomUuid(), 0, "switched")
+    val bornDiskless = new TopicIdPartition(Uuid.randomUuid(), 0, "born-diskless")
+    val replicaManager = spy(createReplicaManager(
+      List(switched.topic(), bornDiskless.topic()),
+      topicIdMapping = Map(
+        switched.topic() -> switched.topicId(),
+        bornDiskless.topic() -> bornDiskless.topicId()),
+      disklessManagedReplicasEnabled = true,
+    ))
+    try {
+      doReturn(new CompletableFuture[Any]())
+        .when(alterPartitionManager).submit(any(), any())
+
+      // Identical partitions -- lagging follower in ISR, leader log ending at 5 -- differing only in
+      // what the metadata view reports for the seal.
+      val switchedPartition = setupDisklessLeaderWithLaggingFollowerInIsr(
+        replicaManager, switched, followerId, logEndOffset = 5L, seal = 5L)
+      val bornDisklessPartition = setupDisklessLeaderWithLaggingFollowerInIsr(
+        replicaManager, bornDiskless, followerId, logEndOffset = 5L,
+        seal = PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET)
+      assertTrue(switchedPartition.inSyncReplicaIds.contains(followerId))
+      assertTrue(bornDisklessPartition.inSyncReplicaIds.contains(followerId))
+      clearInvocations(alterPartitionManager)
+
+      // Push both followers past replica.lag.time.max.ms without either ever fetching.
+      time.sleep(replicaManager.config.replicaLagTimeMaxMs * 2)
+      replicaManager.maybeShrinkIsr()
+
+      // The switched partition still has a classic prefix, so a follower that never reached the seal
+      // must be shrunk out; the born-diskless one has no local log to lag on and is exempt.
+      verify(alterPartitionManager, times(1)).submit(
+        ArgumentMatchers.eq(new org.apache.kafka.server.common.TopicIdPartition(
+          switched.topicId(), switched.partition())),
+        argThat[LeaderAndIsr](!_.isr.contains(followerId)))
+      verify(alterPartitionManager, never()).submit(
+        ArgumentMatchers.eq(new org.apache.kafka.server.common.TopicIdPartition(
+          bornDiskless.topicId(), bornDiskless.partition())),
+        any())
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
+  def testMaybeShrinkIsrKeepsConsolidatingFollowerAtSealInIsr(): Unit = {
+    val followerId = 2
+    val switched = new TopicIdPartition(Uuid.randomUuid(), 0, "switched-consolidating")
+    val seal = 5L
+    val replicaManager = spy(createReplicaManager(
+      List(switched.topic()),
+      topicIdMapping = Map(switched.topic() -> switched.topicId()),
+      disklessRemoteStorageConsolidationEnabled = true,
+      consolidatingDisklessTopics = Set(switched.topic()),
+    ))
+    try {
+      doReturn(new CompletableFuture[Any]())
+        .when(alterPartitionManager).submit(any(), any())
+
+      // Leader log runs past the seal: the consolidation fetcher appends the consolidated suffix on
+      // every replica, including this leader, so its LEO keeps advancing after the switch.
+      val partition = setupDisklessLeaderWithLaggingFollowerInIsr(
+        replicaManager, switched, followerId, logEndOffset = 12L, seal = seal)
+
+      // The follower replicated the whole classic prefix and then handed off to its own consolidation
+      // fetcher, which reads from object storage and never fetches from this leader again -- so the
+      // last state the leader recorded for it stops at the seal.
+      val followerReplica = partition.getReplica(followerId).get
+      partition.updateFollowerFetchState(
+        followerReplica,
+        followerFetchOffsetMetadata = new LogOffsetMetadata(seal),
+        followerStartOffset = 0L,
+        followerFetchTimeMs = time.milliseconds(),
+        leaderEndOffset = seal,
+        brokerEpoch = -1L)
+      assertTrue(partition.inSyncReplicaIds.contains(followerId))
+      clearInvocations(alterPartitionManager)
+
+      time.sleep(replicaManager.config.replicaLagTimeMaxMs * 2)
+      replicaManager.maybeShrinkIsr()
+
+      // Lag is judged against the seal, not the advancing LEO, so a follower that reached the seal
+      // stays in ISR. Judging it against the LEO would shrink every consolidating follower out and
+      // nothing would re-expand: expansion also needs a fetch that never comes.
+      verify(alterPartitionManager, never()).submit(any(), any())
+      assertTrue(partition.inSyncReplicaIds.contains(followerId))
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  /**
+   * Leader of a diskless partition with `followerId` inside the ISR and never having fetched, so it
+   * goes out of sync once the clock passes replica.lag.time.max.ms. `seal` is what the metadata view
+   * reports for the partition, which is what decides whether lag-based shrink applies.
+   */
+  private def setupDisklessLeaderWithLaggingFollowerInIsr(replicaManager: ReplicaManager,
+                                                          topicIdPartition: TopicIdPartition,
+                                                          followerId: Int,
+                                                          logEndOffset: Long,
+                                                          seal: Long): Partition = {
+    val leaderId = replicaManager.config.brokerId
+    val topicDelta = new TopicsDelta(TopicsImage.EMPTY)
+    topicDelta.replay(new TopicRecord()
+      .setName(topicIdPartition.topic())
+      .setTopicId(topicIdPartition.topicId()))
+    topicDelta.replay(new PartitionRecord()
+      .setTopicId(topicIdPartition.topicId())
+      .setPartitionId(topicIdPartition.partition())
+      .setLeader(leaderId)
+      .setLeaderEpoch(0)
+      .setPartitionEpoch(0)
+      .setReplicas(List[Integer](leaderId, followerId).asJava)
+      .setIsr(List[Integer](leaderId, followerId).asJava))
+
+    val (partition, _) = replicaManager.getOrCreatePartition(
+      topicIdPartition.topicPartition(),
+      topicDelta,
+      topicIdPartition.topicId()).get
+    partition.makeLeader(
+      partitionRegistration(
+        leaderId,
+        leaderEpoch = 0,
+        isr = Array(leaderId, followerId),
+        partitionEpoch = 0,
+        replicas = Array(leaderId, followerId)),
+      isNew = false,
+      new LazyOffsetCheckpoints(replicaManager.highWatermarkCheckpoints.asJava),
+      None)
+
+    val records = (0L until logEndOffset).map { i =>
+      new SimpleRecord(s"key-$i".getBytes, s"value-$i".getBytes)
+    }.toArray
+    val log = partition.localLogOrException
+    log.appendAsLeader(MemoryRecords.withRecords(0L, Compression.NONE, 0, records: _*), 0)
+    log.updateHighWatermark(logEndOffset)
+
+    when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(topicIdPartition.topicPartition()))
+      .thenReturn(seal)
+    partition
   }
 
   private def setupSwitchedLeaderWithOutOfSyncFollower(replicaManager: ReplicaManager,


### PR DESCRIPTION
`maybeShrinkIsr` skipped every diskless topic, which includes a partition switched from classic. Those keep records below `classicToDisklessStartOffset` in the replicas' local logs, so a follower that stalls before reaching the seal is genuinely behind. Nothing removed it from ISR either: the controller shrinks only on fencing, and the seal is taken at the leader's LEO, so a lagging follower does not hold the switch back. It stayed in ISR without the prefix and was electable.

Switched partitions are now shrunk. Three things the shrink alone gets wrong:

- **Lag is judged against the seal, not the leader's LEO.** Past a committed seal the local log grows only by consolidation, which every replica appends from object storage through `DisklessLeaderEndPoint` -- a local fetch that never reaches the leader. The leader's recorded state for a healthy consolidating follower therefore stops at the seal while its own LEO keeps advancing, so comparing the two would shrink the entire ISR out, with nothing to re-expand it (expansion also waits for a follower fetch). `Partition` takes the ceiling as an optional argument, defaulted off, so classic partitions are unaffected.
- **A catch-up fetch is scheduled when the leader moves.** A new leader resets an in-ISR follower's recorded state to `UNKNOWN`, and a follower at the seal starts no fetcher, so the lag grace period would expire and the follower would be shrunk and re-admitted on every leader change.
- **A consolidating follower is diverted to the classic fetcher for one round on a leader change.** Consolidation reads from object storage, so a new leader never sees a fetch from that replica and keeps the `UNKNOWN` state, which the shrink then acts on: the ISR collapses to the leader alone on every rolling restart, with nothing to re-expand it. One classic fetch records the position; the fetcher self-evicts at the seal and hands the partition back to consolidation. The diverted partition also leaves the consolidation fetcher manager, so two fetchers never append to the same log.

Only partitions with no committed seal stay exempt: born-diskless, or a switch aborted through `AlterDisklessSwitch`. Neither replicates a classic prefix from this leader.

## Commits

- `fix(inkless:switch): keep switched partitions eligible for ISR shrink` -- the shrink predicate, the seal-capped lag comparison, and the leader-change catch-up fetch, with tests.
- `test(inkless:switch): assert the catch-up fetch target on leader change` -- test-only: the leader-change regression test picked a broker that `ClusterImageTest.IMAGE1` does not register, so the leader endpoint never resolved and the assertion held on an empty fetcher map. It now moves the leader between two registered brokers and asserts the exact `InitialFetchState`.
- `fix(inkless:switch): re-establish leader fetch evidence for consolidating followers` -- the classic-fetcher diversion on a leader change, and the ceiling applied to both sides of the lag comparison.

See the commit messages for the reasoning behind each.

## Operator impact

A switched partition whose follower never replicated the classic prefix now shows up as under-replicated and is logged by the usual `Shrinking ISR from ... to ...` line, instead of silently staying in ISR. No new config or metric.

## Test plan

Unit tests in `ReplicaManagerInklessTest` cover: a switched partition shrinking a follower that never reached the seal while a born-diskless partition is left alone; a consolidating switched partition keeping a follower recorded at the seal in ISR while the leader's log end offset advances past it; and the catch-up fetch scheduled on a leader change, asserted against the expected `InitialFetchState`. Two further tests cover the consolidating leader change: the follower is scheduled on the classic fetcher rather than handed to the reconciler, and a follower recorded beyond the seal stays in ISR. Each fails without its production change. The upstream `PartitionTest` suite passes unchanged, which covers the classic path through the new default argument.

## Relation to #757

ISR correctness for a switched partition has two legs, and these PRs are one each. #757 closes **admission**: `changePartitionReassignment` applied the target replica set in one step for any diskless topic, so a replica added by a reassignment entered ISR holding none of the classic prefix. This PR closes **recovery**: a replica that ended up in ISR without the prefix -- however it got there -- was never lag-shrunk out. They are independent (either can merge first) and complementary: with only #757, a replica that stalls mid-switch stays in ISR forever; with only this PR, a wrongly admitted replica is electable until the lag timeout expires.

Both, together with the unfence guard from #754, key on `classicToDisklessStartOffset == -1` to mean "born-diskless". That reading is imprecise for a partition whose switch was aborted via `AlterDisklessSwitch(-1)` while `diskless.enable` is still true -- it keeps a local classic prefix. Pre-existing (the predicate this replaces, `!isDisklessTopic`, skipped that partition too) and not fixable at any single one of these sites, since `LogConfig.validateDisklessTransition` forbids disabling diskless afterwards, which makes that state terminal. Tracked as a follow-up.


