### PR TITLE
feat(inkless:consume): default the lagging request-rate limit off, cap batches per partition

### DIFF
--- a/docs/inkless/PERFORMANCE.md
+++ b/docs/inkless/PERFORMANCE.md
@@ -231,7 +231,7 @@ Inkless implements a two-tier fetch architecture that separates recent data requ
 - For consumers reading data older than the threshold (`inkless.fetch.lagging.consumer.threshold.ms`)
 - Bypasses cache to avoid evicting hot data
 - Dedicated bounded executor pool (`inkless.fetch.lagging.consumer.thread.pool.size`, default: 16 threads)
-- Optional rate limiting (`inkless.fetch.lagging.consumer.request.rate.limit`, default: 200 req/s)
+- Optional rate limiting (`inkless.fetch.lagging.consumer.request.rate.limit`, default: 0, disabled)
 - Separate storage client for resource isolation
 
 **Path selection** is based on data age (batch timestamp), not consumer lag:
@@ -272,19 +272,20 @@ Unlike traditional Kafka where each partition's data is stored contiguously, Ink
 
 #### Broker Configuration
 
-The read path can be tuned using three key broker configurations under the `inkless.` prefix:
+The read path can be tuned using these key broker configurations under the `inkless.` prefix:
 
 | Configuration | Default | Description |
 |---------------|---------|-------------|
 | `fetch.lagging.consumer.thread.pool.size` | 16 | Thread pool size for lagging consumers. Set to **0** to disable the feature entirely. |
 | `fetch.lagging.consumer.threshold.ms` | -1 (auto) | Time threshold (ms) to distinguish recent vs lagging data. `-1` uses cache TTL automatically. Must be ≥ cache lifespan when set explicitly. |
-| `fetch.lagging.consumer.request.rate.limit` | 200 | Maximum requests/second for lagging consumers. Set to **0** to disable rate limiting. |
+| `fetch.lagging.consumer.request.rate.limit` | 0 (disabled) | Maximum object storage GET requests/second for lagging consumers. `0` disables the limit and lets the thread pool govern the GET rate. Set a positive value to bound the sustained request rate (token bucket; an idle bucket allows an initial burst up to the configured value). |
+| `fetch.find.batches.max.per.partition` | 1024 | Maximum batches returned per partition per fetch. Bounds the control-plane scan and object GET fan-out on deep partitions of small batches. `0` removes the cap. Consolidation has separate settings under `diskless.consolidation.*`. |
 
 **Tuning guidance:**
 
 - **Thread pool size**: Default of 16 threads (half of hot path's 32) is suitable for most workloads. Increase for higher lagging consumer concurrency, but be mindful of storage backend capacity.
 - **Threshold**: The `-1` default aligns with cache lifecycle. Set an explicit value (e.g., `120000` for 2 minutes) if you need different lagging consumer classification.
-- **Rate limit**: Default 200 req/s balances throughput with cost control. Adjust based on your object storage budget and capacity requirements.
+- **Rate limit**: Disabled by default. The thread pool bounds the steady-state GET rate at pool size divided by GET latency. Set a positive value to bound the sustained request rate (a token bucket sized to this value, so an idle bucket allows an initial one-second burst up to it). Bandwidth is bounded only by pool concurrency, so raise the thread pool with care.
 
 #### Consumer Configuration
 

--- a/docs/inkless/configs.rst
+++ b/docs/inkless/configs.rst
@@ -47,11 +47,11 @@ Under ``inkless.``
   * Importance: medium
 
 ``fetch.lagging.consumer.request.rate.limit``
-  Maximum requests per second for lagging consumer data fetches. Set to 0 to disable rate limiting. The upper bound of 10000 req/s is a safety limit to prevent misconfiguration. For high-throughput systems, consider the relationship between this rate limit, thread pool size, and storage backend capacity. At the default rate of 200 req/s with ~50ms per request latency, this allows ~10 concurrent requests. Note: hedge requests triggered by slow fetches are exempt from this limit. In the worst case, effective storage GET rate can reach up to 2x this value.
+  Maximum object storage GET requests per second for lagging consumer data fetches. A value of 0 disables the limit; the lagging consumer thread pool (fetch.lagging.consumer.thread.pool.size) then governs the steady-state GET rate at pool size divided by GET latency. Set a positive value to bound the sustained request rate independent of storage latency, for example to cap object storage request cost. The limiter is a token bucket sized to this value, so an idle bucket allows an initial one-second burst up to it before settling to the sustained rate. Note: when a positive limit is set, hedge requests triggered by slow fetches, if enabled, are exempt from it, so the effective GET rate can reach up to 2x the configured value.
 
   * Type: int
-  * Default: 200
-  * Valid Values: [0,...,10000]
+  * Default: 0
+  * Valid Values: [0,...,1000000]
   * Importance: medium
 
 ``fetch.lagging.consumer.threshold.ms``
@@ -180,10 +180,10 @@ Under ``inkless.``
   * Importance: low
 
 ``fetch.find.batches.max.per.partition``
-  The maximum number of batches to find per partition when processing a fetch request. A value of 0 means all available batches are fetched. This is primarily intended for environments where the batches fan-out on fetch requests can overload the control plane back-end.
+  The maximum number of batches to find per partition when processing a fetch request. A value of 0 removes the cap and returns all eligible batches per partition. This is a per-partition batch count, not a byte size. fetch.max.bytes and the consumer's max.partition.fetch.bytes are the byte budgets for a fetch, so this cap bounds the control-plane batch scan and the object GET fan-out when batches are small. The default of 1024 covers a full partition response (about 16 MiB at 16 KiB batches) while capping the scan on deep partitions of many small batches; a deeper backlog drains over successive fetches. Consolidation has separate settings under diskless.consolidation.
 
   * Type: int
-  * Default: 0
+  * Default: 1024
   * Valid Values: [0,...]
   * Importance: low
 
@@ -204,7 +204,7 @@ Under ``inkless.``
   * Importance: low
 
 ``fetch.lagging.consumer.thread.pool.size``
-  Thread pool size for lagging consumer fetch requests (consumers reading old data). Set to 0 to disable the lagging consumer feature (all requests will use the recent data path). The default value of 16 is designed as approximately half of the default fetch.data.thread.pool.size (32), providing sufficient capacity for typical cold storage access patterns while leaving headroom for the hot path. The queue capacity is automatically set to thread.pool.size * 100, providing burst buffering (e.g., 16 threads = 1600 queue capacity ~= 8 seconds buffer at 200 req/s). Tune based on lagging consumer SLA and expected load patterns.
+  Thread pool size for lagging consumer fetch requests (consumers reading old data). Set to 0 to disable the lagging consumer feature (all requests will use the recent data path). The default value of 16 is designed as approximately half of the default fetch.data.thread.pool.size (32), providing sufficient capacity for typical cold storage access patterns while leaving headroom for the hot path. The queue capacity is automatically set to thread.pool.size * 100, providing burst buffering (for example, 16 threads = 1600 queue capacity); the drain time depends on storage latency and load. Tune based on lagging consumer SLA and expected load patterns.
 
   * Type: int
   * Default: 16

--- a/storage/inkless/src/main/java/io/aiven/inkless/config/InklessConfig.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/config/InklessConfig.java
@@ -189,7 +189,7 @@ public class InklessConfig extends AbstractConfig {
         + "The default value of 16 is designed as approximately half of the default fetch.data.thread.pool.size (32), "
         + "providing sufficient capacity for typical cold storage access patterns while leaving headroom for the hot path. "
         + "The queue capacity is automatically set to thread.pool.size * 100, providing burst buffering "
-        + "(e.g., 16 threads = 1600 queue capacity ~= 8 seconds buffer at 200 req/s). "
+        + "(for example, 16 threads = 1600 queue capacity); the drain time depends on storage latency and load. "
         + "Tune based on lagging consumer SLA and expected load patterns.";
     // Default 16: Designed as half of default fetch.data.thread.pool.size (32), sufficient for typical
     // cold storage access patterns while leaving headroom for hot path. Tune based on lagging consumer SLA.
@@ -212,17 +212,13 @@ public class InklessConfig extends AbstractConfig {
     private static final int FETCH_LAGGING_CONSUMER_THRESHOLD_MS_DEFAULT = -1;
 
     public static final String FETCH_LAGGING_CONSUMER_REQUEST_RATE_LIMIT_CONFIG = "fetch.lagging.consumer.request.rate.limit";
-    public static final String FETCH_LAGGING_CONSUMER_REQUEST_RATE_LIMIT_DOC = "Maximum requests per second for lagging consumer data fetches. "
-        + "Set to 0 to disable rate limiting. "
-        + "The upper bound of 10000 req/s is a safety limit to prevent misconfiguration. For high-throughput systems, "
-        + "consider the relationship between this rate limit, thread pool size, and storage backend capacity. "
-        + "At the default rate of 200 req/s with ~50ms per request latency, this allows ~10 concurrent requests. "
-        + "Note: hedge requests triggered by slow fetches are exempt from this limit. In the worst case, "
-        + "effective storage GET rate can reach up to 2x this value.";
-    // Default 200 req/s: Conservative limit based on typical object storage GET request costs and latency.
-    // At ~50ms per request, 200 req/s = ~10 concurrent requests, balancing throughput with cost control.
-    // Tune based on storage backend capacity and budget constraints.
-    private static final int FETCH_LAGGING_CONSUMER_REQUEST_RATE_LIMIT_DEFAULT = 200;
+    public static final String FETCH_LAGGING_CONSUMER_REQUEST_RATE_LIMIT_DOC = "Maximum object storage GET requests per second for lagging consumer data fetches. "
+        + "A value of 0 disables the limit; the lagging consumer thread pool (fetch.lagging.consumer.thread.pool.size) "
+        + "then governs the steady-state GET rate at pool size divided by GET latency. "
+        + "Set a positive value to bound the sustained request rate independent of storage latency, for example to cap object storage request cost. "
+        + "The limiter is a token bucket sized to this value, so an idle bucket allows an initial one-second burst up to it before settling to the sustained rate. "
+        + "Note: when a positive limit is set, hedge requests triggered by slow fetches, if enabled, are exempt from it, so the effective GET rate can reach up to 2x the configured value.";
+    private static final int FETCH_LAGGING_CONSUMER_REQUEST_RATE_LIMIT_DEFAULT = 0;
 
     public static final String FETCH_HEDGE_TTFB_THRESHOLD_MS_CONFIG = "fetch.hedge.ttfb.threshold.ms";
     public static final String FETCH_HEDGE_TTFB_THRESHOLD_MS_DOC = "Time-to-first-byte threshold in milliseconds to trigger a hedge request. "
@@ -249,9 +245,13 @@ public class InklessConfig extends AbstractConfig {
 
     public static final String FETCH_FIND_BATCHES_MAX_BATCHES_PER_PARTITION_CONFIG = "fetch.find.batches.max.per.partition";
     public static final String FETCH_FIND_BATCHES_MAX_BATCHES_PER_PARTITION_DOC = "The maximum number of batches to find per partition when processing a fetch request. "
-        + "A value of 0 means all available batches are fetched. "
-        + "This is primarily intended for environments where the batches fan-out on fetch requests can overload the control plane back-end.";
-    private static final int FETCH_FIND_BATCHES_MAX_BATCHES_PER_PARTITION_DEFAULT = 0;
+        + "A value of 0 removes the cap and returns all eligible batches per partition. "
+        + "This is a per-partition batch count, not a byte size. fetch.max.bytes and the consumer's max.partition.fetch.bytes "
+        + "are the byte budgets for a fetch, so this cap bounds the control-plane batch scan and the object GET fan-out "
+        + "when batches are small. The default of 1024 covers a full partition response (about 16 MiB at 16 KiB batches) while "
+        + "capping the scan on deep partitions of many small batches; a deeper backlog drains over successive fetches. "
+        + "Consolidation has separate settings under diskless.consolidation.";
+    private static final int FETCH_FIND_BATCHES_MAX_BATCHES_PER_PARTITION_DEFAULT = 1024;
 
     public static final String RETENTION_ENFORCEMENT_MAX_BATCHES_PER_REQUEST_CONFIG = "retention.enforcement.max.batches.per.request";
     public static final String RETENTION_ENFORCEMENT_MAX_BATCHES_PER_REQUEST_DOC = "The maximum number of batches to delete per partition when enforcing retention. "
@@ -483,9 +483,9 @@ public class InklessConfig extends AbstractConfig {
             FETCH_LAGGING_CONSUMER_REQUEST_RATE_LIMIT_CONFIG,
             ConfigDef.Type.INT,
             FETCH_LAGGING_CONSUMER_REQUEST_RATE_LIMIT_DEFAULT,
-            ConfigDef.Range.between(0, 10000),
-            // Safety limit to prevent misconfiguration. For high-throughput systems,
-            // consider the relationship between this rate limit, thread pool size, and storage backend capacity.
+            ConfigDef.Range.between(0, 1_000_000),
+            // Safety limit to prevent misconfiguration. This is an opt-in hard cap; even at the
+            // ceiling the object storage request cost is bounded and left to the operator to set.
             ConfigDef.Importance.MEDIUM,
             FETCH_LAGGING_CONSUMER_REQUEST_RATE_LIMIT_DOC
         );

--- a/storage/inkless/src/main/java/io/aiven/inkless/consume/Reader.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/consume/Reader.java
@@ -84,8 +84,8 @@ public class Reader implements AutoCloseable {
      * rejects tasks and exceptions propagate to Kafka's error handler.
      *
      * <p>Example: With default 16 threads and multiplier of 100, capacity = 1600 tasks.
-     * At 200 req/s rate limit, this provides ~8 seconds of buffer before rejections occur.
-     * Note: These values are derived from defaults and may differ if configuration is changed.
+     * The buffer drains as fast as the executor completes fetches, which depends on storage latency
+     * and load; request-rate limiting is disabled by default (see fetch.lagging.consumer.request.rate.limit).
      */
     private static final int LAGGING_CONSUMER_QUEUE_MULTIPLIER = 100;
     private final Time time;

--- a/storage/inkless/src/test/java/io/aiven/inkless/config/InklessConfigTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/config/InklessConfigTest.java
@@ -316,8 +316,11 @@ class InklessConfigTest {
         // Default thread pool size
         assertThat(config.fetchLaggingConsumerThreadPoolSize()).isEqualTo(16);
 
-        // Default rate limit
-        assertThat(config.fetchLaggingConsumerRequestRateLimit()).isEqualTo(200);
+        // Default rate limit: disabled (the lagging consumer thread pool governs the steady-state GET rate)
+        assertThat(config.fetchLaggingConsumerRequestRateLimit()).isEqualTo(0);
+
+        // Default per-partition batch cap
+        assertThat(config.maxBatchesPerPartitionToFind()).isEqualTo(1024);
 
         // Default threshold: -1 (auto) should use heuristic: cache TTL
         // Default cache TTL is 60 seconds, so threshold should follow that
@@ -491,17 +494,17 @@ class InklessConfigTest {
 
     @Test
     void laggingConsumerRateLimitExceedsUpperBoundInvalid() {
-        // Test that rate limit exceeding upper bound (10000) is invalid
+        // Test that rate limit exceeding upper bound (1000000) is invalid
         final Map<String, String> config = Map.of(
             "control.plane.class", InMemoryControlPlane.class.getCanonicalName(),
             "storage.backend.class", ConfigTestStorageBackend.class.getCanonicalName(),
-            "fetch.lagging.consumer.request.rate.limit", "10001"
+            "fetch.lagging.consumer.request.rate.limit", "1000001"
         );
 
         assertThatThrownBy(() -> new InklessConfig(config))
             .isInstanceOf(ConfigException.class)
             .hasMessageContaining("fetch.lagging.consumer.request.rate.limit")
-            .hasMessageContaining("Value must be no more than 10000");
+            .hasMessageContaining("Value must be no more than 1000000");
     }
 
     @Test


### PR DESCRIPTION
The lagging request-rate limit shipped defaulting to 200 req/s as a bandwidth defense. Recent incidents were control-plane load, not bandwidth, and mitigating them meant tuning fetch.find.batches.max.per.partition down by hand. The find_batches request-level budget fix (KC-407) plus batch coalescing now let the consumer's fetch.max.bytes drive per-fetch fan-out fairly, which changes which lever governs what:

- The lagging consumer thread pool is the steady-state GET-rate governor: pool size / GET latency. That replaces the request-rate limit as the default throttle, so the limit defaults to 0 (disabled) and becomes opt-in for operators who want a hard request/sec cap independent of storage latency, for example to bound object storage request cost. The upper bound is raised to 1000000: even at the ceiling the request cost is bounded, and it is left to the operator to set.
- fetch.find.batches.max.per.partition defaults to 1024 (was 0, unbounded). It is a per-partition batch count: fetch.max.bytes and max.partition.fetch.bytes already bound bytes, so it bounds the control-plane scan and object GET fan-out when batches are small. It is the only per-partition bound on the consolidation fetch path, which calls find_batches with no byte budget, so this is where the cap does most of its work. 1024 covers a full partition response (about 16 MiB at 16 KiB batches); deeper backlogs drain over successive fetches.

These move together: dropping the rate-limit default is only safe once the batch cap is finite, otherwise both governors would be off at once.

Tradeoff: with no byte-rate limiter yet, cold-path bandwidth is bounded only by pool concurrency (pool size x range / latency). Raise the lagging thread pool with that in mind.

Out of scope: consolidation keeps its own diskless.consolidation.fetch.find.batches.max.per.partition (default 0); it's already byte-budgeted via KC-407, so a count cap there is a separate, measured decision.

[KC-453]
[KC-455]

[KC-453]: https://aiven.atlassian.net/browse/KC-453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ