### PR TITLE
fix(inkless:metadata): accept pipe as a client.id AZ separator [KC-443]

### DIFF
--- a/docs/inkless/CLIENT-BROKER-AZ-ALIGNMENT.md
+++ b/docs/inkless/CLIENT-BROKER-AZ-ALIGNMENT.md
@@ -148,13 +148,21 @@ The Inkless broker parses the `client.id` field using a regex pattern:
 ```java
 // From ClientAZExtractor.java
 private static final Pattern CLIENT_AZ_PATTERN = 
-    Pattern.compile("(^|[ ,])diskless_az=(?<az>[^=, ]*)");
+    Pattern.compile("(^|[ ,|])diskless_az=(?<az>[^=,| ]*)");
 ```
 
 This allows flexibility in placement:
 - `diskless_az=us-east-1a` (at start)
 - `my-app,diskless_az=us-east-1a` (after comma)
 - `my-app diskless_az=us-east-1a` (after space)
+- `my-app|diskless_az=us-east-1a` (after pipe)
+
+The pipe (`|`) is both a valid separator and a terminator because MirrorMaker 2
+appends `|<source>-><target>|<connector>|<role>` to any configured `client.id`
+(`MirrorConnectorConfig.addClientId`). Setting `client.id=diskless_az=us-east-1a`
+for a MirrorMaker 2 flow therefore reaches the broker as
+`diskless_az=us-east-1a|source->target|connector|role`, and the parser stops the
+AZ capture at the first pipe.
 
 #### Producer Flow
 

--- a/storage/inkless/src/main/java/io/aiven/inkless/metadata/ClientAZExtractor.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/metadata/ClientAZExtractor.java
@@ -23,7 +23,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 class ClientAZExtractor {
-    private static final Pattern CLIENT_AZ_PATTERN = Pattern.compile("(^|[ ,])diskless_az=(?<az>[^=, ]*)");
+    // Commas as default separator and pipes added to support MirrorConnectorConfig.addClientId appends to client.id
+    private static final Pattern CLIENT_AZ_PATTERN = Pattern.compile("(^|[ ,|])diskless_az=(?<az>[^=,| ]*)");
 
     // Visible for testing
     static String getClientAZ(final String clientId) {

--- a/storage/inkless/src/test/java/io/aiven/inkless/metadata/ClientAZExtractorTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/metadata/ClientAZExtractorTest.java
@@ -47,7 +47,13 @@ class ClientAZExtractorTest {
         "aaa=bbb,diskless_az=az1",
         "aaa=bbb, diskless_az=az1",
         "diskless_az=az1,aaa=bbb",
-        "diskless_az=az1, aaa=bbb"
+        "aaa=bbb|diskless_az=az1",
+        "aaa=bbb| diskless_az=az1",
+        "diskless_az=az1|aaa=bbb",
+        "diskless_az=az1| aaa=bbb",
+        "aaa=bbb,diskless_az=az1|ccc=ddd",
+        "aaa=bbb|diskless_az=az1,ccc=ddd",
+        "aaa=bbb, ccc=ddd|diskless_az=az1|eee=fff"
     })
     void getClientAZWhenProvided(final String clientId) {
         assertThat(ClientAZExtractor.getClientAZ(clientId)).isEqualTo("az1");
@@ -59,7 +65,12 @@ class ClientAZExtractorTest {
         "aaa=bbb,diskless_az=",
         "aaa=bbb, diskless_az=",
         "diskless_az=,aaa=bbb",
-        "diskless_az=, aaa=bbb"
+        "aaa=bbb|diskless_az=",
+        "aaa=bbb| diskless_az=",
+        "diskless_az=|aaa=bbb",
+        "diskless_az=| aaa=bbb",
+        "aaa=bbb,diskless_az=|ccc=ddd",
+        "aaa=bbb|diskless_az=,ccc=ddd"
     })
     void getClientAZWhenProvidedEmptyValue(final String clientId) {
         assertThat(ClientAZExtractor.getClientAZ(clientId)).isEqualTo("");
@@ -114,6 +125,8 @@ class ClientAZExtractorTest {
             // Progressive stripping removes from the right, so the longest prefix that matches wins.
             arguments("my-app,diskless_az=us-east-1a-suffix", Set.of("us", "us-east", "us-east-1a"), "us-east-1a"),
             arguments("kafka-connect,diskless_az=use1-az2-575969bf-aae2-47c5-98d6-8750ef0536f8", Set.of("use1-az2"), "use1-az2"),
+            arguments("mm-producer,diskless_az=use1-az2|source->target|MirrorSourceConnector-0|replication-consumer", Set.of("use1-az2"), "use1-az2"),
+            arguments("my-app,diskless_az=use1-az2-suffix|source->target|conn|producer", Set.of("use1-az2"), "use1-az2"),
             arguments("my-app,diskless_az=", euWest, ""),
             arguments("my-app,diskless_az=completely-wrong-value", euWest, null),
             arguments("my-app,diskless_az=unknown", euWest, null),


### PR DESCRIPTION
MirrorMaker 2 appends `|<source>-><target>|<connector>|<role>` to any configured `client.id` via `MirrorConnectorConfig.addClientId()`. With the old regex, that suffix was swallowed into the `diskless_az` capture, so a `client.id` of `diskless_az=euc1-az2` arrived as
`diskless_az=euc1-az2|primary->backup|MirrorSourceConnector|producer` and AZ extraction returned null after failing every hyphen-truncation candidate.

Treat `|` as both a valid leading separator and an AZ stop character so MM2's pipe-appended `client.id` parses the same as the comma-separated form Connect produces. This is symmetric with the existing comma handling and removes the fragility for any client that suffixes client.id with a pipe.
