### PR TITLE
fix(inkless:build): stop reusing `inklessTag` as both the override key and the resolved value [KC-384]

### DIFF
--- a/.github/scripts/test-inkless-tag.sh
+++ b/.github/scripts/test-inkless-tag.sh
@@ -3,11 +3,16 @@
 #
 # Checks how the inkless release tag baked into kafka-version.properties resolves.
 #
-# Two regressions this guards against:
+# Three regressions this guards against:
 #   1. a source tree without .git must resolve to "unknown", not fail the build
 #      (release packaging builds from a tarball, where git describe exits 128);
 #   2. -PinklessTag must be honoured verbatim (it lands in the project's `ext`
-#      namespace, which the ext block then shadows with the provider itself).
+#      namespace, which the ext block then shadows with the provider itself);
+#   3. that same override must resolve at every subproject's createVersionFile
+#      task, not only at root's printInklessTag (Gradle seeds -PinklessTag as an
+#      extra property on every project, so a fix that only decouples root's own
+#      read can still leave subprojects reading the raw CLI string instead of
+#      the resolved provider).
 #
 # Usage: .github/scripts/test-inkless-tag.sh
 # Run from the repository root of a git checkout.
@@ -38,6 +43,25 @@ resolve_tag() {
   rm -f "$log"
 }
 
+# Resolves the tag baked into a subproject's kafka-version.properties by its own
+# createVersionFile task, the call site that actually broke (root's printInklessTag
+# never exercised it). Extra args are passed to gradle.
+resolve_tag_via_create_version_file() {
+  local dir=$1
+  shift
+  local log
+  log=$(mktemp)
+  if ! (cd "$dir" && ./gradlew --console=plain --no-daemon "$@" -x generateJooqClasses \
+      :tools:tools-api:createVersionFile) >"$log" 2>&1; then
+    echo "gradle failed in $dir:" >&2
+    cat "$log" >&2
+    rm -f "$log"
+    return 0
+  fi
+  rm -f "$log"
+  sed -n 's/^inklessTag=//p' "$dir/tools/tools-api/build/kafka/kafka-version.properties"
+}
+
 expect_eq() {
   local name=$1 expected=$2 actual=$3
   if [[ "$actual" == "$expected" ]]; then
@@ -66,6 +90,8 @@ expect_eq "no .git and no property falls back to unknown" \
   "unknown" "$(resolve_tag "$EXPORT_DIR")"
 expect_eq "no .git honours -PinklessTag" \
   "inkless-release-9.99" "$(resolve_tag "$EXPORT_DIR" -PinklessTag=inkless-release-9.99)"
+expect_eq "no .git honours -PinklessTag at a subproject's createVersionFile" \
+  "inkless-release-9.99" "$(resolve_tag_via_create_version_file "$EXPORT_DIR" -PinklessTag=inkless-release-9.99)"
 
 echo "== git checkout =="
 expect_resolved "git checkout resolves from git describe" \

--- a/.github/scripts/test-inkless-tag.sh
+++ b/.github/scripts/test-inkless-tag.sh
@@ -90,7 +90,7 @@ expect_eq "no .git and no property falls back to unknown" \
   "unknown" "$(resolve_tag "$EXPORT_DIR")"
 expect_eq "no .git honours -PinklessTag" \
   "inkless-release-9.99" "$(resolve_tag "$EXPORT_DIR" -PinklessTag=inkless-release-9.99)"
-expect_eq "no .git honours -PinklessTag at a subproject's createVersionFile" \
+expect_eq "no .git honors -PinklessTag at a subproject's createVersionFile" \
   "inkless-release-9.99" "$(resolve_tag_via_create_version_file "$EXPORT_DIR" -PinklessTag=inkless-release-9.99)"
 
 echo "== git checkout =="

--- a/build.gradle
+++ b/build.gradle
@@ -117,7 +117,7 @@ ext {
   repo = file("$rootDir/.git").isDirectory() ? Grgit.open(currentDir: project.getRootDir()) : null
 
   commitId = determineCommitId()
-  inklessTag = determineInklessTag()
+  resolvedInklessTag = determineInklessTag()
 
   configureJavaCompiler = { name, options, projectPath ->
     // -parameters generates arguments with parameter names in TestInfo#getDisplayName.
@@ -253,9 +253,12 @@ def determineCommitId() {
 //
 // An explicit `inklessTag` gradle property wins, so builds without a git checkout
 // (release packaging from a source tarball) can supply it. It must be read through
-// providers.gradleProperty: `-PinklessTag` lands in the project's `ext` namespace,
-// which `ext { inklessTag = ... }` then overwrites with this very provider, so
-// project.property('inklessTag') would resolve back to the provider itself.
+// providers.gradleProperty, not project.property: `-PinklessTag` lands as an extra
+// property on every project in the build, not only root, so a bare `inklessTag`
+// read from inside a `project(':x') { ... }` block would resolve to that raw,
+// per-project CLI string instead of this function's result. The result is
+// assigned to the differently named `resolvedInklessTag` (see below) precisely so
+// no project ever gets a same-named override and export to collide between.
 //
 // Returned as a lazy Provider using providers.exec (the configuration-cache-safe
 // API) rather than a config-time exec, and evaluated when createVersionFile runs.
@@ -302,7 +305,7 @@ apply from: file('wrapper.gradle')
 // running a build. Used by .github/scripts/test-inkless-tag.sh and by release
 // packaging to check what -PinklessTag resolves to.
 tasks.register('printInklessTag') {
-  def tag = inklessTag
+  def tag = resolvedInklessTag
   doLast {
     println "INKLESS_TAG=${tag.get()}"
   }
@@ -1058,7 +1061,7 @@ project(':server') {
     def receiptFile = file("${layout.buildDirectory.get().asFile.path}/kafka/$buildVersionFileName")
     inputs.property "commitId", commitId
     inputs.property "version", version
-    inputs.property "inklessTag", inklessTag
+    inputs.property "inklessTag", resolvedInklessTag
     outputs.file receiptFile
     outputs.cacheIf { true }
 
@@ -1066,7 +1069,7 @@ project(':server') {
       def data = [
         commitId: commitId,
         version: version,
-        inklessTag: inklessTag.get(),
+        inklessTag: resolvedInklessTag.get(),
       ]
 
       receiptFile.parentFile.mkdirs()
@@ -1522,7 +1525,7 @@ project(':group-coordinator:group-coordinator-api') {
     def receiptFile = file("${layout.buildDirectory.get().asFile.path}/kafka/$buildVersionFileName")
     inputs.property "commitId", commitId
     inputs.property "version", version
-    inputs.property "inklessTag", inklessTag
+    inputs.property "inklessTag", resolvedInklessTag
     outputs.file receiptFile
     outputs.cacheIf { true }
 
@@ -1530,7 +1533,7 @@ project(':group-coordinator:group-coordinator-api') {
       def data = [
               commitId: commitId,
               version: version,
-              inklessTag: inklessTag.get(),
+              inklessTag: resolvedInklessTag.get(),
       ]
 
       receiptFile.parentFile.mkdirs()
@@ -1997,7 +2000,7 @@ project(':clients') {
     def receiptFile = file("${layout.buildDirectory.get().asFile.path}/kafka/$buildVersionFileName")
     inputs.property "commitId", commitId
     inputs.property "version", version
-    inputs.property "inklessTag", inklessTag
+    inputs.property "inklessTag", resolvedInklessTag
     outputs.file receiptFile
     outputs.cacheIf { true }
 
@@ -2005,7 +2008,7 @@ project(':clients') {
       def data = [
         commitId: commitId,
         version: version,
-        inklessTag: inklessTag.get(),
+        inklessTag: resolvedInklessTag.get(),
       ]
 
       receiptFile.parentFile.mkdirs()
@@ -2199,7 +2202,7 @@ project(':raft') {
     def receiptFile = file("${layout.buildDirectory.get().asFile.path}/kafka/$buildVersionFileName")
     inputs.property "commitId", commitId
     inputs.property "version", version
-    inputs.property "inklessTag", inklessTag
+    inputs.property "inklessTag", resolvedInklessTag
     outputs.file receiptFile
     outputs.cacheIf { true }
 
@@ -2207,7 +2210,7 @@ project(':raft') {
       def data = [
         commitId: commitId,
         version: version,
-        inklessTag: inklessTag.get(),
+        inklessTag: resolvedInklessTag.get(),
       ]
 
       receiptFile.parentFile.mkdirs()
@@ -2295,7 +2298,7 @@ project(':server-common') {
     def receiptFile = file("${layout.buildDirectory.get().asFile.path}/kafka/$buildVersionFileName")
     inputs.property "commitId", commitId
     inputs.property "version", version
-    inputs.property "inklessTag", inklessTag
+    inputs.property "inklessTag", resolvedInklessTag
     outputs.file receiptFile
     outputs.cacheIf { true }
 
@@ -2303,7 +2306,7 @@ project(':server-common') {
       def data = [
               commitId: commitId,
               version: version,
-              inklessTag: inklessTag.get(),
+              inklessTag: resolvedInklessTag.get(),
       ]
 
       receiptFile.parentFile.mkdirs()
@@ -2356,7 +2359,7 @@ project(':storage:storage-api') {
     def receiptFile = file("${layout.buildDirectory.get().asFile.path}/kafka/$buildVersionFileName")
     inputs.property "commitId", commitId
     inputs.property "version", version
-    inputs.property "inklessTag", inklessTag
+    inputs.property "inklessTag", resolvedInklessTag
     outputs.file receiptFile
     outputs.cacheIf { true }
 
@@ -2364,7 +2367,7 @@ project(':storage:storage-api') {
       def data = [
               commitId: commitId,
               version: version,
-              inklessTag: inklessTag.get(),
+              inklessTag: resolvedInklessTag.get(),
       ]
 
       receiptFile.parentFile.mkdirs()
@@ -2454,7 +2457,7 @@ project(':storage') {
     def receiptFile = file("${layout.buildDirectory.get().asFile.path}/kafka/$buildVersionFileName")
     inputs.property "commitId", commitId
     inputs.property "version", version
-    inputs.property "inklessTag", inklessTag
+    inputs.property "inklessTag", resolvedInklessTag
     outputs.file receiptFile
     outputs.cacheIf { true }
 
@@ -2462,7 +2465,7 @@ project(':storage') {
       def data = [
               commitId: commitId,
               version: version,
-              inklessTag: inklessTag.get(),
+              inklessTag: resolvedInklessTag.get(),
       ]
 
       receiptFile.parentFile.mkdirs()
@@ -2820,7 +2823,7 @@ project(':tools:tools-api') {
     def receiptFile = file("${layout.buildDirectory.get().asFile.path}/kafka/$buildVersionFileName")
     inputs.property "commitId", commitId
     inputs.property "version", version
-    inputs.property "inklessTag", inklessTag
+    inputs.property "inklessTag", resolvedInklessTag
     outputs.file receiptFile
     outputs.cacheIf { true }
 
@@ -2828,7 +2831,7 @@ project(':tools:tools-api') {
       def data = [
               commitId: commitId,
               version: version,
-              inklessTag: inklessTag.get(),
+              inklessTag: resolvedInklessTag.get(),
       ]
 
       receiptFile.parentFile.mkdirs()
@@ -3152,14 +3155,14 @@ project(':streams') {
     def receiptFile = file("${layout.buildDirectory.get().asFile.path}/kafka/$buildStreamsVersionFileName")
     inputs.property "commitId", commitId
     inputs.property "version", version
-    inputs.property "inklessTag", inklessTag
+    inputs.property "inklessTag", resolvedInklessTag
     outputs.file receiptFile
 
     doLast {
       def data = [
               commitId: commitId,
               version: version,
-              inklessTag: inklessTag.get(),
+              inklessTag: resolvedInklessTag.get(),
       ]
 
       receiptFile.parentFile.mkdirs()


### PR DESCRIPTION
`determineInklessTag()`'s own read is safe: it resolves `-PinklessTag` through `providers.gradleProperty`, not `project.property`. But the result gets assigned back to a same-named `ext.inklessTag` at the top level. Gradle also seeds `-PinklessTag` as a raw-string extra property on every project in the build, not only root, so nine `createVersionFile` call sites inside `project(':x') { ... }` blocks read that subproject's own raw string before ever falling back to root's provider. `inklessTag.get()` then fails with `No signature of method: java.lang.String.get()` whenever `-PinklessTag` is passed and a `createVersionFile` task other than root's `printInklessTag` runs, for example during release packaging from a source tarball.

Renames the exported provider to `resolvedInklessTag`, so the override input and the resolved output never share a name and no project can seed a collision between them. The CLI flag stays `-PinklessTag` and the `kafka-version.properties` field stays `inklessTag`, so neither the release packaging contract nor the file format changes.

Extends `test-inkless-tag.sh` to exercise
`:tools:tools-api:createVersionFile` directly, the call site that broke. The existing check only exercised root's `printInklessTag`, which never touched the collision.

Testing
- `.github/scripts/test-inkless-tag.sh` passes, and reproduces the original crash when run against the pre-fix `build.gradle`.
- `./gradlew :tools:tools-api:createVersionFile -PinklessTag=<tag> -x generateJooqClasses` succeeds both with and without a `.git` checkout present.
