### PR TITLE
fix(inkless:consume): size fetch buffers to the payload [KC-481]

### DIFF
--- a/storage/inkless/src/main/java/io/aiven/inkless/consume/FileFetchJob.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/consume/FileFetchJob.java
@@ -75,7 +75,7 @@ public class FileFetchJob implements Callable<FileExtent> {
 
     private FileExtent doWork() throws IOException, StorageBackendException {
         final var startTime = TimeUtils.durationMeasurementNow(time);
-        try (final var channel = new TimingReadableByteChannel(objectFetcher.fetch(key, range), time, startTime, ttfbCallback)) {
+        try (final var channel = TimingReadableByteChannel.wrap(objectFetcher.fetch(key, range), time, startTime, ttfbCallback)) {
             final ByteBuffer byteBuffer = objectFetcher.readToByteBuffer(channel);
             return createFileExtent(key, range, byteBuffer);
         }

--- a/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/azure/AzureBlobStorage.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/azure/AzureBlobStorage.java
@@ -20,9 +20,11 @@ package io.aiven.inkless.storage_backend.azure;
 
 import org.apache.kafka.common.metrics.Metrics;
 
+import com.azure.core.util.Context;
 import com.azure.identity.DefaultAzureCredentialBuilder;
 import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.BlobServiceClientBuilder;
+import com.azure.storage.blob.models.BlobDownloadContentResponse;
 import com.azure.storage.blob.models.BlobErrorCode;
 import com.azure.storage.blob.models.BlobRange;
 import com.azure.storage.blob.models.BlobStorageException;
@@ -40,7 +42,7 @@ import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.nio.channels.Channels;
+import java.nio.ByteBuffer;
 import java.nio.channels.ReadableByteChannel;
 import java.util.HashSet;
 import java.util.Map;
@@ -52,6 +54,7 @@ import io.aiven.inkless.common.ByteRange;
 import io.aiven.inkless.common.ObjectKey;
 import io.aiven.inkless.storage_backend.common.InvalidRangeException;
 import io.aiven.inkless.storage_backend.common.KeyNotFoundException;
+import io.aiven.inkless.storage_backend.common.SizedReadableByteChannel;
 import io.aiven.inkless.storage_backend.common.StorageBackend;
 import io.aiven.inkless.storage_backend.common.StorageBackendException;
 import reactor.core.Exceptions;
@@ -172,17 +175,23 @@ public final class AzureBlobStorage extends StorageBackend {
     @Override
     public ReadableByteChannel fetch(final ObjectKey key, final ByteRange range) throws StorageBackendException, IOException {
         try {
-            if (range!= null && range.empty()) {
-                return Channels.newChannel(InputStream.nullInputStream());
+            if (range != null && range.empty()) {
+                return SizedReadableByteChannel.empty();
             }
-            final ReadableByteChannel channel;
-            if (range != null) {
-                channel = Channels.newChannel(blobContainerClient.getBlobClient(key.value()).openInputStream(
-                        new BlobRange(range.offset(), range.size()), null));
-            } else {
-                channel = Channels.newChannel(blobContainerClient.getBlobClient(key.value()).openInputStream());
+            // Downloading the range materializes the exact payload, so its length needs no
+            // clipping against the blob size and nothing has to stage bytes through a stream.
+            final BlobRange blobRange = range == null
+                ? null
+                : new BlobRange(range.offset(), range.size());
+            final BlobDownloadContentResponse response = blobContainerClient.getBlobClient(key.value())
+                .downloadContentWithResponse(null, null, blobRange, false, null, Context.NONE);
+            final ByteBuffer payload = response.getValue().toByteBuffer();
+            if (range != null && !payload.hasRemaining()) {
+                // Azure answers an offset at the blob end with empty content rather than 416, and the
+                // request was for a non-empty range, so nothing but an out-of-range offset explains this.
+                throw new InvalidRangeException("Failed to fetch " + key + ": Invalid range " + range);
             }
-            return channel;
+            return SizedReadableByteChannel.of(payload);
         } catch (final BlobStorageException e) {
             if (e.getStatusCode() == 404) {
                 throw new KeyNotFoundException(this, key, e);

--- a/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/common/ObjectFetcher.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/common/ObjectFetcher.java
@@ -41,17 +41,19 @@ public interface ObjectFetcher extends Closeable {
     /**
      * Reads the channel into a single buffer.
      *
-     * <p>Each scratch buffer is filled before another is allocated.
-     * Otherwise, a channel that returns small amounts of data per read causes
-     * one 1 MiB allocation per read,
-     * which creates unnecessary garbage-collection and out-of-memory pressure.
+     * <p>If the channel is a {@link SizedReadableByteChannel}, the destination is that length.
+     * A mismatch fails the fetch. Otherwise the channel is drained into 1 MiB scratch buffers
+     * that are filled before another is allocated, then copied.
      *
      * <p>A {@code 0}-byte read is not EOF.
-     * The loop retries until {@code tempBuffer} is full or the channel returns {@code -1},
-     * so the channel must eventually return data or EOF.
+     * Both paths retry until the destination is full or the channel returns {@code -1},
+     * so a channel must eventually return data or EOF.
+     * A channel that returns {@code 0} indefinitely never completes the read.
      */
     default ByteBuffer readToByteBuffer(final ReadableByteChannel readableByteChannel) throws IOException {
-        final ByteBuffer byteBuffer;
+        if (readableByteChannel instanceof SizedReadableByteChannel sized) {
+            return readExactly(sized, sized.contentLength());
+        }
         final List<ByteBuffer> buffers = new ArrayList<>(5);
         int readSize;
         int totalSize = 0;
@@ -66,8 +68,27 @@ public interface ObjectFetcher extends Closeable {
                 totalSize += tempBuffer.remaining();
             }
         } while (readSize >= 0);
-        byteBuffer = ByteBuffer.allocate(totalSize);
+        final ByteBuffer byteBuffer = ByteBuffer.allocate(totalSize);
         buffers.forEach(byteBuffer::put);
         return byteBuffer.flip();
+    }
+
+    private static ByteBuffer readExactly(final ReadableByteChannel channel, final int contentLength)
+        throws IOException {
+        final ByteBuffer buffer = ByteBuffer.allocate(contentLength);
+        int readSize = 0;
+        while (buffer.hasRemaining() && readSize >= 0) {
+            readSize = channel.read(buffer);
+        }
+        if (buffer.hasRemaining()) {
+            throw new IOException(
+                "Channel delivered " + buffer.position() + " of " + contentLength + " bytes");
+        }
+        // Only a strictly positive read proves over-delivery.
+        // A 0 means no data is available yet, which is not evidence either way.
+        if (channel.read(ByteBuffer.allocate(1)) > 0) {
+            throw new IOException("Channel delivered more than " + contentLength + " bytes");
+        }
+        return buffer.flip();
     }
 }

--- a/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/common/ObjectFetcher.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/common/ObjectFetcher.java
@@ -30,14 +30,26 @@ import io.aiven.inkless.common.ObjectKey;
 public interface ObjectFetcher extends Closeable {
 
     /**
-     * Use large enough buffer for reading the blob content to byte buffers to reduce required number
-     * of allocations. Usually default implementations in input streams use 16 KiB buffers. The expectation
-     * of blob sizes from cloud storages are multi-megabyte.
+     * Use a large enough buffer when reading blob content to reduce the number of allocations.
+     * Cloud storage blobs are expected to be multiple megabytes,
+     * while channels may return much less data per read.
      */
     int READ_BUFFER_1MiB = 1024 * 1024;
 
     ReadableByteChannel fetch(ObjectKey key, ByteRange range) throws StorageBackendException, IOException;
 
+    /**
+     * Reads the channel into a single buffer.
+     *
+     * <p>Each scratch buffer is filled before another is allocated.
+     * Otherwise, a channel that returns small amounts of data per read causes
+     * one 1 MiB allocation per read,
+     * which creates unnecessary garbage-collection and out-of-memory pressure.
+     *
+     * <p>A {@code 0}-byte read is not EOF.
+     * The loop retries until {@code tempBuffer} is full or the channel returns {@code -1},
+     * so the channel must eventually return data or EOF.
+     */
     default ByteBuffer readToByteBuffer(final ReadableByteChannel readableByteChannel) throws IOException {
         final ByteBuffer byteBuffer;
         final List<ByteBuffer> buffers = new ArrayList<>(5);
@@ -45,11 +57,13 @@ public interface ObjectFetcher extends Closeable {
         int totalSize = 0;
         do {
             final ByteBuffer tempBuffer = ByteBuffer.allocate(READ_BUFFER_1MiB);
-            readSize = readableByteChannel.read(tempBuffer);
-            if (readSize > 0) {
+            do {
+                readSize = readableByteChannel.read(tempBuffer);
+            } while (readSize >= 0 && tempBuffer.hasRemaining());
+            if (tempBuffer.position() > 0) {
                 buffers.add(tempBuffer);
                 tempBuffer.flip();
-                totalSize += readSize;
+                totalSize += tempBuffer.remaining();
             }
         } while (readSize >= 0);
         byteBuffer = ByteBuffer.allocate(totalSize);

--- a/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/common/SizedReadableByteChannel.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/common/SizedReadableByteChannel.java
@@ -1,0 +1,132 @@
+/*
+ * Inkless
+ * Copyright (C) 2024 - 2026 Aiven OY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.aiven.inkless.storage_backend.common;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.ClosedChannelException;
+import java.nio.channels.ReadableByteChannel;
+import java.util.Objects;
+
+/**
+ * A channel that knows how many bytes it delivers before EOF.
+ *
+ * <p>Lets {@link ObjectFetcher#readToByteBuffer} allocate the destination once.
+ * Implement this only when the length is exact: a mismatch fails the fetch.
+ */
+public interface SizedReadableByteChannel extends ReadableByteChannel {
+
+    /**
+     * Returns the exact number of bytes this channel delivers before EOF.
+     *
+     * <p>An {@code int} because the payload lands in a single {@code ByteBuffer} and a
+     * {@code byte[]} on the extent, so a fetch cannot exceed {@link Integer#MAX_VALUE} bytes.
+     * That is also why backends narrow their own {@code long} sizes to reach this.
+     */
+    int contentLength();
+
+    /**
+     * Returns a channel that reports a length of {@code 0} and reads EOF immediately.
+     */
+    static SizedReadableByteChannel empty() {
+        return of(ByteBuffer.allocate(0));
+    }
+
+    /**
+     * Returns a channel over the buffer's remaining bytes, reading from it without an intermediate copy.
+     * The length is taken when this is called, so later changes to the buffer's position are not reflected.
+     */
+    static SizedReadableByteChannel of(final ByteBuffer source) {
+        Objects.requireNonNull(source, "source cannot be null");
+        final int contentLength = source.remaining();
+        return new SizedReadableByteChannel() {
+            private boolean open = true;
+
+            @Override
+            public int contentLength() {
+                return contentLength;
+            }
+
+            @Override
+            public int read(final ByteBuffer dst) throws IOException {
+                if (!open) {
+                    throw new ClosedChannelException();
+                }
+                if (!source.hasRemaining()) {
+                    return -1;
+                }
+                final int readSize = Math.min(dst.remaining(), source.remaining());
+                if (readSize == 0) {
+                    return 0;
+                }
+                final int sourceLimit = source.limit();
+                source.limit(source.position() + readSize);
+                dst.put(source);
+                source.limit(sourceLimit);
+                return readSize;
+            }
+
+            @Override
+            public boolean isOpen() {
+                return open;
+            }
+
+            @Override
+            public void close() {
+                open = false;
+            }
+        };
+    }
+
+    /**
+     * Returns a channel that reports {@code contentLength} and delegates everything else.
+     */
+    static SizedReadableByteChannel of(final ReadableByteChannel delegate, final int contentLength) {
+        Objects.requireNonNull(delegate, "delegate cannot be null");
+        if (contentLength < 0) {
+            throw new IllegalArgumentException("contentLength cannot be negative: " + contentLength);
+        }
+        return new SizedReadableByteChannel() {
+            private boolean open = true;
+
+            @Override
+            public int contentLength() {
+                return contentLength;
+            }
+
+            @Override
+            public int read(final ByteBuffer dst) throws IOException {
+                if (!open) {
+                    throw new ClosedChannelException();
+                }
+                return delegate.read(dst);
+            }
+
+            @Override
+            public boolean isOpen() {
+                return open && delegate.isOpen();
+            }
+
+            @Override
+            public void close() throws IOException {
+                open = false;
+                delegate.close();
+            }
+        };
+    }
+}

--- a/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/common/TimingReadableByteChannel.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/common/TimingReadableByteChannel.java
@@ -55,7 +55,18 @@ public class TimingReadableByteChannel implements ReadableByteChannel {
     // Not volatile: channel is confined to a single thread within FileFetchJob.doWork().
     private boolean firstByteRecorded;
 
-    public TimingReadableByteChannel(ReadableByteChannel delegate, Time time, Instant startTime, Consumer<Long> ttfbCallback) {
+    /**
+     * Returns a timing decorator that preserves the delegate's {@link SizedReadableByteChannel}
+     * capability, so a sized channel still reaches {@link ObjectFetcher#readToByteBuffer}.
+     */
+    public static TimingReadableByteChannel wrap(ReadableByteChannel delegate, Time time, Instant startTime, Consumer<Long> ttfbCallback) {
+        if (delegate instanceof SizedReadableByteChannel sized) {
+            return new Sized(sized, time, startTime, ttfbCallback);
+        }
+        return new TimingReadableByteChannel(delegate, time, startTime, ttfbCallback);
+    }
+
+    private TimingReadableByteChannel(ReadableByteChannel delegate, Time time, Instant startTime, Consumer<Long> ttfbCallback) {
         this.delegate = Objects.requireNonNull(delegate, "delegate");
         this.time = Objects.requireNonNull(time, "time");
         this.startTime = Objects.requireNonNull(startTime, "startTime");
@@ -82,5 +93,19 @@ public class TimingReadableByteChannel implements ReadableByteChannel {
     @Override
     public void close() throws IOException {
         delegate.close();
+    }
+
+    private static final class Sized extends TimingReadableByteChannel implements SizedReadableByteChannel {
+        private final int contentLength;
+
+        private Sized(SizedReadableByteChannel delegate, Time time, Instant startTime, Consumer<Long> ttfbCallback) {
+            super(delegate, time, startTime, ttfbCallback);
+            this.contentLength = delegate.contentLength();
+        }
+
+        @Override
+        public int contentLength() {
+            return contentLength;
+        }
     }
 }

--- a/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/common/TimingReadableByteChannel.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/common/TimingReadableByteChannel.java
@@ -35,13 +35,15 @@ import io.aiven.inkless.TimeUtils;
  *
  * <p>The start time is provided externally so that it can be captured <em>before</em> the storage
  * fetch is initiated (e.g., before {@code ObjectFetcher.fetch()}). This ensures TTFB includes
- * all setup overhead (DNS, TLS, HTTP request, metadata lookup) regardless of whether the backend
- * downloads eagerly (S3) or streams lazily (GCS, Azure).
+ * all setup overhead (DNS, TLS, HTTP request, metadata lookup) whether the backend downloads the
+ * payload inside {@code fetch()} (S3, Azure, in-memory) or streams it on read (GCS).
  *
- * <p><strong>Measurement granularity:</strong> The timestamp is captured <em>after</em>
- * {@code delegate.read(dst)} returns, so the reported TTFB includes the transfer time for the
- * first chunk (typically up to the buffer size), not the precise instant the first byte arrives
- * on the wire. For most storage backends and buffer sizes this difference is negligible.
+ * <p><strong>What the number means:</strong> the timestamp is captured <em>after</em>
+ * {@code delegate.read(dst)} returns, so the reported value includes the transfer that read
+ * triggered, not the instant the first byte arrived on the wire. For a backend that downloads
+ * inside {@code fetch()} the first read returns once the whole payload is already in memory, so
+ * TTFB is effectively whole-fetch time. Only for a streaming backend does it approximate
+ * first-byte latency.
  *
  * <p>The callback is invoked at most once, on the first successful read that returns &gt; 0 bytes.
  * If the channel is closed or exhausted without ever returning data, the callback is never invoked.

--- a/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/gcs/GcsStorage.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/gcs/GcsStorage.java
@@ -32,7 +32,6 @@ import com.groupcdg.pitest.annotations.CoverageIgnore;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
 import java.util.Map;
 import java.util.Objects;
@@ -43,18 +42,12 @@ import io.aiven.inkless.common.ByteRange;
 import io.aiven.inkless.common.ObjectKey;
 import io.aiven.inkless.storage_backend.common.InvalidRangeException;
 import io.aiven.inkless.storage_backend.common.KeyNotFoundException;
+import io.aiven.inkless.storage_backend.common.SizedReadableByteChannel;
 import io.aiven.inkless.storage_backend.common.StorageBackend;
 import io.aiven.inkless.storage_backend.common.StorageBackendException;
 
 @CoverageIgnore  // tested on integration level
 public class GcsStorage extends StorageBackend {
-    /**
-     * The file extent max size is 16 MiB. Most files are few megabytes but usually over 2 MiB.
-     * Good value here is to allow most files to be fetched in single chunk. Worst case is to load
-     * the file in two chunks.
-     */
-    private static final int READER_8MB_CHUNK_SIZE = 1024 * 1024 * 8;
-
     private volatile Storage storage;
     private String bucketName;
     private ReloadableCredentialsProvider credentialsProvider;
@@ -146,7 +139,7 @@ public class GcsStorage extends StorageBackend {
     public ReadableByteChannel fetch(ObjectKey key, ByteRange range) throws StorageBackendException, IOException {
         try {
             if (range != null && range.empty()) {
-                return Channels.newChannel(InputStream.nullInputStream());
+                return SizedReadableByteChannel.empty();
             }
 
             final Blob blob = getBlob(key);
@@ -155,13 +148,20 @@ public class GcsStorage extends StorageBackend {
                 throw new InvalidRangeException("Failed to fetch " + key + ": Invalid range " + range + " for blob size " + blob.getSize());
             }
 
+            final long contentLength = range == null
+                ? blob.getSize()
+                : Math.min(range.size(), blob.getSize() - range.offset());
+
             final ReadChannel reader = blob.reader();
-            reader.setChunkSize(READER_8MB_CHUNK_SIZE);
+            // A chunk size of 0 makes the client read straight into the destination buffer.
+            // Any positive size stages a second buffer of that size first,
+            // and the caller already allocates a destination the size of the whole payload.
+            reader.setChunkSize(0);
             if (range != null) {
                 reader.limit(range.endOffset() + 1);
                 reader.seek(range.offset());
             }
-            return reader;
+            return SizedReadableByteChannel.of(reader, Math.toIntExact(contentLength));
         } catch (final IOException e) {
             throw new StorageBackendException("Failed to fetch " + key, e);
         } catch (final BaseServiceException e) {

--- a/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/in_memory/InMemoryStorage.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/in_memory/InMemoryStorage.java
@@ -19,11 +19,10 @@ package io.aiven.inkless.storage_backend.in_memory;
 
 import org.apache.kafka.common.metrics.Metrics;
 
-import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.channels.Channels;
+import java.nio.ByteBuffer;
 import java.nio.channels.ReadableByteChannel;
 import java.util.Map;
 import java.util.Objects;
@@ -34,6 +33,7 @@ import io.aiven.inkless.common.ByteRange;
 import io.aiven.inkless.common.ObjectKey;
 import io.aiven.inkless.storage_backend.common.InvalidRangeException;
 import io.aiven.inkless.storage_backend.common.KeyNotFoundException;
+import io.aiven.inkless.storage_backend.common.SizedReadableByteChannel;
 import io.aiven.inkless.storage_backend.common.StorageBackend;
 import io.aiven.inkless.storage_backend.common.StorageBackendException;
 
@@ -86,21 +86,19 @@ public final class InMemoryStorage extends StorageBackend {
             throw new KeyNotFoundException(this, key);
         }
 
+        if (range.empty()) {
+            return SizedReadableByteChannel.empty();
+        }
+
         if (range.offset() >= data.length) {
             throw new InvalidRangeException("Failed to fetch " + key + ": Invalid range " + range + " for blob size " + data.length);
         }
 
-        final int dataSize;
-        if (range.size() > data.length - range.offset()) {
-            dataSize = Math.toIntExact((data.length - range.offset()));
-        }  else {
-            dataSize = Math.toIntExact(Math.min(range.size(), data.length));
-        }
-        final int copyLength = Math.toIntExact(Math.min(range.size(), data.length - 1));
+        final int dataSize = Math.toIntExact(Math.min(range.size(), data.length - range.offset()));
         final byte[] dstData = new byte[dataSize];
-        System.arraycopy(data, range.bufferOffset(), dstData, 0, copyLength);
+        System.arraycopy(data, range.bufferOffset(), dstData, 0, dataSize);
 
-        return Channels.newChannel(new ByteArrayInputStream(dstData));
+        return SizedReadableByteChannel.of(ByteBuffer.wrap(dstData));
     }
 
     @Override

--- a/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/s3/S3Storage.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/s3/S3Storage.java
@@ -135,7 +135,6 @@ public final class S3Storage extends StorageBackend {
             final GetObjectRequest getRequest = builder.build();
             // for the small 4-8MiB blobs expected here, reading the whole object into memory is more efficient
             // than streaming it via S3ObjectInputStream which has significant overhead per read call
-            // and does not play well with the buffering done in ObjectFetcher.readToByteBuffer()
             final var buffer = s3Client.getObjectAsBytes(getRequest).asByteBuffer();
             return Channels.newChannel(new ByteBufferInputStream(buffer));
         } catch (final AwsServiceException e) {

--- a/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/s3/S3Storage.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/s3/S3Storage.java
@@ -18,7 +18,6 @@
 package io.aiven.inkless.storage_backend.s3;
 
 import org.apache.kafka.common.metrics.Metrics;
-import org.apache.kafka.common.utils.ByteBufferInputStream;
 
 import com.groupcdg.pitest.annotations.CoverageIgnore;
 
@@ -27,7 +26,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -42,6 +40,7 @@ import io.aiven.inkless.common.ByteRange;
 import io.aiven.inkless.common.ObjectKey;
 import io.aiven.inkless.storage_backend.common.InvalidRangeException;
 import io.aiven.inkless.storage_backend.common.KeyNotFoundException;
+import io.aiven.inkless.storage_backend.common.SizedReadableByteChannel;
 import io.aiven.inkless.storage_backend.common.StorageBackend;
 import io.aiven.inkless.storage_backend.common.StorageBackendException;
 import io.aiven.inkless.storage_backend.common.StorageBackendTimeoutException;
@@ -123,7 +122,7 @@ public final class S3Storage extends StorageBackend {
     public ReadableByteChannel fetch(final ObjectKey key, final ByteRange range) throws StorageBackendException, IOException {
         try {
             if (range != null && range.empty()) {
-                return Channels.newChannel(InputStream.nullInputStream());
+                return SizedReadableByteChannel.empty();
             }
 
             var builder = GetObjectRequest.builder()
@@ -133,10 +132,10 @@ public final class S3Storage extends StorageBackend {
                 builder = builder.range(formatRange(range));
             }
             final GetObjectRequest getRequest = builder.build();
-            // for the small 4-8MiB blobs expected here, reading the whole object into memory is more efficient
-            // than streaming it via S3ObjectInputStream which has significant overhead per read call
-            final var buffer = s3Client.getObjectAsBytes(getRequest).asByteBuffer();
-            return Channels.newChannel(new ByteBufferInputStream(buffer));
+            // Materializing the 4-8 MiB blobs expected here beats streaming them,
+            // which carries significant per-read overhead.
+            // S3 clips the range to the object, so the response is already the exact payload.
+            return SizedReadableByteChannel.of(s3Client.getObjectAsBytes(getRequest).asByteBuffer());
         } catch (final AwsServiceException e) {
             if (e.statusCode() == 404) {
                 throw new KeyNotFoundException(this, key, e);

--- a/storage/inkless/src/test/java/io/aiven/inkless/consume/FileFetchJobTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/consume/FileFetchJobTest.java
@@ -39,6 +39,8 @@ import io.aiven.inkless.common.ObjectKey;
 import io.aiven.inkless.common.PlainObjectKey;
 import io.aiven.inkless.generated.FileExtent;
 import io.aiven.inkless.storage_backend.common.ObjectFetcher;
+import io.aiven.inkless.storage_backend.common.SizedReadableByteChannel;
+import io.aiven.inkless.storage_backend.common.fixtures.RecordingReadChannel;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -179,6 +181,27 @@ public class FileFetchJobTest {
         );
 
         assertThat(fileRanges).containsExactlyInAnyOrderElementsOf(expectedRanges);
+    }
+
+    @Test
+    public void testSizedChannelReachesTheReader() throws Exception {
+        final byte[] array = new byte[]{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+        final ByteRange range = new ByteRange(0, array.length);
+        final RecordingReadChannel channel = new RecordingReadChannel(array);
+
+        when(fetcher.fetch(objectA, range))
+            .thenReturn(SizedReadableByteChannel.of(channel, array.length));
+        when(fetcher.readToByteBuffer(any())).thenCallRealMethod();
+
+        final FileFetchJob job =
+            new FileFetchJob(time, fetcher, objectA, range, durationMs -> { }, ttfbMs -> { });
+        final FileExtent extent = job.call();
+
+        assertThat(extent.data()).isEqualTo(array);
+        // The job wraps the channel for timing, so the wrapper has to carry the declared length
+        // through to the reader. Without it the destination is a 1 MiB scratch buffer.
+        assertThat(channel.destinations).extracting(ByteBuffer::capacity)
+            .containsExactlyInAnyOrder(array.length, 1);
     }
 
 }

--- a/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/azure/integration/AzureBlobStorageTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/azure/integration/AzureBlobStorageTest.java
@@ -28,18 +28,11 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-import java.io.ByteArrayInputStream;
-
-import io.aiven.inkless.common.ByteRange;
-import io.aiven.inkless.storage_backend.common.InvalidRangeException;
-import io.aiven.inkless.storage_backend.common.ObjectUploader;
-import io.aiven.inkless.storage_backend.common.StorageBackendException;
 import io.aiven.inkless.storage_backend.common.fixtures.BaseStorageTest;
 import io.aiven.inkless.storage_backend.common.fixtures.TestUtils;
 
 import static io.aiven.inkless.storage_backend.azure.integration.AzuriteBlobStorageUtils.azuriteContainer;
 import static io.aiven.inkless.storage_backend.azure.integration.AzuriteBlobStorageUtils.connectionString;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @Testcontainers
 abstract class AzureBlobStorageTest extends BaseStorageTest {
@@ -62,18 +55,5 @@ abstract class AzureBlobStorageTest extends BaseStorageTest {
     void setUp(final TestInfo testInfo) {
         azureContainerName = TestUtils.testNameToBucketName(testInfo);
         blobServiceClient.createBlobContainer(azureContainerName);
-    }
-
-    @Override
-    protected void testFetchWithRangeOutsideFileSize() throws StorageBackendException {
-        // For some reason, Azure (or only Azurite) considers range 3-5 valid for a 3-byte blob,
-        // so the generic test fails.
-        final String content = "ABC";
-        ObjectUploader objectUploader = storage();
-        byte[] data = content.getBytes();
-        objectUploader.upload(TOPIC_PARTITION_SEGMENT_KEY, new ByteArrayInputStream(data), data.length);
-
-        assertThatThrownBy(() -> storage().fetch(TOPIC_PARTITION_SEGMENT_KEY, new ByteRange(4, 6)))
-            .isInstanceOf(InvalidRangeException.class);
     }
 }

--- a/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/common/ObjectFetcherTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/common/ObjectFetcherTest.java
@@ -23,16 +23,17 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.channels.ClosedChannelException;
 import java.nio.channels.ReadableByteChannel;
-import java.util.Collections;
-import java.util.IdentityHashMap;
-import java.util.Set;
+import java.util.List;
 import java.util.stream.Stream;
 
 import io.aiven.inkless.common.ByteRange;
 import io.aiven.inkless.common.ObjectKey;
+import io.aiven.inkless.storage_backend.common.fixtures.RecordingReadChannel;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class ObjectFetcherTest {
 
@@ -56,6 +57,14 @@ class ObjectFetcherTest {
         }
     }
 
+    private static byte[] content(final int size) {
+        final byte[] content = new byte[size];
+        for (int i = 0; i < size; i++) {
+            content[i] = (byte) i;
+        }
+        return content;
+    }
+
     static Stream<ReadCase> reads() {
         return Stream.of(
             new ReadCase("empty", 0, 1),
@@ -75,75 +84,119 @@ class ObjectFetcherTest {
     @MethodSource("reads")
     void fillsEachScratchBufferBeforeAllocatingAnother(final ReadCase readCase) throws IOException {
         final byte[] content = content(readCase.contentSize);
-        final CappedReadChannel channel = new CappedReadChannel(content, 8 * 1024);
+        final RecordingReadChannel channel = new RecordingReadChannel(content, 8 * 1024);
 
         final ByteBuffer buffer = FETCHER.readToByteBuffer(channel);
 
         assertThat(buffer.array()).isEqualTo(content);
-        assertThat(channel.scratchBuffers).hasSize(readCase.expectedScratchBuffers);
-        assertThat(channel.scratchBuffers).allMatch(bufferSeen -> bufferSeen.capacity() == ONE_MIB);
+        assertThat(channel.destinations).hasSize(readCase.expectedScratchBuffers);
+        assertThat(channel.destinations).allMatch(bufferSeen -> bufferSeen.capacity() == ONE_MIB);
     }
 
     @Test
     void continuesAfterZeroByteReadThatIsNotEof() throws IOException {
         final byte[] content = content(4);
-        final CappedReadChannel channel = new CappedReadChannel(content, content.length);
+        final RecordingReadChannel channel = new RecordingReadChannel(content, content.length);
         channel.zeroReadsRemaining = 3;
 
         final ByteBuffer buffer = FETCHER.readToByteBuffer(channel);
 
         assertThat(buffer.array()).isEqualTo(content);
         assertThat(channel.readCalls).isEqualTo(5);
-        assertThat(channel.scratchBuffers).hasSize(1);
+        assertThat(channel.destinations).hasSize(1);
     }
 
-    private static byte[] content(final int size) {
-        final byte[] content = new byte[size];
-        for (int i = 0; i < size; i++) {
-            content[i] = (byte) i;
-        }
-        return content;
-    }
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("reads")
+    void sizedChannelReadsIntoOneExactAllocation(final ReadCase readCase) throws IOException {
+        final byte[] content = content(readCase.contentSize);
+        final RecordingReadChannel channel = new RecordingReadChannel(content, 8 * 1024);
 
-    private static final class CappedReadChannel implements ReadableByteChannel {
-        private final byte[] content;
-        private final int maxBytesPerRead;
-        private final Set<ByteBuffer> scratchBuffers = Collections.newSetFromMap(new IdentityHashMap<>());
-        private int position;
-        private int readCalls;
-        private int zeroReadsRemaining;
-        private boolean open = true;
+        final ByteBuffer buffer = FETCHER.readToByteBuffer(
+            SizedReadableByteChannel.of(channel, content.length));
 
-        CappedReadChannel(final byte[] content, final int maxBytesPerRead) {
-            this.content = content;
-            this.maxBytesPerRead = maxBytesPerRead;
-        }
-
-        @Override
-        public int read(final ByteBuffer dst) {
-            readCalls++;
-            scratchBuffers.add(dst);
-            if (zeroReadsRemaining > 0) {
-                zeroReadsRemaining--;
-                return 0;
-            }
-            if (position == content.length) {
-                return -1;
-            }
-            final int readSize = Math.min(Math.min(maxBytesPerRead, dst.remaining()), content.length - position);
-            dst.put(content, position, readSize);
-            position += readSize;
-            return readSize;
-        }
-
-        @Override
-        public boolean isOpen() {
-            return open;
-        }
-
-        @Override
-        public void close() {
-            open = false;
+        assertThat(buffer.array()).isEqualTo(content);
+        // Destination plus the 1-byte over-delivery probe.
+        if (content.length == 0) {
+            assertThat(channel.destinations)
+                .extracting(ByteBuffer::capacity)
+                .containsExactly(1);
+        } else {
+            assertThat(channel.destinations)
+                .extracting(ByteBuffer::capacity)
+                .containsExactlyInAnyOrder(content.length, 1);
         }
     }
+
+    @Test
+    void sizedChannelContinuesAfterZeroByteReadThatIsNotEof() throws IOException {
+        final byte[] content = content(4);
+        final RecordingReadChannel channel = new RecordingReadChannel(content, content.length);
+        channel.zeroReadsRemaining = 3;
+
+        final ByteBuffer buffer = FETCHER.readToByteBuffer(
+            SizedReadableByteChannel.of(channel, content.length));
+
+        assertThat(buffer.array()).isEqualTo(content);
+    }
+
+    @Test
+    void failsWhenSizedChannelUnderDelivers() {
+        try (final RecordingReadChannel channel = new RecordingReadChannel(content(10), 10)) {
+            assertThatThrownBy(() -> FETCHER.readToByteBuffer(SizedReadableByteChannel.of(channel, 20)))
+                .isInstanceOf(IOException.class)
+                .hasMessage("Channel delivered 10 of 20 bytes");
+        }
+    }
+
+    @Test
+    void failsWhenSizedChannelOverDelivers() {
+        try (final RecordingReadChannel channel = new RecordingReadChannel(content(20), 20)) {
+            assertThatThrownBy(() -> FETCHER.readToByteBuffer(SizedReadableByteChannel.of(channel, 10)))
+                .isInstanceOf(IOException.class)
+                .hasMessage("Channel delivered more than 10 bytes");
+        }
+    }
+
+    @Test
+    void rejectsNegativeContentLength() {
+        try (final RecordingReadChannel channel = new RecordingReadChannel(content(1), 1)) {
+            assertThatThrownBy(() -> SizedReadableByteChannel.of(channel, -1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("contentLength cannot be negative: -1");
+        }
+    }
+
+    @Test
+    void closedChannelsRejectReads() throws IOException {
+        final SizedReadableByteChannel overBuffer = SizedReadableByteChannel.of(ByteBuffer.wrap(content(3)));
+        final SizedReadableByteChannel overDelegate =
+            SizedReadableByteChannel.of(new RecordingReadChannel(content(3), 3), 3);
+
+        for (final SizedReadableByteChannel channel : List.of(overBuffer, overDelegate)) {
+            channel.close();
+            assertThatThrownBy(() -> channel.read(ByteBuffer.allocate(1)))
+                .as("read after close on %s", channel)
+                .isInstanceOf(ClosedChannelException.class);
+        }
+    }
+
+    @Test
+    void ofDelegatesIsOpenAndClose() throws IOException {
+        final RecordingReadChannel delegate = new RecordingReadChannel(content(3), 3);
+        final SizedReadableByteChannel channel = SizedReadableByteChannel.of(delegate, 3);
+
+        assertThat(channel.isOpen()).isTrue();
+        channel.close();
+        assertThat(delegate.isOpen()).isFalse();
+        assertThat(channel.isOpen()).isFalse();
+    }
+
+    @Test
+    void ofRejectsNullDelegate() {
+        assertThatThrownBy(() -> SizedReadableByteChannel.of(null, 0))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessage("delegate cannot be null");
+    }
+
 }

--- a/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/common/ObjectFetcherTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/common/ObjectFetcherTest.java
@@ -1,0 +1,149 @@
+/*
+ * Inkless
+ * Copyright (C) 2024 - 2026 Aiven OY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.aiven.inkless.storage_backend.common;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.ReadableByteChannel;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import io.aiven.inkless.common.ByteRange;
+import io.aiven.inkless.common.ObjectKey;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ObjectFetcherTest {
+
+    private static final int ONE_MIB = ObjectFetcher.READ_BUFFER_1MiB;
+
+    private static final ObjectFetcher FETCHER = new ObjectFetcher() {
+        @Override
+        public ReadableByteChannel fetch(final ObjectKey key, final ByteRange range) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void close() {
+        }
+    };
+
+    private record ReadCase(String name, int contentSize, int expectedScratchBuffers) {
+        @Override
+        public String toString() {
+            return name;
+        }
+    }
+
+    static Stream<ReadCase> reads() {
+        return Stream.of(
+            new ReadCase("empty", 0, 1),
+            new ReadCase("1 byte", 1, 1),
+            new ReadCase("just under 8 KiB", 8_191, 1),
+            new ReadCase("8 KiB", 8_192, 1),
+            new ReadCase("just over 8 KiB", 8_193, 1),
+            new ReadCase("several 8 KiB reads", 40_000, 1),
+            new ReadCase("just under 1 MiB", ONE_MIB - 1, 1),
+            new ReadCase("1 MiB", ONE_MIB, 2),
+            new ReadCase("just over 1 MiB", ONE_MIB + 12_345, 2),
+            new ReadCase("just over 2 MiB", 2 * ONE_MIB + 1, 3)
+        );
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("reads")
+    void fillsEachScratchBufferBeforeAllocatingAnother(final ReadCase readCase) throws IOException {
+        final byte[] content = content(readCase.contentSize);
+        final CappedReadChannel channel = new CappedReadChannel(content, 8 * 1024);
+
+        final ByteBuffer buffer = FETCHER.readToByteBuffer(channel);
+
+        assertThat(buffer.array()).isEqualTo(content);
+        assertThat(channel.scratchBuffers).hasSize(readCase.expectedScratchBuffers);
+        assertThat(channel.scratchBuffers).allMatch(bufferSeen -> bufferSeen.capacity() == ONE_MIB);
+    }
+
+    @Test
+    void continuesAfterZeroByteReadThatIsNotEof() throws IOException {
+        final byte[] content = content(4);
+        final CappedReadChannel channel = new CappedReadChannel(content, content.length);
+        channel.zeroReadsRemaining = 3;
+
+        final ByteBuffer buffer = FETCHER.readToByteBuffer(channel);
+
+        assertThat(buffer.array()).isEqualTo(content);
+        assertThat(channel.readCalls).isEqualTo(5);
+        assertThat(channel.scratchBuffers).hasSize(1);
+    }
+
+    private static byte[] content(final int size) {
+        final byte[] content = new byte[size];
+        for (int i = 0; i < size; i++) {
+            content[i] = (byte) i;
+        }
+        return content;
+    }
+
+    private static final class CappedReadChannel implements ReadableByteChannel {
+        private final byte[] content;
+        private final int maxBytesPerRead;
+        private final Set<ByteBuffer> scratchBuffers = Collections.newSetFromMap(new IdentityHashMap<>());
+        private int position;
+        private int readCalls;
+        private int zeroReadsRemaining;
+        private boolean open = true;
+
+        CappedReadChannel(final byte[] content, final int maxBytesPerRead) {
+            this.content = content;
+            this.maxBytesPerRead = maxBytesPerRead;
+        }
+
+        @Override
+        public int read(final ByteBuffer dst) {
+            readCalls++;
+            scratchBuffers.add(dst);
+            if (zeroReadsRemaining > 0) {
+                zeroReadsRemaining--;
+                return 0;
+            }
+            if (position == content.length) {
+                return -1;
+            }
+            final int readSize = Math.min(Math.min(maxBytesPerRead, dst.remaining()), content.length - position);
+            dst.put(content, position, readSize);
+            position += readSize;
+            return readSize;
+        }
+
+        @Override
+        public boolean isOpen() {
+            return open;
+        }
+
+        @Override
+        public void close() {
+            open = false;
+        }
+    }
+}

--- a/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/common/TimingReadableByteChannelTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/common/TimingReadableByteChannelTest.java
@@ -42,7 +42,7 @@ class TimingReadableByteChannelTest {
         final Instant startTime = TimeUtils.durationMeasurementNow(time);
         final ReadableByteChannel delegate = Channels.newChannel(new ByteArrayInputStream(new byte[]{1, 2, 3}));
 
-        final TimingReadableByteChannel channel = new TimingReadableByteChannel(delegate, time, startTime, recordedTtfb::set);
+        final TimingReadableByteChannel channel = TimingReadableByteChannel.wrap(delegate, time, startTime, recordedTtfb::set);
 
         // Advance time before first read
         time.sleep(42);
@@ -61,7 +61,7 @@ class TimingReadableByteChannelTest {
         final Instant startTime = TimeUtils.durationMeasurementNow(time);
         final ReadableByteChannel delegate = Channels.newChannel(new ByteArrayInputStream(new byte[]{1, 2, 3, 4}));
 
-        final TimingReadableByteChannel channel = new TimingReadableByteChannel(delegate, time, startTime, ttfb -> callCount.incrementAndGet());
+        final TimingReadableByteChannel channel = TimingReadableByteChannel.wrap(delegate, time, startTime, ttfb -> callCount.incrementAndGet());
 
         time.sleep(10);
         channel.read(ByteBuffer.allocate(2));
@@ -79,7 +79,7 @@ class TimingReadableByteChannelTest {
         // Empty stream returns -1 on read
         final ReadableByteChannel delegate = Channels.newChannel(new ByteArrayInputStream(new byte[0]));
 
-        final TimingReadableByteChannel channel = new TimingReadableByteChannel(delegate, time, startTime, recordedTtfb::set);
+        final TimingReadableByteChannel channel = TimingReadableByteChannel.wrap(delegate, time, startTime, recordedTtfb::set);
 
         time.sleep(10);
         final int bytesRead = channel.read(ByteBuffer.allocate(10));
@@ -89,12 +89,47 @@ class TimingReadableByteChannelTest {
     }
 
     @Test
+    void wrapPreservesContentLength() throws IOException {
+        final MockTime time = new MockTime();
+        final AtomicLong callCount = new AtomicLong(0);
+        final Instant startTime = TimeUtils.durationMeasurementNow(time);
+        final byte[] content = new byte[]{1, 2, 3};
+        final ReadableByteChannel delegate = SizedReadableByteChannel.of(
+            Channels.newChannel(new ByteArrayInputStream(content)), content.length);
+
+        final TimingReadableByteChannel channel =
+            TimingReadableByteChannel.wrap(delegate, time, startTime, ttfb -> callCount.incrementAndGet());
+
+        assertThat(channel).isInstanceOf(SizedReadableByteChannel.class);
+        assertThat(((SizedReadableByteChannel) channel).contentLength()).isEqualTo(3);
+
+        time.sleep(10);
+        channel.read(ByteBuffer.allocate(2));
+        time.sleep(20);
+        channel.read(ByteBuffer.allocate(2));
+
+        assertThat(callCount.get()).isEqualTo(1);
+    }
+
+    @Test
+    void wrapOfUnsizedDelegateIsNotSized() {
+        final MockTime time = new MockTime();
+        final Instant startTime = TimeUtils.durationMeasurementNow(time);
+        final ReadableByteChannel delegate = Channels.newChannel(new ByteArrayInputStream(new byte[]{1}));
+
+        final TimingReadableByteChannel channel =
+            TimingReadableByteChannel.wrap(delegate, time, startTime, ttfb -> {});
+
+        assertThat(channel).isNotInstanceOf(SizedReadableByteChannel.class);
+    }
+
+    @Test
     void delegatesIsOpenAndClose() throws IOException {
         final MockTime time = new MockTime();
         final Instant startTime = TimeUtils.durationMeasurementNow(time);
         final ReadableByteChannel delegate = Channels.newChannel(new ByteArrayInputStream(new byte[]{1}));
 
-        final TimingReadableByteChannel channel = new TimingReadableByteChannel(delegate, time, startTime, ttfb -> {});
+        final TimingReadableByteChannel channel = TimingReadableByteChannel.wrap(delegate, time, startTime, ttfb -> {});
 
         assertThat(channel.isOpen()).isTrue();
         channel.close();

--- a/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/common/fixtures/BaseStorageTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/common/fixtures/BaseStorageTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.nio.ByteBuffer;
+import java.nio.channels.ReadableByteChannel;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -30,6 +31,7 @@ import io.aiven.inkless.common.ByteRange;
 import io.aiven.inkless.common.ObjectKey;
 import io.aiven.inkless.storage_backend.common.InvalidRangeException;
 import io.aiven.inkless.storage_backend.common.KeyNotFoundException;
+import io.aiven.inkless.storage_backend.common.SizedReadableByteChannel;
 import io.aiven.inkless.storage_backend.common.StorageBackend;
 import io.aiven.inkless.storage_backend.common.StorageBackendException;
 
@@ -223,6 +225,51 @@ public abstract class BaseStorageTest {
                 storage.fetch(TOPIC_PARTITION_SEGMENT_KEY, new ByteRange(0, 10)));
         }
         assertThat(new String(fetch.array())).isEqualTo("ABC");
+    }
+
+    @Test
+    void testFetchWithMaxRange() throws Exception {
+        final ByteBuffer fetch;
+        try (StorageBackend storage = storage()) {
+            final byte[] data = "ABC".getBytes();
+            storage.upload(TOPIC_PARTITION_SEGMENT_KEY, new ByteArrayInputStream(data), data.length);
+
+            fetch = storage.readToByteBuffer(
+                storage.fetch(TOPIC_PARTITION_SEGMENT_KEY, ByteRange.maxRange()));
+        }
+        assertThat(new String(fetch.array())).isEqualTo("ABC");
+    }
+
+    @Test
+    void testFetchDeclaresContentLength() throws Exception {
+        try (StorageBackend storage = storage()) {
+            final byte[] data = "ABC".getBytes();
+            storage.upload(TOPIC_PARTITION_SEGMENT_KEY, new ByteArrayInputStream(data), data.length);
+
+            assertDeclaredContentLength(storage, new ByteRange(0, data.length), data.length);
+            // Clipped ranges are where each backend's own length arithmetic runs.
+            assertDeclaredContentLength(storage, new ByteRange(0, 10), 3);
+            assertDeclaredContentLength(storage, new ByteRange(2, 10), 1);
+            // An empty range short-circuits ahead of the bounds check, so an offset past the end
+            // is still an empty read rather than an out-of-range failure.
+            assertDeclaredContentLength(storage, new ByteRange(0, 0), 0);
+            assertDeclaredContentLength(storage, new ByteRange(5, 0), 0);
+        }
+    }
+
+    private void assertDeclaredContentLength(
+        final StorageBackend storage,
+        final ByteRange range,
+        final int expectedLength
+    ) throws Exception {
+        try (ReadableByteChannel channel = storage.fetch(TOPIC_PARTITION_SEGMENT_KEY, range)) {
+            assertThat(channel)
+                .as("fetch(%s) must declare its content length", range)
+                .isInstanceOf(SizedReadableByteChannel.class);
+            assertThat(((SizedReadableByteChannel) channel).contentLength())
+                .as("declared content length for %s", range)
+                .isEqualTo(expectedLength);
+        }
     }
 
     @Test

--- a/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/common/fixtures/BaseStorageTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/common/fixtures/BaseStorageTest.java
@@ -212,6 +212,20 @@ public abstract class BaseStorageTest {
     }
 
     @Test
+    void testFetchWithRangeFromStartLargerThanFileSize() throws Exception {
+        final ByteBuffer fetch;
+        try (StorageBackend storage = storage()) {
+            final String content = "ABC";
+            byte[] data = content.getBytes();
+            storage.upload(TOPIC_PARTITION_SEGMENT_KEY, new ByteArrayInputStream(data), data.length);
+
+            fetch = storage.readToByteBuffer(
+                storage.fetch(TOPIC_PARTITION_SEGMENT_KEY, new ByteRange(0, 10)));
+        }
+        assertThat(new String(fetch.array())).isEqualTo("ABC");
+    }
+
+    @Test
     protected void testFetchWithRangeOutsideFileSize() throws Exception {
         try (StorageBackend storage = storage()) {
             final String content = "ABC";

--- a/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/common/fixtures/BaseStorageTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/common/fixtures/BaseStorageTest.java
@@ -149,7 +149,7 @@ public abstract class BaseStorageTest {
     }
 
     @Test
-    void testFetchWithoutRange() throws Exception {
+    protected void testFetchWithoutRange() throws Exception {
         final String content;
         final ByteBuffer fetch;
         try (StorageBackend storage = storage()) {

--- a/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/common/fixtures/RecordingReadChannel.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/common/fixtures/RecordingReadChannel.java
@@ -1,0 +1,81 @@
+/*
+ * Inkless
+ * Copyright (C) 2024 - 2026 Aiven OY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.aiven.inkless.storage_backend.common.fixtures;
+
+import java.nio.ByteBuffer;
+import java.nio.channels.ReadableByteChannel;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Set;
+
+/**
+ * A channel over a byte array that records what it was asked to fill, so a test can assert on the
+ * buffers a reader allocated rather than only on the bytes it returned.
+ *
+ * <p>Caps each read at {@code maxBytesPerRead} to reproduce a short-reading backend, and can be told
+ * to return a run of {@code 0}-byte reads that are not EOF.
+ */
+public final class RecordingReadChannel implements ReadableByteChannel {
+    private final byte[] content;
+    private final int maxBytesPerRead;
+
+    /** Identity set, so a reader that reuses one buffer is distinguishable from one that allocates. */
+    public final Set<ByteBuffer> destinations = Collections.newSetFromMap(new IdentityHashMap<>());
+
+    public int readCalls;
+    public int zeroReadsRemaining;
+
+    private int position;
+    private boolean open = true;
+
+    public RecordingReadChannel(final byte[] content, final int maxBytesPerRead) {
+        this.content = content;
+        this.maxBytesPerRead = maxBytesPerRead;
+    }
+
+    public RecordingReadChannel(final byte[] content) {
+        this(content, Integer.MAX_VALUE);
+    }
+
+    @Override
+    public int read(final ByteBuffer dst) {
+        readCalls++;
+        destinations.add(dst);
+        if (zeroReadsRemaining > 0) {
+            zeroReadsRemaining--;
+            return 0;
+        }
+        if (position == content.length) {
+            return -1;
+        }
+        final int readSize = Math.min(Math.min(maxBytesPerRead, dst.remaining()), content.length - position);
+        dst.put(content, position, readSize);
+        position += readSize;
+        return readSize;
+    }
+
+    @Override
+    public boolean isOpen() {
+        return open;
+    }
+
+    @Override
+    public void close() {
+        open = false;
+    }
+}

--- a/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/in_memory/InMemoryStorageTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/in_memory/InMemoryStorageTest.java
@@ -22,22 +22,38 @@ import org.apache.kafka.common.metrics.Metrics;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.util.Set;
 
 import io.aiven.inkless.common.ByteRange;
 import io.aiven.inkless.common.ObjectKey;
 import io.aiven.inkless.common.PlainObjectKey;
 import io.aiven.inkless.storage_backend.common.InvalidRangeException;
-import io.aiven.inkless.storage_backend.common.KeyNotFoundException;
+import io.aiven.inkless.storage_backend.common.StorageBackend;
 import io.aiven.inkless.storage_backend.common.StorageBackendException;
+import io.aiven.inkless.storage_backend.common.fixtures.BaseStorageTest;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-class InMemoryStorageTest {
+class InMemoryStorageTest extends BaseStorageTest {
     static final PlainObjectKey OBJECT_KEY = PlainObjectKey.create("a", "b");
+
+    @Override
+    protected StorageBackend storage() {
+        return new InMemoryStorage(new Metrics());
+    }
+
+    @Test
+    @Override
+    protected void testFetchWithoutRange() throws Exception {
+        try (StorageBackend storage = storage()) {
+            final byte[] data = "AABBBBAA".getBytes();
+            storage.upload(TOPIC_PARTITION_SEGMENT_KEY, new ByteArrayInputStream(data), data.length);
+
+            assertThatThrownBy(() -> storage.fetch(TOPIC_PARTITION_SEGMENT_KEY, null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("range cannot be null");
+        }
+    }
 
     @Test
     void fetchNulls() {
@@ -46,9 +62,6 @@ class InMemoryStorageTest {
         assertThatThrownBy(() -> storage.fetch(null, new ByteRange(0, 10)))
             .isInstanceOf(NullPointerException.class)
             .hasMessage("key cannot be null");
-        assertThatThrownBy(() -> storage.fetch(OBJECT_KEY, null))
-            .isInstanceOf(NullPointerException.class)
-            .hasMessage("range cannot be null");
     }
 
     @Test
@@ -63,40 +76,9 @@ class InMemoryStorageTest {
             .hasMessage("keys cannot be null");
     }
 
-    @Test
-    void fetchNonExistent() {
-        final Metrics metrics = new Metrics();
-        final InMemoryStorage storage = new InMemoryStorage(metrics);
-        assertThatThrownBy(() -> storage.fetch(OBJECT_KEY, ByteRange.maxRange()))
-            .isInstanceOf(KeyNotFoundException.class);
-    }
-
-    @Test
-    void uploadAndFetch() throws StorageBackendException, IOException {
-        final Metrics metrics = new Metrics();
-        final InMemoryStorage storage = new InMemoryStorage(metrics);
-        final byte[] data = new byte[10];
-        storage.upload(OBJECT_KEY, new ByteArrayInputStream(data), data.length);
-
-        final ByteBuffer fetch = storage.readToByteBuffer(storage.fetch(OBJECT_KEY, ByteRange.maxRange()));
-
-        assertThat(fetch.array()).isEqualTo(data);
-    }
-
-    @Test
-    void fetchRanged() throws StorageBackendException, IOException {
-        final Metrics metrics = new Metrics();
-        final InMemoryStorage storage = new InMemoryStorage(metrics);
-        final byte[] data = new byte[]{0, 1, 2, 3, 4, 5, 6, 7};
-        storage.upload(OBJECT_KEY, new ByteArrayInputStream(data), data.length);
-
-        final ByteBuffer fetch1 = storage.readToByteBuffer(storage.fetch(OBJECT_KEY, new ByteRange(1, 2)));
-        assertThat(fetch1.array()).isEqualTo(new byte[]{1, 2});
-
-        final ByteBuffer fetch2 = storage.readToByteBuffer(storage.fetch(OBJECT_KEY, new ByteRange(1, 100)));
-        assertThat(fetch2.array()).isEqualTo(new byte[]{1, 2, 3, 4, 5, 6, 7});
-    }
-
+    /**
+     * The shared fixture asserts the exception type; this pins the message the backend produces.
+     */
     @Test
     void fetchOutsideOfSize() throws StorageBackendException {
         final Metrics metrics = new Metrics();
@@ -107,37 +89,5 @@ class InMemoryStorageTest {
         assertThatThrownBy(() -> storage.fetch(OBJECT_KEY, new ByteRange(8, 1)))
             .isInstanceOf(InvalidRangeException.class)
             .hasMessage("Failed to fetch a/b: Invalid range ByteRange[offset=8, size=1] for blob size 8");
-    }
-
-    @Test
-    void delete() throws StorageBackendException, IOException {
-        final Metrics metrics = new Metrics();
-        final InMemoryStorage storage = new InMemoryStorage(metrics);
-        final byte[] data = new byte[]{0, 1, 2, 3, 4, 5, 6, 7};
-        storage.upload(OBJECT_KEY, new ByteArrayInputStream(data), data.length);
-
-        final ByteBuffer fetch = storage.readToByteBuffer(storage.fetch(OBJECT_KEY, new ByteRange(1, 2)));
-        assertThat(fetch.array()).isEqualTo(new byte[]{1, 2});
-
-        storage.delete(OBJECT_KEY);
-
-        assertThatThrownBy(() -> storage.fetch(OBJECT_KEY, ByteRange.maxRange()))
-            .isInstanceOf(KeyNotFoundException.class);
-    }
-
-    @Test
-    void deleteMany() throws StorageBackendException, IOException {
-        final Metrics metrics = new Metrics();
-        final InMemoryStorage storage = new InMemoryStorage(metrics);
-        final byte[] data = new byte[]{0, 1, 2, 3, 4, 5, 6, 7};
-        storage.upload(OBJECT_KEY, new ByteArrayInputStream(data), data.length);
-
-        final ByteBuffer fetch = storage.readToByteBuffer(storage.fetch(OBJECT_KEY, new ByteRange(1, 2)));
-        assertThat(fetch.array()).isEqualTo(new byte[]{1, 2});
-
-        storage.delete(Set.of(OBJECT_KEY, PlainObjectKey.create("un", "related")));
-
-        assertThatThrownBy(() -> storage.fetch(OBJECT_KEY, ByteRange.maxRange()))
-            .isInstanceOf(KeyNotFoundException.class);
     }
 }

--- a/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/s3/integration/S3StorageTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/s3/integration/S3StorageTest.java
@@ -86,6 +86,7 @@ public class S3StorageTest extends BaseStorageTest {
         return s3Storage;
     }
 
+    @Test
     @Override
     protected void testUploadUndersizedStream() throws IOException {
         try (StorageBackend storage = storage()) {
@@ -102,6 +103,7 @@ public class S3StorageTest extends BaseStorageTest {
     }
 
     @Test
+    @Override
     protected void testUploadOversizeStream() throws IOException {
         try (StorageBackend storage = storage()) {
             final byte[] content = "content".getBytes();


### PR DESCRIPTION
The diskless fetch path allocated a 1 MiB scratch buffer per object to carry a payload that is usually tens of kilobytes. A lagging fetch touches about one object per batch, so that allocation dominates the read path.

The size the caller already has isn't that payload. On the hot path `FixedBlockAlignment` requests a full `inkless.consume.cache.block.bytes` block (16 MiB by default) with no clip to the object. Sizing to `range.bufferSize()` would allocate a full block to deliver tens of kilobytes, since the object itself is capped by `produce.buffer.max.bytes`. Every backend already knows the true length before anything reads the channel. This PR sizes the allocation to that length.

`readToByteBuffer` drained every channel into 1 MiB scratches and copied. This PR changes that in two steps:

1. The scratch path fills each buffer before allocating the next, so buffer count tracks the payload, not the read count.
2. A channel can declare its exact content length. All four backends do. `readToByteBuffer` then allocates once and reads straight into that destination.

The scratch path stays for any channel that doesn't declare a length. After this PR no backend uses it: S3, GCS, Azure, and in-memory all declare a length. `BaseStorageTest` asserts that, so dropping a declaration fails the shared tests instead of silently allocating a 1 MiB scratch per fetch. Deleting the fallback means narrowing `fetch` to `SizedReadableByteChannel` and making `wrap` always sized. That change is broad (the fetch signature, wrap, the consume-test stubs, and the scratch-path suite) and is a follow-up.

## Impact

The two paths differ by more than the numbers below suggest, and it is worth saying why: the same 1 MiB scratch buffer was proportionate on one and dominant on the other.

**Hot path.** `FixedBlockAlignment` requests a full cache block (16 MiB by default), which is always at least the object size, since an object is capped by `produce.buffer.max.bytes` (8 MiB by default). A hot fetch therefore reads essentially the whole object: a 4 MiB object cost four scratch buffers plus the EOF probe, about 1.25x overhead. Add the cache in front of it - a hot object is fetched once and reused - and the cost was real but not visible.

**Lagging path.** `BoundingRangeAlignment` collapses an object's ranges to one min-to-max span, and for a lagging consumer that span is only its own partition's slice of an object shared with many partitions: tens of kilobytes. The same 1 MiB buffer is then 16-25x the payload. Three things compound:

1. The scratch-to-payload ratio inverts, as above.
2. Objects per fetch tracks batch count, because `planJobs` groups by object key across all partitions and then collapses each object to one range. So that ratio is paid per object, many times per fetch request.
3. The cold path bypasses the cache, so every fetch pays it again rather than amortizing over the cache lifetime.

The fixed EOF-probe buffer is the clearest illustration: a full 1 MiB regardless of payload, so for a small cold read it was half the allocation on its own. That is what the first commit removes, before the sized path removes the rest.

64 KiB is the common cache-aligned fetch against a small object. 8 MiB is the object-size cap. S3 and GCS already filled a whole scratch per read. Azure used to stream through `BlobInputStream` and the JDK 8 KiB channel adapter; that path is gone.

- 64 KiB dest: 2.06 MiB (S3/GCS) or ~9 MiB (Azure-as-stream) → 64 KiB.
- 8 MiB dest: 17 MiB (S3/GCS) or ~1 GiB (Azure-as-stream) → 8 MiB.

The sized path also drops the extra copy of the payload. The reader fills the destination from the channel instead of joining scratches. An empty range no longer allocates 1 MiB to read nothing.

GCS `setChunkSize(0)` also drops the reader's staging buffer. A positive chunk size allocated a second buffer of that size (8 MiB by default) on first read; the client now writes straight into the dest.

S3 and Azure hand the materialized response to `SizedReadableByteChannel.of(ByteBuffer)`. The old JDK channel over an `InputStream` moved every byte through an 8 KiB staging array, so an 8 MiB fetch paid about a thousand reads and a full extra copy of a payload that was already exactly sized. Azure also drops `BlobInputStream`'s 4 MiB chunk.

No new or modified config, no new or renamed metrics, no API or protocol change.

## Operator impact

**GCS fetch TTFB drops, and dashboards or alerts on it need re-baselining.** `TimingReadableByteChannel` records time-to-first-byte on the first read that returns data. The buffered GCS reader filled the destination before returning, so with a 1 MiB scratch the first read came back only after about 1 MiB (or the whole payload) had transferred, and TTFB was close to whole-fetch time for a small range. The unbuffered reader returns on the first socket read, so the reported number is now much smaller and much closer to actual time-to-first-byte. Nothing else about the metric changed: same name, same units, same call site.

S3 TTFB is unaffected: it materializes the response inside `fetch`, so its first read already returned after the whole transfer. Azure now does the same, so its TTFB also becomes whole-download time - Azure isn't in production, so there is nothing to re-baseline there.

**Which metric catches a bad fetch.** A backend that declares a content length it doesn't deliver throws `IOException` from `readToByteBuffer`. That is wrapped as `FileFetchException`, then converted to a per-object `Failure`. The FETCH completes. The partition is `KAFKA_STORAGE_ERROR` and marks `PartitionStorageErrorRate`. `FileFetchErrorRate` is only marked when the whole Reader future fails, which this path does not. Content corruption is unaffected and already covered - `createMemoryRecords` calls `ensureValid()` before patching offsets, so a CRC or size failure is classified per partition as `CORRUPT_MESSAGE` and marks `PartitionCorruptRecordRate` while other partitions in the same request still succeed. A missing extent marks `PartitionStorageErrorRate`, a short batch count marks `PartitionPartialFetchRate`.

One pre-existing limitation worth naming, unchanged by this PR: those per-partition counters distinguish the failure shapes, but at request level only the generic `FailedFetchRequestsPerSec` is marked, so a steady trickle can't be attributed to one error class from request-level metrics alone.

## Commits

- `fix(inkless:consume): fill fetch scratch buffers before allocating another`: bound the scratch path. Fill each scratch before allocating the next.
- `feat(inkless:consume): read sized channels into one exact allocation`: the sized channel, the exact destination, `wrap`, and in-memory adopting it.
- `fix(inkless:storage): align in-memory ranged fetches with the other backends`: clip over-runs, short-circuit empty ranges, and read the clip through `of(ByteBuffer)`.
- `feat(inkless:storage): report content length from S3 fetches`: S3 declares the length it already knew and reads its response buffer directly.
- `feat(inkless:storage): report content length from GCS fetches`: GCS declares the length it already knew and reads straight into the dest (`setChunkSize(0)`).
- `feat(inkless:storage): report content length from Azure fetches`: Azure downloads the range with `downloadContentWithResponse` and reads that buffer directly. The shared tests assert every backend declares a length.

See the commit messages for the reasoning behind each step.

## Test plan

`ObjectFetcherTest` is new. `RecordingReadChannel` is a shared fixture: it caps every read at 8 KiB and records dest identity, so the assertions check allocation, not only output bytes.

Unsized reads cover empty through just over 2 MiB. Scratch count tracks payload size: one 1 MiB scratch below 1 MiB, a second scratch at exactly 1 MiB to observe EOF. Sized reads expect dest capacity equal to the payload plus a 1-byte over-delivery probe. An empty sized channel is the probe only. An upper bound on capacity would stay green with a leftover 1 MiB scratch once the payload is at least 1 MiB.

Both paths retry a `0`-byte read that isn't EOF. A declared length that doesn't match what the channel delivers fails. Both `of` factories throw `ClosedChannelException` after `close`. The delegate factory forwards `close` and `isOpen` and rejects a null delegate. The 8 KiB cap on `RecordingReadChannel` is a short-read stand-in; Azure no longer returns 8 KiB per `read()`.

`FileFetchJobTest.testSizedChannelReachesTheReader` runs the same fake through the real job. The job wraps the channel for TTFB, then calls the real `readToByteBuffer`. Dest plus probe capacities prove the wrapper carried the length. Without that, the dest would be a 1 MiB scratch and the test would still see the right bytes.

`TimingReadableByteChannelTest` covers `wrap`: a sized channel keeps its length, a plain channel doesn't claim one. The TTFB callback fires only on a strictly positive read.

`BaseStorageTest` gains an offset-0 over-run (the cache-aligned shape), `testFetchWithMaxRange` (`ByteRange.maxRange()`), and `testFetchDeclaresContentLength` on the exact range, two clipped ranges, and two empty ranges including an offset past the object end, so each backend's length arithmetic is checked against the same expectations. Azure no longer overrides the out-of-range case: `available <= 0` matches the other backends and the fixture case runs as-is. `InMemoryStorage` gained the empty-range short-circuit the other three already had, so an empty range is an empty read on every backend rather than an out-of-range failure on one. `InMemoryStorageTest` extends the fixture, which is what surfaced the off-by-one.

These fixture cases run on every backend: in-memory and the GCS and Azure container suites under `:storage:inkless:test`, and the S3 container suite under `:storage:inkless:integrationTest`. `S3StorageTest.testUploadUndersizedStream` executes for the first time in this PR - it carried `@Override` without `@Test`, which JUnit does not inherit, so it had never run since it was written.

## Scope

This lands the per-object allocation fix and nothing else. No config, no metrics, no API change.

The scratch-buffer fallback is the non-production path. Deleting it means narrowing `fetch` to `SizedReadableByteChannel` and making `wrap` always sized. That change is broad: the fetch signature, wrap, the consume-test stubs, and the scratch-path suite. It is a follow-up.

It doesn't bound how many fetched extents a broker holds at once. A request still assembles every extent before returning any of them. That peak is untouched here and is being worked on separately.

[KC-481]

[KC-481]: https://aiven.atlassian.net/browse/KC-481?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
