### PR TITLE
sync(ci): extend inkless system tests timeout to 3 hours

### DIFF
--- a/.github/workflows/inkless-system-tests.yml
+++ b/.github/workflows/inkless-system-tests.yml
@@ -22,7 +22,7 @@ jobs:
   inkless-system-tests:
     name: Inkless system tests
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    timeout-minutes: 200
 
     steps:
       - name: Checkout code
@@ -77,7 +77,7 @@ jobs:
         run: |
           set +e
           test_target="${REQUESTED_TEST_TARGET:-${DEFAULT_TEST_TARGET}}"
-          timeout 100m bash tests/docker/ducker-ak test "$test_target" -- --test-runner-timeout 7200000
+          timeout 180m bash tests/docker/ducker-ak test "$test_target" -- --test-runner-timeout 7200000
           exitcode="$?"
           echo "exitcode=$exitcode" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
The system test suite was hitting the 100-minute wall-clock timeout mid-run (test 22/37 canceled), even though every test that finished passed. Raise the ducker-ak run timeout from 100m to 180m and the job's timeout-minutes from 120 to 200 to leave headroom for setup, archiving, and cleanup steps around the 3-hour test run.