### PR TITLE
feat(inkless:metrics): add classic-to-diskless replicas outside ISR gauge

### DIFF
--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -28,7 +28,7 @@ import kafka.cluster.Partition
 import kafka.log.LogManager
 import kafka.server.HostedPartition.Online
 import kafka.server.QuotaFactory.QuotaManagers
-import kafka.server.ReplicaManager.{AtMinIsrPartitionCountMetricName, ConsolidationFetchBytesInPerSecMetricName, ConsolidationLocalBytesPerSecMetricName, ConsolidationSupplementBytesPerSecMetricName, ConsolidationSupplementRateMetricName, FailedIsrUpdatesPerSecMetricName, IsrExpandsPerSecMetricName, IsrShrinksPerSecMetricName, LeaderCountMetricName, OfflineReplicaCountMetricName, PartitionCountMetricName, PartitionsWithLateTransactionsCountMetricName, ProducerIdCountMetricName, ReassigningPartitionsMetricName, SealedPartitionsCountMetricName, UnderMinIsrPartitionCountMetricName, UnderReplicatedPartitionsMetricName, createLogReadResult, isListOffsetsTimestampUnsupported}
+import kafka.server.ReplicaManager.{AtMinIsrPartitionCountMetricName, ConsolidationFetchBytesInPerSecMetricName, ConsolidationLocalBytesPerSecMetricName, ConsolidationSupplementBytesPerSecMetricName, ConsolidationSupplementRateMetricName, FailedIsrUpdatesPerSecMetricName, IsrExpandsPerSecMetricName, IsrShrinksPerSecMetricName, LeaderCountMetricName, OfflineReplicaCountMetricName, PartitionCountMetricName, PartitionsWithLateTransactionsCountMetricName, ProducerIdCountMetricName, ReassigningPartitionsMetricName, SealedPartitionsCountMetricName, DisklessSwitchedReplicasOutsideIsrCountMetricName, UnderMinIsrPartitionCountMetricName, UnderReplicatedPartitionsMetricName, createLogReadResult, isListOffsetsTimestampUnsupported}
 import kafka.server.metadata.{InklessMetadataView, KRaftMetadataCache}
 import kafka.server.share.DelayedShareFetch
 import kafka.utils._
@@ -155,6 +155,8 @@ object ReplicaManager {
   private val AtMinIsrPartitionCountMetricName = "AtMinIsrPartitionCount"
   private val ReassigningPartitionsMetricName = "ReassigningPartitions"
   private val SealedPartitionsCountMetricName = "SealedPartitionsCount"
+  private[server] val DisklessSwitchedReplicasOutsideIsrCountMetricName =
+    "DisklessSwitchedReplicasOutsideIsrCount"
   private val PartitionsWithLateTransactionsCountMetricName = "PartitionsWithLateTransactionsCount"
   private val ProducerIdCountMetricName = "ProducerIdCount"
   private val IsrExpandsPerSecMetricName = "IsrExpandsPerSec"
@@ -174,6 +176,7 @@ object ReplicaManager {
     AtMinIsrPartitionCountMetricName,
     ReassigningPartitionsMetricName,
     SealedPartitionsCountMetricName,
+    DisklessSwitchedReplicasOutsideIsrCountMetricName,
     PartitionsWithLateTransactionsCountMetricName,
     ProducerIdCountMetricName
   )
@@ -438,6 +441,8 @@ class ReplicaManager(val config: KafkaConfig,
   metricsGroup.newGauge(AtMinIsrPartitionCountMetricName, () => atMinIsrPartitionCount)
   metricsGroup.newGauge(ReassigningPartitionsMetricName, () => reassigningPartitionsCount)
   metricsGroup.newGauge(SealedPartitionsCountMetricName, () => sealedPartitionsCount)
+  metricsGroup.newGauge(DisklessSwitchedReplicasOutsideIsrCountMetricName,
+    () => disklessSwitchedReplicasOutsideIsrCount)
   metricsGroup.newGauge(PartitionsWithLateTransactionsCountMetricName, () => lateTransactionsCount)
   metricsGroup.newGauge(ProducerIdCountMetricName, () => producerIdCount)
 
@@ -462,6 +467,14 @@ class ReplicaManager(val config: KafkaConfig,
 
   private def isConsolidatingPartition(partition: Partition): Boolean =
     config.disklessRemoteStorageConsolidationEnabled && _inklessMetadataView.isConsolidatingDisklessTopic(partition.topic)
+
+  private[server] def disklessSwitchedReplicasOutsideIsrCount: Int = onlinePartitionsIterator.count { partition =>
+    val topicPartition = partition.topicPartition
+    val seal = _inklessMetadataView.getClassicToDisklessStartOffset(topicPartition)
+    seal >= 0L &&
+      partition.log.exists(_.logEndOffset >= seal) &&
+      !_inklessMetadataView.isReplicaInIsr(topicPartition, config.brokerId)
+  }
 
   def recordConsolidationFetchBytesIn(bytes: Long): Unit = consolidationFetchBytesInPerSec.mark(bytes)
 

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerInklessTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerInklessTest.scala
@@ -8622,6 +8622,54 @@ class ReplicaManagerInklessTest {
   }
 
   @Test
+  def testDisklessSwitchedReplicasOutsideIsrCount(): Unit = {
+    val topic = "consolidating-topic"
+    val topicPartition = new TopicPartition(topic, 0)
+    val replicaManager = createReplicaManager(
+      disklessTopics = List(topic),
+      disklessRemoteStorageConsolidationEnabled = true,
+      consolidatingDisklessTopics = Set(topic),
+    )
+    try {
+      val log = mock(classOf[UnifiedLog])
+      val partition = mock(classOf[Partition])
+      when(partition.topic).thenReturn(topic)
+      when(partition.topicPartition).thenReturn(topicPartition)
+      when(partition.log).thenReturn(Some(log))
+      replicaManager.addOnlinePartition(topicPartition, partition)
+
+      when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(topicPartition)).thenReturn(100L)
+      when(replicaManager.inklessMetadataView().isReplicaInIsr(topicPartition, 1)).thenReturn(false)
+
+      when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(topicPartition))
+        .thenReturn(PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING)
+      assertEquals(0, replicaManager.disklessSwitchedReplicasOutsideIsrCount,
+        "a pending switch has no committed seal for ISR recovery")
+
+      when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(topicPartition)).thenReturn(100L)
+      when(log.logEndOffset).thenReturn(99L)
+      assertEquals(0, replicaManager.disklessSwitchedReplicasOutsideIsrCount,
+        "a replica below the seal is still catching up")
+
+      when(log.logEndOffset).thenReturn(100L)
+      assertEquals(1, replicaManager.disklessSwitchedReplicasOutsideIsrCount,
+        "a replica at the seal and outside ISR is awaiting readmission")
+
+      when(replicaManager.inklessMetadataView().isReplicaInIsr(topicPartition, 1)).thenReturn(true)
+      assertEquals(0, replicaManager.disklessSwitchedReplicasOutsideIsrCount,
+        "ISR admission ends the recovery wait")
+
+      when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(topicPartition))
+        .thenReturn(PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET)
+      when(replicaManager.inklessMetadataView().isReplicaInIsr(topicPartition, 1)).thenReturn(false)
+      assertEquals(0, replicaManager.disklessSwitchedReplicasOutsideIsrCount,
+        "born-diskless replicas do not have a classic-prefix recovery wait")
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
   def testUrpMetricsExcludeConsolidatingDisklessTopicsAcrossStates(): Unit = {
     val consolidatingTopic = "consolidating-topic"
     val classicTopic = "classic-topic"


### PR DESCRIPTION
The standard under-replicated partition gauges intentionally exclude consolidating topics because those topics do not materialize ordinary followers. That leaves no direct broker metric for a classic-to-diskless replica that has reached the committed seal but remains outside ISR.

Add DisklessSwitchedReplicasOutsideIsrCount under the ReplicaManager metric group. It counts hosted replicas whose switch has a committed seal, whose local log end offset is at or beyond that seal, and whose broker is absent from metadata ISR. The gauge covers consolidating and non-consolidating switched topics and describes only the observed state, so it can measure the condition before and after ISR recovery changes land.

A brief nonzero value is expected during normal ISR admission. Monitoring can alert on a sustained value without adding timers or logging state to ReplicaFetcherThread.

Testing

testDisklessSwitchedReplicasOutsideIsrCount covers a pending switch, a replica below the seal, a replica at the seal outside ISR, ISR admission, and a born-diskless replica.