### PR TITLE
fix(inkless:switch): let a consolidating switched replica rejoin ISR [KC-434]

### DIFF
--- a/core/src/main/scala/io/aiven/inkless/consolidation/ConsolidationReconciler.scala
+++ b/core/src/main/scala/io/aiven/inkless/consolidation/ConsolidationReconciler.scala
@@ -96,9 +96,9 @@ class ConsolidationReconciler(replicaManager: ReplicaManager,
     val consolidatingDisklessPartitionsToStartFetching = new mutable.HashMap[TopicPartition, Partition]
     topicPartitions.foreach { tp =>
       // Only diskless topics may be handed to the consolidation fetcher.
-      // The sole caller (ReplicaFetcherThread self-eviction, via ReplicaManager) selects partitions by
-      // seal state (committed seal + local LEO caught up), not by whether the topic is diskless,
-      // so this gate is where that precondition is established.
+      // The sole caller (ReplicaFetcherThread hand-off, via ReplicaManager) selects partitions by
+      // seal state and local LEO, not by whether the topic is diskless, so this gate is where that
+      // precondition is established.
       // Under the diskless+remote-storage invariant, a diskless topic is always consolidating.
       if (inklessMetadataView.isDisklessTopic(tp.topic) && switchedReplicaMayConsolidate(tp)) {
         replicaManager.onlinePartition(tp).foreach(partition => consolidatingDisklessPartitionsToStartFetching.put(tp, partition))
@@ -112,7 +112,7 @@ class ConsolidationReconciler(replicaManager: ReplicaManager,
    * True if the partition never switched; for a switched partition, true only while this replica
    * is in ISR.
    *
-   * The caller queues the hand-off on the classic fetcher thread and cannot hold partitionMapLock
+   * The caller queues the hand-off on the classic fetcher thread and cannot hold `partitionMapLock`
    * across the fetcher-manager call, so an ISR-shrink delta can land in between and leave the
    * queued decision stale. A replica that consolidates outside ISR sends no fetch to the leader,
    * so nothing would readmit it.

--- a/core/src/main/scala/io/aiven/inkless/consolidation/ConsolidationReconciler.scala
+++ b/core/src/main/scala/io/aiven/inkless/consolidation/ConsolidationReconciler.scala
@@ -100,11 +100,26 @@ class ConsolidationReconciler(replicaManager: ReplicaManager,
       // seal state (committed seal + local LEO caught up), not by whether the topic is diskless,
       // so this gate is where that precondition is established.
       // Under the diskless+remote-storage invariant, a diskless topic is always consolidating.
-      if (inklessMetadataView.isDisklessTopic(tp.topic)) {
+      if (inklessMetadataView.isDisklessTopic(tp.topic) && switchedReplicaMayConsolidate(tp)) {
         replicaManager.onlinePartition(tp).foreach(partition => consolidatingDisklessPartitionsToStartFetching.put(tp, partition))
       }
     }
     startConsolidationFetchers(consolidatingDisklessPartitionsToStartFetching)
+  }
+
+  /**
+   * Checks whether a replica may leave the classic fetcher for consolidation.
+   * True if the partition never switched; for a switched partition, true only while this replica
+   * is in ISR.
+   *
+   * The caller queues the hand-off on the classic fetcher thread and cannot hold partitionMapLock
+   * across the fetcher-manager call, so an ISR-shrink delta can land in between and leave the
+   * queued decision stale. A replica that consolidates outside ISR sends no fetch to the leader,
+   * so nothing would readmit it.
+   */
+  private def switchedReplicaMayConsolidate(topicPartition: TopicPartition): Boolean = {
+    val seal = inklessMetadataView.getClassicToDisklessStartOffset(topicPartition)
+    seal < 0 || inklessMetadataView.isReplicaInIsr(topicPartition, replicaManager.config.brokerId)
   }
 
   def initConsolidatingPartitionFetching(consolidatingDisklessPartitionsToStartFetching: mutable.HashMap[TopicPartition, Partition]

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -1031,6 +1031,42 @@ class Partition(val topicPartition: TopicPartition,
     canAddReplicaToIsr(followerReplica.brokerId) && isFollowerInSync(followerReplica)
   }
 
+  /**
+   * Expands the ISR for a switched diskless partition on the evidence of a follower fetch at the seal.
+   *
+   * Inkless: the generic in-sync check compares the recorded follower offset against this leader's
+   * local high watermark. A consolidating leader advances that watermark to the diskless frontier,
+   * which a follower must never replicate over the inter-broker path, so the follower cannot reach it
+   * and never joins the ISR. Reaching the seal is the whole evidence a switched partition needs: the
+   * records below it are the only ones replicated from this leader.
+   *
+   * @param seal the partition's classicToDisklessStartOffset, which the caller has already confirmed
+   *             the follower reached.
+   */
+  private[kafka] def maybeExpandIsrAtSeal(followerReplica: Replica, seal: Long): Unit = {
+    def caughtUpToSeal: Boolean =
+      leaderLogIfLocal.isDefined &&
+        canAddReplicaToIsr(followerReplica.brokerId) &&
+        followerReplica.stateSnapshot.logEndOffset >= seal
+
+    val needsIsrUpdate = !partitionState.isInflight &&
+      canAddReplicaToIsr(followerReplica.brokerId) &&
+      inReadLock(leaderIsrUpdateLock) { caughtUpToSeal }
+    if (needsIsrUpdate) {
+      val alterIsrUpdateOpt = inWriteLock(leaderIsrUpdateLock) {
+        partitionState match {
+          case currentState: CommittedPartitionState if caughtUpToSeal =>
+            Some(prepareIsrExpand(currentState, followerReplica.brokerId))
+          case _ =>
+            None
+        }
+      }
+      // Submitted outside the lock, as maybeExpandIsr does: completion may increment the high
+      // watermark and complete delayed operations.
+      alterIsrUpdateOpt.foreach(submitAlterPartition)
+    }
+  }
+
   private def canAddReplicaToIsr(followerReplicaId: Int): Boolean = {
     val current = partitionState
     !current.isInflight &&
@@ -1477,6 +1513,30 @@ class Partition(val topicPartition: TopicPartition,
         readFromLocalLog(localLog)
       }
     }
+  }
+
+  /**
+   * Records an assigned follower's actual position after the classic prefix has expired.
+   *
+   * Once the leader's logical start is past the switch seal, epoch lineage below that start no
+   * longer proves classic-prefix ownership. The caller uses this validation only when the follower's
+   * requested offset is also below the retained range, then admits against the seal separately.
+   */
+  private[kafka] def recordFollowerFetchAfterClassicPrefixExpired(
+    fetchParams: FetchParams,
+    fetchPartitionData: FetchRequest.PartitionData,
+    fetchTimeMs: Long
+  ): Replica = inReadLock(leaderIsrUpdateLock) {
+    val localLog = localLogWithEpochOrThrow(fetchPartitionData.currentLeaderEpoch, requireLeader = true)
+    val replica = followerReplicaOrThrow(fetchParams.replicaId, fetchPartitionData)
+    replica.updateFetchStateOrThrow(
+      new LogOffsetMetadata(fetchPartitionData.fetchOffset),
+      fetchPartitionData.logStartOffset,
+      fetchTimeMs,
+      localLog.logEndOffset,
+      fetchParams.replicaEpoch
+    )
+    replica
   }
 
   private def followerReplicaOrThrow(

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -1032,6 +1032,42 @@ class Partition(val topicPartition: TopicPartition,
     canAddReplicaToIsr(followerReplica.brokerId) && isFollowerInSync(followerReplica)
   }
 
+  /**
+   * Expands the ISR for a switched diskless partition on the evidence of a follower fetch at the seal.
+   *
+   * Inkless: the generic in-sync check compares the recorded follower offset against this leader's
+   * local high watermark. A consolidating leader advances that watermark to the diskless frontier,
+   * which a follower must never replicate over the inter-broker path, so the follower cannot reach it
+   * and never joins the ISR. Reaching the seal is the whole evidence a switched partition needs: the
+   * records below it are the only ones replicated from this leader.
+   *
+   * @param seal the partition's classicToDisklessStartOffset, which the caller has already confirmed
+   *             the follower reached.
+   */
+  private[kafka] def maybeExpandIsrAtSeal(followerReplica: Replica, seal: Long): Unit = {
+    def caughtUpToSeal: Boolean =
+      leaderLogIfLocal.isDefined &&
+        canAddReplicaToIsr(followerReplica.brokerId) &&
+        followerReplica.stateSnapshot.logEndOffset >= seal
+
+    val needsIsrUpdate = !partitionState.isInflight &&
+      canAddReplicaToIsr(followerReplica.brokerId) &&
+      inReadLock(leaderIsrUpdateLock, () => caughtUpToSeal)
+    if (needsIsrUpdate) {
+      val alterIsrUpdateOpt = inWriteLock(leaderIsrUpdateLock, () => {
+        partitionState match {
+          case currentState: CommittedPartitionState if caughtUpToSeal =>
+            Some(prepareIsrExpand(currentState, followerReplica.brokerId))
+          case _ =>
+            None
+        }
+      })
+      // Submitted outside the lock, as maybeExpandIsr does: completion may increment the high
+      // watermark and complete delayed operations.
+      alterIsrUpdateOpt.foreach(submitAlterPartition)
+    }
+  }
+
   private def canAddReplicaToIsr(followerReplicaId: Int): Boolean = {
     val current = partitionState
     !current.isInflight &&
@@ -1479,6 +1515,90 @@ class Partition(val topicPartition: TopicPartition,
       })
     }
   }
+
+  /**
+   * Validates a follower fetch at the classic-to-diskless seal and records the follower's position,
+   * without reading any records.
+   *
+   * Returns the diverging epoch when the offered epoch's lineage does not match this leader's, and
+   * nothing otherwise. Recording the follower's position does not admit it to ISR: the caller decides
+   * that separately from whether the offered epoch proves the classic prefix.
+   *
+   * The read path resolves lineage by reading at the seal, which throws once local retention has
+   * deleted the segment holding it even though the range is still retained in the remote tier. The
+   * leader epoch cache answers the same question without touching a segment, so this validates the
+   * same four things `fetchRecords` would -- leadership, leader epoch, replica assignment, and
+   * broker epoch -- plus lineage, for a range the leader no longer holds locally.
+   */
+  private[kafka] def validateFollowerFetchAtSeal(
+    fetchParams: FetchParams,
+    fetchPartitionData: FetchRequest.PartitionData,
+    fetchTimeMs: Long
+  ): Optional[FetchResponseData.EpochEndOffset] = inReadLock(leaderIsrUpdateLock, () => {
+    val localLog = localLogWithEpochOrThrow(fetchPartitionData.currentLeaderEpoch, requireLeader = true)
+    val fetchOffset = fetchPartitionData.fetchOffset
+    var divergingEpoch = Optional.empty[FetchResponseData.EpochEndOffset]()
+    fetchPartitionData.lastFetchedEpoch.ifPresent { fetchEpoch =>
+      val epochEndOffset = lastOffsetForLeaderEpoch(
+        fetchPartitionData.currentLeaderEpoch, fetchEpoch, fetchOnlyFromLeader = false)
+      val error = Errors.forCode(epochEndOffset.errorCode)
+      if (error != Errors.NONE) {
+        throw error.exception()
+      }
+      if (epochEndOffset.endOffset == UNDEFINED_EPOCH_OFFSET || epochEndOffset.leaderEpoch == UNDEFINED_EPOCH) {
+        throw new OffsetOutOfRangeException(s"Could not determine the end offset of the last fetched " +
+          s"epoch $fetchEpoch from the request for partition $topicPartition")
+      }
+      if (fetchOffset < localLog.logStartOffset) {
+        throw new OffsetOutOfRangeException(s"Received request for offset $fetchOffset for partition " +
+          s"$topicPartition, but we only have log segments in the range ${localLog.logStartOffset} " +
+          s"to ${localLog.logEndOffset}.")
+      }
+      if (epochEndOffset.leaderEpoch < fetchEpoch || epochEndOffset.endOffset < fetchOffset) {
+        divergingEpoch = Optional.of(new FetchResponseData.EpochEndOffset()
+          .setEpoch(epochEndOffset.leaderEpoch)
+          .setEndOffset(epochEndOffset.endOffset))
+      }
+    }
+    if (!divergingEpoch.isPresent) {
+      // Every request is validated whether or not it proves the prefix, matching the read path: a
+      // request from a replica this leader does not have, or from a stale broker incarnation, is
+      // rejected rather than answered. The broker epoch is only checked while recording.
+      val replica = followerReplicaOrThrow(fetchParams.replicaId, fetchPartitionData)
+      replica.updateFetchStateOrThrow(
+        new LogOffsetMetadata(fetchOffset),
+        fetchPartitionData.logStartOffset,
+        fetchTimeMs,
+        localLog.logEndOffset,
+        fetchParams.replicaEpoch
+      )
+    }
+    divergingEpoch
+  })
+
+  /**
+   * Records an assigned follower's actual position after the classic prefix has expired.
+   *
+   * Once the leader's logical start has reached the switch seal, no retained record carries a classic
+   * epoch, so lineage proves nothing about prefix ownership and comparing it would only truncate a
+   * consolidated suffix the follower may keep. The caller admits against the seal separately.
+   */
+  private[kafka] def recordFollowerFetchAfterClassicPrefixExpired(
+    fetchParams: FetchParams,
+    fetchPartitionData: FetchRequest.PartitionData,
+    fetchTimeMs: Long
+  ): Replica = inReadLock(leaderIsrUpdateLock, () => {
+    val localLog = localLogWithEpochOrThrow(fetchPartitionData.currentLeaderEpoch, requireLeader = true)
+    val replica = followerReplicaOrThrow(fetchParams.replicaId, fetchPartitionData)
+    replica.updateFetchStateOrThrow(
+      new LogOffsetMetadata(fetchPartitionData.fetchOffset),
+      fetchPartitionData.logStartOffset,
+      fetchTimeMs,
+      localLog.logEndOffset,
+      fetchParams.replicaEpoch
+    )
+    replica
+  })
 
   private def followerReplicaOrThrow(
     replicaId: Int,

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -1062,7 +1062,7 @@ class Partition(val topicPartition: TopicPartition,
             None
         }
       })
-      // Submitted outside the lock, as maybeExpandIsr does: completion may increment the high
+      // Submitted outside the lock, as `maybeExpandIsr` does: completion may increment the high
       // watermark and complete delayed operations.
       alterIsrUpdateOpt.foreach(submitAlterPartition)
     }

--- a/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
@@ -119,9 +119,10 @@ class ReplicaFetcherThread(name: String,
 
   /**
    * Whether the eviction check in processPartitionData should mark fully-switched partitions
-   * for removal. The classic ReplicaFetcherThread enables this (so it self-evicts at the seal
-   * and hands off to consolidation). The ConsolidationFetcherThread disables it because it
-   * intentionally fetches for already-switched partitions.
+   * for removal. The classic ReplicaFetcherThread enables this, so it hands off to consolidation
+   * once the replica is at the seal and back in ISR.
+   * The ConsolidationFetcherThread disables it because it intentionally fetches for
+   * already-switched partitions.
    */
 
   protected def shouldEvictFullySwitchedDisklessPartitions: Boolean = true

--- a/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
@@ -17,11 +17,12 @@
 
 package kafka.server
 
+import kafka.utils.CoreUtils.inLock
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.requests.FetchResponse
 import org.apache.kafka.server.common.OffsetAndEpoch
 import org.apache.kafka.storage.internals.log.{LogAppendInfo, LogStartOffsetIncrementReason}
-import org.apache.kafka.server.LeaderEndPoint
+import org.apache.kafka.server.{LeaderEndPoint, PartitionFetchState}
 
 import java.util.Optional
 import scala.collection.mutable
@@ -68,6 +69,16 @@ class ReplicaFetcherThread(name: String,
 
   override protected def endOffsetForEpoch(topicPartition: TopicPartition, epoch: Int): Optional[OffsetAndEpoch] = {
     replicaMgr.localLogOrException(topicPartition).endOffsetForEpoch(epoch)
+  }
+
+  // Never hold partitionMapLock across replicaFetcherManager or consolidationFetcherManager calls:
+  // their monitors lead back to this thread. replicaAlterLogDirsManager reaches a different thread.
+  override def removePartitions(
+    topicPartitions: scala.collection.Set[TopicPartition]
+  ): scala.collection.Map[TopicPartition, PartitionFetchState] = inLock(partitionMapLock) {
+    val removed = super.removePartitions(topicPartitions)
+    partitionsAwaitingIsrRecovery --= topicPartitions
+    removed
   }
 
   override def initiateShutdown(): Boolean = {
@@ -172,23 +183,24 @@ class ReplicaFetcherThread(name: String,
     if (shouldRecordReplicationBytesIn)
       brokerTopicStats.updateReplicationBytesIn(records.sizeInBytes)
 
-    // Stop fetching once the switch is complete: seal is committed, local LEO has reached it,
-    // and this replica is in ISR. A consolidating partition evicts without waiting for ISR so
-    // it can hand off to the consolidation fetcher.
+    // Stop fetching once the switch is complete: the seal is committed, the local log end offset has
+    // reached it, and this replica is in ISR.
     val inklessMetadataView = replicaMgr.inklessMetadataView()
     val classicToDisklessStartOffset = inklessMetadataView.getClassicToDisklessStartOffset(topicPartition)
-    def isConsolidatingPartition: Boolean =
-      brokerConfig.disklessRemoteStorageConsolidationEnabled &&
-        inklessMetadataView.isConsolidatingDisklessTopic(topicPartition.topic)
     if (shouldEvictFullySwitchedDisklessPartitions &&
         classicToDisklessStartOffset >= 0 &&
         log.logEndOffset >= classicToDisklessStartOffset) {
-      if (isConsolidatingPartition || inklessMetadataView.isReplicaInIsr(topicPartition, brokerConfig.brokerId)) {
+      if (inklessMetadataView.isReplicaInIsr(topicPartition, brokerConfig.brokerId)) {
         partitionsToEvictAfterDisklessSwitch += topicPartition
       } else {
-        // The leader answers this fetch from immediateFetchResponses and does not park it
-        // in the fetch purgatory, so maxWaitMs is ignored. Delay here or we re-fetch at
-        // network rate until the ISR expansion lands.
+        // A replica outside ISR keeps fetching until the leader observes the catch-up. The leader
+        // records the offset carried by the fetch request, not the log end offset after the append,
+        // so it sees this replica at the seal only on the following fetch.
+        // A consolidating partition waits here too: once it hands off, the consolidation fetcher
+        // reads object storage and sends no fetch to the leader, so no other path expands ISR.
+        // The leader answers this fetch from `immediateFetchResponses` and does not park it in the
+        // fetch purgatory, so `maxWaitMs` is ignored. Delay here to avoid refetching at network rate
+        // until the ISR expansion lands.
         partitionsAwaitingIsrRecovery += topicPartition
       }
     }
@@ -206,9 +218,12 @@ class ReplicaFetcherThread(name: String,
   // Visible for testing. Must run from doWork, not processPartitionData: processFetchRequest
   // overwrites fetch state right after processPartitionData and would drop an inline delay.
   private[server] def backOffPartitionsAwaitingIsrRecovery(): Unit = {
-    if (partitionsAwaitingIsrRecovery.nonEmpty) {
-      val toDelay = partitionsAwaitingIsrRecovery.toSet
+    val toDelay = inLock(partitionMapLock) {
+      val pending = partitionsAwaitingIsrRecovery.toSet
       partitionsAwaitingIsrRecovery.clear()
+      pending
+    }
+    if (toDelay.nonEmpty) {
       delayPartitions(toDelay, brokerConfig.replicaFetchBackoffMs.toLong)
     }
   }

--- a/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
@@ -55,8 +55,32 @@ class ReplicaFetcherThread(name: String,
   // At the seal but not yet in metadata ISR, so we cannot evict. Visible for testing.
   private[server] val partitionsAwaitingIsrRecovery = mutable.Buffer[TopicPartition]()
 
+  /**
+   * Returns the epoch this follower offers the leader for the divergence check.
+   *
+   * A switched follower at or above the seal offers the epoch of its last classic record instead of
+   * its latest epoch. Above the seal the latest epoch is the diskless one, stamped on records that
+   * came from object storage rather than from this leader, so checking it proves the suffix resolves
+   * in the leader's cache and says nothing about the classic prefix. The prefix is what ISR
+   * membership vouches for, and the boundary epoch is what the leader can check against its own
+   * history. Below the seal, or once the prefix has left the local log, the latest epoch applies.
+   *
+   * Only the classic fetcher does this. The consolidation fetcher inherits this method, and its
+   * endpoint answers any epoch below the diskless one with the seal, so offering the boundary epoch
+   * there would truncate the consolidated suffix on every start.
+   */
   override protected def latestEpoch(topicPartition: TopicPartition): Optional[Integer] = {
-    replicaMgr.localLogOrException(topicPartition).latestEpoch
+    val log = replicaMgr.localLogOrException(topicPartition)
+    if (!shouldEvictFullySwitchedDisklessPartitions) return log.latestEpoch
+    val inklessMetadataView = replicaMgr.inklessMetadataView()
+    if (!inklessMetadataView.isDisklessTopic(topicPartition.topic)) return log.latestEpoch
+    val seal = inklessMetadataView.getClassicToDisklessStartOffset(topicPartition)
+    if (seal > 0 && log.logEndOffset >= seal && log.logStartOffset < seal) {
+      val boundaryEpoch = log.leaderEpochCache.epochForOffset(seal - 1)
+      if (boundaryEpoch.isPresent) Optional.of(Integer.valueOf(boundaryEpoch.getAsInt)) else log.latestEpoch
+    } else {
+      log.latestEpoch
+    }
   }
 
   override protected def logStartOffset(topicPartition: TopicPartition): Long = {

--- a/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
@@ -20,8 +20,9 @@ package kafka.server
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.requests.FetchResponse
 import org.apache.kafka.server.common.OffsetAndEpoch
+import org.apache.kafka.server.util.LockUtils
 import org.apache.kafka.storage.internals.log.{LogAppendInfo, LogStartOffsetIncrementReason}
-import org.apache.kafka.server.LeaderEndPoint
+import org.apache.kafka.server.{LeaderEndPoint, PartitionFetchState}
 
 import java.util.Optional
 import scala.collection.mutable
@@ -80,6 +81,21 @@ class ReplicaFetcherThread(name: String,
       replicaEndOffset == 0 &&
       leaderEndOffset != 0
   }
+
+  // Never hold partitionMapLock across replicaFetcherManager or consolidationFetcherManager calls:
+  // their monitors lead back to this thread. replicaAlterLogDirsManager reaches a different thread.
+  override def removePartitions(
+    topicPartitions: scala.collection.Set[TopicPartition]
+  ): scala.collection.Map[TopicPartition, PartitionFetchState] =
+    LockUtils.inLock(partitionMapLock, () => {
+      val removed = super.removePartitions(topicPartitions)
+      partitionsAwaitingIsrRecovery --= topicPartitions
+      // Deferred work must not outlive the fetcher assignment it was queued for. An ISR-only
+      // delta can remove and re-add a partition here, and a stale eviction would hand the
+      // re-added partition to the consolidation fetcher while the replica sits outside ISR.
+      partitionsToEvictAfterDisklessSwitch --= topicPartitions
+      removed
+    })
 
   override def initiateShutdown(): Boolean = {
     val justShutdown = super.initiateShutdown()
@@ -183,23 +199,24 @@ class ReplicaFetcherThread(name: String,
     if (shouldRecordReplicationBytesIn)
       brokerTopicStats.updateReplicationBytesIn(records.sizeInBytes)
 
-    // Stop fetching once the switch is complete: seal is committed, local LEO has reached it,
-    // and this replica is in ISR. A consolidating partition evicts without waiting for ISR so
-    // it can hand off to the consolidation fetcher.
+    // Stop fetching once the switch is complete: the seal is committed, the local log end offset has
+    // reached it, and this replica is in ISR.
     val inklessMetadataView = replicaMgr.inklessMetadataView()
     val classicToDisklessStartOffset = inklessMetadataView.getClassicToDisklessStartOffset(topicPartition)
-    def isConsolidatingPartition: Boolean =
-      brokerConfig.disklessRemoteStorageConsolidationEnabled &&
-        inklessMetadataView.isConsolidatingDisklessTopic(topicPartition.topic)
     if (shouldEvictFullySwitchedDisklessPartitions &&
         classicToDisklessStartOffset >= 0 &&
         log.logEndOffset >= classicToDisklessStartOffset) {
-      if (isConsolidatingPartition || inklessMetadataView.isReplicaInIsr(topicPartition, brokerConfig.brokerId)) {
+      if (inklessMetadataView.isReplicaInIsr(topicPartition, brokerConfig.brokerId)) {
         partitionsToEvictAfterDisklessSwitch += topicPartition
       } else {
-        // The leader answers this fetch from immediateFetchResponses and does not park it
-        // in the fetch purgatory, so maxWaitMs is ignored. Delay here or we re-fetch at
-        // network rate until the ISR expansion lands.
+        // A replica outside ISR keeps fetching until the leader observes the catch-up. The leader
+        // records the offset carried by the fetch request, not the log end offset after the append,
+        // so it sees this replica at the seal only on the following fetch.
+        // A consolidating partition waits here too: once it hands off, the consolidation fetcher
+        // reads object storage and sends no fetch to the leader, so no other path expands ISR.
+        // The leader answers this fetch from `immediateFetchResponses` and does not park it in the
+        // fetch purgatory, so `maxWaitMs` is ignored. Delay here to avoid refetching at network rate
+        // until the ISR expansion lands.
         partitionsAwaitingIsrRecovery += topicPartition
       }
     }
@@ -217,21 +234,36 @@ class ReplicaFetcherThread(name: String,
   // Visible for testing. Must run from doWork, not processPartitionData: processFetchRequest
   // overwrites fetch state right after processPartitionData and would drop an inline delay.
   private[server] def backOffPartitionsAwaitingIsrRecovery(): Unit = {
-    if (partitionsAwaitingIsrRecovery.nonEmpty) {
-      val toDelay = partitionsAwaitingIsrRecovery.toSet
-      partitionsAwaitingIsrRecovery.clear()
-      delayPartitions(toDelay, brokerConfig.replicaFetchBackoffMs.toLong)
-    }
+    LockUtils.inLock[Exception](partitionMapLock, () => {
+      if (partitionsAwaitingIsrRecovery.nonEmpty) {
+        // Delay inside the lock so a remove and re-add cannot pass this backoff to the re-added
+        // partition. partitionMapLock is reentrant and delayPartitions reaches no fetcher manager.
+        delayPartitions(partitionsAwaitingIsrRecovery.toSet, brokerConfig.replicaFetchBackoffMs.toLong)
+        partitionsAwaitingIsrRecovery.clear()
+      }
+    })
   }
 
-  private def evictFullySwitchedDisklessPartitions(): Unit = {
-    if (partitionsToEvictAfterDisklessSwitch.nonEmpty) {
-      val toEvict = partitionsToEvictAfterDisklessSwitch.toSet
+  // Visible for testing.
+  private[server] def evictFullySwitchedDisklessPartitions(): Unit = {
+    // Drain under the lock, since removePartitions discards queued evictions from other threads.
+    // The manager calls stay outside it, per the note on removePartitions.
+    val toEvict = LockUtils.inLock(partitionMapLock, () => {
+      val pending = partitionsToEvictAfterDisklessSwitch.toSet
       partitionsToEvictAfterDisklessSwitch.clear()
+      pending
+    })
+    // Re-read ISR after the drain. partitionMapLock cannot cover the manager calls below, so an
+    // ISR-shrink delta can land here and re-add the partition to this fetcher; removing it again
+    // right after would strand it. The reconciler re-checks as well, so a delta landing after
+    // this filter cannot start consolidation outside ISR.
+    val stillEligible = toEvict.filter(tp =>
+      replicaMgr.inklessMetadataView().isReplicaInIsr(tp, brokerConfig.brokerId))
+    if (stillEligible.nonEmpty) {
       info(s"Evicting partitions from this replica fetcher because they have completed the " +
-        s"classic-to-diskless switch and the local log has caught up to the seal offset: $toEvict")
-      replicaMgr.replicaFetcherManager.removeFetcherForPartitions(toEvict)
-      replicaMgr.startConsolidationFetchersForCaughtUpClassicPartitions(toEvict)
+        s"classic-to-diskless switch and the local log has caught up to the seal offset: $stillEligible")
+      replicaMgr.replicaFetcherManager.removeFetcherForPartitions(stillEligible)
+      replicaMgr.startConsolidationFetchersForCaughtUpClassicPartitions(stillEligible)
     }
   }
 

--- a/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
@@ -106,8 +106,8 @@ class ReplicaFetcherThread(name: String,
       leaderEndOffset != 0
   }
 
-  // Never hold partitionMapLock across replicaFetcherManager or consolidationFetcherManager calls:
-  // their monitors lead back to this thread. replicaAlterLogDirsManager reaches a different thread.
+  // Never hold `partitionMapLock` across `replicaFetcherManager` or `consolidationFetcherManager` calls:
+  // their monitors lead back to this thread. `replicaAlterLogDirsManager` reaches a different thread.
   override def removePartitions(
     topicPartitions: scala.collection.Set[TopicPartition]
   ): scala.collection.Map[TopicPartition, PartitionFetchState] =
@@ -159,9 +159,10 @@ class ReplicaFetcherThread(name: String,
 
   /**
    * Whether the eviction check in processPartitionData should mark fully-switched partitions
-   * for removal. The classic ReplicaFetcherThread enables this (so it self-evicts at the seal
-   * and hands off to consolidation). The ConsolidationFetcherThread disables it because it
-   * intentionally fetches for already-switched partitions.
+   * for removal. The classic ReplicaFetcherThread enables this, so it hands off to consolidation
+   * once the replica is at the seal and back in ISR.
+   * The ConsolidationFetcherThread disables it because it intentionally fetches for
+   * already-switched partitions.
    */
 
   protected def shouldEvictFullySwitchedDisklessPartitions: Boolean = true
@@ -261,7 +262,7 @@ class ReplicaFetcherThread(name: String,
     LockUtils.inLock[Exception](partitionMapLock, () => {
       if (partitionsAwaitingIsrRecovery.nonEmpty) {
         // Delay inside the lock so a remove and re-add cannot pass this backoff to the re-added
-        // partition. partitionMapLock is reentrant and delayPartitions reaches no fetcher manager.
+        // partition. `partitionMapLock` is reentrant and `delayPartitions` reaches no fetcher manager.
         delayPartitions(partitionsAwaitingIsrRecovery.toSet, brokerConfig.replicaFetchBackoffMs.toLong)
         partitionsAwaitingIsrRecovery.clear()
       }
@@ -270,14 +271,14 @@ class ReplicaFetcherThread(name: String,
 
   // Visible for testing.
   private[server] def evictFullySwitchedDisklessPartitions(): Unit = {
-    // Drain under the lock, since removePartitions discards queued evictions from other threads.
-    // The manager calls stay outside it, per the note on removePartitions.
+    // Drain under the lock, since `removePartitions` discards queued evictions from other threads.
+    // The manager calls stay outside it, per the note on `removePartitions`.
     val toEvict = LockUtils.inLock(partitionMapLock, () => {
       val pending = partitionsToEvictAfterDisklessSwitch.toSet
       partitionsToEvictAfterDisklessSwitch.clear()
       pending
     })
-    // Re-read ISR after the drain. partitionMapLock cannot cover the manager calls below, so an
+    // Re-read ISR after the drain. `partitionMapLock` cannot cover the manager calls below, so an
     // ISR-shrink delta can land here and re-add the partition to this fetcher; removing it again
     // right after would strand it. The reconciler re-checks as well, so a delta landing after
     // this filter cannot start consolidation outside ISR.

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -3879,13 +3879,23 @@ class ReplicaManager(val config: KafkaConfig,
    *    that the whole classic prefix has been replicated locally; while below the seal it stays on
    *    the classic fetcher, which self-evicts and hands off to consolidation at the seal.
    * Non-consolidating topics are never routed to the consolidation fetcher.
+   *
+   * A follower sitting exactly at the seal and outside ISR is held back, because the consolidation
+   * fetcher reads object storage and sends no fetch to the leader, so the leader would never observe
+   * the catch-up and nothing would expand ISR. The classic fetcher waits at the seal instead until the
+   * leader records the position, then evicts and hands off. Only LEO == seal qualifies: past the seal
+   * the local latest epoch is the diskless one, which the classic fetcher's divergence check against
+   * the leader's epoch cache is not built for.
    */
   private def isReadyForConsolidation(tp: TopicPartition, partition: Partition): Boolean = {
     if (!_inklessMetadataView.isConsolidatingDisklessTopic(tp.topic)) return false
     _inklessMetadataView.getClassicToDisklessStartOffset(tp) match {
       case PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET => true
       case PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING => false
-      case committedSeal => partition.localLogOrException.logEndOffset >= committedSeal
+      case committedSeal =>
+        val logEndOffset = partition.localLogOrException.logEndOffset
+        if (logEndOffset < committedSeal) false
+        else partition.isLeader || _inklessMetadataView.isReplicaInIsr(tp, config.brokerId)
     }
   }
 
@@ -4206,15 +4216,20 @@ class ReplicaManager(val config: KafkaConfig,
             val partitionAssignedDirectoryId = directoryIds.find(_._1.topicPartition() == tp).map(_._2)
             val isNewLeaderEpoch = partition.makeFollower(info.partition, isNew, offsetCheckpoints, Some(info.topicId), partitionAssignedDirectoryId)
 
+            val switchedConsolidatingReplicaOutsideIsr =
+              isConsolidatingDisklessTopic &&
+                _inklessMetadataView.getClassicToDisklessStartOffset(tp) >= 0 &&
+                !info.partition.isr.contains(config.brokerId)
+
             if (isInControlledShutdown && (info.partition.leader == NO_LEADER ||
               !info.partition.isr.contains(config.brokerId))) {
               // During controlled shutdown, replica with no leaders and replica
               // where this broker is not in the ISR are stopped.
               partitionsToStopFetching.put(tp, false)
-            } else if (isNewLeaderEpoch) {
-              // Invoke the follower transition listeners for the partition.
-              partition.invokeOnBecomingFollowerListeners()
-              // Otherwise, fetcher is restarted if the leader epoch has changed.
+            } else if (isNewLeaderEpoch || switchedConsolidatingReplicaOutsideIsr) {
+              if (isNewLeaderEpoch) {
+                partition.invokeOnBecomingFollowerListeners()
+              }
               partitionsToStartFetching.put(tp, partition)
             }
 
@@ -4267,8 +4282,8 @@ class ReplicaManager(val config: KafkaConfig,
       val (consolidatingDisklessPartitionsToStartFetching, classicPartitionsToStartFetching) = partitionsToStartFetching.partition { case (tp, partition) =>
         isReadyForConsolidation(tp, partition)
       }
-      replicaFetcherManager.removeFetcherForPartitions(classicPartitionsToStartFetching.keySet)
-      consolidationFetcherManager.foreach(_.removeFetcherForPartitions(consolidatingDisklessPartitionsToStartFetching.keySet))
+      replicaFetcherManager.removeFetcherForPartitions(partitionsToStartFetching.keySet)
+      consolidationFetcherManager.foreach(_.removeFetcherForPartitions(partitionsToStartFetching.keySet))
       stateChangeLogger.info(s"Stopped fetchers as part of become-follower for ${partitionsToStartFetching.size} partitions")
 
       val listenerName = config.interBrokerListenerName.value

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -2532,10 +2532,9 @@ class ReplicaManager(val config: KafkaConfig,
           if (params.isFromFollower && disklessSwitchCompleted) {
             var fetchError = Errors.NONE
             var divergingEpoch = Optional.empty[FetchResponseData.EpochEndOffset]
-            // A recovered follower for a switched partition may already be caught up to the
-            // seal offset but still be outside ISR. Record the seal-offset fetch so the normal
-            // ISR expansion path can observe that the follower is caught up without reading
-            // diskless data into the local log.
+            // A recovered follower for a switched partition may already hold the whole classic
+            // prefix but sit outside ISR. Validate the fetch at the seal so replica state tracks the
+            // follower, without reading diskless data into its local log.
             if (fetchPartitionData.fetchOffset >= classicToDisklessStartOffset) {
               getPartitionOrError(tp.topicPartition) match {
                 case Right(partition) =>
@@ -2603,7 +2602,7 @@ class ReplicaManager(val config: KafkaConfig,
             // The partition has fully switched to diskless and the follower is asking for an offset at or beyond it.
             // Followers must never replicate diskless records into their local log.
             // Empty records and HW at the seal offset make the follower treat the local log as caught up.
-            // ReplicaFetcherThread evicts once this replica is in ISR, or immediately if consolidating.
+            // ReplicaFetcherThread evicts once this replica is in ISR.
             // logStartOffset=0 is a no-op for the follower (maybeIncrementLogStartOffset only ever advances),
             // so classic local data stays in place and can still serve consumer reads.
             immediateFetchResponses += tp ->
@@ -3907,15 +3906,17 @@ class ReplicaManager(val config: KafkaConfig,
    *    fetcher until the controller commits the seal;
    *  - switched (seal >= 0): only consolidate once the local LEO has reached the committed seal, so
    *    that the whole classic prefix has been replicated locally; while below the seal it stays on
-   *    the classic fetcher, which self-evicts and hands off to consolidation at the seal.
+   *    the classic fetcher, which hands off to consolidation once the leader has admitted it back
+   *    to ISR.
    * Non-consolidating topics are never routed to the consolidation fetcher.
    *
-   * A follower sitting exactly at the seal and outside ISR is held back, because the consolidation
-   * fetcher reads object storage and sends no fetch to the leader, so the leader would never observe
-   * the catch-up and nothing would expand ISR. The classic fetcher waits at the seal instead until the
-   * leader records the position, then evicts and hands off. Only LEO == seal qualifies: past the seal
-   * the local latest epoch is the diskless one, which the classic fetcher's divergence check against
-   * the leader's epoch cache is not built for.
+   * A follower at or above the seal and outside ISR is held back, because the consolidation fetcher
+   * reads object storage and sends no fetch to the leader, so the leader would never observe the
+   * catch-up and nothing would expand ISR. The classic fetcher waits instead until the leader admits
+   * the replica back to ISR, then evicts and hands off. A replica that already consolidated past the
+   * seal keeps its diskless suffix while it waits: the fetcher starts at the real log end offset, and
+   * the diskless epoch it reports resolves in the leader's epoch cache whenever the leader has
+   * consolidated at least as far.
    */
   private def isReadyForConsolidation(tp: TopicPartition, partition: Partition): Boolean = {
     if (!_inklessMetadataView.isConsolidatingDisklessTopic(tp.topic)) return false
@@ -4305,8 +4306,9 @@ class ReplicaManager(val config: KafkaConfig,
       // A consolidating diskless follower only joins the consolidation fetcher once its local log
       // has replicated the entire classic prefix (LEO >= committed seal). While the switch is still
       // pending or the log is below the seal, it must stay on the classic ReplicaFetcher so it can
-      // catch up from the leader; that fetcher self-evicts at the seal and hands the partition off
-      // to the consolidation reconciler (startConsolidationFetchersForCaughtUpClassicPartitions).
+      // catch up from the leader; that fetcher hands the partition off to the consolidation
+      // reconciler (startConsolidationFetchersForCaughtUpClassicPartitions) once the local log
+      // reaches the seal and the leader has admitted the replica back to ISR.
       // Routing a below-seal/pending partition straight to the reconciler would strand it: the
       // reconciler returns Retry and no classic fetcher would ever bring it up to the seal.
       val (consolidatingDisklessPartitionsToStartFetching, classicPartitionsToStartFetching) = partitionsToStartFetching.partition { case (tp, partition) =>

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -2469,6 +2469,14 @@ class ReplicaManager(val config: KafkaConfig,
               // few deleted records may survive until it refreshes.
               val mayServeFromFollowerLocalLog =
                 params.isFromConsumer && !partition.isLeader
+              // On a consolidating leader the local log end offset is the consolidated frontier, well
+              // past the seal, so a follower fetch at the seal would otherwise read the consolidated
+              // suffix from the local log. That ships diskless records over the inter-broker path and
+              // defers ISR admission until the follower matches the frontier. Such a fetch belongs to
+              // the at-seal branch, which answers empty with the high watermark clamped to the seal.
+              val followerAtOrAboveSeal =
+                params.isFromFollower && classicToDisklessStartOffset >= 0 &&
+                  fetchPartitionData.fetchOffset >= classicToDisklessStartOffset
               val crossTierEarliest =
                 if (mayServeFromFollowerLocalLog) crossTierEarliestOffset(tp.topicPartition())
                 else OptionalLong.empty()
@@ -2485,7 +2493,7 @@ class ReplicaManager(val config: KafkaConfig,
                   false
                 )
                 partitionLookupFailed = true
-              } else if (fetchPartitionData.fetchOffset < logEndOffset) {
+              } else if (fetchPartitionData.fetchOffset < logEndOffset && !followerAtOrAboveSeal) {
                 // Local log has data for this offset range — serve from local, track for diskless supplement
                 shouldReadFromUnifiedLog = true
                 // Skip supplement tracking when the fetch offset falls in the tiered-storage range

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -2540,24 +2540,54 @@ class ReplicaManager(val config: KafkaConfig,
               getPartitionOrError(tp.topicPartition) match {
                 case Right(partition) =>
                   try {
-                    // Use the classic follower-read validation without returning any records.
-                    val fetchAtSeal = new PartitionData(
-                      fetchPartitionData.topicId,
-                      classicToDisklessStartOffset,
-                      fetchPartitionData.logStartOffset,
-                      0,
-                      fetchPartitionData.currentLeaderEpoch,
-                      fetchPartitionData.lastFetchedEpoch
-                    )
-                    val readInfo = partition.fetchRecords(
-                      fetchParams = params,
-                      fetchPartitionData = fetchAtSeal,
-                      fetchTimeMs = time.milliseconds,
-                      maxBytes = 0,
-                      minOneMessage = false,
-                      updateFetchState = true
-                    )
-                    divergingEpoch = readInfo.divergingEpoch
+                    // A leader below the seal is rebuilding its classic prefix and cannot safely
+                    // validate an intact follower against its incomplete epoch cache.
+                    val leaderLog = partition.localLogOrException
+                    if (leaderLog.logEndOffset >= classicToDisklessStartOffset) {
+                      if (leaderLog.logStartOffset > classicToDisklessStartOffset &&
+                          fetchPartitionData.fetchOffset < leaderLog.logStartOffset) {
+                        // The classic prefix has expired from the authoritative range, so its epoch
+                        // lineage no longer gates ISR membership. Record the follower's real offset
+                        // after validating leadership, assignment, and broker epoch.
+                        val follower = partition.recordFollowerFetchAfterClassicPrefixExpired(
+                          params, fetchPartitionData, time.milliseconds)
+                        partition.maybeExpandIsrAtSeal(follower, classicToDisklessStartOffset)
+                      } else {
+                        // Use the classic follower-read validation without returning any records.
+                        val validationOffset = if (leaderLog.logStartOffset > classicToDisklessStartOffset) {
+                          fetchPartitionData.fetchOffset
+                        } else {
+                          classicToDisklessStartOffset
+                        }
+                        val fetchAtSeal = new PartitionData(
+                          fetchPartitionData.topicId,
+                          validationOffset,
+                          fetchPartitionData.logStartOffset,
+                          0,
+                          fetchPartitionData.currentLeaderEpoch,
+                          fetchPartitionData.lastFetchedEpoch
+                        )
+                        val readInfo = partition.fetchRecords(
+                          fetchParams = params,
+                          fetchPartitionData = fetchAtSeal,
+                          fetchTimeMs = time.milliseconds,
+                          maxBytes = 0,
+                          minOneMessage = false,
+                          updateFetchState = true
+                        )
+                        divergingEpoch = readInfo.divergingEpoch
+                        if (!divergingEpoch.isPresent) {
+                          // Required: fetchRecords preserves earlier follower state on divergence, so
+                          // admission must depend on this fetch validating successfully.
+                          // Admit on the seal rather than on the generic in-sync check, which compares
+                          // against the leader's local high watermark. A consolidating leader holds that
+                          // watermark at the diskless frontier, so the follower could never reach it.
+                          partition.getReplica(params.replicaId).foreach { follower =>
+                            partition.maybeExpandIsrAtSeal(follower, classicToDisklessStartOffset)
+                          }
+                        }
+                      }
+                    }
                   } catch {
                     case NonFatal(e) =>
                       fetchError = Errors.forException(e)
@@ -3895,7 +3925,7 @@ class ReplicaManager(val config: KafkaConfig,
       case committedSeal =>
         val logEndOffset = partition.localLogOrException.logEndOffset
         if (logEndOffset < committedSeal) false
-        else partition.isLeader || _inklessMetadataView.isReplicaInIsr(tp, config.brokerId)
+        else _inklessMetadataView.isReplicaInIsr(tp, config.brokerId)
     }
   }
 

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -4024,13 +4024,23 @@ class ReplicaManager(val config: KafkaConfig,
    *    that the whole classic prefix has been replicated locally; while below the seal it stays on
    *    the classic fetcher, which self-evicts and hands off to consolidation at the seal.
    * Non-consolidating topics are never routed to the consolidation fetcher.
+   *
+   * A follower sitting exactly at the seal and outside ISR is held back, because the consolidation
+   * fetcher reads object storage and sends no fetch to the leader, so the leader would never observe
+   * the catch-up and nothing would expand ISR. The classic fetcher waits at the seal instead until the
+   * leader records the position, then evicts and hands off. Only LEO == seal qualifies: past the seal
+   * the local latest epoch is the diskless one, which the classic fetcher's divergence check against
+   * the leader's epoch cache is not built for.
    */
   private def isReadyForConsolidation(tp: TopicPartition, partition: Partition): Boolean = {
-    if (!_inklessMetadataView.isConsolidatingDisklessTopic(tp.topic)) return false
+    if (!consolidationActiveFor(tp.topic)) return false
     _inklessMetadataView.getClassicToDisklessStartOffset(tp) match {
       case PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET => true
       case PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING => false
-      case committedSeal => partition.localLogOrException.logEndOffset >= committedSeal
+      case committedSeal =>
+        val logEndOffset = partition.localLogOrException.logEndOffset
+        if (logEndOffset < committedSeal) false
+        else partition.isLeader || _inklessMetadataView.isReplicaInIsr(tp, config.brokerId)
     }
   }
 
@@ -4282,10 +4292,12 @@ class ReplicaManager(val config: KafkaConfig,
     val followerTopicSet = new mutable.HashSet[String]
     localFollowers.foreachEntry { (tp, info) =>
       val isConsolidatingDisklessTopic = consolidationActiveFor(tp.topic)
+      // Lazy: a classic follower never reads it, and the consolidating branch below is guarded by
+      // isConsolidatingDisklessTopic, so a diskless follower resolves the seal at most once.
+      lazy val seal = _inklessMetadataView.getClassicToDisklessStartOffset(tp)
       if (_inklessMetadataView.isDisklessTopic(tp.topic())) {
         // Clean up classic-to-diskless switch tracking since only the leader drives classic-to-diskless switch.
         initDisklessLogManager.foreach(_.removePartition(tp))
-        val seal = _inklessMetadataView.getClassicToDisklessStartOffset(tp)
         // Create the Partition (and a local log on the fly if missing) when either:
         //   (a) the broker already has classic data on disk -- typical post-restart case
         //       for a pre-existing replica; or
@@ -4347,15 +4359,20 @@ class ReplicaManager(val config: KafkaConfig,
             val partitionAssignedDirectoryId = directoryIds.find(_._1.topicPartition() == tp).map(_._2)
             val isNewLeaderEpoch = partition.makeFollower(info.partition, isNew, offsetCheckpoints, Some(info.topicId), partitionAssignedDirectoryId)
 
+            val switchedConsolidatingReplicaOutsideIsr =
+              isConsolidatingDisklessTopic &&
+                seal >= 0 &&
+                !info.partition.isr.contains(config.brokerId)
+
             if (isInControlledShutdown && (info.partition.leader == NO_LEADER ||
               !info.partition.isr.contains(config.brokerId))) {
               // During controlled shutdown, replica with no leaders and replica
               // where this broker is not in the ISR are stopped.
               partitionsToStopFetching.put(tp, false)
-            } else if (isNewLeaderEpoch) {
-              // Invoke the follower transition listeners for the partition.
-              partition.invokeOnBecomingFollowerListeners()
-              // Otherwise, fetcher is restarted if the leader epoch has changed.
+            } else if (isNewLeaderEpoch || switchedConsolidatingReplicaOutsideIsr) {
+              if (isNewLeaderEpoch) {
+                partition.invokeOnBecomingFollowerListeners()
+              }
               partitionsToStartFetching.put(tp, partition)
             }
 
@@ -4408,8 +4425,8 @@ class ReplicaManager(val config: KafkaConfig,
       val (consolidatingDisklessPartitionsToStartFetching, classicPartitionsToStartFetching) = partitionsToStartFetching.partition { case (tp, partition) =>
         isReadyForConsolidation(tp, partition)
       }
-      replicaFetcherManager.removeFetcherForPartitions(classicPartitionsToStartFetching.keySet)
-      consolidationFetcherManager.foreach(_.removeFetcherForPartitions(consolidatingDisklessPartitionsToStartFetching.keySet))
+      replicaFetcherManager.removeFetcherForPartitions(partitionsToStartFetching.keySet)
+      consolidationFetcherManager.foreach(_.removeFetcherForPartitions(partitionsToStartFetching.keySet))
       stateChangeLogger.info(s"Stopped fetchers as part of become-follower for ${partitionsToStartFetching.size} partitions")
 
       val listenerName = config.interBrokerListenerName.value

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -465,6 +465,16 @@ class ReplicaManager(val config: KafkaConfig,
   private def consolidationActiveFor(topic: String): Boolean =
     config.disklessRemoteStorageConsolidationEnabled && _inklessMetadataView.isConsolidatingDisklessTopic(topic)
 
+  /**
+   * Checks whether the epoch a follower offered at the seal is the one that ends there on this leader.
+   * True only when the epoch is present and the leader's log resolves it to an end offset at the seal;
+   * false otherwise.
+   */
+  private def offeredEpochEndsAtSeal(leaderLog: UnifiedLog, offered: Optional[Integer], seal: Long): Boolean =
+    offered.isPresent && leaderLog.endOffsetForEpoch(offered.get).toScala.exists { endOffsetAndEpoch =>
+      endOffsetAndEpoch.epoch == offered.get && endOffsetAndEpoch.offset == seal
+    }
+
   private[server] def disklessSwitchedReplicasOutsideIsrCount: Int = onlinePartitionsIterator.count { partition =>
     val topicPartition = partition.topicPartition
     val seal = _inklessMetadataView.getClassicToDisklessStartOffset(topicPartition)
@@ -2549,6 +2559,14 @@ class ReplicaManager(val config: KafkaConfig,
               // few deleted records may survive until it refreshes.
               val mayServeFromFollowerLocalLog =
                 params.isFromConsumer && !partition.isLeader
+              // On a consolidating leader the local log end offset is the consolidated frontier, well
+              // past the seal, so a follower fetch at the seal would otherwise read the consolidated
+              // suffix from the local log. That ships diskless records over the inter-broker path and
+              // defers ISR admission until the follower matches the frontier. Such a fetch belongs to
+              // the at-seal branch, which answers empty with the high watermark clamped to the seal.
+              val followerAtOrAboveSeal =
+                params.isFromFollower && classicToDisklessStartOffset >= 0 &&
+                  fetchPartitionData.fetchOffset >= classicToDisklessStartOffset
               val crossTierEarliest =
                 if (mayServeFromFollowerLocalLog) crossTierEarliestOffset(tp.topicPartition())
                 else OptionalLong.empty()
@@ -2565,7 +2583,7 @@ class ReplicaManager(val config: KafkaConfig,
                   false
                 )
                 partitionLookupFailed = true
-              } else if (fetchPartitionData.fetchOffset < readableFrontier) {
+              } else if (fetchPartitionData.fetchOffset < readableFrontier && !followerAtOrAboveSeal) {
                 shouldReadFromUnifiedLog = true
                 // Same population as isBelowSealAndAheadOfLocalLog: inside this branch only the seal
                 // can have raised the frontier. Keep the two in step. Marked here, not in the
@@ -2584,10 +2602,12 @@ class ReplicaManager(val config: KafkaConfig,
                   fetchPartitionData.fetchOffset < logEndOffset &&
                   localReadFrontier >= logEndOffset)
                   consolidatingLocalFetchSupplements += (tp -> logEndOffset)
-              } else if (!shouldReadFromUnifiedLog && fetchPartitionData.fetchOffset < logEndOffset) {
+              } else if (params.isFromConsumer && !shouldReadFromUnifiedLog &&
+                fetchPartitionData.fetchOffset < logEndOffset) {
                 // The local log holds this offset but cannot serve it, so this read goes to Inkless.
                 // A switch-pending partition is excluded because it was already routed to the local
-                // log above, and a follower cannot reach this branch: its frontier is LEO.
+                // log above. A follower reaches this branch only via followerAtOrAboveSeal, which
+                // routes it to the at-seal branch below rather than to Inkless.
                 consolidationHighWatermarkLagFetchRate.mark()
               }
               // else: the fetch is at or beyond the frontier and beyond the local log, so diskless
@@ -2628,24 +2648,52 @@ class ReplicaManager(val config: KafkaConfig,
               getPartitionOrError(tp.topicPartition) match {
                 case Right(partition) =>
                   try {
-                    // Use the classic follower-read validation without returning any records.
-                    val fetchAtSeal = new PartitionData(
-                      fetchPartitionData.topicId,
-                      classicToDisklessStartOffset,
-                      fetchPartitionData.logStartOffset,
-                      0,
-                      fetchPartitionData.currentLeaderEpoch,
-                      fetchPartitionData.lastFetchedEpoch
-                    )
-                    val readInfo = partition.fetchRecords(
-                      fetchParams = params,
-                      fetchPartitionData = fetchAtSeal,
-                      fetchTimeMs = time.milliseconds,
-                      maxBytes = 0,
-                      minOneMessage = false,
-                      updateFetchState = true
-                    )
-                    divergingEpoch = readInfo.divergingEpoch
+                    // A leader below the seal is rebuilding its classic prefix and cannot safely
+                    // validate an intact follower against its incomplete epoch cache.
+                    val leaderLog = partition.localLogOrException
+                    if (leaderLog.logEndOffset >= classicToDisklessStartOffset) {
+                      if (leaderLog.logStartOffset >= classicToDisklessStartOffset) {
+                        // No classic record is retained, so nothing about this fetch can prove the
+                        // prefix and nothing needs to. Every offset the leader still holds carries the
+                        // diskless epoch, and both replicas rebuild that range from object storage, so
+                        // comparing lineage there only truncates a suffix the follower may keep. Record
+                        // the follower's real offset after validating leadership, assignment, and broker
+                        // epoch.
+                        val follower = partition.recordFollowerFetchAfterClassicPrefixExpired(
+                          params, fetchPartitionData, time.milliseconds)
+                        partition.maybeExpandIsrAtSeal(follower, classicToDisklessStartOffset)
+                      } else {
+                        // Validate at the seal, which is where the retained prefix ends, and return no
+                        // records.
+                        val fetchAtSeal = new PartitionData(
+                          fetchPartitionData.topicId,
+                          classicToDisklessStartOffset,
+                          fetchPartitionData.logStartOffset,
+                          0,
+                          fetchPartitionData.currentLeaderEpoch,
+                          fetchPartitionData.lastFetchedEpoch
+                        )
+                        // Divergence alone admits too much: a request carrying no epoch skips the check,
+                        // and the diskless epoch passes it whenever the leader has consolidated too. Only
+                        // the epoch that ends at the seal is the follower's last classic epoch, so only it
+                        // proves the prefix, and an unproven fetch is validated but keeps waiting outside
+                        // ISR.
+                        val prefixProven = offeredEpochEndsAtSeal(
+                          leaderLog, fetchPartitionData.lastFetchedEpoch, classicToDisklessStartOffset)
+                        divergingEpoch = partition.validateFollowerFetchAtSeal(
+                          fetchParams = params,
+                          fetchPartitionData = fetchAtSeal,
+                          fetchTimeMs = time.milliseconds
+                        )
+                        // Required: validation leaves earlier follower state alone on divergence, so
+                        // admission must depend on this fetch validating successfully.
+                        if (!divergingEpoch.isPresent && prefixProven) {
+                          partition.getReplica(params.replicaId).foreach { follower =>
+                            partition.maybeExpandIsrAtSeal(follower, classicToDisklessStartOffset)
+                          }
+                        }
+                      }
+                    }
                   } catch {
                     case NonFatal(e) =>
                       fetchError = Errors.forException(e)
@@ -2660,14 +2708,15 @@ class ReplicaManager(val config: KafkaConfig,
             }
             // The partition has fully switched to diskless and the follower is asking for an offset at or beyond it.
             // Followers must never replicate diskless records into their local log.
-            // Empty records and HW at the seal offset make the follower treat the local log as caught up.
-            // ReplicaFetcherThread evicts once this replica is in ISR, or immediately if consolidating.
+            // Empty records and a high watermark at the requested offset make the follower treat its local
+            // log as caught up without lowering the watermark of a follower that consolidated past the seal.
+            // ReplicaFetcherThread evicts once this replica is in ISR.
             // logStartOffset=0 is a no-op for the follower (maybeIncrementLogStartOffset only ever advances),
             // so classic local data stays in place and can still serve consumer reads.
             immediateFetchResponses += tp ->
               new FetchPartitionData(
                 fetchError,
-                if (fetchError == Errors.NONE) classicToDisklessStartOffset else UnifiedLog.UNKNOWN_OFFSET,
+                if (fetchError == Errors.NONE) fetchPartitionData.fetchOffset else UnifiedLog.UNKNOWN_OFFSET,
                 if (fetchError == Errors.NONE) 0L else UnifiedLog.UNKNOWN_OFFSET,
                 MemoryRecords.EMPTY,
                 divergingEpoch,
@@ -4025,12 +4074,12 @@ class ReplicaManager(val config: KafkaConfig,
    *    the classic fetcher, which self-evicts and hands off to consolidation at the seal.
    * Non-consolidating topics are never routed to the consolidation fetcher.
    *
-   * A follower sitting exactly at the seal and outside ISR is held back, because the consolidation
-   * fetcher reads object storage and sends no fetch to the leader, so the leader would never observe
-   * the catch-up and nothing would expand ISR. The classic fetcher waits at the seal instead until the
-   * leader records the position, then evicts and hands off. Only LEO == seal qualifies: past the seal
-   * the local latest epoch is the diskless one, which the classic fetcher's divergence check against
-   * the leader's epoch cache is not built for.
+   * A follower at or above the seal and outside ISR is held back, because the consolidation fetcher
+   * reads object storage and sends no fetch to the leader, so the leader would never observe the
+   * catch-up and nothing would expand ISR. The classic fetcher waits instead until the leader admits
+   * the replica back to ISR, then evicts and hands off. A replica that already consolidated past the
+   * seal keeps its diskless suffix while it waits: the fetcher starts at the real log end offset, and
+   * the leader never asks it to truncate a range both replicas rebuild from object storage.
    */
   private def isReadyForConsolidation(tp: TopicPartition, partition: Partition): Boolean = {
     if (!consolidationActiveFor(tp.topic)) return false
@@ -4040,7 +4089,7 @@ class ReplicaManager(val config: KafkaConfig,
       case committedSeal =>
         val logEndOffset = partition.localLogOrException.logEndOffset
         if (logEndOffset < committedSeal) false
-        else partition.isLeader || _inklessMetadataView.isReplicaInIsr(tp, config.brokerId)
+        else _inklessMetadataView.isReplicaInIsr(tp, config.brokerId)
     }
   }
 

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -2640,10 +2640,9 @@ class ReplicaManager(val config: KafkaConfig,
           if (params.isFromFollower && disklessSwitchCompleted) {
             var fetchError = Errors.NONE
             var divergingEpoch = Optional.empty[FetchResponseData.EpochEndOffset]
-            // A recovered follower for a switched partition may already be caught up to the
-            // seal offset but still be outside ISR. Record the seal-offset fetch so the normal
-            // ISR expansion path can observe that the follower is caught up without reading
-            // diskless data into the local log.
+            // A recovered follower for a switched partition may already hold the whole classic
+            // prefix but sit outside ISR. Validate the fetch at the seal so replica state tracks the
+            // follower, without reading diskless data into its local log.
             if (fetchPartitionData.fetchOffset >= classicToDisklessStartOffset) {
               getPartitionOrError(tp.topicPartition) match {
                 case Right(partition) =>
@@ -4071,7 +4070,8 @@ class ReplicaManager(val config: KafkaConfig,
    *    fetcher until the controller commits the seal;
    *  - switched (seal >= 0): only consolidate once the local LEO has reached the committed seal, so
    *    that the whole classic prefix has been replicated locally; while below the seal it stays on
-   *    the classic fetcher, which self-evicts and hands off to consolidation at the seal.
+   *    the classic fetcher, which hands off to consolidation once the leader has admitted it back
+   *    to ISR.
    * Non-consolidating topics are never routed to the consolidation fetcher.
    *
    * A follower at or above the seal and outside ISR is held back, because the consolidation fetcher
@@ -4342,7 +4342,7 @@ class ReplicaManager(val config: KafkaConfig,
     localFollowers.foreachEntry { (tp, info) =>
       val isConsolidatingDisklessTopic = consolidationActiveFor(tp.topic)
       // Lazy: a classic follower never reads it, and the consolidating branch below is guarded by
-      // isConsolidatingDisklessTopic, so a diskless follower resolves the seal at most once.
+      // `isConsolidatingDisklessTopic`, so a diskless follower resolves the seal at most once.
       lazy val seal = _inklessMetadataView.getClassicToDisklessStartOffset(tp)
       if (_inklessMetadataView.isDisklessTopic(tp.topic())) {
         // Clean up classic-to-diskless switch tracking since only the leader drives classic-to-diskless switch.
@@ -4467,8 +4467,9 @@ class ReplicaManager(val config: KafkaConfig,
       // A consolidating diskless follower only joins the consolidation fetcher once its local log
       // has replicated the entire classic prefix (LEO >= committed seal). While the switch is still
       // pending or the log is below the seal, it must stay on the classic ReplicaFetcher so it can
-      // catch up from the leader; that fetcher self-evicts at the seal and hands the partition off
-      // to the consolidation reconciler (startConsolidationFetchersForCaughtUpClassicPartitions).
+      // catch up from the leader; that fetcher hands the partition off to the consolidation
+      // reconciler (`startConsolidationFetchersForCaughtUpClassicPartitions`) once the local log
+      // reaches the seal and the leader has admitted the replica back to ISR.
       // Routing a below-seal/pending partition straight to the reconciler would strand it: the
       // reconciler returns Retry and no classic fetcher would ever bring it up to the seal.
       val (consolidatingDisklessPartitionsToStartFetching, classicPartitionsToStartFetching) = partitionsToStartFetching.partition { case (tp, partition) =>

--- a/core/src/test/java/kafka/server/InklessConsolidatedDisklessTopicsTest.java
+++ b/core/src/test/java/kafka/server/InklessConsolidatedDisklessTopicsTest.java
@@ -48,11 +48,13 @@ import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.common.test.KafkaClusterTestKit;
 import org.apache.kafka.common.test.TestKitNodes;
 import org.apache.kafka.coordinator.group.GroupCoordinatorConfig;
+import org.apache.kafka.metadata.PartitionRegistration;
 import org.apache.kafka.server.config.ReplicationConfigs;
 import org.apache.kafka.server.config.ServerConfigs;
 import org.apache.kafka.server.log.remote.metadata.storage.TopicBasedRemoteLogMetadataManager;
 import org.apache.kafka.server.log.remote.metadata.storage.TopicBasedRemoteLogMetadataManagerConfig;
 import org.apache.kafka.server.log.remote.storage.RemoteLogManagerConfig;
+import org.apache.kafka.storage.internals.log.UnifiedLog;
 import org.apache.kafka.test.TestUtils;
 
 import org.junit.jupiter.api.AfterEach;
@@ -74,10 +76,12 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.OptionalLong;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
@@ -109,6 +113,7 @@ import static org.apache.kafka.common.config.TopicConfig.REMOTE_LOG_STORAGE_ENAB
 import static org.apache.kafka.common.config.TopicConfig.SEGMENT_BYTES_CONFIG;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Testcontainers
 public class InklessConsolidatedDisklessTopicsTest {
@@ -284,6 +289,65 @@ public class InklessConsolidatedDisklessTopicsTest {
         waitUntilTieredDisklessDataPrunedFromControlPlane(topicUuid, beforeConsumeSnapshot);
 
         consumeAndVerify(commonConfigs, recordsToSendAndReceive);
+    }
+
+    @Test
+    public void testSwitchedConsolidatingFollowerRejoinsIsrAfterRestart() throws Exception {
+        numPartitions = 1;
+        final int classicRecords = 10;
+        final int disklessRecords = 20;
+        final long seal = classicRecords;
+        final Map<String, Object> commonConfigs = new HashMap<>();
+        commonConfigs.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers());
+
+        try (Admin admin = AdminClient.create(commonConfigs)) {
+            // Phase 1: switch a fully replicated classic prefix to diskless.
+            final Uuid topicId = createClassicTopic(admin, Map.of(0, List.of(0, 1)));
+            produceRecords(commonConfigs, classicRecords, largeValueRecordFactory());
+            switchTopicToConsolidatedDiskless(admin);
+            assertEquals(seal,
+                awaitPartitionHighWatermark(toJavaUuid(topicId), 0, seal, 60_000),
+                "The committed switch seal must match the classic prefix end");
+
+            // Phase 2: require both replicas to consolidate beyond the seal.
+            produceRecords(commonConfigs, disklessRecords, largeValueRecordFactory());
+            final PartitionRegistration initial = waitForKRaftIsrSize(0, 2);
+            final int restartedBrokerId = 1;
+            assertTrue(Arrays.stream(initial.replicas).anyMatch(id -> id == restartedBrokerId),
+                "Broker 1 must host the partition so the test can restart the broker-only node");
+            assertTrue(initial.leader != restartedBrokerId,
+                "Broker 1 must be the follower so the test exercises follower recovery without a leader change");
+
+            TestUtils.waitForCondition(
+                () -> localLogEndOffset(restartedBrokerId).orElse(-1L) > seal,
+                120_000,
+                () -> "Broker " + restartedBrokerId + " must consolidate past seal " + seal
+                    + " before restart; last LEO=" + localLogEndOffset(restartedBrokerId).orElse(-1L));
+            final long leoBeforeRestart = localLogEndOffset(restartedBrokerId).orElseThrow();
+            final int peerBrokerId = 0;
+            TestUtils.waitForCondition(
+                () -> localLogEndOffset(peerBrokerId).orElse(-1L) >= leoBeforeRestart,
+                120_000,
+                () -> "Peer broker must be able to validate diskless LEO " + leoBeforeRestart
+                    + "; last LEO=" + localLogEndOffset(peerBrokerId).orElse(-1L));
+
+            // Phase 3: stop the follower and observe the controller ISR shrink.
+            cluster.brokers().get(restartedBrokerId).shutdown();
+            waitForKRaftIsrSize(peerBrokerId, 1);
+
+            // Phase 4: require leader-observed recovery before consolidation resumes.
+            cluster.brokers().get(restartedBrokerId).startup();
+            waitForKRaftIsrSize(peerBrokerId, 2);
+
+            final long leoAfterRecovery = localLogEndOffset(restartedBrokerId).orElseThrow();
+            assertTrue(leoAfterRecovery >= seal,
+                "Recovered follower must retain the complete classic prefix");
+            assertTrue(leoAfterRecovery >= leoBeforeRestart,
+                "When the leader can validate the diskless epoch, restart must preserve the consolidated suffix");
+        }
+
+        // Phase 5: verify the classic prefix and diskless suffix remain readable.
+        consumeAndVerify(commonConfigs, classicRecords + disklessRecords);
     }
 
     @Test
@@ -658,6 +722,10 @@ public class InklessConsolidatedDisklessTopicsTest {
     }
 
     private Uuid createClassicTopic(Admin admin) throws Exception {
+        return createClassicTopic(admin, null);
+    }
+
+    private Uuid createClassicTopic(Admin admin, Map<Integer, List<Integer>> replicaAssignments) throws Exception {
         // Create the topic as a classic topic by relying on the broker defaults (diskless.enable=false,
         // remote.storage.enable=false). Setting both keys explicitly at creation time — even to false —
         // trips the diskless/remote-storage mutual-exclusion validation, so we deliberately omit them.
@@ -665,7 +733,10 @@ public class InklessConsolidatedDisklessTopicsTest {
             CLEANUP_POLICY_CONFIG, CLEANUP_POLICY_DELETE,
             SEGMENT_BYTES_CONFIG, "1048576"
         );
-        final NewTopic topic = new NewTopic(topicName, numPartitions, (short) -1).configs(classicConfigs);
+        final NewTopic topic = replicaAssignments == null
+            ? new NewTopic(topicName, numPartitions, (short) -1)
+            : new NewTopic(topicName, replicaAssignments);
+        topic.configs(classicConfigs);
         admin.createTopics(Collections.singletonList(topic)).all().get(30, TimeUnit.SECONDS);
 
         final TopicDescription[] descriptionHolder = new TopicDescription[1];
@@ -685,6 +756,29 @@ public class InklessConsolidatedDisklessTopicsTest {
             }
         }, 60_000, () -> "Classic topic should become visible with " + numPartitions + " partitions");
         return descriptionHolder[0].topicId();
+    }
+
+    private PartitionRegistration waitForKRaftIsrSize(int observerBrokerId, int expectedSize)
+        throws InterruptedException {
+        final AtomicReference<PartitionRegistration> lastSeen = new AtomicReference<>();
+        TestUtils.waitForCondition(() -> {
+            final var topic = cluster.brokers().get(observerBrokerId).metadataCache()
+                .currentImage().topics().getTopic(topicName);
+            if (topic == null) {
+                return false;
+            }
+            final PartitionRegistration partition = topic.partitions().get(0);
+            lastSeen.set(partition);
+            return partition != null && partition.isr.length == expectedSize;
+        }, 120_000, () -> "Expected KRaft ISR size " + expectedSize + " for " + topicName
+            + "-0; last observed=" + lastSeen.get());
+        return lastSeen.get();
+    }
+
+    private OptionalLong localLogEndOffset(int brokerId) {
+        final TopicPartition tp = new TopicPartition(topicName, 0);
+        final scala.Option<UnifiedLog> log = cluster.brokers().get(brokerId).logManager().getLog(tp, false);
+        return log.isDefined() ? OptionalLong.of(log.get().logEndOffset()) : OptionalLong.empty();
     }
 
     private void incrementalAlterTopicConfigs(Admin admin, Map<String, String> configs)

--- a/core/src/test/java/kafka/server/InklessConsolidatedDisklessTopicsTest.java
+++ b/core/src/test/java/kafka/server/InklessConsolidatedDisklessTopicsTest.java
@@ -49,11 +49,13 @@ import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.common.test.KafkaClusterTestKit;
 import org.apache.kafka.common.test.TestKitNodes;
 import org.apache.kafka.coordinator.group.GroupCoordinatorConfig;
+import org.apache.kafka.metadata.PartitionRegistration;
 import org.apache.kafka.server.config.ReplicationConfigs;
 import org.apache.kafka.server.config.ServerConfigs;
 import org.apache.kafka.server.log.remote.metadata.storage.TopicBasedRemoteLogMetadataManager;
 import org.apache.kafka.server.log.remote.metadata.storage.TopicBasedRemoteLogMetadataManagerConfig;
 import org.apache.kafka.server.log.remote.storage.RemoteLogManagerConfig;
+import org.apache.kafka.storage.internals.log.UnifiedLog;
 import org.apache.kafka.test.TestUtils;
 
 import org.junit.jupiter.api.AfterEach;
@@ -76,12 +78,14 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableSet;
+import java.util.OptionalLong;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.UUID;
@@ -290,6 +294,77 @@ public class InklessConsolidatedDisklessTopicsTest {
         waitUntilTieredDisklessDataPrunedFromControlPlane(topicUuid, beforeConsumeSnapshot);
 
         consumeAndVerify(commonConfigs, recordsToSendAndReceive);
+    }
+
+    @Test
+    public void testSwitchedConsolidatingFollowerRejoinsIsrAfterRestart() throws Exception {
+        numPartitions = 1;
+        final int classicRecords = 10;
+        final int disklessRecords = 20;
+        final int postRecoveryRecords = 10;
+        final long seal = classicRecords;
+        final Map<String, Object> commonConfigs = new HashMap<>();
+        commonConfigs.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers());
+
+        try (Admin admin = AdminClient.create(commonConfigs)) {
+            // Phase 1: switch a fully replicated classic prefix to diskless.
+            final Uuid topicId = createClassicTopic(admin, Map.of(0, List.of(0, 1)));
+            produceRecords(commonConfigs, classicRecords, largeValueRecordFactory());
+            switchTopicToConsolidatedDiskless(admin);
+            assertEquals(seal,
+                awaitPartitionHighWatermark(toJavaUuid(topicId), 0, seal, 60_000),
+                "The committed switch seal must match the classic prefix end");
+
+            // Phase 2: require both replicas to consolidate beyond the seal.
+            produceRecords(commonConfigs, disklessRecords, largeValueRecordFactory());
+            final PartitionRegistration initial = waitForKRaftIsrSize(0, 2);
+            final int restartedBrokerId = 1;
+            assertTrue(Arrays.stream(initial.replicas).anyMatch(id -> id == restartedBrokerId),
+                "Broker 1 must host the partition so the test can restart the broker-only node");
+            assertTrue(initial.leader != restartedBrokerId,
+                "Broker 1 must be the follower so the test exercises follower recovery without a leader change");
+
+            TestUtils.waitForCondition(
+                () -> localLogEndOffset(restartedBrokerId).orElse(-1L) > seal,
+                120_000,
+                () -> "Broker " + restartedBrokerId + " must consolidate past seal " + seal
+                    + " before restart; last LEO=" + localLogEndOffset(restartedBrokerId).orElse(-1L));
+            final long leoBeforeRestart = localLogEndOffset(restartedBrokerId).orElseThrow();
+            final int peerBrokerId = 0;
+            TestUtils.waitForCondition(
+                () -> localLogEndOffset(peerBrokerId).orElse(-1L) >= leoBeforeRestart,
+                120_000,
+                () -> "Peer broker must be able to validate diskless LEO " + leoBeforeRestart
+                    + "; last LEO=" + localLogEndOffset(peerBrokerId).orElse(-1L));
+
+            // Phase 3: stop the follower and observe the controller ISR shrink.
+            cluster.brokers().get(restartedBrokerId).shutdown();
+            waitForKRaftIsrSize(peerBrokerId, 1);
+
+            // Phase 4: require leader-observed recovery before consolidation resumes.
+            cluster.brokers().get(restartedBrokerId).startup();
+            waitForKRaftIsrSize(peerBrokerId, 2);
+
+            final long leoAfterRecovery = localLogEndOffset(restartedBrokerId).orElseThrow();
+            assertTrue(leoAfterRecovery >= seal,
+                "Recovered follower must retain the complete classic prefix");
+            assertTrue(leoAfterRecovery >= leoBeforeRestart,
+                "Restart must preserve the consolidated suffix");
+
+            // Phase 5: require consolidation to resume on the restarted follower. Only the consolidation
+            // fetcher advances its local log from here, so an advancing LEO proves the classic fetcher
+            // handed the partition back after readmission rather than leaving it parked at the seal.
+            produceRecords(commonConfigs, postRecoveryRecords, largeValueRecordFactory());
+            TestUtils.waitForCondition(
+                () -> localLogEndOffset(restartedBrokerId).orElse(-1L) > leoAfterRecovery,
+                120_000,
+                () -> "Broker " + restartedBrokerId + " must resume consolidation after rejoining ISR;"
+                    + " LEO stuck at " + localLogEndOffset(restartedBrokerId).orElse(-1L)
+                    + " (was " + leoAfterRecovery + " at readmission)");
+        }
+
+        // Phase 6: verify the classic prefix and the whole diskless suffix remain readable.
+        consumeAndVerify(commonConfigs, classicRecords + disklessRecords + postRecoveryRecords);
     }
 
     @Test
@@ -858,6 +933,10 @@ public class InklessConsolidatedDisklessTopicsTest {
     }
 
     private Uuid createClassicTopic(Admin admin) throws Exception {
+        return createClassicTopic(admin, null);
+    }
+
+    private Uuid createClassicTopic(Admin admin, Map<Integer, List<Integer>> replicaAssignments) throws Exception {
         // Create the topic as a classic topic by relying on the broker defaults (diskless.enable=false,
         // remote.storage.enable=false). Setting both keys explicitly at creation time — even to false —
         // trips the diskless/remote-storage mutual-exclusion validation, so we deliberately omit them.
@@ -865,7 +944,10 @@ public class InklessConsolidatedDisklessTopicsTest {
             CLEANUP_POLICY_CONFIG, CLEANUP_POLICY_DELETE,
             SEGMENT_BYTES_CONFIG, "1048576"
         );
-        final NewTopic topic = new NewTopic(topicName, numPartitions, (short) -1).configs(classicConfigs);
+        final NewTopic topic = replicaAssignments == null
+            ? new NewTopic(topicName, numPartitions, (short) -1)
+            : new NewTopic(topicName, replicaAssignments);
+        topic.configs(classicConfigs);
         admin.createTopics(Collections.singletonList(topic)).all().get(30, TimeUnit.SECONDS);
 
         final TopicDescription[] descriptionHolder = new TopicDescription[1];
@@ -885,6 +967,29 @@ public class InklessConsolidatedDisklessTopicsTest {
             }
         }, 60_000, () -> "Classic topic should become visible with " + numPartitions + " partitions");
         return descriptionHolder[0].topicId();
+    }
+
+    private PartitionRegistration waitForKRaftIsrSize(int observerBrokerId, int expectedSize)
+        throws InterruptedException {
+        final AtomicReference<PartitionRegistration> lastSeen = new AtomicReference<>();
+        TestUtils.waitForCondition(() -> {
+            final var topic = cluster.brokers().get(observerBrokerId).metadataCache()
+                .currentImage().topics().getTopic(topicName);
+            if (topic == null) {
+                return false;
+            }
+            final PartitionRegistration partition = topic.partitions().get(0);
+            lastSeen.set(partition);
+            return partition != null && partition.isr.length == expectedSize;
+        }, 120_000, () -> "Expected KRaft ISR size " + expectedSize + " for " + topicName
+            + "-0; last observed=" + lastSeen.get());
+        return lastSeen.get();
+    }
+
+    private OptionalLong localLogEndOffset(int brokerId) {
+        final TopicPartition tp = new TopicPartition(topicName, 0);
+        final scala.Option<UnifiedLog> log = cluster.brokers().get(brokerId).logManager().getLog(tp, false);
+        return log.isDefined() ? OptionalLong.of(log.get().logEndOffset()) : OptionalLong.empty();
     }
 
     private void incrementalAlterTopicConfigs(Admin admin, Map<String, String> configs)

--- a/core/src/test/java/kafka/server/InklessTopicTypeSwitcherClusterTest.java
+++ b/core/src/test/java/kafka/server/InklessTopicTypeSwitcherClusterTest.java
@@ -327,6 +327,8 @@ public class InklessTopicTypeSwitcherClusterTest {
                                              final Map<String, Integer> expectedCounts) {
         final Map<String, Integer> consumedCounts = new HashMap<>();
         topics.forEach(topic -> consumedCounts.put(topic, 0));
+        final Map<TopicPartition, Integer> perPartitionCounts = new HashMap<>();
+        final Map<TopicPartition, Long> lastOffsetSeen = new HashMap<>();
         log.warn("[stage=consume-start] topics={}, expectedCounts={}", topics, expectedCounts);
 
         try (Consumer<byte[], byte[]> consumer = new KafkaConsumer<>(consumerConfigs)) {
@@ -337,11 +339,17 @@ public class InklessTopicTypeSwitcherClusterTest {
                 final ConsumerRecords<byte[], byte[]> records = consumer.poll(Duration.ofSeconds(1));
                 for (ConsumerRecord<byte[], byte[]> record : records) {
                     consumedCounts.compute(record.topic(), (k, v) -> v == null ? 1 : v + 1);
+                    final TopicPartition rtp = new TopicPartition(record.topic(), record.partition());
+                    perPartitionCounts.compute(rtp, (k, v) -> v == null ? 1 : v + 1);
+                    lastOffsetSeen.put(rtp, record.offset());
                 }
 
                 if (hasReachedExpected(consumedCounts, expectedCounts, topics)) {
                     break;
                 }
+            }
+            if (!hasReachedExpected(consumedCounts, expectedCounts, topics)) {
+                logConsumerDiagnostics(consumer, perPartitionCounts, lastOffsetSeen);
             }
         }
         log.warn("[stage=consume-end] consumedCounts={}", consumedCounts);
@@ -349,10 +357,97 @@ public class InklessTopicTypeSwitcherClusterTest {
         for (String topic : topics) {
             final int expected = expectedCounts.getOrDefault(topic, 0);
             final int actual = consumedCounts.getOrDefault(topic, 0);
-            if (expected > 0) {
-                assertTrue(actual >= expected,
-                    "Expected to consume at least " + expected + " record(s) from topic "
-                        + topic + " after producing to it, but consumed " + actual);
+            if (expected == 0) {
+                continue;
+            }
+            if (actual < expected) {
+                // A bare count says nothing about which partition stalled or why. Dump before the
+                // assertion so a CI-only failure carries its own diagnosis.
+                dumpPartitionState(topic);
+            }
+            assertTrue(actual >= expected,
+                "Expected to consume at least " + expected + " record(s) from topic "
+                    + topic + " after producing to it, but consumed " + actual);
+        }
+    }
+
+    /**
+     * Reports what the consumer itself saw, for a run that came up short.
+     *
+     * <p>Positions have to be read while the consumer is still open. A partition the consumer never
+     * positioned is missing from the assignment entirely, which distinguishes a partition that
+     * stalled before fetching from one that stalled part way through.
+     */
+    private void logConsumerDiagnostics(final Consumer<byte[], byte[]> consumer,
+                                        final Map<TopicPartition, Integer> perPartitionCounts,
+                                        final Map<TopicPartition, Long> lastOffsetSeen) {
+        final Map<TopicPartition, Long> positions = new HashMap<>();
+        for (final TopicPartition tp : consumer.assignment()) {
+            try {
+                positions.put(tp, consumer.position(tp, Duration.ofSeconds(5)));
+            } catch (Exception e) {
+                log.warn("[diag] position() failed for {}", tp, e);
+            }
+        }
+        log.warn("[diag] consumerPositions={}", positions);
+        log.warn("[diag] perPartitionCounts={}", perPartitionCounts);
+        log.warn("[diag] lastOffsetSeenPerPartition={}", lastOffsetSeen);
+    }
+
+    /**
+     * Reports per-broker log state and per-partition offset lookups for a topic that came up short.
+     *
+     * <p>A stalled partition shows up here as a replica whose high watermark trails the switch seal,
+     * or as an offset lookup that times out while the others answer.
+     */
+    private void dumpPartitionState(final String topic) {
+        // One call per partition and spec, so a hang on a single partition cannot mask the others.
+        try (Admin admin = AdminClient.create(baseClientConfigs())) {
+            for (int p = 0; p < NUM_PARTITIONS; p++) {
+                final TopicPartition tp = new TopicPartition(topic, p);
+                for (final Map.Entry<String, OffsetSpec> spec
+                    : Map.of("EARLIEST", OffsetSpec.earliest(), "LATEST", OffsetSpec.latest()).entrySet()) {
+                    try {
+                        final var res = admin.listOffsets(Map.of(tp, spec.getValue()))
+                            .all().get(10, TimeUnit.SECONDS);
+                        log.warn("[diag] listOffsets {} tp={} -> {}", spec.getKey(), tp, res);
+                    } catch (Exception e) {
+                        log.warn("[diag] listOffsets {} tp={} FAILED: {}", spec.getKey(), tp,
+                            e.getClass().getSimpleName() + ": " + e.getMessage());
+                    }
+                }
+            }
+            try {
+                log.warn("[diag] describeTopics={}",
+                    admin.describeTopics(List.of(topic)).allTopicNames().get(10, TimeUnit.SECONDS));
+            } catch (Exception e) {
+                log.warn("[diag] describeTopics FAILED: {}", e.getClass().getSimpleName() + ": " + e.getMessage());
+            }
+        } catch (Exception e) {
+            log.warn("[diag] admin setup failed", e);
+        }
+        for (int p = 0; p < NUM_PARTITIONS; p++) {
+            final TopicPartition tp = new TopicPartition(topic, p);
+            for (final int brokerId : cluster.brokers().keySet()) {
+                final var broker = cluster.brokers().get(brokerId);
+                final var rm = broker.replicaManager();
+                final long seal = rm.inklessMetadataView().getClassicToDisklessStartOffset(tp);
+                final boolean inIsr = rm.inklessMetadataView().isReplicaInIsr(tp, brokerId);
+                final var logOpt = broker.logManager().getLog(tp, false);
+                final var partitionOpt = rm.onlinePartition(tp);
+                final String leaderState = partitionOpt.isDefined()
+                    ? "isLeader=" + partitionOpt.get().isLeader()
+                    : "noPartition";
+                if (logOpt.isEmpty()) {
+                    log.warn("[diag] tp={} broker={} seal={} inIsr={} {} log=ABSENT",
+                        tp, brokerId, seal, inIsr, leaderState);
+                } else {
+                    final var l = logOpt.get();
+                    log.warn("[diag] tp={} broker={} seal={} inIsr={} {} "
+                            + "logStart={} localLogStart={} hw={} leo={}",
+                        tp, brokerId, seal, inIsr, leaderState,
+                        l.logStartOffset(), l.localLogStartOffset(), l.highWatermark(), l.logEndOffset());
+                }
             }
         }
     }

--- a/core/src/test/scala/io/aiven/inkless/consolidation/ConsolidationReconcilerTest.scala
+++ b/core/src/test/scala/io/aiven/inkless/consolidation/ConsolidationReconcilerTest.scala
@@ -331,7 +331,7 @@ class ConsolidationReconcilerTest {
 
   @Test
   def testStartConsolidationFetchersForCaughtUpClassicPartitionsSkipsSwitchedReplicaOutsideIsr(): Unit = {
-    // The classic fetcher queues the hand-off and cannot hold partitionMapLock across the
+    // The classic fetcher queues the hand-off and cannot hold `partitionMapLock` across the
     // fetcher-manager call, so its decision can be stale by the time it lands here. Enforce ISR
     // membership at the point of effect: consolidating outside ISR sends no fetch to the leader,
     // so nothing would readmit the replica.

--- a/core/src/test/scala/io/aiven/inkless/consolidation/ConsolidationReconcilerTest.scala
+++ b/core/src/test/scala/io/aiven/inkless/consolidation/ConsolidationReconcilerTest.scala
@@ -20,14 +20,15 @@ package io.aiven.inkless.consolidation
 
 import kafka.cluster.Partition
 import kafka.server.metadata.InklessMetadataView
-import kafka.server.{InitialFetchState, ReplicaManager, ReplicationQuotaManager}
+import kafka.server.{InitialFetchState, KafkaConfig, ReplicaManager, ReplicationQuotaManager}
+import kafka.utils.TestUtils
 import org.apache.kafka.common.{TopicPartition, Uuid}
 import org.apache.kafka.logger.StateChangeLogger
 import org.apache.kafka.metadata.PartitionRegistration
 import org.apache.kafka.storage.internals.log.UnifiedLog
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.Test
-import org.mockito.ArgumentMatchers.{any, anyBoolean, anyLong}
+import org.mockito.ArgumentMatchers.{any, anyBoolean, anyInt, anyLong}
 import org.mockito.Mockito
 import org.mockito.Mockito._
 
@@ -38,6 +39,7 @@ class ConsolidationReconcilerTest {
 
   private val topicPartition = new TopicPartition("reconcile-topic", 0)
   private val topicId = Uuid.randomUuid()
+  private val brokerConfig = KafkaConfig.fromProps(TestUtils.createBrokerConfig(0))
 
   private def newReconciler(
     metadataView: InklessMetadataView,
@@ -316,6 +318,8 @@ class ConsolidationReconcilerTest {
     val replicaManager = mock(classOf[ReplicaManager])
     val (partition, _) = mockPartition(logStartOffset = 0L, logEndOffset = 100L)
     when(replicaManager.onlinePartition(topicPartition)).thenReturn(Some(partition))
+    when(replicaManager.config).thenReturn(brokerConfig)
+    when(view.isReplicaInIsr(topicPartition, brokerConfig.brokerId)).thenReturn(true)
     val reconciler = newReconciler(view, fetcherManager, replicaManager = replicaManager)
 
     reconciler.startConsolidationFetchersForCaughtUpClassicPartitions(Set(topicPartition))
@@ -323,6 +327,51 @@ class ConsolidationReconcilerTest {
     // Admitted and armed at the seal (LEO == seal): the fetcher is started for the partition.
     verify(fetcherManager).addFetcherForPartitions(any())
     verify(view, never()).isConsolidatingDisklessTopic(topicPartition.topic)
+  }
+
+  @Test
+  def testStartConsolidationFetchersForCaughtUpClassicPartitionsSkipsSwitchedReplicaOutsideIsr(): Unit = {
+    // The classic fetcher queues the hand-off and cannot hold partitionMapLock across the
+    // fetcher-manager call, so its decision can be stale by the time it lands here. Enforce ISR
+    // membership at the point of effect: consolidating outside ISR sends no fetch to the leader,
+    // so nothing would readmit the replica.
+    val view = mock(classOf[InklessMetadataView])
+    when(view.isDisklessTopic(topicPartition.topic)).thenReturn(true)
+    when(view.getClassicToDisklessStartOffset(topicPartition)).thenReturn(100L)
+
+    val fetcherManager = mock(classOf[ConsolidationFetcherManager])
+    val replicaManager = mock(classOf[ReplicaManager])
+    when(replicaManager.config).thenReturn(brokerConfig)
+    when(view.isReplicaInIsr(topicPartition, brokerConfig.brokerId)).thenReturn(false)
+    val reconciler = newReconciler(view, fetcherManager, replicaManager = replicaManager)
+
+    reconciler.startConsolidationFetchersForCaughtUpClassicPartitions(Set(topicPartition))
+
+    verify(replicaManager, never()).onlinePartition(topicPartition)
+    verify(fetcherManager, never()).addFetcherForPartitions(any())
+  }
+
+  @Test
+  def testStartConsolidationFetchersForCaughtUpClassicPartitionsAdmitsNeverSwitchedPartition(): Unit = {
+    // A born-diskless partition has no classic prefix and no seal, so ISR membership is not a
+    // precondition for it.
+    val view = mock(classOf[InklessMetadataView])
+    when(view.isDisklessTopic(topicPartition.topic)).thenReturn(true)
+    when(view.isRemoteStorageEnabled(topicPartition.topic)).thenReturn(true)
+    when(view.getTopicId(topicPartition.topic)).thenReturn(topicId)
+    when(view.getClassicToDisklessStartOffset(topicPartition))
+      .thenReturn(PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET)
+
+    val fetcherManager = mock(classOf[ConsolidationFetcherManager])
+    val replicaManager = mock(classOf[ReplicaManager])
+    val (partition, _) = mockPartition(logStartOffset = 0L, logEndOffset = 100L)
+    when(replicaManager.onlinePartition(topicPartition)).thenReturn(Some(partition))
+    val reconciler = newReconciler(view, fetcherManager, replicaManager = replicaManager)
+
+    reconciler.startConsolidationFetchersForCaughtUpClassicPartitions(Set(topicPartition))
+
+    verify(fetcherManager).addFetcherForPartitions(any())
+    verify(view, never()).isReplicaInIsr(any(), anyInt())
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/server/ReplicaFetcherThreadTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaFetcherThreadTest.scala
@@ -36,6 +36,8 @@ import org.apache.kafka.common.requests.{FetchRequest, FetchResponse}
 import org.apache.kafka.common.utils.{LogContext, Time}
 import org.apache.kafka.metadata.PartitionRegistration
 import org.apache.kafka.server.common.{KRaftVersion, MetadataVersion, OffsetAndEpoch}
+import org.apache.kafka.server.config.ServerConfigs
+import org.apache.kafka.server.log.remote.storage.RemoteLogManagerConfig
 import org.apache.kafka.server.network.BrokerEndPoint
 import org.apache.kafka.server.ReplicaState
 import org.apache.kafka.server.PartitionFetchState
@@ -849,6 +851,104 @@ class ReplicaFetcherThreadTest {
       classicToDisklessStartOffset = PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING,
       logEndOffsetAfterAppend = 100L,
       expectEviction = false)
+  }
+
+  @Test
+  def shouldDelayConsolidatingPartitionAtSealWhileOutsideIsr(): Unit = {
+    // Consolidation used to short-circuit the ISR check, evicting the partition at the seal. It must
+    // not: once the partition hands off, the consolidation fetcher reads object storage and sends no
+    // fetch to the leader, so the leader never observes the catch-up and no path expands ISR.
+    val f = consolidatingFollowerAtSealOutsideIsr()
+
+    f.thread.processPartitionData(t1p0, 100L, Int.MaxValue, f.partitionData)
+
+    // Queued for back-off rather than eviction. Assert before doWork, which drains the buffer.
+    assertEquals(mutable.Buffer(t1p0), f.thread.partitionsAwaitingIsrRecovery)
+    assertEquals(mutable.Buffer.empty, f.thread.partitionsToEvictAfterDisklessSwitch)
+    verify(f.replicaFetcherManager, times(0)).removeFetcherForPartitions(any())
+
+    f.thread.backOffPartitionsAwaitingIsrRecovery()
+
+    val fetchState = f.thread.fetchState(t1p0).get
+    assertTrue(fetchState.isDelayed,
+      s"Consolidating replica outside ISR must be delayed, not evicted, got $fetchState")
+    assertEquals(f.config.replicaFetchBackoffMs.toLong, fetchState.delay.orElse(0L))
+    assertEquals(mutable.Buffer.empty, f.thread.partitionsAwaitingIsrRecovery)
+  }
+
+  @Test
+  def shouldClearPendingIsrRecoveryBackoffWhenPartitionIsRemoved(): Unit = {
+    val f = consolidatingFollowerAtSealOutsideIsr()
+
+    f.thread.processPartitionData(t1p0, 100L, Int.MaxValue, f.partitionData)
+    assertEquals(mutable.Buffer(t1p0), f.thread.partitionsAwaitingIsrRecovery)
+
+    f.thread.removePartitions(Set(t1p0))
+    assertEquals(mutable.Buffer.empty, f.thread.partitionsAwaitingIsrRecovery)
+
+    f.thread.addPartitions(Map(t1p0 -> initialFetchState(Some(topicId1), 100L)))
+    f.thread.backOffPartitionsAwaitingIsrRecovery()
+    assertFalse(f.thread.fetchState(t1p0).get.isDelayed,
+      "a new fetcher residency must not inherit pending backoff from the removed residency")
+  }
+
+  private case class ConsolidatingAtSealFetcher(thread: ReplicaFetcherThread,
+                                                partitionData: FetchResponseData.PartitionData,
+                                                inklessMetadataView: InklessMetadataView,
+                                                replicaFetcherManager: ReplicaFetcherManager,
+                                                config: KafkaConfig)
+
+  private def consolidatingFollowerAtSealOutsideIsr(): ConsolidatingAtSealFetcher = {
+    val props = TestUtils.createBrokerConfig(1)
+    props.setProperty(ServerConfigs.DISKLESS_STORAGE_SYSTEM_ENABLE_CONFIG, "true")
+    props.setProperty(ServerConfigs.DISKLESS_MANAGED_REPLICAS_ENABLE_CONFIG, "true")
+    props.setProperty(RemoteLogManagerConfig.REMOTE_LOG_STORAGE_SYSTEM_ENABLE_PROP, "true")
+    props.setProperty(ServerConfigs.DISKLESS_ALLOW_FROM_CLASSIC_ENABLE_CONFIG, "true")
+    props.setProperty(ServerConfigs.DISKLESS_REMOTE_STORAGE_CONSOLIDATION_ENABLE_CONFIG, "true")
+    val config = KafkaConfig.fromProps(props)
+
+    val mockBlockingSend: BlockingSend = mock(classOf[BlockingSend])
+    when(mockBlockingSend.brokerEndPoint()).thenReturn(brokerEndPoint)
+
+    val log: UnifiedLog = mock(classOf[UnifiedLog])
+    when(log.logEndOffset).thenReturn(100L)
+    when(log.latestEpoch).thenReturn(Optional.of(Integer.valueOf(1)))
+    when(log.maybeUpdateHighWatermark(anyLong())).thenReturn(Optional.empty)
+
+    val partition: Partition = mock(classOf[Partition])
+    when(partition.localLogOrException).thenReturn(log)
+    when(partition.appendRecordsToFollowerOrFutureReplica(any[MemoryRecords], any[Boolean], any[Int]))
+      .thenReturn(Some(mock(classOf[LogAppendInfo])))
+
+    val inklessMetadataView: InklessMetadataView = mock(classOf[InklessMetadataView])
+    when(inklessMetadataView.getClassicToDisklessStartOffset(t1p0)).thenReturn(100L)
+    when(inklessMetadataView.isReplicaInIsr(t1p0, config.brokerId)).thenReturn(false)
+    when(inklessMetadataView.isConsolidatingDisklessTopic(t1p0.topic)).thenReturn(true)
+
+    val replicaFetcherManager: ReplicaFetcherManager = mock(classOf[ReplicaFetcherManager])
+    val replicaManager: ReplicaManager = mock(classOf[ReplicaManager])
+    when(replicaManager.getPartitionOrException(any[TopicPartition])).thenReturn(partition)
+    when(replicaManager.localLogOrException(t1p0)).thenReturn(log)
+    when(replicaManager.localLog(t1p0)).thenReturn(Some(log))
+    when(replicaManager.brokerTopicStats).thenReturn(new BrokerTopicStats)
+    when(replicaManager.inklessMetadataView()).thenReturn(inklessMetadataView)
+    when(replicaManager.replicaFetcherManager).thenReturn(replicaFetcherManager)
+
+    val thread = createReplicaFetcherThread(
+      name = "replica-fetcher",
+      fetcherId = 0,
+      brokerConfig = config,
+      failedPartitions = failedPartitions,
+      replicaMgr = replicaManager,
+      quota = mock(classOf[ReplicaQuota]),
+      leaderEndpointBlockingSend = mockBlockingSend)
+
+    thread.addPartitions(Map(t1p0 -> initialFetchState(Some(topicId1), 100L)))
+    val partitionData = new FetchResponseData.PartitionData()
+      .setPartitionIndex(t1p0.partition)
+      .setRecords(MemoryRecords.withRecords(Compression.NONE,
+        new SimpleRecord(1000, "foo".getBytes(StandardCharsets.UTF_8))))
+    ConsolidatingAtSealFetcher(thread, partitionData, inklessMetadataView, replicaFetcherManager, config)
   }
 
   private def verifyDisklessSwitchEviction(

--- a/core/src/test/scala/unit/kafka/server/ReplicaFetcherThreadTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaFetcherThreadTest.scala
@@ -874,7 +874,7 @@ class ReplicaFetcherThreadTest {
 
     f.thread.processPartitionData(t1p0, 100L, Int.MaxValue, f.partitionData)
 
-    // Queued for back-off rather than eviction. Assert before doWork, which drains the buffer.
+    // Queued for back-off rather than eviction. Assert before `doWork`, which drains the buffer.
     assertEquals(mutable.Buffer(t1p0), f.thread.partitionsAwaitingIsrRecovery)
     assertEquals(mutable.Buffer.empty, f.thread.partitionsToEvictAfterDisklessSwitch)
     verify(f.replicaFetcherManager, times(0)).removeFetcherForPartitions(any())
@@ -930,7 +930,7 @@ class ReplicaFetcherThreadTest {
   @Test
   def shouldNotEvictWhenIsrShrinksAfterTheBufferDrains(): Unit = {
     // The buffer is already drained when the ISR delta lands, so clearing it on removal cannot
-    // help. partitionMapLock cannot cover the fetcher-manager calls, so the eviction re-reads ISR
+    // help. `partitionMapLock` cannot cover the fetcher-manager calls, so the eviction re-reads ISR
     // instead: removing it here would leave the replica with no fetcher at all.
     val f = consolidatingFollowerAtSeal(replicaInIsr = true)
 

--- a/core/src/test/scala/unit/kafka/server/ReplicaFetcherThreadTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaFetcherThreadTest.scala
@@ -36,6 +36,8 @@ import org.apache.kafka.common.requests.{FetchRequest, FetchResponse}
 import org.apache.kafka.common.utils.{LogContext, Time}
 import org.apache.kafka.metadata.{KRaftMetadataCache, PartitionRegistration}
 import org.apache.kafka.server.common.{KRaftVersion, MetadataVersion, OffsetAndEpoch}
+import org.apache.kafka.server.config.ServerConfigs
+import org.apache.kafka.server.log.remote.storage.RemoteLogManagerConfig
 import org.apache.kafka.server.network.BrokerEndPoint
 import org.apache.kafka.server.ReplicaState
 import org.apache.kafka.server.PartitionFetchState
@@ -850,6 +852,148 @@ class ReplicaFetcherThreadTest {
       classicToDisklessStartOffset = PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING,
       logEndOffsetAfterAppend = 100L,
       expectEviction = false)
+  }
+
+  @Test
+  def shouldDelayConsolidatingPartitionAtSealWhileOutsideIsr(): Unit = {
+    // Consolidation used to short-circuit the ISR check, evicting the partition at the seal. It must
+    // not: once the partition hands off, the consolidation fetcher reads object storage and sends no
+    // fetch to the leader, so the leader never observes the catch-up and no path expands ISR.
+    val f = consolidatingFollowerAtSeal()
+
+    f.thread.processPartitionData(t1p0, 100L, Int.MaxValue, f.partitionData)
+
+    // Queued for back-off rather than eviction. Assert before doWork, which drains the buffer.
+    assertEquals(mutable.Buffer(t1p0), f.thread.partitionsAwaitingIsrRecovery)
+    assertEquals(mutable.Buffer.empty, f.thread.partitionsToEvictAfterDisklessSwitch)
+    verify(f.replicaFetcherManager, times(0)).removeFetcherForPartitions(any())
+
+    f.thread.backOffPartitionsAwaitingIsrRecovery()
+
+    val fetchState = f.thread.fetchState(t1p0).get
+    assertTrue(fetchState.isDelayed,
+      s"Consolidating replica outside ISR must be delayed, not evicted, got $fetchState")
+    assertEquals(f.config.replicaFetchBackoffMs.toLong, fetchState.delay.orElse(0L))
+    assertEquals(mutable.Buffer.empty, f.thread.partitionsAwaitingIsrRecovery)
+  }
+
+  @Test
+  def shouldClearPendingIsrRecoveryBackoffWhenPartitionIsRemoved(): Unit = {
+    val f = consolidatingFollowerAtSeal()
+
+    f.thread.processPartitionData(t1p0, 100L, Int.MaxValue, f.partitionData)
+    assertEquals(mutable.Buffer(t1p0), f.thread.partitionsAwaitingIsrRecovery)
+
+    f.thread.removePartitions(Set(t1p0))
+    assertEquals(mutable.Buffer.empty, f.thread.partitionsAwaitingIsrRecovery)
+
+    f.thread.addPartitions(Map(t1p0 -> initialFetchState(Some(topicId1), 100L)))
+    f.thread.backOffPartitionsAwaitingIsrRecovery()
+    assertFalse(f.thread.fetchState(t1p0).get.isDelayed,
+      "a re-added partition must not inherit pending backoff from its removed assignment")
+  }
+
+  @Test
+  def shouldClearPendingEvictionWhenPartitionIsRemoved(): Unit = {
+    // Queued while the replica was in ISR, then an ISR-only delta drops it and routes it back to
+    // this fetcher. Handing the re-added partition to consolidation would strand the replica
+    // outside ISR, which is the state the ISR gate exists to prevent.
+    val f = consolidatingFollowerAtSeal(replicaInIsr = true)
+
+    f.thread.processPartitionData(t1p0, 100L, Int.MaxValue, f.partitionData)
+    assertEquals(mutable.Buffer(t1p0), f.thread.partitionsToEvictAfterDisklessSwitch)
+
+    when(f.inklessMetadataView.isReplicaInIsr(t1p0, f.config.brokerId)).thenReturn(false)
+    f.thread.removePartitions(Set(t1p0))
+    assertEquals(mutable.Buffer.empty, f.thread.partitionsToEvictAfterDisklessSwitch)
+
+    f.thread.addPartitions(Map(t1p0 -> initialFetchState(Some(topicId1), 100L)))
+    f.thread.evictFullySwitchedDisklessPartitions()
+
+    verify(f.replicaFetcherManager, times(0)).removeFetcherForPartitions(any())
+    verify(f.replicaManager, times(0)).startConsolidationFetchersForCaughtUpClassicPartitions(any())
+    assertTrue(f.thread.fetchState(t1p0).isDefined,
+      "the re-added partition must keep fetching from the classic leader")
+  }
+
+  @Test
+  def shouldNotEvictWhenIsrShrinksAfterTheBufferDrains(): Unit = {
+    // The buffer is already drained when the ISR delta lands, so clearing it on removal cannot
+    // help. partitionMapLock cannot cover the fetcher-manager calls, so the eviction re-reads ISR
+    // instead: removing it here would leave the replica with no fetcher at all.
+    val f = consolidatingFollowerAtSeal(replicaInIsr = true)
+
+    f.thread.processPartitionData(t1p0, 100L, Int.MaxValue, f.partitionData)
+    assertEquals(mutable.Buffer(t1p0), f.thread.partitionsToEvictAfterDisklessSwitch)
+
+    when(f.inklessMetadataView.isReplicaInIsr(t1p0, f.config.brokerId)).thenReturn(false)
+    f.thread.evictFullySwitchedDisklessPartitions()
+
+    assertEquals(mutable.Buffer.empty, f.thread.partitionsToEvictAfterDisklessSwitch)
+    verify(f.replicaFetcherManager, times(0)).removeFetcherForPartitions(any())
+    verify(f.replicaManager, times(0)).startConsolidationFetchersForCaughtUpClassicPartitions(any())
+    assertTrue(f.thread.fetchState(t1p0).isDefined,
+      "the replica must stay on the classic fetcher until the leader readmits it")
+  }
+
+  private case class ConsolidatingAtSealFetcher(thread: ReplicaFetcherThread,
+                                                partitionData: FetchResponseData.PartitionData,
+                                                inklessMetadataView: InklessMetadataView,
+                                                replicaFetcherManager: ReplicaFetcherManager,
+                                                replicaManager: ReplicaManager,
+                                                config: KafkaConfig)
+
+  private def consolidatingFollowerAtSeal(replicaInIsr: Boolean = false): ConsolidatingAtSealFetcher = {
+    val props = TestUtils.createBrokerConfig(1)
+    props.setProperty(ServerConfigs.DISKLESS_STORAGE_SYSTEM_ENABLE_CONFIG, "true")
+    props.setProperty(ServerConfigs.DISKLESS_MANAGED_REPLICAS_ENABLE_CONFIG, "true")
+    props.setProperty(RemoteLogManagerConfig.REMOTE_LOG_STORAGE_SYSTEM_ENABLE_PROP, "true")
+    props.setProperty(ServerConfigs.DISKLESS_ALLOW_FROM_CLASSIC_ENABLE_CONFIG, "true")
+    props.setProperty(ServerConfigs.DISKLESS_REMOTE_STORAGE_CONSOLIDATION_ENABLE_CONFIG, "true")
+    val config = KafkaConfig.fromProps(props)
+
+    val mockBlockingSend: BlockingSend = mock(classOf[BlockingSend])
+    when(mockBlockingSend.brokerEndPoint()).thenReturn(brokerEndPoint)
+
+    val log: UnifiedLog = mock(classOf[UnifiedLog])
+    when(log.logEndOffset).thenReturn(100L)
+    when(log.latestEpoch).thenReturn(Optional.of(Integer.valueOf(1)))
+    when(log.maybeUpdateHighWatermark(anyLong())).thenReturn(Optional.empty)
+
+    val partition: Partition = mock(classOf[Partition])
+    when(partition.localLogOrException).thenReturn(log)
+    when(partition.appendRecordsToFollowerOrFutureReplica(any[MemoryRecords], any[Boolean], any[Int]))
+      .thenReturn(Some(mock(classOf[LogAppendInfo])))
+
+    val inklessMetadataView: InklessMetadataView = mock(classOf[InklessMetadataView])
+    when(inklessMetadataView.getClassicToDisklessStartOffset(t1p0)).thenReturn(100L)
+    when(inklessMetadataView.isReplicaInIsr(t1p0, config.brokerId)).thenReturn(replicaInIsr)
+    when(inklessMetadataView.isConsolidatingDisklessTopic(t1p0.topic)).thenReturn(true)
+
+    val replicaFetcherManager: ReplicaFetcherManager = mock(classOf[ReplicaFetcherManager])
+    val replicaManager: ReplicaManager = mock(classOf[ReplicaManager])
+    when(replicaManager.getPartitionOrException(any[TopicPartition])).thenReturn(partition)
+    when(replicaManager.localLogOrException(t1p0)).thenReturn(log)
+    when(replicaManager.localLog(t1p0)).thenReturn(Some(log))
+    when(replicaManager.brokerTopicStats).thenReturn(new BrokerTopicStats)
+    when(replicaManager.inklessMetadataView()).thenReturn(inklessMetadataView)
+    when(replicaManager.replicaFetcherManager).thenReturn(replicaFetcherManager)
+
+    val thread = createReplicaFetcherThread(
+      name = "replica-fetcher",
+      fetcherId = 0,
+      brokerConfig = config,
+      failedPartitions = failedPartitions,
+      replicaMgr = replicaManager,
+      quota = mock(classOf[ReplicaQuota]),
+      leaderEndpointBlockingSend = mockBlockingSend)
+
+    thread.addPartitions(Map(t1p0 -> initialFetchState(Some(topicId1), 100L)))
+    val partitionData = new FetchResponseData.PartitionData()
+      .setPartitionIndex(t1p0.partition)
+      .setRecords(MemoryRecords.withRecords(Compression.NONE,
+        new SimpleRecord(1000, "foo".getBytes(StandardCharsets.UTF_8))))
+    ConsolidatingAtSealFetcher(thread, partitionData, inklessMetadataView, replicaFetcherManager, replicaManager, config)
   }
 
   private def verifyDisklessSwitchEviction(

--- a/core/src/test/scala/unit/kafka/server/ReplicaFetcherThreadTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaFetcherThreadTest.scala
@@ -17,6 +17,7 @@
 package kafka.server
 
 import kafka.cluster.Partition
+import io.aiven.inkless.consolidation.ConsolidationFetcherThread
 import kafka.log.LogManager
 import kafka.server.QuotaFactory.UNBOUNDED_QUOTA
 import kafka.server.epoch.util.MockBlockingSender
@@ -40,9 +41,13 @@ import org.apache.kafka.server.config.ServerConfigs
 import org.apache.kafka.server.log.remote.storage.RemoteLogManagerConfig
 import org.apache.kafka.server.network.BrokerEndPoint
 import org.apache.kafka.server.ReplicaState
+import org.apache.kafka.server.LeaderEndPoint
+import org.apache.kafka.server.ResultWithPartitions
+import org.apache.kafka.server.ReplicaFetch
 import org.apache.kafka.server.PartitionFetchState
 import org.apache.kafka.server.config.ReplicationConfigs
 import org.apache.kafka.storage.internals.log.{LogAppendInfo, LogConfig, RecordValidationStats, UnifiedLog}
+import org.apache.kafka.storage.internals.epoch.LeaderEpochFileCache
 import org.apache.kafka.storage.log.metrics.BrokerTopicStats
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{AfterEach, Test}
@@ -55,7 +60,7 @@ import org.mockito.Mockito.{mock, times, verify, when}
 import java.lang.{Long => JLong}
 import java.nio.charset.StandardCharsets
 import java.util
-import java.util.{Collections, Optional, Properties}
+import java.util.{Collections, Optional, OptionalInt, Properties}
 import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 import scala.jdk.OptionConverters._
@@ -213,6 +218,7 @@ class ReplicaFetcherThreadTest {
     when(replicaManager.replicaAlterLogDirsManager).thenReturn(replicaAlterLogDirsManager)
     when(replicaManager.brokerTopicStats).thenReturn(mock(classOf[BrokerTopicStats]))
     stub(partition, replicaManager, log)
+    when(replicaManager.inklessMetadataView()).thenReturn(mock(classOf[InklessMetadataView]))
 
     //Define the offsets for the OffsetsForLeaderEpochResponse
     val offsets = java.util.Map.of(
@@ -282,6 +288,7 @@ class ReplicaFetcherThreadTest {
     when(replicaManager.replicaAlterLogDirsManager).thenReturn(replicaAlterLogDirsManager)
     when(replicaManager.brokerTopicStats).thenReturn(mock(classOf[BrokerTopicStats]))
     stub(partition, replicaManager, log)
+    when(replicaManager.inklessMetadataView()).thenReturn(mock(classOf[InklessMetadataView]))
 
     // Create the fetcher thread
     val mockNetwork = new MockBlockingSender(Collections.emptyMap(), brokerEndPoint, Time.SYSTEM)
@@ -783,6 +790,9 @@ class ReplicaFetcherThreadTest {
     when(log.logEndOffset).thenReturn(100L)
     when(log.latestEpoch).thenReturn(Optional.of(Integer.valueOf(1)))
     when(log.maybeUpdateHighWatermark(anyLong())).thenReturn(Optional.empty)
+    val epochCache: LeaderEpochFileCache = mock(classOf[LeaderEpochFileCache])
+    when(epochCache.epochForOffset(99L)).thenReturn(OptionalInt.of(1))
+    when(log.leaderEpochCache).thenReturn(epochCache)
 
     val partition: Partition = mock(classOf[Partition])
     when(partition.localLogOrException).thenReturn(log)
@@ -791,6 +801,7 @@ class ReplicaFetcherThreadTest {
 
     val inklessMetadataView: InklessMetadataView = mock(classOf[InklessMetadataView])
     when(inklessMetadataView.getClassicToDisklessStartOffset(t1p0)).thenReturn(100L)
+    when(inklessMetadataView.isDisklessTopic(t1p0.topic)).thenReturn(true)
     when(inklessMetadataView.isReplicaInIsr(t1p0, config.brokerId)).thenReturn(false)
 
     val replicaFetcherManager: ReplicaFetcherManager = mock(classOf[ReplicaFetcherManager])
@@ -936,12 +947,66 @@ class ReplicaFetcherThreadTest {
       "the replica must stay on the classic fetcher until the leader readmits it")
   }
 
+  @Test
+  def shouldOfferClassicBoundaryEpochAtOrAboveTheSeal(): Unit = {
+    // Above the seal the latest epoch is the diskless one, stamped on records from object storage.
+    // Offering it proves the suffix resolves on the leader and nothing about the classic prefix, so
+    // the fetcher offers the epoch of the last classic record instead. The fixture seals at 100 with
+    // latest epoch 7 and boundary epoch 1.
+    val f = consolidatingFollowerAtSeal()
+
+    assertEquals(Optional.of(Integer.valueOf(1)), f.thread.fetchState(t1p0).get.lastFetchedEpoch,
+      "at the seal the fetcher must offer the classic boundary epoch, not the diskless latest epoch")
+
+    when(f.log.logEndOffset).thenReturn(4000L)
+    f.thread.removePartitions(Set(t1p0))
+    f.thread.addPartitions(Map(t1p0 -> initialFetchState(Some(topicId1), 4000L)))
+    assertEquals(Optional.of(Integer.valueOf(1)), f.thread.fetchState(t1p0).get.lastFetchedEpoch,
+      "past the seal the boundary epoch still applies")
+
+    when(f.log.logEndOffset).thenReturn(50L)
+    f.thread.removePartitions(Set(t1p0))
+    f.thread.addPartitions(Map(t1p0 -> initialFetchState(Some(topicId1), 50L)))
+    assertEquals(Optional.of(Integer.valueOf(7)), f.thread.fetchState(t1p0).get.lastFetchedEpoch,
+      "below the seal the latest epoch applies")
+  }
+
+  @Test
+  def consolidationFetcherOffersLatestEpochNotClassicBoundary(): Unit = {
+    // Same fixture as above, but the thread is the consolidation fetcher, which inherits latestEpoch.
+    // Its endpoint does not support truncation on fetch, so the epoch is not stored at addPartitions;
+    // it is asked for on the truncation pass and sent in OffsetsForLeaderEpoch. The endpoint answers
+    // any epoch below the diskless one with the seal, so offering the boundary epoch there would
+    // truncate the consolidated suffix on every start. It must offer the latest epoch.
+    val f = consolidatingFollowerAtSeal()
+    when(f.log.logEndOffset).thenReturn(4000L)
+    val leader: LeaderEndPoint = mock(classOf[LeaderEndPoint])
+    when(leader.brokerEndPoint()).thenReturn(brokerEndPoint)
+    when(leader.isTruncationOnFetchSupported).thenReturn(false)
+    when(leader.fetchEpochEndOffsets(any())).thenReturn(java.util.Map.of())
+    when(leader.buildFetch(any())).thenReturn(
+      new ResultWithPartitions[Optional[ReplicaFetch]](Optional.empty(), java.util.Set.of()))
+    val consolidationThread = new ConsolidationFetcherThread(
+      "consolidation-fetcher", leader, f.config, failedPartitions, f.replicaManager,
+      mock(classOf[ReplicaQuota]), "[ConsolidationFetcher test] ")
+    consolidationThread.addPartitions(Map(t1p0 -> initialFetchState(Some(topicId1), 4000L)))
+
+    consolidationThread.doWork()
+
+    val offered = ArgumentCaptor.forClass(classOf[java.util.Map[TopicPartition, OffsetForLeaderPartition]])
+    verify(leader).fetchEpochEndOffsets(offered.capture())
+    assertEquals(7, offered.getValue.get(t1p0).leaderEpoch,
+      "the consolidation fetcher must offer its latest epoch, not the classic boundary epoch")
+  }
+
+
   private case class ConsolidatingAtSealFetcher(thread: ReplicaFetcherThread,
                                                 partitionData: FetchResponseData.PartitionData,
                                                 inklessMetadataView: InklessMetadataView,
                                                 replicaFetcherManager: ReplicaFetcherManager,
                                                 replicaManager: ReplicaManager,
-                                                config: KafkaConfig)
+                                                config: KafkaConfig,
+                                                log: UnifiedLog)
 
   private def consolidatingFollowerAtSeal(replicaInIsr: Boolean = false): ConsolidatingAtSealFetcher = {
     val props = TestUtils.createBrokerConfig(1)
@@ -957,8 +1022,11 @@ class ReplicaFetcherThreadTest {
 
     val log: UnifiedLog = mock(classOf[UnifiedLog])
     when(log.logEndOffset).thenReturn(100L)
-    when(log.latestEpoch).thenReturn(Optional.of(Integer.valueOf(1)))
+    when(log.latestEpoch).thenReturn(Optional.of(Integer.valueOf(7)))
     when(log.maybeUpdateHighWatermark(anyLong())).thenReturn(Optional.empty)
+    val epochCache: LeaderEpochFileCache = mock(classOf[LeaderEpochFileCache])
+    when(epochCache.epochForOffset(99L)).thenReturn(OptionalInt.of(1))
+    when(log.leaderEpochCache).thenReturn(epochCache)
 
     val partition: Partition = mock(classOf[Partition])
     when(partition.localLogOrException).thenReturn(log)
@@ -967,6 +1035,7 @@ class ReplicaFetcherThreadTest {
 
     val inklessMetadataView: InklessMetadataView = mock(classOf[InklessMetadataView])
     when(inklessMetadataView.getClassicToDisklessStartOffset(t1p0)).thenReturn(100L)
+    when(inklessMetadataView.isDisklessTopic(t1p0.topic)).thenReturn(true)
     when(inklessMetadataView.isReplicaInIsr(t1p0, config.brokerId)).thenReturn(replicaInIsr)
     when(inklessMetadataView.isConsolidatingDisklessTopic(t1p0.topic)).thenReturn(true)
 
@@ -993,7 +1062,7 @@ class ReplicaFetcherThreadTest {
       .setPartitionIndex(t1p0.partition)
       .setRecords(MemoryRecords.withRecords(Compression.NONE,
         new SimpleRecord(1000, "foo".getBytes(StandardCharsets.UTF_8))))
-    ConsolidatingAtSealFetcher(thread, partitionData, inklessMetadataView, replicaFetcherManager, replicaManager, config)
+    ConsolidatingAtSealFetcher(thread, partitionData, inklessMetadataView, replicaFetcherManager, replicaManager, config, log)
   }
 
   private def verifyDisklessSwitchEviction(

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerInklessTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerInklessTest.scala
@@ -36,7 +36,7 @@ import org.apache.kafka.common.config.TopicConfig
 import org.apache.kafka.common.{DirectoryId, IsolationLevel, Node, TopicIdPartition, TopicPartition, Uuid}
 import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.compress.Compression
-import org.apache.kafka.common.errors.UnknownTopicOrPartitionException
+import org.apache.kafka.common.errors.{NotLeaderOrFollowerException, UnknownTopicOrPartitionException}
 import org.apache.kafka.common.message.ListOffsetsRequestData.{ListOffsetsPartition, ListOffsetsTopic}
 import org.apache.kafka.common.message.ListOffsetsResponseData.{ListOffsetsPartitionResponse, ListOffsetsTopicResponse}
 import org.apache.kafka.common.message.DeleteRecordsResponseData
@@ -65,7 +65,7 @@ import org.apache.kafka.server.util.timer.MockTimer
 import org.apache.kafka.server.metrics.KafkaYammerMetrics
 import org.apache.kafka.storage.log.metrics.BrokerTopicStats
 import org.apache.kafka.storage.internals.checkpoint.LazyOffsetCheckpoints
-import org.apache.kafka.storage.internals.log.{AppendOrigin, AsyncOffsetReadFutureHolder, FetchDataInfo, LogConfig, LogDirFailureChannel, LogOffsetMetadata, LogOffsetSnapshot, LogReadResult, OffsetResultHolder, UnifiedLog}
+import org.apache.kafka.storage.internals.log.{AppendOrigin, AsyncOffsetReadFutureHolder, FetchDataInfo, LogConfig, LogDirFailureChannel, LogOffsetMetadata, LogOffsetSnapshot, LogReadResult, LogStartOffsetIncrementReason, OffsetResultHolder, UnifiedLog}
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
 import org.junit.jupiter.params.ParameterizedTest
@@ -7355,6 +7355,9 @@ class ReplicaManagerInklessTest {
       log.appendAsLeader(MemoryRecords.withRecords(0L, Compression.NONE, 0,
         new SimpleRecord("consolidated".getBytes, "value".getBytes)), 0)
       assertTrue(log.logEndOffset > sealOffset, "precondition: leader consolidated past the seal")
+      // The leader runs its own consolidation fetcher, whose maybeUpdateHighWatermark sets the local
+      // high watermark to the diskless frontier directly, bypassing the ISR-minimum logic.
+      log.updateHighWatermark(log.logEndOffset)
 
       doReturn(new CompletableFuture[Any]())
         .when(alterPartitionManager).submit(any(), any())
@@ -7379,6 +7382,188 @@ class ReplicaManagerInklessTest {
         "The high watermark must be clamped to the seal, not the consolidated frontier")
       assertEquals(sealOffset, partition.getReplica(followerId).get.stateSnapshot.logEndOffset,
         "The at-seal branch must still record the follower's position so ISR can expand")
+      verify(alterPartitionManager).submit(any(), argThat[LeaderAndIsr](_.isr.contains(followerId)))
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
+  def testFollowerAtSealWaitsWhileConsolidatingLeaderRebuildsClassicPrefix(): Unit = {
+    val followerId = 2
+    val sealOffset = 5L
+    val replicaManager = createReplicaManager(
+      List(disklessTopicPartition.topic()),
+      topicIdMapping = Map(disklessTopicPartition.topic() -> disklessTopicPartition.topicId()),
+      disklessManagedReplicasEnabled = true,
+      disklessRemoteStorageConsolidationEnabled = true,
+      consolidatingDisklessTopics = Set(disklessTopicPartition.topic()),
+    )
+    try {
+      val partition = setupSwitchedLeaderWithOutOfSyncFollower(
+        replicaManager, disklessTopicPartition, followerId, sealOffset)
+      partition.truncateTo(3L, isFuture = false)
+      assertTrue(partition.localLogOrException.logEndOffset < sealOffset,
+        "precondition: leader is rebuilding a lost classic prefix")
+
+      prepareAlterPartitionSubmit()
+      val data = fetchFollowerAtSeal(
+        replicaManager, disklessTopicPartition, followerId, sealOffset,
+        Optional.of(partition.getLeaderEpoch),
+        lastFetchedEpoch = Optional.of(partition.getLeaderEpoch))
+
+      assertEquals(Errors.NONE, data.error)
+      assertFalse(data.divergingEpoch.isPresent)
+      assertEquals(MemoryRecords.EMPTY, data.records)
+      assertEquals(sealOffset, data.highWatermark)
+      verify(alterPartitionManager, never()).submit(any(), any())
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
+  def testFollowerAtSealIsAdmittedAfterLeaderRetentionPassesSeal(): Unit = {
+    val followerId = 2
+    val sealOffset = 5L
+    val retainedStartOffset = 7L
+    val disklessLeaderEpoch = 7
+    val replicaManager = createReplicaManager(
+      List(disklessTopicPartition.topic()),
+      topicIdMapping = Map(disklessTopicPartition.topic() -> disklessTopicPartition.topicId()),
+      disklessManagedReplicasEnabled = true,
+      disklessRemoteStorageConsolidationEnabled = true,
+      consolidatingDisklessTopics = Set(disklessTopicPartition.topic()),
+    )
+    try {
+      val partition = setupSwitchedLeaderWithOutOfSyncFollower(
+        replicaManager, disklessTopicPartition, followerId, sealOffset)
+      val log = partition.localLogOrException
+      val classicLeaderEpoch = partition.getLeaderEpoch
+      log.appendAsLeader(MemoryRecords.withRecords(
+        0L,
+        Compression.NONE,
+        disklessLeaderEpoch,
+        new SimpleRecord("consolidated-1".getBytes, "value".getBytes),
+        new SimpleRecord("consolidated-2".getBytes, "value".getBytes),
+        new SimpleRecord("consolidated-3".getBytes, "value".getBytes)), disklessLeaderEpoch)
+      log.updateHighWatermark(log.logEndOffset)
+      log.maybeIncrementLogStartOffset(
+        retainedStartOffset, LogStartOffsetIncrementReason.ClientRecordDeletion)
+      assertTrue(log.logEndOffset > log.logStartOffset)
+      assertTrue(log.logStartOffset > sealOffset)
+
+      prepareAlterPartitionSubmit()
+      val data = fetchFollowerAtSeal(
+        replicaManager, disklessTopicPartition, followerId, sealOffset,
+        Optional.of(classicLeaderEpoch),
+        lastFetchedEpoch = Optional.of(classicLeaderEpoch))
+
+      assertEquals(Errors.NONE, data.error)
+      assertFalse(data.divergingEpoch.isPresent)
+      assertEquals(MemoryRecords.EMPTY, data.records)
+      assertEquals(sealOffset, data.highWatermark)
+      assertEquals(sealOffset, partition.getReplica(followerId).get.stateSnapshot.logEndOffset,
+        "expired-prefix admission must record the follower's actual requested offset")
+      verify(alterPartitionManager).submit(any(), argThat[LeaderAndIsr](_.isr.contains(followerId)))
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
+  def testFollowerFetchPastSealCarryingDisklessEpochIsAdmittedWhenLeaderHasConsolidated(): Unit = {
+    val followerId = 2
+    val sealOffset = 5L
+    val disklessLeaderEpoch = 7
+    val replicaManager = createReplicaManager(
+      List(disklessTopicPartition.topic()),
+      topicIdMapping = Map(disklessTopicPartition.topic() -> disklessTopicPartition.topicId()),
+      disklessManagedReplicasEnabled = true,
+      disklessRemoteStorageConsolidationEnabled = true,
+      consolidatingDisklessTopics = Set(disklessTopicPartition.topic()),
+    )
+    try {
+      val partition = setupSwitchedLeaderWithOutOfSyncFollower(
+        replicaManager, disklessTopicPartition, followerId, sealOffset)
+
+      // Both sides consolidated: the leader's suffix above the seal carries the diskless leader epoch,
+      // so the epoch the follower reports resolves in the leader's cache and no divergence is reported.
+      val log = partition.localLogOrException
+      log.appendAsLeader(MemoryRecords.withRecords(0L, Compression.NONE, disklessLeaderEpoch,
+        new SimpleRecord("consolidated".getBytes, "value".getBytes)), disklessLeaderEpoch)
+      log.updateHighWatermark(log.logEndOffset)
+      val followerLogEndOffset = log.logEndOffset
+
+      doReturn(new CompletableFuture[Any]())
+        .when(alterPartitionManager).submit(any(), any())
+      clearInvocations(alterPartitionManager)
+
+      val fetchParams = new FetchParams(
+        followerId, -1L, 0L, 1, 1024 * 1024, FetchIsolation.LOG_END, Optional.empty())
+      val fetchInfos = Seq(
+        disklessTopicPartition ->
+          new PartitionData(disklessTopicPartition.topicId(), followerLogEndOffset, 0L, 1024 * 1024,
+            Optional.of(partition.getLeaderEpoch), Optional.of(Integer.valueOf(disklessLeaderEpoch))))
+
+      @volatile var responseData: Map[TopicIdPartition, FetchPartitionData] = null
+      replicaManager.fetchMessages(fetchParams, fetchInfos, QuotaFactory.UNBOUNDED_QUOTA,
+        response => responseData = response.toMap)
+
+      val data = responseData(disklessTopicPartition)
+      assertEquals(Errors.NONE, data.error)
+      assertFalse(data.divergingEpoch.isPresent,
+        "A diskless epoch the leader also holds must not read as divergence")
+      assertEquals(sealOffset, data.highWatermark)
+      assertEquals(followerLogEndOffset, log.logEndOffset,
+        "The leader must not truncate its own consolidated suffix")
+      verify(alterPartitionManager).submit(any(), argThat[LeaderAndIsr](_.isr.contains(followerId)))
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
+  def testFollowerFetchPastSealSignalsOutOfRangeWhenLeaderLacksTheDisklessEpoch(): Unit = {
+    val followerId = 2
+    val sealOffset = 5L
+    val disklessLeaderEpoch = 7
+    val replicaManager = createReplicaManager(
+      List(disklessTopicPartition.topic()),
+      topicIdMapping = Map(disklessTopicPartition.topic() -> disklessTopicPartition.topicId()),
+      disklessManagedReplicasEnabled = true,
+      disklessRemoteStorageConsolidationEnabled = true,
+      consolidatingDisklessTopics = Set(disklessTopicPartition.topic()),
+    )
+    try {
+      // The follower consolidated past the seal but this leader has not, so its epoch cache holds no
+      // entry for the diskless leader epoch. Reachable after a leader change to a replica that never
+      // consolidated.
+      val partition = setupSwitchedLeaderWithOutOfSyncFollower(
+        replicaManager, disklessTopicPartition, followerId, sealOffset)
+
+      doReturn(new CompletableFuture[Any]())
+        .when(alterPartitionManager).submit(any(), any())
+      clearInvocations(alterPartitionManager)
+
+      val fetchParams = new FetchParams(
+        followerId, -1L, 0L, 1, 1024 * 1024, FetchIsolation.LOG_END, Optional.empty())
+      val fetchInfos = Seq(
+        disklessTopicPartition ->
+          new PartitionData(disklessTopicPartition.topicId(), sealOffset + 3, 0L, 1024 * 1024,
+            Optional.of(partition.getLeaderEpoch), Optional.of(Integer.valueOf(disklessLeaderEpoch))))
+
+      @volatile var responseData: Map[TopicIdPartition, FetchPartitionData] = null
+      replicaManager.fetchMessages(fetchParams, fetchInfos, QuotaFactory.UNBOUNDED_QUOTA,
+        response => responseData = response.toMap)
+
+      val data = responseData(disklessTopicPartition)
+      // Out of range is the right answer and the follower recovers from it: it asks the leader for the
+      // latest offset, which a follower request reads from the leader's local log, and truncates to the
+      // seal because that is where this leader's log ends. The next fetch carries a classic epoch and is
+      // admitted. Discarding the suffix is unavoidable here, since this leader does not hold it locally.
+      assertEquals(Errors.OFFSET_OUT_OF_RANGE, data.error)
+      verify(alterPartitionManager, never()).submit(any(), any())
     } finally {
       replicaManager.shutdown(checkpointHW = false)
     }
@@ -7474,6 +7659,57 @@ class ReplicaManagerInklessTest {
       assertEquals(UnifiedLog.UNKNOWN_OFFSET,
         partition.getReplica(followerId).get.stateSnapshot.logEndOffset)
       verify(alterPartitionManager, never()).submit(any(), any())
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
+  def testFollowerFetchAtSealIsolatesUnavailableLocalLog(): Unit = {
+    val followerId = 2
+    val sealOffset = 5L
+    val unavailableTopicPartition = disklessTopicPartition
+    val validTopicPartition = new TopicIdPartition(
+      disklessTopicPartition.topicId(), 1, disklessTopicPartition.topic())
+    val replicaManager = spy(createReplicaManager(
+      List(disklessTopicPartition.topic()),
+      topicIdMapping = Map(disklessTopicPartition.topic() -> disklessTopicPartition.topicId()),
+      disklessManagedReplicasEnabled = true,
+    ))
+    try {
+      setupSwitchedLeaderWithOutOfSyncFollower(
+        replicaManager, unavailableTopicPartition, followerId, sealOffset)
+      val validPartition = setupSwitchedLeaderWithOutOfSyncFollower(
+        replicaManager, validTopicPartition, followerId, sealOffset)
+      val unavailablePartition = mock(classOf[Partition])
+      when(unavailablePartition.localLogOrException)
+        .thenThrow(new NotLeaderOrFollowerException("local log unavailable"))
+      doReturn(Right(unavailablePartition)).when(replicaManager)
+        .getPartitionOrError(unavailableTopicPartition.topicPartition())
+      prepareAlterPartitionSubmit()
+
+      val fetchParams = new FetchParams(
+        followerId, -1L, 0L, 1, 1024 * 1024, FetchIsolation.LOG_END, Optional.empty())
+      val fetchInfos = Seq(
+        unavailableTopicPartition ->
+          new PartitionData(unavailableTopicPartition.topicId(), sealOffset, 0L, 1024 * 1024,
+            Optional.of(validPartition.getLeaderEpoch)),
+        validTopicPartition ->
+          new PartitionData(validTopicPartition.topicId(), sealOffset, 0L, 1024 * 1024,
+            Optional.of(validPartition.getLeaderEpoch))
+      )
+
+      @volatile var responseData: Map[TopicIdPartition, FetchPartitionData] = null
+      replicaManager.fetchMessages(fetchParams, fetchInfos, QuotaFactory.UNBOUNDED_QUOTA,
+        response => responseData = response.toMap)
+
+      assertEquals(Errors.NOT_LEADER_OR_FOLLOWER, responseData(unavailableTopicPartition).error)
+      assertEquals(Errors.NONE, responseData(validTopicPartition).error)
+      assertEquals(sealOffset, validPartition.getReplica(followerId).get.stateSnapshot.logEndOffset)
+      verify(alterPartitionManager, times(1)).submit(
+        ArgumentMatchers.eq(new org.apache.kafka.server.common.TopicIdPartition(
+          validTopicPartition.topicId(), validTopicPartition.partition())),
+        any())
     } finally {
       replicaManager.shutdown(checkpointHW = false)
     }
@@ -8005,14 +8241,21 @@ class ReplicaManagerInklessTest {
     followerId: Int,
     sealOffset: Long,
     currentLeaderEpoch: Optional[Integer],
-    fetchOffset: Option[Long] = None
+    fetchOffset: Option[Long] = None,
+    lastFetchedEpoch: Optional[Integer] = Optional.empty()
   ): FetchPartitionData = {
     val offset = fetchOffset.getOrElse(sealOffset)
     val fetchParams = new FetchParams(
       followerId, -1L, 0L, 1, 1024 * 1024, FetchIsolation.LOG_END, Optional.empty())
     val fetchInfos = Seq(
       topicIdPartition ->
-        new PartitionData(topicIdPartition.topicId(), offset, 0L, 1024 * 1024, currentLeaderEpoch))
+        new PartitionData(
+          topicIdPartition.topicId(),
+          offset,
+          0L,
+          1024 * 1024,
+          currentLeaderEpoch,
+          lastFetchedEpoch))
     @volatile var responseData: Map[TopicIdPartition, FetchPartitionData] = null
     replicaManager.fetchMessages(fetchParams, fetchInfos, QuotaFactory.UNBOUNDED_QUOTA,
       response => responseData = response.toMap)

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerInklessTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerInklessTest.scala
@@ -7103,6 +7103,57 @@ class ReplicaManagerInklessTest {
   }
 
   @Test
+  def testFollowerFetchAtSealOnConsolidatingLeaderGetsAtSealResponse(): Unit = {
+    val followerId = 2
+    val sealOffset = 5L
+    val replicaManager = createReplicaManager(
+      List(disklessTopicPartition.topic()),
+      topicIdMapping = Map(disklessTopicPartition.topic() -> disklessTopicPartition.topicId()),
+      disklessManagedReplicasEnabled = true,
+      disklessRemoteStorageConsolidationEnabled = true,
+      consolidatingDisklessTopics = Set(disklessTopicPartition.topic()),
+    )
+    try {
+      val partition = setupSwitchedLeaderWithOutOfSyncFollower(
+        replicaManager, disklessTopicPartition, followerId, sealOffset)
+
+      // Consolidation has run on the leader, so its local log end offset is past the seal. Without
+      // the follower-at-or-above-seal exclusion the fetch reads that consolidated suffix from the
+      // local log instead of taking the at-seal branch.
+      val log = partition.localLogOrException
+      log.appendAsLeader(MemoryRecords.withRecords(0L, Compression.NONE, 0,
+        new SimpleRecord("consolidated".getBytes, "value".getBytes)), 0)
+      assertTrue(log.logEndOffset > sealOffset, "precondition: leader consolidated past the seal")
+
+      doReturn(new CompletableFuture[Any]())
+        .when(alterPartitionManager).submit(any(), any())
+      clearInvocations(alterPartitionManager)
+
+      val fetchParams = new FetchParams(
+        followerId, -1L, 0L, 1, 1024 * 1024, FetchIsolation.LOG_END, Optional.empty())
+      val fetchInfos = Seq(
+        disklessTopicPartition ->
+          new PartitionData(disklessTopicPartition.topicId(), sealOffset, 0L, 1024 * 1024,
+            Optional.of(partition.getLeaderEpoch)))
+
+      @volatile var responseData: Map[TopicIdPartition, FetchPartitionData] = null
+      replicaManager.fetchMessages(fetchParams, fetchInfos, QuotaFactory.UNBOUNDED_QUOTA,
+        response => responseData = response.toMap)
+
+      val data = responseData(disklessTopicPartition)
+      assertEquals(Errors.NONE, data.error)
+      assertEquals(MemoryRecords.EMPTY, data.records,
+        "A follower at the seal must not receive the leader's consolidated records")
+      assertEquals(sealOffset, data.highWatermark,
+        "The high watermark must be clamped to the seal, not the consolidated frontier")
+      assertEquals(sealOffset, partition.getReplica(followerId).get.stateSnapshot.logEndOffset,
+        "The at-seal branch must still record the follower's position so ISR can expand")
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
   def testFollowerFetchAtSealRecordsFetchStateAndAllowsIsrExpansionWhenEpochMatches(): Unit = {
     val followerId = 2
     val sealOffset = 5L

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerInklessTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerInklessTest.scala
@@ -72,7 +72,7 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
-import org.mockito.{Answers, ArgumentMatchers, MockedConstruction, Mockito}
+import org.mockito.{Answers, ArgumentCaptor, ArgumentMatchers, MockedConstruction, Mockito}
 
 import java.io.File
 import java.net.InetAddress
@@ -6548,6 +6548,237 @@ class ReplicaManagerInklessTest {
   }
 
   @Test
+  def testApplyDeltaKeepsConsolidatingFollowerAtSealOnClassicFetcherWhileOutsideIsr(): Unit = {
+    val topicName = "switched-consolidating"
+    val topicId = Uuid.randomUuid()
+    val tp = new TopicPartition(topicName, 0)
+    val brokerId = 1
+    val leaderId = 2
+    val sealOffset = 10L
+
+    val mockFetcherManager = mock(classOf[ReplicaFetcherManager])
+    when(mockFetcherManager.removeFetcherForPartitions(any())).thenReturn(Map.empty[TopicPartition, PartitionFetchState])
+
+    val replicaManager = spy(createReplicaManager(
+      List(topicName),
+      disklessManagedReplicasEnabled = true,
+      disklessRemoteStorageConsolidationEnabled = true,
+      consolidatingDisklessTopics = Set(topicName),
+      mockReplicaFetcherManager = Some(mockFetcherManager)
+    ))
+    try {
+      // Caught up exactly to the seal, so consolidation would normally take over. Outside ISR it must
+      // stay on the classic fetcher: the consolidation fetcher reads object storage, so the leader
+      // would never observe this replica and nothing would expand ISR.
+      val log = replicaManager.logManager.getOrCreateLog(tp, isNew = true, topicId = Optional.of(topicId))
+      populateLocalLogAtLeoAndCheckpointedHwm(replicaManager, tp, log, leo = sealOffset, hw = sealOffset)
+      when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(tp)).thenReturn(sealOffset)
+      when(replicaManager.inklessMetadataView().isReplicaInIsr(tp, brokerId)).thenReturn(false)
+
+      val delta = disklessFollowerDelta(topicName, topicId, brokerId, leaderId, followerInIsr = false)
+      replicaManager.applyDelta(delta, imageFromTopics(delta.apply()))
+
+      val captor: ArgumentCaptor[Map[TopicPartition, InitialFetchState]] =
+        ArgumentCaptor.forClass(classOf[Map[TopicPartition, InitialFetchState]])
+      verify(mockFetcherManager).addFetcherForPartitions(captor.capture())
+      assertTrue(captor.getValue.contains(tp),
+        s"Expected the classic fetcher to take $tp, got ${captor.getValue.keySet}")
+      assertEquals(sealOffset, captor.getValue.apply(tp).initOffset,
+        "The classic fetch must resume at the seal so the leader records this replica there")
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
+  def testApplyDeltaSendsConsolidatingFollowerAtSealToConsolidationWhileInIsr(): Unit = {
+    val topicName = "switched-consolidating"
+    val topicId = Uuid.randomUuid()
+    val tp = new TopicPartition(topicName, 0)
+    val brokerId = 1
+    val leaderId = 2
+    val sealOffset = 10L
+
+    val ctorInit: MockedConstruction.MockInitializer[ConsolidationFetcherManager] = {
+      case (mock, _) =>
+        when(mock.removeFetcherForPartitions(any())).thenReturn(Map.empty[TopicPartition, PartitionFetchState])
+    }
+    val consolidationCtor = mockConstruction(classOf[ConsolidationFetcherManager], ctorInit)
+    val mockFetcherManager = mock(classOf[ReplicaFetcherManager])
+    when(mockFetcherManager.removeFetcherForPartitions(any())).thenReturn(Map.empty[TopicPartition, PartitionFetchState])
+    try {
+      val replicaManager = spy(createReplicaManager(
+        List(topicName),
+        disklessManagedReplicasEnabled = true,
+        disklessRemoteStorageConsolidationEnabled = true,
+        consolidatingDisklessTopics = Set(topicName),
+        mockReplicaFetcherManager = Some(mockFetcherManager)
+      ))
+      try {
+        val mockCfm = consolidationCtor.constructed().get(0)
+        // Same state as the hold-back test, except the replica is in ISR: the leader already has its
+        // evidence, so consolidation takes over.
+        val log = replicaManager.logManager.getOrCreateLog(tp, isNew = true, topicId = Optional.of(topicId))
+        populateLocalLogAtLeoAndCheckpointedHwm(replicaManager, tp, log, leo = sealOffset, hw = sealOffset)
+        when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(tp)).thenReturn(sealOffset)
+        when(replicaManager.inklessMetadataView().isReplicaInIsr(tp, brokerId)).thenReturn(true)
+
+        val delta = disklessFollowerDelta(topicName, topicId, brokerId, leaderId)
+        replicaManager.applyDelta(delta, imageFromTopics(delta.apply()))
+
+        verify(mockCfm).removeFetcherForPartitions(Set(tp))
+        val captor: ArgumentCaptor[Map[TopicPartition, InitialFetchState]] =
+          ArgumentCaptor.forClass(classOf[Map[TopicPartition, InitialFetchState]])
+        verify(mockFetcherManager).addFetcherForPartitions(captor.capture())
+        assertFalse(captor.getValue.contains(tp),
+          s"An in-ISR replica at the seal must not stay on the classic fetcher, got ${captor.getValue.keySet}")
+      } finally {
+        replicaManager.shutdown(checkpointHW = false)
+      }
+    } finally {
+      consolidationCtor.close()
+    }
+  }
+
+  @Test
+  def testApplyDeltaReroutesConsolidatingFollowerToClassicFetcherWhenRemovedFromIsr(): Unit = {
+    val topicName = "switched-consolidating"
+    val topicId = Uuid.randomUuid()
+    val tp = new TopicPartition(topicName, 0)
+    val brokerId = 1
+    val leaderId = 2
+    val sealOffset = 10L
+
+    val ctorInit: MockedConstruction.MockInitializer[ConsolidationFetcherManager] = {
+      case (mock, _) =>
+        when(mock.removeFetcherForPartitions(any())).thenReturn(Map.empty[TopicPartition, PartitionFetchState])
+    }
+    val consolidationCtor = mockConstruction(classOf[ConsolidationFetcherManager], ctorInit)
+    val mockFetcherManager = mock(classOf[ReplicaFetcherManager])
+    when(mockFetcherManager.removeFetcherForPartitions(any())).thenReturn(Map.empty[TopicPartition, PartitionFetchState])
+    try {
+      val replicaManager = spy(createReplicaManager(
+        List(topicName),
+        disklessManagedReplicasEnabled = true,
+        disklessRemoteStorageConsolidationEnabled = true,
+        consolidatingDisklessTopics = Set(topicName),
+        mockReplicaFetcherManager = Some(mockFetcherManager)
+      ))
+      try {
+        val mockCfm = consolidationCtor.constructed().get(0)
+        val log = replicaManager.logManager.getOrCreateLog(tp, isNew = true, topicId = Optional.of(topicId))
+        populateLocalLogAtLeoAndCheckpointedHwm(replicaManager, tp, log, leo = sealOffset, hw = sealOffset)
+        when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(tp)).thenReturn(sealOffset)
+        when(replicaManager.inklessMetadataView().isReplicaInIsr(tp, brokerId)).thenReturn(true)
+
+        val initialDelta = disklessFollowerDelta(
+          topicName,
+          topicId,
+          brokerId,
+          leaderId,
+          classicToDisklessStartOffset = sealOffset
+        )
+        val initialImage = imageFromTopics(initialDelta.apply())
+        replicaManager.applyDelta(initialDelta, initialImage)
+        verify(mockCfm).addFetcherForPartitions(argThat[Map[TopicPartition, InitialFetchState]](_.contains(tp)))
+        clearInvocations(mockFetcherManager, mockCfm)
+
+        when(replicaManager.inklessMetadataView().isReplicaInIsr(tp, brokerId)).thenReturn(false)
+        val isrRemovalDelta = new TopicsDelta(initialImage.topics())
+        isrRemovalDelta.replay(new PartitionChangeRecord()
+          .setTopicId(topicId)
+          .setPartitionId(tp.partition)
+          .setIsr(util.Arrays.asList(leaderId)))
+
+        val updatedRegistration = isrRemovalDelta.apply().getTopic(topicId).partitions().get(tp.partition)
+        assertEquals(0, updatedRegistration.leaderEpoch,
+          "Removing a follower from ISR must not change the leader epoch")
+        assertEquals(1, updatedRegistration.partitionEpoch,
+          "Removing a follower from ISR must advance the partition epoch")
+
+        replicaManager.applyDelta(isrRemovalDelta, imageFromTopics(isrRemovalDelta.apply()))
+
+        verify(mockCfm).removeFetcherForPartitions(Set(tp))
+        verify(mockFetcherManager).removeFetcherForPartitions(Set(tp))
+        val captor: ArgumentCaptor[Map[TopicPartition, InitialFetchState]] =
+          ArgumentCaptor.forClass(classOf[Map[TopicPartition, InitialFetchState]])
+        verify(mockFetcherManager).addFetcherForPartitions(captor.capture())
+        assertEquals(sealOffset, captor.getValue.apply(tp).initOffset,
+          "The classic fetch must resume at the existing LEO so the leader can readmit the replica")
+      } finally {
+        replicaManager.shutdown(checkpointHW = false)
+      }
+    } finally {
+      consolidationCtor.close()
+    }
+  }
+
+  @Test
+  def testApplyDeltaKeepsConsolidatingFollowerPastSealOnClassicFetcherWhileOutsideIsr(): Unit = {
+    val topicName = "switched-consolidating"
+    val topicId = Uuid.randomUuid()
+    val tp = new TopicPartition(topicName, 0)
+    val brokerId = 1
+    val leaderId = 2
+    val sealOffset = 10L
+    val leo = sealOffset + 3
+    val disklessLeaderEpoch = 5
+
+    val ctorInit: MockedConstruction.MockInitializer[ConsolidationFetcherManager] = {
+      case (mock, _) =>
+        when(mock.removeFetcherForPartitions(any())).thenReturn(Map.empty[TopicPartition, PartitionFetchState])
+    }
+    val consolidationCtor = mockConstruction(classOf[ConsolidationFetcherManager], ctorInit)
+    val mockFetcherManager = mock(classOf[ReplicaFetcherManager])
+    when(mockFetcherManager.removeFetcherForPartitions(any())).thenReturn(Map.empty[TopicPartition, PartitionFetchState])
+    try {
+      val replicaManager = spy(createReplicaManager(
+        List(topicName),
+        disklessManagedReplicasEnabled = true,
+        disklessRemoteStorageConsolidationEnabled = true,
+        consolidatingDisklessTopics = Set(topicName),
+        mockReplicaFetcherManager = Some(mockFetcherManager)
+      ))
+      try {
+        // Already consolidated past the seal and outside ISR. Consolidation sends the leader no fetch,
+        // so taking this replica there would leave it with no admission path at all. It waits on the
+        // classic fetcher instead, starting at its real log end offset so the diskless suffix survives.
+        val log = replicaManager.logManager.getOrCreateLog(tp, isNew = true, topicId = Optional.of(topicId))
+        populateConsolidatedLocalLogAndCheckpointedHwm(
+          replicaManager, tp, log, sealOffset, leo, disklessLeaderEpoch, hw = sealOffset)
+        when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(tp)).thenReturn(sealOffset)
+        when(replicaManager.inklessMetadataView().getDisklessLeaderEpoch(tp)).thenReturn(disklessLeaderEpoch)
+        when(replicaManager.inklessMetadataView().isReplicaInIsr(tp, brokerId)).thenReturn(false)
+
+        val delta = disklessFollowerDelta(
+          topicName,
+          topicId,
+          brokerId,
+          leaderId,
+          classicToDisklessStartOffset = sealOffset,
+          disklessLeaderEpoch = disklessLeaderEpoch,
+          followerInIsr = false
+        )
+        replicaManager.applyDelta(delta, imageFromTopics(delta.apply()))
+
+        val captor: ArgumentCaptor[Map[TopicPartition, InitialFetchState]] =
+          ArgumentCaptor.forClass(classOf[Map[TopicPartition, InitialFetchState]])
+        verify(mockFetcherManager).addFetcherForPartitions(captor.capture())
+        assertTrue(captor.getValue.contains(tp),
+          s"A replica past the seal and outside ISR must wait on the classic fetcher, got ${captor.getValue.keySet}")
+        assertEquals(leo, captor.getValue.apply(tp).initOffset,
+          "The fetch must resume at the real log end offset so the consolidated suffix is not discarded")
+        assertEquals(leo, replicaManager.localLogOrException(tp).logEndOffset,
+          "The diskless suffix must survive the routing decision")
+      } finally {
+        replicaManager.shutdown(checkpointHW = false)
+      }
+    } finally {
+      consolidationCtor.close()
+    }
+  }
+
+  @Test
   def testApplyDeltaDoesNotStartCatchUpFetcherWhenDisklessFollowerHwmAtSealOffset(): Unit = {
     val topicName = "switched-topic"
     val topicId = Uuid.randomUuid()
@@ -8625,8 +8856,8 @@ class ReplicaManagerInklessTest {
   @Test
   def testSwitchedConsolidatingFollowerBelowSealStaysOnClassicFetcher(): Unit = {
     // A switched consolidating follower whose local log is still below the committed seal must
-    // keep replicating the classic prefix via the classic ReplicaFetcher (which self-evicts and
-    // hands off to consolidation once it reaches the seal). It must NOT be routed straight to the
+    // keep replicating the classic prefix via the classic ReplicaFetcher, which hands off to
+    // consolidation once it reaches the seal and is in ISR. It must NOT be routed straight to the
     // consolidation fetcher, otherwise the reconciler would Retry it and, since a follower's only
     // catch-up path is the classic fetcher, it would be stranded without ever reaching the seal.
     val consolidatingTopic = disklessTopicPartition.topic()

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerInklessTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerInklessTest.scala
@@ -67,7 +67,7 @@ import org.apache.kafka.server.util.timer.MockTimer
 import org.apache.kafka.server.metrics.KafkaYammerMetrics
 import org.apache.kafka.storage.log.metrics.BrokerTopicStats
 import org.apache.kafka.storage.internals.checkpoint.LazyOffsetCheckpoints
-import org.apache.kafka.storage.internals.log.{AppendOrigin, AsyncOffsetReadFutureHolder, FetchDataInfo, LogConfig, LogDirFailureChannel, LogOffsetMetadata, LogOffsetSnapshot, LogReadInfo, LogReadResult, OffsetResultHolder, UnifiedLog}
+import org.apache.kafka.storage.internals.log.{AppendOrigin, AsyncOffsetReadFutureHolder, FetchDataInfo, LogConfig, LogDirFailureChannel, LogOffsetMetadata, LogOffsetSnapshot, LogReadInfo, LogReadResult, LogStartOffsetIncrementReason, OffsetResultHolder, UnifiedLog}
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
 import org.junit.jupiter.params.ParameterizedTest
@@ -7856,10 +7856,730 @@ class ReplicaManagerInklessTest {
         Optional.of(partition.getLeaderEpoch),
         fetchOffset = Some(150L))
 
-      assertEmptySealResponseWithoutDisklessIo(data, replicaManager, fetchHandlerCtor, cp, sealOffset)
+      // Fetching at 150 past a seal of 100: the watermark follows the requested offset.
+      assertEmptySealResponseWithoutDisklessIo(data, replicaManager, fetchHandlerCtor, cp, 150L)
     } finally {
       replicaManager.shutdown(checkpointHW = false)
       fetchHandlerCtor.close()
+    }
+  }
+
+  @Test
+  def testFollowerFetchAtSealOnConsolidatingLeaderGetsAtSealResponse(): Unit = {
+    val followerId = 2
+    val sealOffset = 5L
+    val replicaManager = createReplicaManager(
+      List(disklessTopicPartition.topic()),
+      topicIdMapping = Map(disklessTopicPartition.topic() -> disklessTopicPartition.topicId()),
+      disklessManagedReplicasEnabled = true,
+      disklessRemoteStorageConsolidationEnabled = true,
+      consolidatingDisklessTopics = Set(disklessTopicPartition.topic()),
+    )
+    try {
+      val partition = setupSwitchedLeaderWithOutOfSyncFollower(
+        replicaManager, disklessTopicPartition, followerId, sealOffset)
+
+      // Consolidation has run on the leader, so its local log end offset is past the seal. Without
+      // the follower-at-or-above-seal exclusion the fetch reads that consolidated suffix from the
+      // local log instead of taking the at-seal branch.
+      val log = partition.localLogOrException
+      // Consolidated records carry the diskless leader epoch, distinct from the classic prefix's.
+      log.appendAsLeader(MemoryRecords.withRecords(0L, Compression.NONE, 7,
+        new SimpleRecord("consolidated".getBytes, "value".getBytes)), 7)
+      assertTrue(log.logEndOffset > sealOffset, "precondition: leader consolidated past the seal")
+      // The leader runs its own consolidation fetcher, whose maybeUpdateHighWatermark sets the local
+      // high watermark to the diskless frontier directly, bypassing the ISR-minimum logic.
+      log.updateHighWatermark(log.logEndOffset)
+
+      doReturn(new CompletableFuture[Any]())
+        .when(alterPartitionManager).submit(any(), any())
+      clearInvocations(alterPartitionManager)
+
+      val fetchParams = new FetchParams(
+        followerId, -1L, 0L, 1, 1024 * 1024, FetchIsolation.LOG_END, Optional.empty())
+      val fetchInfos = Seq(
+        disklessTopicPartition ->
+          new PartitionData(disklessTopicPartition.topicId(), sealOffset, 0L, 1024 * 1024,
+            Optional.of(partition.getLeaderEpoch), Optional.of(Integer.valueOf(0))))
+
+      @volatile var responseData: Map[TopicIdPartition, FetchPartitionData] = null
+      val hwLagFetchesBefore = yammerMeterCount("ConsolidationHighWatermarkLagFetchRate")
+      replicaManager.fetchMessages(fetchParams, fetchInfos, QuotaFactory.UNBOUNDED_QUOTA,
+        response => responseData = response.toMap)
+
+      val data = responseData(disklessTopicPartition)
+      assertEquals(Errors.NONE, data.error)
+      assertEquals(MemoryRecords.EMPTY, data.records,
+        "A follower at the seal must not receive the leader's consolidated records")
+      // The exclusion routes this fetch past the local-read branch, which is where the
+      // consumer-only high-watermark-lag meter is marked. It must not count replication.
+      assertEquals(hwLagFetchesBefore, yammerMeterCount("ConsolidationHighWatermarkLagFetchRate"),
+        "A follower held back by the at-seal exclusion must not mark the consumer meter")
+      assertEquals(sealOffset, data.highWatermark,
+        "The high watermark must be clamped to the seal, not the consolidated frontier")
+      assertEquals(sealOffset, partition.getReplica(followerId).get.stateSnapshot.logEndOffset,
+        "The at-seal branch must still record the follower's position so ISR can expand")
+      verify(alterPartitionManager).submit(any(), argThat[LeaderAndIsr](_.isr.contains(followerId)))
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
+  def testFollowerAtSealWaitsWhileConsolidatingLeaderRebuildsClassicPrefix(): Unit = {
+    val followerId = 2
+    val sealOffset = 5L
+    val replicaManager = createReplicaManager(
+      List(disklessTopicPartition.topic()),
+      topicIdMapping = Map(disklessTopicPartition.topic() -> disklessTopicPartition.topicId()),
+      disklessManagedReplicasEnabled = true,
+      disklessRemoteStorageConsolidationEnabled = true,
+      consolidatingDisklessTopics = Set(disklessTopicPartition.topic()),
+    )
+    try {
+      val partition = setupSwitchedLeaderWithOutOfSyncFollower(
+        replicaManager, disklessTopicPartition, followerId, sealOffset)
+      partition.truncateTo(3L, isFuture = false)
+      assertTrue(partition.localLogOrException.logEndOffset < sealOffset,
+        "precondition: leader is rebuilding a lost classic prefix")
+
+      prepareAlterPartitionSubmit()
+      val data = fetchFollowerAtSeal(
+        replicaManager, disklessTopicPartition, followerId, sealOffset,
+        Optional.of(partition.getLeaderEpoch),
+        lastFetchedEpoch = Optional.of(partition.getLeaderEpoch))
+
+      assertEquals(Errors.NONE, data.error)
+      assertFalse(data.divergingEpoch.isPresent)
+      assertEquals(MemoryRecords.EMPTY, data.records)
+      assertEquals(sealOffset, data.highWatermark)
+      verify(alterPartitionManager, never()).submit(any(), any())
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
+  def testFollowerAtSealIsAdmittedAfterLeaderRetentionPassesSeal(): Unit = {
+    val followerId = 2
+    val sealOffset = 5L
+    val retainedStartOffset = 7L
+    val disklessLeaderEpoch = 7
+    val replicaManager = createReplicaManager(
+      List(disklessTopicPartition.topic()),
+      topicIdMapping = Map(disklessTopicPartition.topic() -> disklessTopicPartition.topicId()),
+      disklessManagedReplicasEnabled = true,
+      disklessRemoteStorageConsolidationEnabled = true,
+      consolidatingDisklessTopics = Set(disklessTopicPartition.topic()),
+    )
+    try {
+      val partition = setupSwitchedLeaderWithOutOfSyncFollower(
+        replicaManager, disklessTopicPartition, followerId, sealOffset)
+      val log = partition.localLogOrException
+      val classicLeaderEpoch = partition.getLeaderEpoch
+      log.appendAsLeader(MemoryRecords.withRecords(
+        0L,
+        Compression.NONE,
+        disklessLeaderEpoch,
+        new SimpleRecord("consolidated-1".getBytes, "value".getBytes),
+        new SimpleRecord("consolidated-2".getBytes, "value".getBytes),
+        new SimpleRecord("consolidated-3".getBytes, "value".getBytes)), disklessLeaderEpoch)
+      log.updateHighWatermark(log.logEndOffset)
+      log.maybeIncrementLogStartOffset(
+        retainedStartOffset, LogStartOffsetIncrementReason.ClientRecordDeletion)
+      assertTrue(log.logEndOffset > log.logStartOffset)
+      assertTrue(log.logStartOffset > sealOffset)
+
+      prepareAlterPartitionSubmit()
+      val data = fetchFollowerAtSeal(
+        replicaManager, disklessTopicPartition, followerId, sealOffset,
+        Optional.of(classicLeaderEpoch),
+        lastFetchedEpoch = Optional.of(classicLeaderEpoch))
+
+      assertEquals(Errors.NONE, data.error)
+      assertFalse(data.divergingEpoch.isPresent)
+      assertEquals(MemoryRecords.EMPTY, data.records)
+      assertEquals(sealOffset, data.highWatermark)
+      assertEquals(sealOffset, partition.getReplica(followerId).get.stateSnapshot.logEndOffset,
+        "expired-prefix admission must record the follower's actual requested offset")
+      verify(alterPartitionManager).submit(any(), argThat[LeaderAndIsr](_.isr.contains(followerId)))
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
+  def testFollowerFetchPastSealCarryingClassicBoundaryEpochIsAdmittedWhenLeaderHasConsolidated(): Unit = {
+    val followerId = 2
+    val sealOffset = 5L
+    val classicBoundaryEpoch = 0
+    val disklessLeaderEpoch = 7
+    val replicaManager = createReplicaManager(
+      List(disklessTopicPartition.topic()),
+      topicIdMapping = Map(disklessTopicPartition.topic() -> disklessTopicPartition.topicId()),
+      disklessManagedReplicasEnabled = true,
+      disklessRemoteStorageConsolidationEnabled = true,
+      consolidatingDisklessTopics = Set(disklessTopicPartition.topic()),
+    )
+    try {
+      val partition = setupSwitchedLeaderWithOutOfSyncFollower(
+        replicaManager, disklessTopicPartition, followerId, sealOffset)
+
+      // Both sides consolidated. The follower offers the epoch of its last classic record, which the
+      // leader resolves to an end offset at the seal, so the classic prefix is validated even though the
+      // follower's latest epoch is the diskless one.
+      val log = partition.localLogOrException
+      log.appendAsLeader(MemoryRecords.withRecords(0L, Compression.NONE, disklessLeaderEpoch,
+        new SimpleRecord("consolidated".getBytes, "value".getBytes)), disklessLeaderEpoch)
+      log.updateHighWatermark(log.logEndOffset)
+      val followerLogEndOffset = log.logEndOffset
+
+      doReturn(new CompletableFuture[Any]())
+        .when(alterPartitionManager).submit(any(), any())
+      clearInvocations(alterPartitionManager)
+
+      val fetchParams = new FetchParams(
+        followerId, -1L, 0L, 1, 1024 * 1024, FetchIsolation.LOG_END, Optional.empty())
+      val fetchInfos = Seq(
+        disklessTopicPartition ->
+          new PartitionData(disklessTopicPartition.topicId(), followerLogEndOffset, 0L, 1024 * 1024,
+            Optional.of(partition.getLeaderEpoch), Optional.of(Integer.valueOf(classicBoundaryEpoch))))
+
+      @volatile var responseData: Map[TopicIdPartition, FetchPartitionData] = null
+      replicaManager.fetchMessages(fetchParams, fetchInfos, QuotaFactory.UNBOUNDED_QUOTA,
+        response => responseData = response.toMap)
+
+      val data = responseData(disklessTopicPartition)
+      assertEquals(Errors.NONE, data.error)
+      assertFalse(data.divergingEpoch.isPresent,
+        "A classic boundary epoch that ends at the seal on the leader must not read as divergence")
+      assertEquals(followerLogEndOffset, data.highWatermark,
+        "The watermark must not drop a consolidated follower below its own log end offset")
+      assertEquals(followerLogEndOffset, log.logEndOffset,
+        "The leader must not truncate its own consolidated suffix")
+      verify(alterPartitionManager).submit(any(), argThat[LeaderAndIsr](_.isr.contains(followerId)))
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
+  def testFollowerFetchPastSealCarryingStaleClassicEpochIsNotAdmitted(): Unit = {
+    val followerId = 2
+    val sealOffset = 5L
+    val staleClassicEpoch = 0
+    val replicaManager = createReplicaManager(
+      List(disklessTopicPartition.topic()),
+      topicIdMapping = Map(disklessTopicPartition.topic() -> disklessTopicPartition.topicId()),
+      disklessManagedReplicasEnabled = true,
+      disklessRemoteStorageConsolidationEnabled = true,
+      consolidatingDisklessTopics = Set(disklessTopicPartition.topic()),
+    )
+    try {
+      // The leader's prefix is epoch 0 for [0, 3) and epoch 1 for [3, 5). The follower's prefix is
+      // epoch 0 all the way to the seal: it followed the epoch-0 leader for [3, 5) and never truncated
+      // when epoch 1 rewrote that range. It then consolidated past the seal, so its latest epoch is the
+      // diskless one and would resolve on the leader. Offering the boundary epoch instead exposes the
+      // divergence at offset 3.
+      val partition = setupSwitchedLeaderWithOutOfSyncFollower(
+        replicaManager, disklessTopicPartition, followerId, 3L)
+      val log = partition.localLogOrException
+      log.appendAsLeader(MemoryRecords.withRecords(0L, Compression.NONE, 1,
+        new SimpleRecord("rewritten-3".getBytes, "value".getBytes),
+        new SimpleRecord("rewritten-4".getBytes, "value".getBytes)), 1)
+      log.updateHighWatermark(sealOffset)
+      when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
+        .thenReturn(sealOffset)
+
+      doReturn(new CompletableFuture[Any]())
+        .when(alterPartitionManager).submit(any(), any())
+      clearInvocations(alterPartitionManager)
+
+      val fetchParams = new FetchParams(
+        followerId, -1L, 0L, 1, 1024 * 1024, FetchIsolation.LOG_END, Optional.empty())
+      val fetchInfos = Seq(
+        disklessTopicPartition ->
+          new PartitionData(disklessTopicPartition.topicId(), sealOffset + 3, 0L, 1024 * 1024,
+            Optional.of(partition.getLeaderEpoch), Optional.of(Integer.valueOf(staleClassicEpoch))))
+
+      @volatile var responseData: Map[TopicIdPartition, FetchPartitionData] = null
+      replicaManager.fetchMessages(fetchParams, fetchInfos, QuotaFactory.UNBOUNDED_QUOTA,
+        response => responseData = response.toMap)
+
+      val data = responseData(disklessTopicPartition)
+      assertEquals(Errors.NONE, data.error)
+      assertTrue(data.divergingEpoch.isPresent,
+        "A boundary epoch that ends before the seal on the leader must read as divergence")
+      assertEquals(0, data.divergingEpoch.get.epoch)
+      assertEquals(3L, data.divergingEpoch.get.endOffset)
+      verify(alterPartitionManager, never()).submit(any(), any())
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
+  def testFollowerFetchAtSealWithoutAnEpochIsNotAdmitted(): Unit = {
+    val followerId = 2
+    val sealOffset = 5L
+    val replicaManager = createReplicaManager(
+      List(disklessTopicPartition.topic()),
+      topicIdMapping = Map(disklessTopicPartition.topic() -> disklessTopicPartition.topicId()),
+      disklessManagedReplicasEnabled = true,
+      disklessRemoteStorageConsolidationEnabled = true,
+      consolidatingDisklessTopics = Set(disklessTopicPartition.topic()),
+    )
+    try {
+      // fetchRecords runs no divergence check when the request carries no epoch, so an absent epoch
+      // must not count as a validated prefix.
+      val partition = setupSwitchedLeaderWithOutOfSyncFollower(
+        replicaManager, disklessTopicPartition, followerId, sealOffset)
+      doReturn(new CompletableFuture[Any]())
+        .when(alterPartitionManager).submit(any(), any())
+      clearInvocations(alterPartitionManager)
+
+      val data = fetchFollowerAtSeal(
+        replicaManager, disklessTopicPartition, followerId, sealOffset,
+        Optional.of(partition.getLeaderEpoch))
+
+      assertEquals(Errors.NONE, data.error)
+      assertFalse(data.divergingEpoch.isPresent)
+      assertEquals(sealOffset, data.highWatermark)
+      verify(alterPartitionManager, never()).submit(any(), any())
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
+  def testFollowerFetchPastSealCarryingDisklessEpochIsNotAdmitted(): Unit = {
+    val followerId = 2
+    val sealOffset = 5L
+    val disklessLeaderEpoch = 7
+    val replicaManager = createReplicaManager(
+      List(disklessTopicPartition.topic()),
+      topicIdMapping = Map(disklessTopicPartition.topic() -> disklessTopicPartition.topicId()),
+      disklessManagedReplicasEnabled = true,
+      disklessRemoteStorageConsolidationEnabled = true,
+      consolidatingDisklessTopics = Set(disklessTopicPartition.topic()),
+    )
+    try {
+      // Both sides consolidated, so the diskless epoch resolves on the leader and reports no divergence.
+      // It ends past the seal, not at it, so it proves the suffix and not the prefix, and must not admit.
+      val partition = setupSwitchedLeaderWithOutOfSyncFollower(
+        replicaManager, disklessTopicPartition, followerId, sealOffset)
+      val log = partition.localLogOrException
+      log.appendAsLeader(MemoryRecords.withRecords(0L, Compression.NONE, disklessLeaderEpoch,
+        new SimpleRecord("consolidated".getBytes, "value".getBytes)), disklessLeaderEpoch)
+      log.updateHighWatermark(log.logEndOffset)
+      doReturn(new CompletableFuture[Any]())
+        .when(alterPartitionManager).submit(any(), any())
+      clearInvocations(alterPartitionManager)
+
+      val data = fetchFollowerAtSeal(
+        replicaManager, disklessTopicPartition, followerId, sealOffset,
+        Optional.of(partition.getLeaderEpoch),
+        fetchOffset = Some(log.logEndOffset),
+        lastFetchedEpoch = Optional.of(Integer.valueOf(disklessLeaderEpoch)))
+
+      assertEquals(Errors.NONE, data.error)
+      assertFalse(data.divergingEpoch.isPresent)
+      assertEquals(log.logEndOffset, data.highWatermark)
+      assertEquals(sealOffset, partition.getReplica(followerId).get.stateSnapshot.logEndOffset,
+        "The request is still validated and recorded at the seal, which is what checks the broker epoch")
+      verify(alterPartitionManager, never()).submit(any(), any())
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
+  def testFollowerFetchPastSealIsAdmittedAfterLeaderRetentionPassesSealWithDisklessEpoch(): Unit = {
+    val followerId = 2
+    val sealOffset = 5L
+    val disklessLeaderEpoch = 7
+    val replicaManager = createReplicaManager(
+      List(disklessTopicPartition.topic()),
+      topicIdMapping = Map(disklessTopicPartition.topic() -> disklessTopicPartition.topicId()),
+      disklessManagedReplicasEnabled = true,
+      disklessRemoteStorageConsolidationEnabled = true,
+      consolidatingDisklessTopics = Set(disklessTopicPartition.topic()),
+    )
+    try {
+      // Retention moved the leader's log start to 7, past the seal at 5. A follower fetching at the log end
+      // can only offer the diskless epoch, which ends at the log end, not the seal. No classic record is
+      // retained, so there is no lineage to prove and ordinary validation is all that applies.
+      val partition = setupSwitchedLeaderWithOutOfSyncFollower(
+        replicaManager, disklessTopicPartition, followerId, sealOffset)
+      val log = partition.localLogOrException
+      log.appendAsLeader(MemoryRecords.withRecords(0L, Compression.NONE, disklessLeaderEpoch,
+        (1 to 6).map(i => new SimpleRecord(s"consolidated-$i".getBytes, "value".getBytes)): _*), disklessLeaderEpoch)
+      log.updateHighWatermark(log.logEndOffset)
+      log.maybeIncrementLogStartOffset(7L, LogStartOffsetIncrementReason.ClientRecordDeletion)
+      assertTrue(log.logStartOffset >= sealOffset, "precondition: no classic record is retained")
+      doReturn(new CompletableFuture[Any]())
+        .when(alterPartitionManager).submit(any(), any())
+      clearInvocations(alterPartitionManager)
+
+      val data = fetchFollowerAtSeal(
+        replicaManager, disklessTopicPartition, followerId, sealOffset,
+        Optional.of(partition.getLeaderEpoch),
+        fetchOffset = Some(log.logEndOffset),
+        lastFetchedEpoch = Optional.of(Integer.valueOf(disklessLeaderEpoch)))
+
+      assertEquals(Errors.NONE, data.error)
+      assertFalse(data.divergingEpoch.isPresent)
+      assertEquals(log.logEndOffset, partition.getReplica(followerId).get.stateSnapshot.logEndOffset,
+        "With no retained classic prefix the follower's actual offset is recorded")
+      verify(alterPartitionManager).submit(any(), argThat[LeaderAndIsr](_.isr.contains(followerId)))
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
+  def testFollowerFetchPastSealIsAdmittedWhenLeaderLogStartOffsetEqualsSeal(): Unit = {
+    val followerId = 2
+    val sealOffset = 5L
+    val disklessLeaderEpoch = 7
+    val replicaManager = createReplicaManager(
+      List(disklessTopicPartition.topic()),
+      topicIdMapping = Map(disklessTopicPartition.topic() -> disklessTopicPartition.topicId()),
+      disklessManagedReplicasEnabled = true,
+      disklessRemoteStorageConsolidationEnabled = true,
+      consolidatingDisklessTopics = Set(disklessTopicPartition.topic()),
+    )
+    try {
+      // The log start sits exactly at the seal: the classic prefix is gone, so the diskless epoch admits.
+      val partition = setupSwitchedLeaderWithOutOfSyncFollower(
+        replicaManager, disklessTopicPartition, followerId, sealOffset)
+      val log = partition.localLogOrException
+      log.appendAsLeader(MemoryRecords.withRecords(0L, Compression.NONE, disklessLeaderEpoch,
+        (1 to 6).map(i => new SimpleRecord(s"consolidated-$i".getBytes, "value".getBytes)): _*), disklessLeaderEpoch)
+      log.updateHighWatermark(log.logEndOffset)
+      log.maybeIncrementLogStartOffset(5L, LogStartOffsetIncrementReason.ClientRecordDeletion)
+      assertTrue(log.logStartOffset >= sealOffset, "precondition: no classic record is retained")
+      doReturn(new CompletableFuture[Any]())
+        .when(alterPartitionManager).submit(any(), any())
+      clearInvocations(alterPartitionManager)
+
+      val data = fetchFollowerAtSeal(
+        replicaManager, disklessTopicPartition, followerId, sealOffset,
+        Optional.of(partition.getLeaderEpoch),
+        fetchOffset = Some(log.logEndOffset),
+        lastFetchedEpoch = Optional.of(Integer.valueOf(disklessLeaderEpoch)))
+
+      assertEquals(Errors.NONE, data.error)
+      assertFalse(data.divergingEpoch.isPresent)
+      assertEquals(log.logEndOffset, partition.getReplica(followerId).get.stateSnapshot.logEndOffset,
+        "With no retained classic prefix the follower's actual offset is recorded")
+      verify(alterPartitionManager).submit(any(), argThat[LeaderAndIsr](_.isr.contains(followerId)))
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
+  def testFollowerFetchPastSealIsAdmittedWhenSealIsZero(): Unit = {
+    val followerId = 2
+    val sealOffset = 0L
+    val disklessLeaderEpoch = 7
+    val replicaManager = createReplicaManager(
+      List(disklessTopicPartition.topic()),
+      topicIdMapping = Map(disklessTopicPartition.topic() -> disklessTopicPartition.topicId()),
+      disklessManagedReplicasEnabled = true,
+      disklessRemoteStorageConsolidationEnabled = true,
+      consolidatingDisklessTopics = Set(disklessTopicPartition.topic()),
+    )
+    try {
+      // A topic switched while empty has a seal of 0 and no classic record at all, so there is no
+      // boundary epoch to offer and no prefix to prove.
+      val partition = setupSwitchedLeaderWithOutOfSyncFollower(
+        replicaManager, disklessTopicPartition, followerId, sealOffset)
+      val log = partition.localLogOrException
+      log.appendAsLeader(MemoryRecords.withRecords(0L, Compression.NONE, disklessLeaderEpoch,
+        (1 to 6).map(i => new SimpleRecord(s"consolidated-$i".getBytes, "value".getBytes)): _*), disklessLeaderEpoch)
+      log.updateHighWatermark(log.logEndOffset)
+      // The empty classic prefix leaves the log start at the seal.
+      assertTrue(log.logStartOffset >= sealOffset, "precondition: no classic record is retained")
+      doReturn(new CompletableFuture[Any]())
+        .when(alterPartitionManager).submit(any(), any())
+      clearInvocations(alterPartitionManager)
+
+      val data = fetchFollowerAtSeal(
+        replicaManager, disklessTopicPartition, followerId, sealOffset,
+        Optional.of(partition.getLeaderEpoch),
+        fetchOffset = Some(log.logEndOffset),
+        lastFetchedEpoch = Optional.of(Integer.valueOf(disklessLeaderEpoch)))
+
+      assertEquals(Errors.NONE, data.error)
+      assertFalse(data.divergingEpoch.isPresent)
+      assertEquals(log.logEndOffset, partition.getReplica(followerId).get.stateSnapshot.logEndOffset,
+        "With no retained classic prefix the follower's actual offset is recorded")
+      verify(alterPartitionManager).submit(any(), argThat[LeaderAndIsr](_.isr.contains(followerId)))
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
+  def testAtSealFetchFromStaleBrokerIncarnationIsRejected(): Unit = {
+    val followerId = 2
+    val sealOffset = 5L
+    val replicaManager = createReplicaManager(
+      List(disklessTopicPartition.topic()),
+      topicIdMapping = Map(disklessTopicPartition.topic() -> disklessTopicPartition.topicId()),
+      disklessManagedReplicasEnabled = true,
+      disklessRemoteStorageConsolidationEnabled = true,
+      consolidatingDisklessTopics = Set(disklessTopicPartition.topic()),
+    )
+    try {
+      // The broker-epoch fence lives in updateFetchStateOrThrow, so it only runs where the branch
+      // records. A fetch that carries no epoch proves no prefix and is never admitted, and it still
+      // has to be told it comes from a superseded incarnation rather than answered with NONE.
+      val partition = setupSwitchedLeaderWithOutOfSyncFollower(
+        replicaManager, disklessTopicPartition, followerId, sealOffset)
+      val aliveEpoch = replicaManager.metadataCache.getAliveBrokerEpoch(followerId)
+      assertTrue(aliveEpoch.isPresent, "precondition: the follower broker is registered as alive")
+      clearInvocations(alterPartitionManager)
+
+      val data = fetchFollowerAtSeal(
+        replicaManager, disklessTopicPartition, followerId, sealOffset,
+        Optional.of(partition.getLeaderEpoch),
+        replicaEpoch = aliveEpoch.get.longValue - 1)
+
+      assertEquals(Errors.NOT_LEADER_OR_FOLLOWER, data.error)
+      verify(alterPartitionManager, never()).submit(any(), any())
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
+  def testFollowerFetchCarryingClassicBoundaryEpochKeepsSuffixWhenLeaderRetentionPassedSeal(): Unit = {
+    val followerId = 2
+    val sealOffset = 5L
+    val disklessLeaderEpoch = 7
+    val classicBoundaryEpoch = 0
+    val replicaManager = createReplicaManager(
+      List(disklessTopicPartition.topic()),
+      topicIdMapping = Map(disklessTopicPartition.topic() -> disklessTopicPartition.topicId()),
+      disklessManagedReplicasEnabled = true,
+      disklessRemoteStorageConsolidationEnabled = true,
+      consolidatingDisklessTopics = Set(disklessTopicPartition.topic()),
+    )
+    try {
+      // The at-seal response leaves logStartOffset alone, so a follower keeps its classic prefix and
+      // keeps offering the boundary epoch after the leader's retention has passed the seal. The
+      // leader's epoch cache no longer holds that epoch, and truncateFromStart re-anchored the
+      // diskless one at the seal, so resolving it lands at the seal. Comparing the follower's offset
+      // against that would truncate its whole consolidated suffix.
+      val partition = setupSwitchedLeaderWithOutOfSyncFollower(
+        replicaManager, disklessTopicPartition, followerId, sealOffset)
+      val log = partition.localLogOrException
+      log.appendAsLeader(MemoryRecords.withRecords(0L, Compression.NONE, disklessLeaderEpoch,
+        (1 to 6).map(i => new SimpleRecord(s"consolidated-$i".getBytes, "value".getBytes)): _*), disklessLeaderEpoch)
+      log.updateHighWatermark(log.logEndOffset)
+      log.maybeIncrementLogStartOffset(sealOffset, LogStartOffsetIncrementReason.ClientRecordDeletion)
+      assertTrue(log.logStartOffset >= sealOffset, "precondition: no classic record is retained")
+      assertEquals(sealOffset,
+        log.leaderEpochCache.endOffsetFor(classicBoundaryEpoch, log.logEndOffset).getValue.longValue,
+        "precondition: the evicted boundary epoch resolves to the seal, below the follower's offset")
+      doReturn(new CompletableFuture[Any]())
+        .when(alterPartitionManager).submit(any(), any())
+      clearInvocations(alterPartitionManager)
+
+      val data = fetchFollowerAtSeal(
+        replicaManager, disklessTopicPartition, followerId, sealOffset,
+        Optional.of(partition.getLeaderEpoch),
+        fetchOffset = Some(log.logEndOffset),
+        lastFetchedEpoch = Optional.of(Integer.valueOf(classicBoundaryEpoch)))
+
+      assertEquals(Errors.NONE, data.error)
+      assertFalse(data.divergingEpoch.isPresent,
+        "A follower holding a prefix the leader no longer retains must keep its consolidated suffix")
+      assertEquals(log.logEndOffset, partition.getReplica(followerId).get.stateSnapshot.logEndOffset)
+      verify(alterPartitionManager).submit(any(), argThat[LeaderAndIsr](_.isr.contains(followerId)))
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
+  def testFollowerFetchAheadOfLeaderIsAdmittedAfterLeaderRetentionPassesSeal(): Unit = {
+    val followerId = 2
+    val sealOffset = 5L
+    val disklessLeaderEpoch = 7
+    val replicaManager = createReplicaManager(
+      List(disklessTopicPartition.topic()),
+      topicIdMapping = Map(disklessTopicPartition.topic() -> disklessTopicPartition.topicId()),
+      disklessManagedReplicasEnabled = true,
+      disklessRemoteStorageConsolidationEnabled = true,
+      consolidatingDisklessTopics = Set(disklessTopicPartition.topic()),
+    )
+    try {
+      // Replicas consolidate independently, so a follower can sit past the leader's log end offset.
+      // The diskless epoch is the leader's latest, which resolves to that offset, so comparing the
+      // follower's own position against it would truncate the part of the suffix it is ahead by.
+      val partition = setupSwitchedLeaderWithOutOfSyncFollower(
+        replicaManager, disklessTopicPartition, followerId, sealOffset)
+      val log = partition.localLogOrException
+      log.appendAsLeader(MemoryRecords.withRecords(0L, Compression.NONE, disklessLeaderEpoch,
+        (1 to 6).map(i => new SimpleRecord(s"consolidated-$i".getBytes, "value".getBytes)): _*), disklessLeaderEpoch)
+      log.updateHighWatermark(log.logEndOffset)
+      log.maybeIncrementLogStartOffset(sealOffset, LogStartOffsetIncrementReason.ClientRecordDeletion)
+      assertTrue(log.logStartOffset >= sealOffset, "precondition: no classic record is retained")
+      val followerOffset = log.logEndOffset + 3
+      doReturn(new CompletableFuture[Any]())
+        .when(alterPartitionManager).submit(any(), any())
+      clearInvocations(alterPartitionManager)
+
+      val data = fetchFollowerAtSeal(
+        replicaManager, disklessTopicPartition, followerId, sealOffset,
+        Optional.of(partition.getLeaderEpoch),
+        fetchOffset = Some(followerOffset),
+        lastFetchedEpoch = Optional.of(Integer.valueOf(disklessLeaderEpoch)))
+
+      assertEquals(Errors.NONE, data.error)
+      assertFalse(data.divergingEpoch.isPresent,
+        "A follower that consolidated past the leader must keep the suffix the leader lacks")
+      assertEquals(followerOffset, partition.getReplica(followerId).get.stateSnapshot.logEndOffset)
+      verify(alterPartitionManager).submit(any(), argThat[LeaderAndIsr](_.isr.contains(followerId)))
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
+  def testFollowerFetchAtSealIsAdmittedWhenTheSealSegmentIsNoLongerLocal(): Unit = {
+    val followerId = 2
+    val sealOffset = 5L
+    val replicaManager = createReplicaManager(
+      List(disklessTopicPartition.topic()),
+      topicIdMapping = Map(disklessTopicPartition.topic() -> disklessTopicPartition.topicId()),
+      disklessManagedReplicasEnabled = true,
+      disklessRemoteStorageConsolidationEnabled = true,
+      consolidatingDisklessTopics = Set(disklessTopicPartition.topic()),
+    )
+    try {
+      // A switched topic is tiered, so local retention deletes the segments holding the classic prefix
+      // while the logical log start stays below the seal: the range is still retained, just not here.
+      // Validating by reading at the seal fails in that state; the epoch cache still answers, so the
+      // follower is admitted on its lineage. The spy throws only from `read`, leaving offsets and the
+      // epoch cache real.
+      val partition = setupSwitchedLeaderWithOutOfSyncFollower(
+        replicaManager, disklessTopicPartition, followerId, sealOffset)
+      val spiedLog = spy(partition.localLogOrException)
+      doThrow(new OffsetOutOfRangeException("segment holding the seal is no longer local"))
+        .when(spiedLog).read(anyLong(), anyInt(), any(classOf[FetchIsolation]), anyBoolean())
+      partition.setLog(spiedLog, isFutureLog = false)
+      assertTrue(spiedLog.logStartOffset < sealOffset, "precondition: the prefix is still logically retained")
+
+      doReturn(new CompletableFuture[Any]())
+        .when(alterPartitionManager).submit(any(), any())
+      clearInvocations(alterPartitionManager)
+
+      val data = fetchFollowerAtSeal(
+        replicaManager, disklessTopicPartition, followerId, sealOffset,
+        Optional.of(partition.getLeaderEpoch),
+        lastFetchedEpoch = Optional.of(Integer.valueOf(0)))
+
+      assertEquals(Errors.NONE, data.error, "Validation must not depend on reading at the seal")
+      assertFalse(data.divergingEpoch.isPresent)
+      assertEquals(sealOffset, partition.getReplica(followerId).get.stateSnapshot.logEndOffset)
+      verify(alterPartitionManager).submit(any(), argThat[LeaderAndIsr](_.isr.contains(followerId)))
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
+  def testFollowerFetchPastSealCarryingEpochUnknownToLeaderGetsOutOfRange(): Unit = {
+    val followerId = 2
+    val sealOffset = 5L
+    val replicaManager = createReplicaManager(
+      List(disklessTopicPartition.topic()),
+      topicIdMapping = Map(disklessTopicPartition.topic() -> disklessTopicPartition.topicId()),
+      disklessManagedReplicasEnabled = true,
+      disklessRemoteStorageConsolidationEnabled = true,
+      consolidatingDisklessTopics = Set(disklessTopicPartition.topic()),
+    )
+    try {
+      // The leader's prefix is epoch 0 for [0, 3) and epoch 1 for [3, 5). A follower offering epoch 3, which
+      // this leader never had, gets OFFSET_OUT_OF_RANGE from the divergence lookup rather than a diverging
+      // epoch: the unclean-election shape, left as classic Kafka handles it.
+      val partition = setupSwitchedLeaderWithOutOfSyncFollower(
+        replicaManager, disklessTopicPartition, followerId, 3L)
+      val log = partition.localLogOrException
+      log.appendAsLeader(MemoryRecords.withRecords(0L, Compression.NONE, 1,
+        new SimpleRecord("rewritten-3".getBytes, "value".getBytes),
+        new SimpleRecord("rewritten-4".getBytes, "value".getBytes)), 1)
+      log.updateHighWatermark(sealOffset)
+      when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
+        .thenReturn(sealOffset)
+      doReturn(new CompletableFuture[Any]())
+        .when(alterPartitionManager).submit(any(), any())
+      clearInvocations(alterPartitionManager)
+
+      val data = fetchFollowerAtSeal(
+        replicaManager, disklessTopicPartition, followerId, sealOffset,
+        Optional.of(partition.getLeaderEpoch),
+        fetchOffset = Some(sealOffset + 3),
+        lastFetchedEpoch = Optional.of(Integer.valueOf(3)))
+
+      assertEquals(Errors.OFFSET_OUT_OF_RANGE, data.error)
+      verify(alterPartitionManager, never()).submit(any(), any())
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
+  def testFollowerFetchPastSealIsAdmittedWhenLeaderHasNotConsolidated(): Unit = {
+    val followerId = 2
+    val sealOffset = 5L
+    val classicBoundaryEpoch = 0
+    val replicaManager = createReplicaManager(
+      List(disklessTopicPartition.topic()),
+      topicIdMapping = Map(disklessTopicPartition.topic() -> disklessTopicPartition.topicId()),
+      disklessManagedReplicasEnabled = true,
+      disklessRemoteStorageConsolidationEnabled = true,
+      consolidatingDisklessTopics = Set(disklessTopicPartition.topic()),
+    )
+    try {
+      // The follower consolidated past the seal but this leader has not, so the leader's log ends at the
+      // seal. Reachable after a leader change to a replica that never consolidated. The follower offers
+      // its classic boundary epoch, which the leader resolves to its own log end offset at the seal, so
+      // the prefix validates and the follower keeps its suffix: it came from object storage, not from
+      // this leader, and the leader has no say over it.
+      val partition = setupSwitchedLeaderWithOutOfSyncFollower(
+        replicaManager, disklessTopicPartition, followerId, sealOffset)
+
+      doReturn(new CompletableFuture[Any]())
+        .when(alterPartitionManager).submit(any(), any())
+      clearInvocations(alterPartitionManager)
+
+      val fetchParams = new FetchParams(
+        followerId, -1L, 0L, 1, 1024 * 1024, FetchIsolation.LOG_END, Optional.empty())
+      val fetchInfos = Seq(
+        disklessTopicPartition ->
+          new PartitionData(disklessTopicPartition.topicId(), sealOffset + 3, 0L, 1024 * 1024,
+            Optional.of(partition.getLeaderEpoch), Optional.of(Integer.valueOf(classicBoundaryEpoch))))
+
+      @volatile var responseData: Map[TopicIdPartition, FetchPartitionData] = null
+      replicaManager.fetchMessages(fetchParams, fetchInfos, QuotaFactory.UNBOUNDED_QUOTA,
+        response => responseData = response.toMap)
+
+      val data = responseData(disklessTopicPartition)
+      assertEquals(Errors.NONE, data.error)
+      assertFalse(data.divergingEpoch.isPresent,
+        "A classic boundary epoch ending at the leader's log end offset must not read as divergence")
+      assertEquals(sealOffset + 3, data.highWatermark,
+        "The watermark follows the requested offset, not the leader's log end offset at the seal")
+      assertEquals(0, data.records.sizeInBytes, "No records cross the wire at the seal")
+      verify(alterPartitionManager).submit(any(), argThat[LeaderAndIsr](_.isr.contains(followerId)))
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
     }
   }
 
@@ -7891,7 +8611,7 @@ class ReplicaManagerInklessTest {
       val fetchInfos = Seq(
         disklessTopicPartition ->
           new PartitionData(disklessTopicPartition.topicId(), sealOffset, 0L, 1024 * 1024,
-            Optional.of(partition.getLeaderEpoch)))
+            Optional.of(partition.getLeaderEpoch), Optional.of(Integer.valueOf(0))))
 
       @volatile var responseData: Map[TopicIdPartition, FetchPartitionData] = null
       replicaManager.fetchMessages(fetchParams, fetchInfos, QuotaFactory.UNBOUNDED_QUOTA,
@@ -7938,7 +8658,7 @@ class ReplicaManagerInklessTest {
       val fetchInfos = Seq(
         disklessTopicPartition ->
           new PartitionData(disklessTopicPartition.topicId(), sealOffset, 0L, 1024 * 1024,
-            Optional.of(partition.getLeaderEpoch)))
+            Optional.of(partition.getLeaderEpoch), Optional.of(Integer.valueOf(0))))
 
       @volatile var responseData: Map[TopicIdPartition, FetchPartitionData] = null
       replicaManager.fetchMessages(fetchParams, fetchInfos, QuotaFactory.UNBOUNDED_QUOTA,
@@ -7953,6 +8673,57 @@ class ReplicaManagerInklessTest {
       assertEquals(UnifiedLog.UNKNOWN_OFFSET,
         partition.getReplica(followerId).get.stateSnapshot.logEndOffset)
       verify(alterPartitionManager, never()).submit(any(), any())
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
+  def testFollowerFetchAtSealIsolatesUnavailableLocalLog(): Unit = {
+    val followerId = 2
+    val sealOffset = 5L
+    val unavailableTopicPartition = disklessTopicPartition
+    val validTopicPartition = new TopicIdPartition(
+      disklessTopicPartition.topicId(), 1, disklessTopicPartition.topic())
+    val replicaManager = spy(createReplicaManager(
+      List(disklessTopicPartition.topic()),
+      topicIdMapping = Map(disklessTopicPartition.topic() -> disklessTopicPartition.topicId()),
+      disklessManagedReplicasEnabled = true,
+    ))
+    try {
+      setupSwitchedLeaderWithOutOfSyncFollower(
+        replicaManager, unavailableTopicPartition, followerId, sealOffset)
+      val validPartition = setupSwitchedLeaderWithOutOfSyncFollower(
+        replicaManager, validTopicPartition, followerId, sealOffset)
+      val unavailablePartition = mock(classOf[Partition])
+      when(unavailablePartition.localLogOrException)
+        .thenThrow(new NotLeaderOrFollowerException("local log unavailable"))
+      doReturn(Right(unavailablePartition)).when(replicaManager)
+        .getPartitionOrError(unavailableTopicPartition.topicPartition())
+      prepareAlterPartitionSubmit()
+
+      val fetchParams = new FetchParams(
+        followerId, -1L, 0L, 1, 1024 * 1024, FetchIsolation.LOG_END, Optional.empty())
+      val fetchInfos = Seq(
+        unavailableTopicPartition ->
+          new PartitionData(unavailableTopicPartition.topicId(), sealOffset, 0L, 1024 * 1024,
+            Optional.of(validPartition.getLeaderEpoch), Optional.of(Integer.valueOf(0))),
+        validTopicPartition ->
+          new PartitionData(validTopicPartition.topicId(), sealOffset, 0L, 1024 * 1024,
+            Optional.of(validPartition.getLeaderEpoch), Optional.of(Integer.valueOf(0)))
+      )
+
+      @volatile var responseData: Map[TopicIdPartition, FetchPartitionData] = null
+      replicaManager.fetchMessages(fetchParams, fetchInfos, QuotaFactory.UNBOUNDED_QUOTA,
+        response => responseData = response.toMap)
+
+      assertEquals(Errors.NOT_LEADER_OR_FOLLOWER, responseData(unavailableTopicPartition).error)
+      assertEquals(Errors.NONE, responseData(validTopicPartition).error)
+      assertEquals(sealOffset, validPartition.getReplica(followerId).get.stateSnapshot.logEndOffset)
+      verify(alterPartitionManager, times(1)).submit(
+        ArgumentMatchers.eq(new org.apache.kafka.server.common.TopicIdPartition(
+          validTopicPartition.topicId(), validTopicPartition.partition())),
+        any())
     } finally {
       replicaManager.shutdown(checkpointHW = false)
     }
@@ -7997,7 +8768,7 @@ class ReplicaManagerInklessTest {
             sealOffset,
             0L,
             1024 * 1024,
-            Optional.of(validPartition.getLeaderEpoch))
+            Optional.of(validPartition.getLeaderEpoch), Optional.of(Integer.valueOf(0)))
       )
 
       @volatile var responseData: Map[TopicIdPartition, FetchPartitionData] = null
@@ -8809,14 +9580,22 @@ class ReplicaManagerInklessTest {
     followerId: Int,
     sealOffset: Long,
     currentLeaderEpoch: Optional[Integer],
-    fetchOffset: Option[Long] = None
+    fetchOffset: Option[Long] = None,
+    lastFetchedEpoch: Optional[Integer] = Optional.empty(),
+    replicaEpoch: Long = -1L
   ): FetchPartitionData = {
     val offset = fetchOffset.getOrElse(sealOffset)
     val fetchParams = new FetchParams(
-      followerId, -1L, 0L, 1, 1024 * 1024, FetchIsolation.LOG_END, Optional.empty())
+      followerId, replicaEpoch, 0L, 1, 1024 * 1024, FetchIsolation.LOG_END, Optional.empty())
     val fetchInfos = Seq(
       topicIdPartition ->
-        new PartitionData(topicIdPartition.topicId(), offset, 0L, 1024 * 1024, currentLeaderEpoch))
+        new PartitionData(
+          topicIdPartition.topicId(),
+          offset,
+          0L,
+          1024 * 1024,
+          currentLeaderEpoch,
+          lastFetchedEpoch))
     @volatile var responseData: Map[TopicIdPartition, FetchPartitionData] = null
     replicaManager.fetchMessages(fetchParams, fetchInfos, QuotaFactory.UNBOUNDED_QUOTA,
       response => responseData = response.toMap)
@@ -8829,11 +9608,12 @@ class ReplicaManagerInklessTest {
     replicaManager: ReplicaManager,
     fetchHandlerCtor: MockedConstruction[FetchHandler],
     cp: ControlPlane,
-    sealOffset: Long
+    expectedHighWatermark: Long
   ): Unit = {
     assertEquals(Errors.NONE, data.error)
     assertEquals(MemoryRecords.EMPTY, data.records)
-    assertEquals(sealOffset, data.highWatermark)
+    assertEquals(expectedHighWatermark, data.highWatermark,
+      "The at-seal response reports the requested offset as the watermark")
     // logStartOffset=0 so the follower does not advance its local start and drop classic data.
     assertEquals(0L, data.logStartOffset)
     verify(replicaManager, never()).readFromLog(any(), any(), any(), any())

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerInklessTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerInklessTest.scala
@@ -7138,7 +7138,7 @@ class ReplicaManagerInklessTest {
     val mockFetcherManager = mock(classOf[ReplicaFetcherManager])
     when(mockFetcherManager.removeFetcherForPartitions(any()))
       .thenReturn(Map.empty[TopicPartition, PartitionFetchState])
-    // The switch turns on remote storage by itself, so isConsolidatingDisklessTopic reads true even
+    // The switch turns on remote storage by itself, so `isConsolidatingDisklessTopic` reads true even
     // with consolidation off on this broker. With it off there is no consolidation fetcher, so a
     // partition classified as consolidation-bound is handed to nothing and stops replicating.
     val replicaManager = spy(createReplicaManager(
@@ -7887,7 +7887,7 @@ class ReplicaManagerInklessTest {
       log.appendAsLeader(MemoryRecords.withRecords(0L, Compression.NONE, 7,
         new SimpleRecord("consolidated".getBytes, "value".getBytes)), 7)
       assertTrue(log.logEndOffset > sealOffset, "precondition: leader consolidated past the seal")
-      // The leader runs its own consolidation fetcher, whose maybeUpdateHighWatermark sets the local
+      // The leader runs its own consolidation fetcher, whose `maybeUpdateHighWatermark` sets the local
       // high watermark to the diskless frontier directly, bypassing the ISR-minimum logic.
       log.updateHighWatermark(log.logEndOffset)
 
@@ -8130,7 +8130,7 @@ class ReplicaManagerInklessTest {
       consolidatingDisklessTopics = Set(disklessTopicPartition.topic()),
     )
     try {
-      // fetchRecords runs no divergence check when the request carries no epoch, so an absent epoch
+      // `fetchRecords` runs no divergence check when the request carries no epoch, so an absent epoch
       // must not count as a validated prefix.
       val partition = setupSwitchedLeaderWithOutOfSyncFollower(
         replicaManager, disklessTopicPartition, followerId, sealOffset)

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerInklessTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerInklessTest.scala
@@ -7034,6 +7034,281 @@ class ReplicaManagerInklessTest {
   }
 
   @Test
+  def testApplyDeltaKeepsConsolidatingFollowerAtSealOnClassicFetcherWhileOutsideIsr(): Unit = {
+    val topicName = "switched-consolidating"
+    val topicId = Uuid.randomUuid()
+    val tp = new TopicPartition(topicName, 0)
+    val brokerId = 1
+    val leaderId = 2
+    val sealOffset = 10L
+
+    val mockFetcherManager = mock(classOf[ReplicaFetcherManager])
+    when(mockFetcherManager.removeFetcherForPartitions(any())).thenReturn(Map.empty[TopicPartition, PartitionFetchState])
+
+    val replicaManager = spy(createReplicaManager(
+      List(topicName),
+      disklessManagedReplicasEnabled = true,
+      disklessRemoteStorageConsolidationEnabled = true,
+      consolidatingDisklessTopics = Set(topicName),
+      mockReplicaFetcherManager = Some(mockFetcherManager)
+    ))
+    try {
+      // Caught up exactly to the seal, so consolidation would normally take over. Outside ISR it must
+      // stay on the classic fetcher: the consolidation fetcher reads object storage, so the leader
+      // would never observe this replica and nothing would expand ISR.
+      val log = replicaManager.logManager.getOrCreateLog(tp, isNew = true, topicId = Optional.of(topicId))
+      populateLocalLogAtLeoAndCheckpointedHwm(replicaManager, tp, log, leo = sealOffset, hw = sealOffset)
+      when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(tp)).thenReturn(sealOffset)
+      when(replicaManager.inklessMetadataView().isReplicaInIsr(tp, brokerId)).thenReturn(false)
+
+      val delta = disklessFollowerDelta(topicName, topicId, brokerId, leaderId, followerInIsr = false)
+      replicaManager.applyDelta(delta, imageFromTopics(delta.apply()))
+
+      val captor: ArgumentCaptor[Map[TopicPartition, InitialFetchState]] =
+        ArgumentCaptor.forClass(classOf[Map[TopicPartition, InitialFetchState]])
+      verify(mockFetcherManager).addFetcherForPartitions(captor.capture())
+      assertTrue(captor.getValue.contains(tp),
+        s"Expected the classic fetcher to take $tp, got ${captor.getValue.keySet}")
+      assertEquals(sealOffset, captor.getValue.apply(tp).initOffset,
+        "The classic fetch must resume at the seal so the leader records this replica there")
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
+  def testApplyDeltaSendsConsolidatingFollowerAtSealToConsolidationWhileInIsr(): Unit = {
+    val topicName = "switched-consolidating"
+    val topicId = Uuid.randomUuid()
+    val tp = new TopicPartition(topicName, 0)
+    val brokerId = 1
+    val leaderId = 2
+    val sealOffset = 10L
+
+    val ctorInit: MockedConstruction.MockInitializer[ConsolidationFetcherManager] = {
+      case (mock, _) =>
+        when(mock.removeFetcherForPartitions(any())).thenReturn(Map.empty[TopicPartition, PartitionFetchState])
+    }
+    val consolidationCtor = mockConstruction(classOf[ConsolidationFetcherManager], ctorInit)
+    val mockFetcherManager = mock(classOf[ReplicaFetcherManager])
+    when(mockFetcherManager.removeFetcherForPartitions(any())).thenReturn(Map.empty[TopicPartition, PartitionFetchState])
+    try {
+      val replicaManager = spy(createReplicaManager(
+        List(topicName),
+        disklessManagedReplicasEnabled = true,
+        disklessRemoteStorageConsolidationEnabled = true,
+        consolidatingDisklessTopics = Set(topicName),
+        mockReplicaFetcherManager = Some(mockFetcherManager)
+      ))
+      try {
+        val mockCfm = consolidationCtor.constructed().get(0)
+        // Same state as the hold-back test, except the replica is in ISR: the leader already has its
+        // evidence, so consolidation takes over.
+        val log = replicaManager.logManager.getOrCreateLog(tp, isNew = true, topicId = Optional.of(topicId))
+        populateLocalLogAtLeoAndCheckpointedHwm(replicaManager, tp, log, leo = sealOffset, hw = sealOffset)
+        when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(tp)).thenReturn(sealOffset)
+        when(replicaManager.inklessMetadataView().isReplicaInIsr(tp, brokerId)).thenReturn(true)
+
+        val delta = disklessFollowerDelta(topicName, topicId, brokerId, leaderId)
+        replicaManager.applyDelta(delta, imageFromTopics(delta.apply()))
+
+        verify(mockCfm).removeFetcherForPartitions(Set(tp))
+        val captor: ArgumentCaptor[Map[TopicPartition, InitialFetchState]] =
+          ArgumentCaptor.forClass(classOf[Map[TopicPartition, InitialFetchState]])
+        verify(mockFetcherManager).addFetcherForPartitions(captor.capture())
+        assertFalse(captor.getValue.contains(tp),
+          s"An in-ISR replica at the seal must not stay on the classic fetcher, got ${captor.getValue.keySet}")
+      } finally {
+        replicaManager.shutdown(checkpointHW = false)
+      }
+    } finally {
+      consolidationCtor.close()
+    }
+  }
+
+  @Test
+  def testApplyDeltaKeepsBelowSealFollowerOnClassicFetcherWhenConsolidationDisabled(): Unit = {
+    val topicName = "switched-consolidating"
+    val topicId = Uuid.randomUuid()
+    val tp = new TopicPartition(topicName, 0)
+    val brokerId = 1
+    val leaderId = 2
+    val sealOffset = 10L
+
+    val mockFetcherManager = mock(classOf[ReplicaFetcherManager])
+    when(mockFetcherManager.removeFetcherForPartitions(any()))
+      .thenReturn(Map.empty[TopicPartition, PartitionFetchState])
+    // The switch turns on remote storage by itself, so isConsolidatingDisklessTopic reads true even
+    // with consolidation off on this broker. With it off there is no consolidation fetcher, so a
+    // partition classified as consolidation-bound is handed to nothing and stops replicating.
+    val replicaManager = spy(createReplicaManager(
+      List(topicName),
+      disklessManagedReplicasEnabled = true,
+      disklessRemoteStorageConsolidationEnabled = false,
+      consolidatingDisklessTopics = Set(topicName),
+      mockReplicaFetcherManager = Some(mockFetcherManager)
+    ))
+    try {
+      val log = replicaManager.logManager.getOrCreateLog(tp, isNew = true, topicId = Optional.of(topicId))
+      // High watermark one short of the seal: the leader only learns this replica sits at the seal on
+      // its next fetch, so a catch-up fetch is required for the watermark to reach it.
+      populateLocalLogAtLeoAndCheckpointedHwm(replicaManager, tp, log, leo = sealOffset, hw = sealOffset - 1)
+      when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(tp)).thenReturn(sealOffset)
+      when(replicaManager.inklessMetadataView().isReplicaInIsr(tp, brokerId)).thenReturn(true)
+
+      val delta = disklessFollowerDelta(topicName, topicId, brokerId, leaderId)
+      replicaManager.applyDelta(delta, imageFromTopics(delta.apply()))
+
+      val captor: ArgumentCaptor[Map[TopicPartition, InitialFetchState]] =
+        ArgumentCaptor.forClass(classOf[Map[TopicPartition, InitialFetchState]])
+      verify(mockFetcherManager).addFetcherForPartitions(captor.capture())
+      assertTrue(captor.getValue.contains(tp),
+        "A below-seal replica must be scheduled on the classic fetcher when consolidation is off, " +
+          s"or its high watermark never reaches the seal, got ${captor.getValue.keySet}")
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
+  def testApplyDeltaReroutesConsolidatingFollowerToClassicFetcherWhenRemovedFromIsr(): Unit = {
+    val topicName = "switched-consolidating"
+    val topicId = Uuid.randomUuid()
+    val tp = new TopicPartition(topicName, 0)
+    val brokerId = 1
+    val leaderId = 2
+    val sealOffset = 10L
+
+    val ctorInit: MockedConstruction.MockInitializer[ConsolidationFetcherManager] = {
+      case (mock, _) =>
+        when(mock.removeFetcherForPartitions(any())).thenReturn(Map.empty[TopicPartition, PartitionFetchState])
+    }
+    val consolidationCtor = mockConstruction(classOf[ConsolidationFetcherManager], ctorInit)
+    val mockFetcherManager = mock(classOf[ReplicaFetcherManager])
+    when(mockFetcherManager.removeFetcherForPartitions(any())).thenReturn(Map.empty[TopicPartition, PartitionFetchState])
+    try {
+      val replicaManager = spy(createReplicaManager(
+        List(topicName),
+        disklessManagedReplicasEnabled = true,
+        disklessRemoteStorageConsolidationEnabled = true,
+        consolidatingDisklessTopics = Set(topicName),
+        mockReplicaFetcherManager = Some(mockFetcherManager)
+      ))
+      try {
+        val mockCfm = consolidationCtor.constructed().get(0)
+        val log = replicaManager.logManager.getOrCreateLog(tp, isNew = true, topicId = Optional.of(topicId))
+        populateLocalLogAtLeoAndCheckpointedHwm(replicaManager, tp, log, leo = sealOffset, hw = sealOffset)
+        when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(tp)).thenReturn(sealOffset)
+        when(replicaManager.inklessMetadataView().isReplicaInIsr(tp, brokerId)).thenReturn(true)
+
+        val initialDelta = disklessFollowerDelta(
+          topicName,
+          topicId,
+          brokerId,
+          leaderId,
+          classicToDisklessStartOffset = sealOffset
+        )
+        val initialImage = imageFromTopics(initialDelta.apply())
+        replicaManager.applyDelta(initialDelta, initialImage)
+        verify(mockCfm).addFetcherForPartitions(argThat[Map[TopicPartition, InitialFetchState]](_.contains(tp)))
+        clearInvocations(mockFetcherManager, mockCfm)
+
+        when(replicaManager.inklessMetadataView().isReplicaInIsr(tp, brokerId)).thenReturn(false)
+        val isrRemovalDelta = new TopicsDelta(initialImage.topics())
+        isrRemovalDelta.replay(new PartitionChangeRecord()
+          .setTopicId(topicId)
+          .setPartitionId(tp.partition)
+          .setIsr(util.Arrays.asList(leaderId)))
+
+        val updatedRegistration = isrRemovalDelta.apply().getTopic(topicId).partitions().get(tp.partition)
+        assertEquals(0, updatedRegistration.leaderEpoch,
+          "Removing a follower from ISR must not change the leader epoch")
+        assertEquals(1, updatedRegistration.partitionEpoch,
+          "Removing a follower from ISR must advance the partition epoch")
+
+        replicaManager.applyDelta(isrRemovalDelta, imageFromTopics(isrRemovalDelta.apply()))
+
+        verify(mockCfm).removeFetcherForPartitions(Set(tp))
+        verify(mockFetcherManager).removeFetcherForPartitions(Set(tp))
+        val captor: ArgumentCaptor[Map[TopicPartition, InitialFetchState]] =
+          ArgumentCaptor.forClass(classOf[Map[TopicPartition, InitialFetchState]])
+        verify(mockFetcherManager).addFetcherForPartitions(captor.capture())
+        assertEquals(sealOffset, captor.getValue.apply(tp).initOffset,
+          "The classic fetch must resume at the existing LEO so the leader can readmit the replica")
+      } finally {
+        replicaManager.shutdown(checkpointHW = false)
+      }
+    } finally {
+      consolidationCtor.close()
+    }
+  }
+
+  @Test
+  def testApplyDeltaKeepsConsolidatingFollowerPastSealOnClassicFetcherWhileOutsideIsr(): Unit = {
+    val topicName = "switched-consolidating"
+    val topicId = Uuid.randomUuid()
+    val tp = new TopicPartition(topicName, 0)
+    val brokerId = 1
+    val leaderId = 2
+    val sealOffset = 10L
+    val leo = sealOffset + 3
+    val disklessLeaderEpoch = 5
+
+    val ctorInit: MockedConstruction.MockInitializer[ConsolidationFetcherManager] = {
+      case (mock, _) =>
+        when(mock.removeFetcherForPartitions(any())).thenReturn(Map.empty[TopicPartition, PartitionFetchState])
+    }
+    val consolidationCtor = mockConstruction(classOf[ConsolidationFetcherManager], ctorInit)
+    val mockFetcherManager = mock(classOf[ReplicaFetcherManager])
+    when(mockFetcherManager.removeFetcherForPartitions(any())).thenReturn(Map.empty[TopicPartition, PartitionFetchState])
+    try {
+      val replicaManager = spy(createReplicaManager(
+        List(topicName),
+        disklessManagedReplicasEnabled = true,
+        disklessRemoteStorageConsolidationEnabled = true,
+        consolidatingDisklessTopics = Set(topicName),
+        mockReplicaFetcherManager = Some(mockFetcherManager)
+      ))
+      try {
+        // Already consolidated past the seal and outside ISR. Consolidation sends the leader no fetch,
+        // so taking this replica there would leave it with no admission path at all. It waits on the
+        // classic fetcher instead, starting at its real log end offset so the diskless suffix survives.
+        val log = replicaManager.logManager.getOrCreateLog(tp, isNew = true, topicId = Optional.of(topicId))
+        populateConsolidatedLocalLogAndCheckpointedHwm(
+          replicaManager, tp, log, sealOffset, leo, disklessLeaderEpoch, hw = sealOffset)
+        when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(tp)).thenReturn(sealOffset)
+        when(replicaManager.inklessMetadataView().getDisklessLeaderEpoch(tp)).thenReturn(disklessLeaderEpoch)
+        when(replicaManager.inklessMetadataView().isReplicaInIsr(tp, brokerId)).thenReturn(false)
+
+        val delta = disklessFollowerDelta(
+          topicName,
+          topicId,
+          brokerId,
+          leaderId,
+          classicToDisklessStartOffset = sealOffset,
+          disklessLeaderEpoch = disklessLeaderEpoch,
+          followerInIsr = false
+        )
+        replicaManager.applyDelta(delta, imageFromTopics(delta.apply()))
+
+        val captor: ArgumentCaptor[Map[TopicPartition, InitialFetchState]] =
+          ArgumentCaptor.forClass(classOf[Map[TopicPartition, InitialFetchState]])
+        verify(mockFetcherManager).addFetcherForPartitions(captor.capture())
+        assertTrue(captor.getValue.contains(tp),
+          s"A replica past the seal and outside ISR must wait on the classic fetcher, got ${captor.getValue.keySet}")
+        assertEquals(leo, captor.getValue.apply(tp).initOffset,
+          "The fetch must resume at the real log end offset so the consolidated suffix is not discarded")
+        assertEquals(leo, replicaManager.localLogOrException(tp).logEndOffset,
+          "The diskless suffix must survive the routing decision")
+      } finally {
+        replicaManager.shutdown(checkpointHW = false)
+      }
+    } finally {
+      consolidationCtor.close()
+    }
+  }
+
+  @Test
   def testApplyDeltaDoesNotStartCatchUpFetcherWhenDisklessFollowerHwmAtSealOffset(): Unit = {
     val topicName = "switched-topic"
     val topicId = Uuid.randomUuid()
@@ -9496,8 +9771,8 @@ class ReplicaManagerInklessTest {
   @Test
   def testSwitchedConsolidatingFollowerBelowSealStaysOnClassicFetcher(): Unit = {
     // A switched consolidating follower whose local log is still below the committed seal must
-    // keep replicating the classic prefix via the classic ReplicaFetcher (which self-evicts and
-    // hands off to consolidation once it reaches the seal). It must NOT be routed straight to the
+    // keep replicating the classic prefix via the classic ReplicaFetcher, which hands off to
+    // consolidation once it reaches the seal and is in ISR. It must NOT be routed straight to the
     // consolidation fetcher, otherwise the reconciler would Retry it and, since a follower's only
     // catch-up path is the classic fetcher, it would be stranded without ever reaching the seal.
     val consolidatingTopic = disklessTopicPartition.topic()

--- a/docs/inkless/CLASSIC_TO_DISKLESS_SWITCH.md
+++ b/docs/inkless/CLASSIC_TO_DISKLESS_SWITCH.md
@@ -130,12 +130,12 @@ Once control-plane initialization succeeds, `InitDisklessLogManager` marks the p
 
 ## Additional Behavior
 
-Followers also seal during the switch. While the switch is pending (`-2`), they keep using the classic fetcher to replicate the frozen classic prefix. After the final start offset is committed, followers continue until their local LEO reaches the committed seal offset, then hand off from the classic prefix.
+Followers also seal during the switch. While the switch is pending (`-2`), they keep using the classic fetcher to replicate the frozen classic prefix. After the final start offset is committed, followers continue until their local LEO reaches the committed seal offset. A follower that reached the seal while outside ISR keeps fetching until the leader admits it back, so a replica never leaves the classic prefix without having proven it holds all of it.
 
-When a broker applies a newly committed seal offset, it reconciles the local classic log:
+When a broker applies a newly committed seal offset, it reconciles the local log:
 
-* if local LEO is above the seal, it truncates to the seal because offsets at and above the seal belong to diskless storage
-* if a leader's local LEO is below the seal, it marks the partition offline because the classic prefix is incomplete
+* If local LEO is above the seal, it preserves a consolidated suffix only when the local epoch cache proves that the suffix belongs to the captured diskless epoch; otherwise, it truncates to the seal.
+* If a leader's local LEO is below the seal, it stays online to rebuild the classic prefix when consolidation and remote storage are available; otherwise, it marks the partition offline.
 
 If leadership changes while the switch is pending, the new leader seals and re-drives the `InitDisklessLog` controller request. If leadership changes after the final offset is committed, the new leader skips the controller step and initializes the control plane directly from metadata.
 

--- a/docs/inkless/CLASSIC_TO_DISKLESS_SWITCH.md
+++ b/docs/inkless/CLASSIC_TO_DISKLESS_SWITCH.md
@@ -132,12 +132,12 @@ Once control-plane initialization succeeds, `InitDisklessLogManager` marks the p
 
 ## Additional Behavior
 
-Followers also seal during the switch. While the switch is pending (`-2`), they keep using the classic fetcher to replicate the frozen classic prefix. After the final start offset is committed, followers continue until their local LEO reaches the committed seal offset, then hand off from the classic prefix.
+Followers also seal during the switch. While the switch is pending (`-2`), they keep using the classic fetcher to replicate the frozen classic prefix. After the final start offset is committed, followers continue until their local LEO reaches the committed seal offset. A follower that reached the seal while outside ISR keeps fetching until the leader admits it back. While the leader still retains classic records, admission requires the follower to offer the epoch of its last classic record, so a replica never leaves the classic prefix without having proven it holds all of it. Once retention has moved the leader's log start to the seal, no retained record carries a classic epoch, so there is no lineage left to prove and the follower's own position is what the leader records.
 
-When a broker applies a newly committed seal offset, it reconciles the local classic log:
+When a broker applies a newly committed seal offset, it reconciles the local log:
 
-* if local LEO is above the seal, it truncates to the seal because offsets at and above the seal belong to diskless storage
-* if a leader's local LEO is below the seal, it marks the partition offline because the classic prefix is incomplete
+* If local LEO is above the seal, it preserves a consolidated suffix only when the local epoch cache proves that the suffix belongs to the captured diskless epoch; otherwise, it truncates to the seal.
+* If a leader's local LEO is below the seal, it stays online to rebuild the classic prefix when consolidation and remote storage are available; otherwise, it marks the partition offline.
 
 If leadership changes while the switch is pending, the new leader seals and re-drives the `InitDisklessLog` controller request. If leadership changes after the final offset is committed, the new leader skips the controller step and initializes the control plane directly from metadata.
 


### PR DESCRIPTION
A replica of a switched consolidating partition can sit outside the controller ISR indefinitely. The replica holds the complete classic prefix and may have consolidated past the switch seal, but the consolidation fetcher reads object storage locally and sends no follower fetch to the Kafka leader. Without that fetch the leader never gets the evidence it needs to readmit the replica, so nothing ever expands ISR.

## Affected invariant

A switched follower may leave the classic fetcher only after the leader has observed a validated follower fetch at or above the classic-to-diskless seal and admitted it to ISR.

A switched partition differs from a born-diskless one: it still has a classic prefix that replicas originally copied from the Kafka leader. Broker liveness and `LEO >= seal` do not prove to the *current* leader that a replica holds that prefix, and two replicas reporting the same offsets can differ in whether part of that prefix came from a superseded leader. The leader-observed follower fetch is the proof. That fetch offers the epoch of the last classic record, so the leader compares the prefix itself even when the follower has consolidated and its latest epoch is the diskless one. Two rules follow:

- A switched follower outside ISR uses the classic fetcher, including when it has already consolidated past the seal.
- A follower fetch at or above the seal must not copy the leader's consolidated diskless suffix over inter-broker replication.

The rules hold where the hand-off takes effect, not only where it is decided, which is case D below.

ISR membership here is not about write durability: new records go to the diskless suffix, and that path never consults the ISR or `min.insync.replicas`. What a stranded replica costs is leader eligibility, and with it the availability of the classic prefix below the seal.

## Cases and the commits that close them

### Case A: a restart strands the replica

Controlled shutdown drops the follower from ISR, the restart recovers a log end offset at or beyond the seal, and routing on offsets alone hands the partition to the consolidation fetcher before it can prove itself. Fencing reaches the same state without a restart, because an ISR-only metadata delta advances the partition epoch but not the leader epoch.

Nothing reports it. Reads and writes continue, `DescribeTopics` still shows the replica in sync because Inkless rebuilds client-facing ISR from broker liveness, and `underReplicatedPartitionCount` excludes consolidating partitions. The damage waits for the next leader election, and a rolling restart reaches every partition of a switched topic.

Reachability: an ordinary broker restart, so any rolling restart of a cluster with switched consolidating topics reaches it on every partition. The state persists until the next leader election needs a candidate.

Three commits close it, in the order the replica meets them:

- Commit 3 keeps it on the classic fetcher: reaching the seal is necessary but no longer sufficient, and the replica must also be in ISR or be the leader.
- Commit 2 stops the classic fetcher evicting it on the first fetch, queuing a backoff instead so the fetches keep arriving.
- Commit 4 answers that fetch without moving diskless data: empty records, and a high watermark at the follower's own requested offset, so a follower that consolidated past the seal is not pulled back down on every response. It then checks the prefix the follower offers and admits it against the seal rather than the leader's moving watermark.

### Case B: the replica catches up from below

A separate entry path, not a later stage of case A. The replica is already on the classic fetcher with its log end offset below the seal. It fetches, appends up to the seal, and the old code evicts it immediately. But the leader records the offset carried by the request, not the log end offset after the append, so it has not yet seen the catch-up, and the fetch that would have proved it is never sent.

Reachability: every replica of a switched topic passes through this point once, on its way from below the seal to at it.

The same three commits close it, commit 3 included: a replica waiting at the seal already satisfies the old offset-only routing predicate, so the next metadata delta routes it to consolidation and undoes the wait. The hold-back has to cover at-or-above the seal rather than only equal to it, since a replica that consolidated anything sits strictly above.

### Case C: the broker does not consolidate at all

A misclassification rather than a strand. `isConsolidatingDisklessTopic` means diskless plus remote storage, and the switch turns on remote storage by itself, so the predicate reads true even where `diskless.remote.storage.consolidation.enable` is off and no consolidation fetcher exists. Commit 3 routes on `consolidationActiveFor`, which adds the broker's own config.

Reachability: the config is static and per-broker, so enabling consolidation across a cluster is a rolling restart during which brokers disagree while topic config is identical everywhere. Any cluster that has switched topics but has not finished enabling consolidation is in this state.

### Case D: the hand-off acts on a stale decision

The eviction is queued on the fetcher thread and applied later, and `partitionMapLock` cannot cover the fetcher-manager call, since that call takes the manager monitor before `partitionMapLock`. An ISR-shrink delta landing in between removes and re-adds the partition, and the stale eviction then removes the re-added partition and starts consolidation outside ISR: case A, recreated by the mechanism meant to prevent it.

Commit 2 addresses it in three parts: `removePartitions` discards queued work so it cannot outlive the fetcher assignment it was queued for, the eviction re-reads ISR after draining its queue, and `ConsolidationReconciler` re-checks ISR for a switched partition rather than trusting the caller. A never-switched partition short-circuits that gate, having no classic prefix to prove.

Reachability: much narrower than cases A and B, and this one predates the branch. Both ends of the window run on the fetcher thread within a single `doWork`, separated by the rest of the fetch-response processing, so an ISR-shrink delta has to land inside that span for a partition that was in ISR moments earlier. It also self-heals: commit 3 reclaims a partition wrongly on the consolidation fetcher at the next metadata delta, since the removal is applied to both fetcher managers. The fix is here because the queue it scopes is what commit 2 relies on, not because the race is likely.

### Limits the proof has to respect

Making the at-seal fetch the proof introduces four ways for the new rule to misfire where the old bug did not. All four are closed inside commit 4.

The consolidation fetcher must keep offering its latest epoch. It inherits `latestEpoch` from `ReplicaFetcherThread`, and `DisklessLeaderEndPoint` answers any epoch below the diskless one with the seal, so a boundary epoch offered there truncates the consolidated suffix on every start: broker restart, leader change, and the hand-off this branch performs. The override is scoped to the classic fetcher. Reachability: certain, and on the common path, since it fires on every start of a consolidating replica of a switched topic.

The proof cannot be required once the prefix is gone, and the lineage must not be compared there either. Demanding an epoch that ends at the seal only makes sense while the leader retains classic records: once retention has moved its log start to the seal, the follower can only offer the diskless epoch, and a strict rule strands it for good. Comparing lineage in that state is worse than useless. The leader's epoch cache re-anchors the diskless epoch at the seal when the log start reaches it, so a follower still holding its own prefix offers the boundary epoch, resolves to the seal, and is told to truncate its whole consolidated suffix; a follower that consolidated past the leader is told the same by its own diskless epoch, which resolves to the leader's log end offset. Both recover by re-consolidating from object storage, so no records are lost, but it repeats on every ISR drop from then on. The whole no-retained-prefix case is therefore routed away from the proof path: the leader validates leadership, leader epoch, assignment, and broker epoch, records the follower's real offset, and admits through the same seal predicate. Reachability: any switched topic whose retention reaches the seal, plus every topic switched while empty, whose seal is zero. This is the steady state for an old switched topic, not an edge case.

The proof gates admission, never the validation. Its first shape gated recording the follower's position, on the reasoning that recording is what admits, which held while the branch went through `updateFollowerFetchState` and its generic ISR expansion. Once validation recorded the position directly that expansion became unreachable here and admission was the branch's own explicit call, so gating the record bought nothing and cost the request's only broker-epoch check, which lives in `Replica.updateFetchStateOrThrow`. An unproven fetch was answered `Errors.NONE` without it, so a superseded broker incarnation kept fetching instead of being told `NOT_LEADER_OR_FOLLOWER` and refreshing its metadata. Every request is now validated and recorded, and only ISR expansion waits on the proof. Reachability: needs a stale incarnation still fetching a switched partition it is outside the ISR of, with no ISR or data consequence since an unproven fetch was never going to be admitted. This is the one shape here the branch introduced rather than inherited: `main` passed `updateFetchState = true` unconditionally, so the check always ran.

Validation must not read at the seal. A switched topic is tiered, so local retention deletes the segments holding the classic prefix while the logical range stays retained. `LocalLog.read` throws `OffsetOutOfRangeException` there, and the follower's recovery from that error resets to the same offset with no backoff, so it refetches at RPC rate and is never admitted. `Partition.validateFollowerFetchAtSeal` answers the same questions through the leader epoch cache and touches no segment. Reachability: every switched consolidating topic reaches that state once local retention passes the seal, which is the steady state rather than an edge case.

### Where admission stays unsafe

`maybeExpandIsrAtSeal` mirrors `maybeExpandIsr` and swaps only the progress comparison, keeping its leadership, eligibility, in-flight, and locking safeguards. It drops one requirement on purpose: the follower need not hold data starting in the current leader epoch, since post-seal records live in shared object storage and never came from this leader. Two states block admission, each with its own guard:

- The leader is still below the seal, rebuilding its own classic prefix. It cannot validate an intact follower against an incomplete epoch cache.
- The fetch reports a diverging epoch. Validation leaves a position recorded by an earlier fetch alone, so admission has to depend on this fetch succeeding.

A third state changes what is validated rather than blocking: with no classic prefix retained the fetch leaves the proof path entirely, described under the limits above.

## Commits

1. `test(inkless:switch): cover ISR recovery after consolidation restart` - the baseline, red on `main` and green here.
2. `fix(inkless:switch): make consolidating replicas wait for ISR at the seal`
3. `fix(inkless:switch): hold a switched follower at the seal until ISR admits it`
4. `fix(inkless:switch): answer and prove the at-seal follower fetch` - what the leader returns, what it requires as proof of the prefix, and how it validates without reading at the seal.
5. `docs(inkless:switch): correct the hand-off comments for the ISR gate` - comments that still described the old self-eviction.
6. `test(inkless:switch): diagnose a short consume after the switch` - diagnostics only, no behavior change.

See the commit messages for the reasoning behind each step.

## Why one change

Cases A and B need the same three commits, and no ordering of them makes either case pass earlier. Every proper subset lands in a different failure:

- Commit 2 alone: the follower parks at the seal and reads the leader's consolidated suffix over inter-broker replication, and the next metadata delta undoes the wait.
- Commits 2 and 3 without 4: admission falls to the generic in-sync check and never passes, so the replica sits on the classic fetcher, outside ISR and no longer consolidating.
- Commit 4 alone: unreachable, because a follower evicts at the seal before it can issue an at-seal fetch.

Commit 4 is one commit rather than four because its parts are not independently correct. The answer it returns is what the follower needs the proof for, the proof is what makes admission safe, and the read-free validation is what keeps the proof working on a tiered log. Any two of them without the third leaves a follower that is either admitted without its prefix compared or never admitted at all.

The remaining commits are outside that loop. The docs commit corrects comments this branch falsifies. The diagnostics commit is test-only and is here because it is what found case C.

This project does split work when a piece stands alone. #774 came out of the same investigation and merged by itself, the `ListOffsets` gap below stays out, and #756 and #757 are separate PRs.

## Operator impact

No config, metric, protocol, or client-visible behavior changes.

## Test plan

`testSwitchedConsolidatingFollowerRejoinsIsrAfterRestart` is the baseline for case A: a two-broker cluster with a PostgreSQL control plane and object storage, switched and consolidated past the seal, then the follower restarted. It requires the follower back in the controller ISR, its diskless suffix intact, records produced after recovery replicated to it, and the whole prefix plus suffix readable. On `main` it times out at `isr=[leader]`.

It reads ISR from the KRaft metadata image, not `DescribeTopics`, which rebuilds client-facing ISR from broker liveness and reports the restarted broker as in sync even when the controller never readmits it. The first version used it and passed vacuously.

`ReplicaManagerInklessTest`, `ReplicaFetcherThreadTest`, `ConsolidationReconcilerTest`, and `PartitionTest` pin each link: fetcher routing at and past the seal, the consolidation-disabled case, ISR-only partition-epoch deltas, the epoch the classic fetcher offers at and below the seal against the latest epoch the consolidation fetcher keeps offering, admission with and without a consolidated leader, divergence on a prefix that ends before the seal, refusal of an absent epoch and of the diskless epoch, rejection of a fetch from a superseded broker incarnation, admission with no retained prefix at each of its three boundaries, two shapes in that state where the follower keeps its consolidated suffix instead of being told to truncate it, validation when the seal segment is no longer on the leader's disk, seal-based admission, fetch backoff, hand-off cleanup on removal and after the drain, and the reconciler ISR gate with its never-switched exemption. Each was mutation-checked: reverting one term fails that test and no other.

`InklessTopicTypeSwitcherClusterTest` gains diagnostics only: a short consume now reports which partition stalled and its per-broker log state.

## Follow-up

Cases A, B, and C are the reachable ones and are closed here. Three narrower cases stay out, all of them pre-existing rather than introduced, and all reachable only under conditions this change does not create. They are grouped into a follow-up that hardens request validation on the at-seal path.

Case E, a failed follower filed with the wrong manager. The catch blocks in `applyLocalFollowersDelta` re-read the metadata cache instead of reusing the value the enclosing guard decided on. Wherever the catch is reachable the two agree, so this is a consistency fix rather than a behavior change; they diverge only if the switch commits `diskless.enable` and `remote.storage.enable` between the two reads, on a broker where the consolidation manager is absent, while partition creation is throwing.

Case F, an unvalidated success below the seal. A leader still rebuilding its classic prefix answers a follower fetch at the seal with `Errors.NONE` and the seal high watermark without validating leadership, leader epoch, replica assignment, or broker epoch, since the guard that defers admission also skips the paths that validate. A follower fetching a stepped-down leader then gets empty successes instead of `FENCED_LEADER_EPOCH` and never refreshes its metadata. Reaching it needs a leader below the seal, which this change makes harder by requiring the classic prefix for clean election, so what remains are unclean election and local log loss. `Partition.validateFollowerFetchAtSeal` is the validation-only method it needs, added here for the tiered case; closing case F is a matter of calling it on the below-seal arm with recording off.

`ListOffsets(EARLIEST)` on a switched partition is answered only by a replica whose high watermark has reached the seal, and refused otherwise. Since the metadata transformer prefers an AZ-local replica rather than filtering on that condition, a client sent to a replica that refuses refreshes metadata, is sent back, and makes no progress. No current path reaches it, but the refusal has no useful outcome and is worth replacing with a fallback, as the equivalent Fetch-path case already was.

Case D is narrowed, not closed. The eviction and the reconciler both re-read ISR, but neither check can be made atomic with the fetcher-manager call without inverting a lock order. A delta landing between the reconciler's check and the point where it installs the consolidation fetcher can leave the partition assigned to both fetchers: the delta removes both and re-adds the classic one, and the stale consolidation call arrives after it. The second fetcher to append then fails the log end offset check at the top of `processPartitionData` and is marked failed for that partition, so the outcome is a stalled partition rather than interleaved records. Closing it needs generation-aware fetch state, so a queued hand-off can be rejected once the assignment it was queued against is gone. `PartitionFetchState` does not carry that.
