### PR TITLE
fix(inkless-sync): avoid arithmetic error in conflict count check

### DIFF
--- a/inkless-sync/main-sync.sh
+++ b/inkless-sync/main-sync.sh
@@ -447,7 +447,8 @@ is_auto_resolvable() {
     # For now, consider .java and .scala files with small conflicts as potentially auto-resolvable
     if [[ "$file" == *.java || "$file" == *.scala ]]; then
         # Count conflict markers
-        local conflicts=$(grep -c "^<<<<<<< " "$file" 2>/dev/null || echo "0")
+        local conflicts
+        conflicts=$(grep -c "^<<<<<<< " "$file" 2>/dev/null) || conflicts=0
         if [[ "$conflicts" -le 3 ]]; then
             return 0
         fi


### PR DESCRIPTION
grep -c exits with status 1 when it finds no matches, even though it still prints "0". The old code combined that with an unconditional "|| echo "0"" fallback, so the variable ended up holding two lines ("0\n0") whenever a file had zero conflicts. The following [[ ... -le 3 ]] arithmetic comparison then failed with an arithmetic syntax error because the value wasn't a single integer.

Separate the assignment from the fallback so the fallback only runs when grep itself reports no match, producing a single integer value.
