### PR TITLE
feat(inkless:control-plane): enable batch coalescing by default [KC-296]

### DIFF
--- a/docs/inkless/configs.rst
+++ b/docs/inkless/configs.rst
@@ -46,13 +46,6 @@ Under ``inkless.``
   * Default: ""
   * Importance: medium
 
-``control.plane.batch.coalescing.enabled``
-  When true, contiguous same-partition batch runs within a single commit are collapsed into a single row in the batches table via commit_file_v2, reducing control-plane metadata growth for low-throughput producers. Set to true only after all brokers in the cluster have been upgraded to a version that supports reading coalesced rows. Defaults to false for safe rolling upgrades.
-
-  * Type: boolean
-  * Default: false
-  * Importance: medium
-
 ``fetch.lagging.consumer.request.rate.limit``
   Maximum requests per second for lagging consumer data fetches. Set to 0 to disable rate limiting. The upper bound of 10000 req/s is a safety limit to prevent misconfiguration. For high-throughput systems, consider the relationship between this rate limit, thread pool size, and storage backend capacity. At the default rate of 200 req/s with ~50ms per request latency, this allows ~10 concurrent requests. Note: hedge requests triggered by slow fetches are exempt from this limit. In the worst case, effective storage GET rate can reach up to 2x this value.
 
@@ -315,6 +308,13 @@ Under ``inkless.control.plane.``
   * Type: password
   * Default: null
   * Importance: high
+
+``batch.coalescing.enabled``
+  When true, commit_file_v2 is used to collapse contiguous same-partition batch runs into a single batches row.
+
+  * Type: boolean
+  * Default: true
+  * Importance: medium
 
 ``connection.pool.timeout.ms``
   Maximum time in milliseconds to wait for a PostgreSQL connection from the pool.

--- a/storage/inkless/src/main/java/io/aiven/inkless/config/InklessConfig.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/config/InklessConfig.java
@@ -265,15 +265,6 @@ public class InklessConfig extends AbstractConfig {
         + "retention.enforcement.interval.ms.";
     private static final int RETENTION_ENFORCEMENT_MAX_BATCHES_PER_REQUEST_DEFAULT = 2000;
 
-    public static final String BATCH_COALESCING_ENABLED_CONFIG = CONTROL_PLANE_PREFIX + "batch.coalescing.enabled";
-    public static final String BATCH_COALESCING_ENABLED_DOC = "When true, contiguous same-partition batch runs within a single commit are collapsed "
-        + "into a single row in the batches table via commit_file_v2, reducing control-plane metadata growth "
-        + "for low-throughput producers. "
-        + "Set to true only after all brokers in the cluster have been upgraded to a version that supports "
-        + "reading coalesced rows. "
-        + "Defaults to false for safe rolling upgrades.";
-    private static final boolean BATCH_COALESCING_ENABLED_DEFAULT = false;
-
     public static final String CLIENT_AZ_LISTENER_MAP_CONFIG = "client.az.listener.map";
     private static final String CLIENT_AZ_LISTENER_MAP_DOC = "Cluster-wide mapping from AZ-specific listener aliases to physical "
         + "availability zone (rack) IDs, used for listener-based AZ routing of diskless topic metadata. "
@@ -559,14 +550,6 @@ public class InklessConfig extends AbstractConfig {
             ConfigDef.Range.atLeast(1),
             ConfigDef.Importance.LOW,
             CONSUME_CROSS_TIER_LOG_START_CACHE_TTL_MS_DOC
-        );
-
-        configDef.define(
-            BATCH_COALESCING_ENABLED_CONFIG,
-            ConfigDef.Type.BOOLEAN,
-            BATCH_COALESCING_ENABLED_DEFAULT,
-            ConfigDef.Importance.MEDIUM,
-            BATCH_COALESCING_ENABLED_DOC
         );
 
         configDef.define(

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/PostgresConnectionConfig.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/PostgresConnectionConfig.java
@@ -52,7 +52,7 @@ public class PostgresConnectionConfig extends AbstractControlPlaneConfig {
         "Maximum time in milliseconds to wait for PostgreSQL socket reads.";
     private static final int SOCKET_TIMEOUT_MS_DEFAULT = 5_000;
 
-    public static ConfigDef configDef() {
+    public static ConfigDef connectionConfigDef() {
         return baseConfigDef()
             .define(
                 CONNECTION_STRING_CONFIG,

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/PostgresControlPlaneConfig.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/postgres/PostgresControlPlaneConfig.java
@@ -28,25 +28,28 @@ public class PostgresControlPlaneConfig extends PostgresConnectionConfig {
 
     public static final String BATCH_COALESCING_ENABLED_CONFIG = "batch.coalescing.enabled";
     private static final String BATCH_COALESCING_ENABLED_DOC = "When true, commit_file_v2 is used to collapse contiguous "
-        + "same-partition batch runs into a single batches row. "
-        + "Enable only after all brokers support reading coalesced rows. Defaults to false.";
-    private static final boolean BATCH_COALESCING_ENABLED_DEFAULT = false;
+        + "same-partition batch runs into a single batches row.";
+    private static final boolean BATCH_COALESCING_ENABLED_DEFAULT = true;
 
     private PostgresConnectionConfig readConfig;
     private PostgresConnectionConfig writeConfig;
 
     public PostgresControlPlaneConfig(final Map<?, ?> originals) {
         super(
-            PostgresConnectionConfig.configDef()
-                .define(
-                    BATCH_COALESCING_ENABLED_CONFIG,
-                    ConfigDef.Type.BOOLEAN,
-                    BATCH_COALESCING_ENABLED_DEFAULT,
-                    ConfigDef.Importance.MEDIUM,
-                    BATCH_COALESCING_ENABLED_DOC
-                ),
+            configDef(),
             originals
         );
+    }
+
+    public static ConfigDef configDef() {
+        return PostgresConnectionConfig.connectionConfigDef()
+            .define(
+                BATCH_COALESCING_ENABLED_CONFIG,
+                ConfigDef.Type.BOOLEAN,
+                BATCH_COALESCING_ENABLED_DEFAULT,
+                ConfigDef.Importance.MEDIUM,
+                BATCH_COALESCING_ENABLED_DOC
+            );
     }
 
     public boolean batchCoalescingEnabled() {
@@ -56,12 +59,12 @@ public class PostgresControlPlaneConfig extends PostgresConnectionConfig {
     public void initializeReadWriteConfigs() {
         final Map<String, Object> readConfigs = originalsWithPrefix(READ_CONFIG_PREFIX);
         if (!readConfigs.isEmpty()) {
-            this.readConfig = new PostgresConnectionConfig(configDef(), readConfigs);
+            this.readConfig = new PostgresConnectionConfig(connectionConfigDef(), readConfigs);
         }
 
         final Map<String, Object> writeConfigs = originalsWithPrefix(WRITE_CONFIG_PREFIX);
         if (!writeConfigs.isEmpty()) {
-            this.writeConfig = new PostgresConnectionConfig(configDef(), writeConfigs);
+            this.writeConfig = new PostgresConnectionConfig(connectionConfigDef(), writeConfigs);
         }
     }
 

--- a/storage/inkless/src/main/java/io/aiven/inkless/doc/ConfigsDocs.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/doc/ConfigsDocs.java
@@ -56,11 +56,11 @@ public class ConfigsDocs {
         out.println();
         printSubsectionTitle("PostgresControlPlaneConfig - read overrides");
         out.println("Under ``" + InklessConfig.PREFIX + InklessConfig.CONTROL_PLANE_PREFIX + PostgresControlPlaneConfig.READ_CONFIG_PREFIX + "``\n");
-        out.println(PostgresConnectionConfig.configDef().toEnrichedRst());
+        out.println(PostgresConnectionConfig.connectionConfigDef().toEnrichedRst());
         out.println();
         printSubsectionTitle("PostgresControlPlaneConfig - write overrides");
         out.println("Under ``" + InklessConfig.PREFIX + InklessConfig.CONTROL_PLANE_PREFIX + PostgresControlPlaneConfig.WRITE_CONFIG_PREFIX + "``\n");
-        out.println(PostgresConnectionConfig.configDef().toEnrichedRst());
+        out.println(PostgresConnectionConfig.connectionConfigDef().toEnrichedRst());
         out.println();
 
         printSubsectionTitle("AzureBlobStorageConfig");

--- a/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/PostgresControlPlaneConfigTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/control_plane/postgres/PostgresControlPlaneConfigTest.java
@@ -39,7 +39,8 @@ class PostgresControlPlaneConfigTest {
                 "max.connections", "11",
                 "connection.pool.timeout.ms", "501",
                 "tcp.connect.timeout.ms", "502",
-                "socket.timeout.ms", "503"
+                "socket.timeout.ms", "503",
+                "batch.coalescing.enabled", "false"
             )
         );
 
@@ -50,6 +51,7 @@ class PostgresControlPlaneConfigTest {
         assertThat(config.connectionPoolTimeoutMs()).isEqualTo(501);
         assertThat(config.tcpConnectTimeoutMs()).isEqualTo(502);
         assertThat(config.socketTimeoutMs()).isEqualTo(503);
+        assertThat(config.batchCoalescingEnabled()).isFalse();
     }
 
     @Test
@@ -69,6 +71,7 @@ class PostgresControlPlaneConfigTest {
         assertThat(config.connectionPoolTimeoutMs()).isEqualTo(5000);
         assertThat(config.tcpConnectTimeoutMs()).isEqualTo(5000);
         assertThat(config.socketTimeoutMs()).isEqualTo(5000);
+        assertThat(config.batchCoalescingEnabled()).isTrue();
 
         // ensure read/write configs are null when not set
         config.initializeReadWriteConfigs();
@@ -107,6 +110,50 @@ class PostgresControlPlaneConfigTest {
             )
         );
         assertThat(config.password()).isNull();
+    }
+
+    @Test
+    void controlPlaneConfigDefIncludesBatchCoalescing() {
+        final var names = PostgresControlPlaneConfig.configDef().names();
+        assertThat(names).contains(
+            PostgresControlPlaneConfig.BATCH_COALESCING_ENABLED_CONFIG,
+            PostgresConnectionConfig.CONNECTION_STRING_CONFIG);
+    }
+
+    @Test
+    void connectionConfigDefExcludesBatchCoalescing() {
+        final var names = PostgresConnectionConfig.connectionConfigDef().names();
+        assertThat(names).contains(PostgresConnectionConfig.CONNECTION_STRING_CONFIG);
+        assertThat(names).doesNotContain(PostgresControlPlaneConfig.BATCH_COALESCING_ENABLED_CONFIG);
+    }
+
+    @Test
+    void readWriteOverridesIgnoreBatchCoalescing() {
+        final Map<String, String> configs = new HashMap<>();
+        configs.putAll(
+            Map.of(
+                "connection.string", "jdbc:postgresql://127.0.0.1:5432/inkless",
+                "username", "username",
+                "password", "password"
+            )
+        );
+        configs.putAll(
+            Map.of(
+                "read.connection.string", "jdbc:postgresql://127.0.0.1:5432/inkless-read",
+                "read.username", "username-r",
+                "read.password", "password-r",
+                "read." + PostgresControlPlaneConfig.BATCH_COALESCING_ENABLED_CONFIG, "false"
+            )
+        );
+
+        final var config = new PostgresControlPlaneConfig(configs);
+        config.initializeReadWriteConfigs();
+
+        // The read override is parsed with the connection-only def, so batch.coalescing.enabled
+        // is not a known key and never lands in the parsed values.
+        assertThat(config.readConfig()).isNotNull();
+        assertThat(config.readConfig().values()).doesNotContainKey(
+            PostgresControlPlaneConfig.BATCH_COALESCING_ENABLED_CONFIG);
     }
 
     @Test


### PR DESCRIPTION
Batch coalescing collapses contiguous same-partition batch runs within a commit into a single batches row, curbing control-plane metadata growth. It has run on many customers without issue, so make it the default.

The effective default is owned by PostgresControlPlaneConfig, not InklessConfig. InklessConfig.controlPlaneConfig() passes control-plane settings through originalsWithPrefix(), which carries only user-supplied keys, never parsed defaults. The InklessConfig define for batch.coalescing.enabled therefore never fed behavior, so flipping its default was a no-op. Remove that dead define and flip the default in PostgresControlPlaneConfig, which governs the value read on the commit path.

Fix the config documentation generation. PostgresControlPlaneConfig had no static configDef() of its own, so ConfigsDocs resolved the inherited PostgresConnectionConfig.configDef() and the generated reference omitted batch.coalescing.enabled. Give PostgresControlPlaneConfig its own configDef(), and rename the parent to connectionConfigDef() so the child no longer hides a same-signature static (SpotBugs HSM).

Keep read/write connection overrides on the connection-only def. initializeReadWriteConfigs() builds them from connectionConfigDef(), so batch.coalescing.enabled stays out of the read.*/write.* schemas where it would be a silently accepted no-op.

Testing

Adds PostgresControlPlaneConfigTest cases asserting the control-plane def includes batch.coalescing.enabled, the connection def excludes it, and a read.* override never lands in the parsed read-config values. Existing cases now assert the default is true.
