### PR TITLE
fix(inkless:consume): serve consumer reads from a lagging AZ replica [KC-461]

### DIFF
--- a/core/src/main/scala/kafka/server/DelayedFetch.scala
+++ b/core/src/main/scala/kafka/server/DelayedFetch.scala
@@ -75,6 +75,8 @@ class DelayedFetch(
    * Case H: A diverging epoch was found, return response to trigger truncation
    * Upon completion, should return whatever data is available for each valid partition
    */
+  private val replicaReadAllowed = mutable.Map.empty[TopicIdPartition, Boolean]
+
   override def tryComplete(): Boolean = {
     var accumulatedSize = 0L
     classicFetchPartitionStatus.forEach { (topicIdPartition, fetchStatus) =>
@@ -83,7 +85,15 @@ class DelayedFetch(
       try {
         if (fetchOffset != LogOffsetMetadata.UNKNOWN_OFFSET_METADATA) {
           val partition = replicaManager.getPartitionOrException(topicIdPartition.topicPartition)
-          val offsetSnapshot = partition.fetchOffsetSnapshot(fetchLeaderEpoch, params.fetchOnlyLeader)
+          // An older consumer authorized to read this partition from a non-leader replica must not
+          // be force-completed as case A here: the read itself was allowed, so the snapshot has to
+          // agree or the request stops waiting for the data it was parked for. The answer cannot
+          // change while this request is parked, and every tryComplete runs under the operation's
+          // lock, so it is resolved once per partition instead of on every completion attempt.
+          val fetchOnlyFromLeader = params.fetchOnlyLeader &&
+            !replicaReadAllowed.getOrElseUpdate(topicIdPartition,
+              replicaManager.allowsOlderConsumerReplicaRead(topicIdPartition, params))
+          val offsetSnapshot = partition.fetchOffsetSnapshot(fetchLeaderEpoch, fetchOnlyFromLeader)
 
           val endOffset = params.isolation match {
             case FetchIsolation.LOG_END => offsetSnapshot.logEndOffset
@@ -114,36 +124,36 @@ class DelayedFetch(
             }
           }
 
-            // Case H: If truncation has caused diverging epoch while this request was in purgatory, return to trigger truncation
-            fetchStatus.fetchInfo.lastFetchedEpoch.ifPresent { fetchEpoch =>
-              val epochEndOffset = partition.lastOffsetForLeaderEpoch(fetchLeaderEpoch, fetchEpoch, fetchOnlyFromLeader = false)
-              if (epochEndOffset.errorCode != Errors.NONE.code()
-                || epochEndOffset.endOffset == UNDEFINED_EPOCH_OFFSET
-                || epochEndOffset.leaderEpoch == UNDEFINED_EPOCH) {
-                debug(s"Could not obtain last offset for leader epoch for partition $topicIdPartition, epochEndOffset=$epochEndOffset.")
-                return forceComplete()
-              } else if (epochEndOffset.leaderEpoch < fetchEpoch || epochEndOffset.endOffset < fetchStatus.fetchInfo.fetchOffset) {
-                debug(s"Satisfying fetch $this since it has diverging epoch requiring truncation for partition " +
-                  s"$topicIdPartition epochEndOffset=$epochEndOffset fetchEpoch=$fetchEpoch fetchOffset=${fetchStatus.fetchInfo.fetchOffset}.")
-                return forceComplete()
-              }
+          // Case H: If truncation has caused diverging epoch while this request was in purgatory, return to trigger truncation
+          fetchStatus.fetchInfo.lastFetchedEpoch.ifPresent { fetchEpoch =>
+            val epochEndOffset = partition.lastOffsetForLeaderEpoch(fetchLeaderEpoch, fetchEpoch, fetchOnlyFromLeader = false)
+            if (epochEndOffset.errorCode != Errors.NONE.code()
+              || epochEndOffset.endOffset == UNDEFINED_EPOCH_OFFSET
+              || epochEndOffset.leaderEpoch == UNDEFINED_EPOCH) {
+              debug(s"Could not obtain last offset for leader epoch for partition $topicIdPartition, epochEndOffset=$epochEndOffset.")
+              return forceComplete()
+            } else if (epochEndOffset.leaderEpoch < fetchEpoch || epochEndOffset.endOffset < fetchStatus.fetchInfo.fetchOffset) {
+              debug(s"Satisfying fetch $this since it has diverging epoch requiring truncation for partition " +
+                s"$topicIdPartition epochEndOffset=$epochEndOffset fetchEpoch=$fetchEpoch fetchOffset=${fetchStatus.fetchInfo.fetchOffset}.")
+              return forceComplete()
             }
           }
-        } catch {
-          case _: NotLeaderOrFollowerException =>  // Case A or Case B
-            debug(s"Broker is no longer the leader or follower of $topicIdPartition, satisfy $this immediately")
-            return forceComplete()
-          case _: UnknownTopicOrPartitionException => // Case C
-            debug(s"Broker no longer knows of partition $topicIdPartition, satisfy $this immediately")
-            return forceComplete()
-          case _: KafkaStorageException => // Case D
-            debug(s"Partition $topicIdPartition is in an offline log directory, satisfy $this immediately")
-            return forceComplete()
-          case _: FencedLeaderEpochException => // Case E
-            debug(s"Broker is the leader of partition $topicIdPartition, but the requested epoch " +
-              s"$fetchLeaderEpoch is fenced by the latest leader epoch, satisfy $this immediately")
-            return forceComplete()
         }
+      } catch {
+        case _: NotLeaderOrFollowerException =>  // Case A or Case B
+          debug(s"Broker is no longer the leader or follower of $topicIdPartition, satisfy $this immediately")
+          return forceComplete()
+        case _: UnknownTopicOrPartitionException => // Case C
+          debug(s"Broker no longer knows of partition $topicIdPartition, satisfy $this immediately")
+          return forceComplete()
+        case _: KafkaStorageException => // Case D
+          debug(s"Partition $topicIdPartition is in an offline log directory, satisfy $this immediately")
+          return forceComplete()
+        case _: FencedLeaderEpochException => // Case E
+          debug(s"Broker is the leader of partition $topicIdPartition, but the requested epoch " +
+            s"$fetchLeaderEpoch is fenced by the latest leader epoch, satisfy $this immediately")
+          return forceComplete()
+      }
     }
 
     tryCompleteDiskless(disklessFetchPartitionStatus) match {

--- a/core/src/main/scala/kafka/server/DelayedFetch.scala
+++ b/core/src/main/scala/kafka/server/DelayedFetch.scala
@@ -104,7 +104,13 @@ class DelayedFetch(
           // Go directly to the check for Case G if the message offsets are the same. If the log segment
           // has just rolled, then the high watermark offset will remain the same but be on the old segment,
           // which would incorrectly be seen as an instance of Case F.
-          if (fetchOffset.messageOffset > endOffset.messageOffset) {
+          if (fetchOffset.messageOffset > endOffset.messageOffset &&
+            replicaManager.isBelowSealAndAheadOfLocalLog(topicIdPartition.topicPartition,
+              fetchOffset.messageOffset, offsetSnapshot.logEndOffset.messageOffset)) {
+            // Not case F: the offset is below the seal and this replica has not replicated that far,
+            // so the read already answered empty. Completing now would return it at once and the
+            // consumer would re-fetch in a loop.
+          } else if (fetchOffset.messageOffset > endOffset.messageOffset) {
             // Case F, this can happen when the new fetch operation is on a truncated leader
             debug(s"Satisfying fetch $this since it is fetching later segments of partition $topicIdPartition.")
             return forceComplete()

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -27,7 +27,7 @@ import io.aiven.inkless.consolidation.{ConsolidatedDisklessLogPruner, Consolidat
 import kafka.cluster.Partition
 import kafka.log.LogManager
 import kafka.server.QuotaFactory.QuotaManagers
-import kafka.server.ReplicaManager.{AtMinIsrPartitionCountMetricName, ConsolidationFetchBytesInPerSecMetricName, ConsolidationLocalBytesPerSecMetricName, ConsolidationSupplementBytesPerSecMetricName, ConsolidationSupplementRateMetricName, FailedIsrUpdatesPerSecMetricName, IsrExpandsPerSecMetricName, IsrShrinksPerSecMetricName, LeaderCountMetricName, OfflineReplicaCountMetricName, PartitionCountMetricName, PartitionsWithLateTransactionsCountMetricName, ProducerIdCountMetricName, ReassigningPartitionsMetricName, SealedPartitionsCountMetricName, DisklessSwitchedReplicasOutsideIsrCountMetricName, UnderMinIsrPartitionCountMetricName, UnderReplicatedPartitionsMetricName, createLogReadResult, isListOffsetsTimestampUnsupported}
+import kafka.server.ReplicaManager.{AtMinIsrPartitionCountMetricName, ConsolidationFetchBytesInPerSecMetricName, ConsolidationHighWatermarkLagFetchRateMetricName, ConsolidationHighWatermarkLagPartitionCountMetricName, ConsolidationLocalBytesPerSecMetricName, ConsolidationSupplementBytesPerSecMetricName, ConsolidationSupplementRateMetricName, FailedIsrUpdatesPerSecMetricName, IsrExpandsPerSecMetricName, IsrShrinksPerSecMetricName, LeaderCountMetricName, OfflineReplicaCountMetricName, PartitionCountMetricName, PartitionsWithLateTransactionsCountMetricName, ProducerIdCountMetricName, ReassigningPartitionsMetricName, SealedPartitionsCountMetricName, DisklessSwitchedReplicasOutsideIsrCountMetricName, UnderMinIsrPartitionCountMetricName, UnderReplicatedPartitionsMetricName, createLogReadResult, isListOffsetsTimestampUnsupported}
 import kafka.server.metadata.InklessMetadataView
 import kafka.server.share.DelayedShareFetch
 import kafka.utils._
@@ -118,6 +118,9 @@ object ReplicaManager {
   private val ConsolidationSupplementRateMetricName = "ConsolidationSupplementRate"
   private val ConsolidationSupplementBytesPerSecMetricName = "ConsolidationSupplementBytesPerSec"
   private val ConsolidationLocalBytesPerSecMetricName = "ConsolidationLocalBytesPerSec"
+  private val ConsolidationHighWatermarkLagFetchRateMetricName = "ConsolidationHighWatermarkLagFetchRate"
+  private val ConsolidationHighWatermarkLagPartitionCountMetricName =
+    "ConsolidationHighWatermarkLagPartitionCount"
 
   private[server] val GaugeMetricNames = Set(
     LeaderCountMetricName,
@@ -129,6 +132,7 @@ object ReplicaManager {
     ReassigningPartitionsMetricName,
     SealedPartitionsCountMetricName,
     DisklessSwitchedReplicasOutsideIsrCountMetricName,
+    ConsolidationHighWatermarkLagPartitionCountMetricName,
     PartitionsWithLateTransactionsCountMetricName,
     ProducerIdCountMetricName
   )
@@ -140,7 +144,8 @@ object ReplicaManager {
     ConsolidationFetchBytesInPerSecMetricName,
     ConsolidationSupplementRateMetricName,
     ConsolidationSupplementBytesPerSecMetricName,
-    ConsolidationLocalBytesPerSecMetricName
+    ConsolidationLocalBytesPerSecMetricName,
+    ConsolidationHighWatermarkLagFetchRateMetricName
   )
 
   private[server] val MetricNames = GaugeMetricNames.union(MeterMetricNames)
@@ -395,12 +400,26 @@ class ReplicaManager(val config: KafkaConfig,
   metricsGroup.newGauge(SealedPartitionsCountMetricName, () => sealedPartitionsCount)
   metricsGroup.newGauge(DisklessSwitchedReplicasOutsideIsrCountMetricName,
     () => disklessSwitchedReplicasOutsideIsrCount)
+  metricsGroup.newGauge(ConsolidationHighWatermarkLagPartitionCountMetricName,
+    () => consolidationHighWatermarkLagPartitionCount)
   metricsGroup.newGauge(PartitionsWithLateTransactionsCountMetricName, () => lateTransactionsCount)
   metricsGroup.newGauge(ProducerIdCountMetricName, () => producerIdCount)
 
   private def reassigningPartitionsCount: Int = leaderPartitionsIterator.count(_.isReassigning)
 
   private def sealedPartitionsCount: Int = leaderPartitionsIterator.count(_.isSealed)
+
+  /**
+   * Counts consolidating partitions holding data they cannot serve yet, that is a local high
+   * watermark below the local log end offset. Consumer reads of that range go to Inkless, which
+   * costs object-storage traffic, and below a classic-to-diskless seal Inkless has nothing to serve.
+   * Unlike ConsolidationHighWatermarkLagFetchRate this does not depend on consumer traffic, so a
+   * stalled replica stays visible after consumers have moved past its log end offset.
+   */
+  private[server] def consolidationHighWatermarkLagPartitionCount: Int = onlinePartitionsIterator.count { partition =>
+    consolidationActiveFor(partition.topic) &&
+      partition.log.exists(log => log.highWatermark < log.logEndOffset)
+  }
 
   private def lateTransactionsCount: Int = {
     val currentTimeMs = time.milliseconds()
@@ -416,6 +435,8 @@ class ReplicaManager(val config: KafkaConfig,
   private val consolidationSupplementRate: Meter = metricsGroup.newMeter(ConsolidationSupplementRateMetricName, "supplements", TimeUnit.SECONDS)
   private val consolidationSupplementBytesPerSec: Meter = metricsGroup.newMeter(ConsolidationSupplementBytesPerSecMetricName, "bytes", TimeUnit.SECONDS)
   private val consolidationLocalBytesPerSec: Meter = metricsGroup.newMeter(ConsolidationLocalBytesPerSecMetricName, "bytes", TimeUnit.SECONDS)
+  private val consolidationHighWatermarkLagFetchRate: Meter =
+    metricsGroup.newMeter(ConsolidationHighWatermarkLagFetchRateMetricName, "fetches", TimeUnit.SECONDS)
 
   /**
    * Returns true when this broker consolidates the topic: the feature is enabled here and the topic
@@ -2539,8 +2560,14 @@ class ReplicaManager(val config: KafkaConfig,
                   fetchPartitionData.fetchOffset >= localLogStartOffset &&
                   localReadFrontier >= logEndOffset)
                   consolidatingLocalFetchSupplements += (tp -> logEndOffset)
+              } else if (!shouldReadFromUnifiedLog && fetchPartitionData.fetchOffset < logEndOffset) {
+                // The local log holds this offset but cannot serve it, so this read goes to Inkless.
+                // A switch-pending partition is excluded because it was already routed to the local
+                // log above, and a follower cannot reach this branch: its frontier is LEO.
+                consolidationHighWatermarkLagFetchRate.mark()
               }
-              // else: the fetch is at or beyond the frontier for its source, so diskless is authoritative
+              // else: the fetch is at or beyond the frontier and beyond the local log, so diskless
+              // is authoritative
             case Left(error) =>
               warn(s"Error while fetching partition ${tp.topicPartition()} for consolidating diskless topic: $error. " +
                 s"Returning error for the fetch request since we cannot determine if the partition has switched to diskless or not.")

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -27,7 +27,7 @@ import io.aiven.inkless.consolidation.{ConsolidatedDisklessLogPruner, Consolidat
 import kafka.cluster.Partition
 import kafka.log.LogManager
 import kafka.server.QuotaFactory.QuotaManagers
-import kafka.server.ReplicaManager.{AtMinIsrPartitionCountMetricName, ConsolidationFetchBytesInPerSecMetricName, ConsolidationHighWatermarkLagFetchRateMetricName, ConsolidationHighWatermarkLagPartitionCountMetricName, ConsolidationLocalBytesPerSecMetricName, ConsolidationSupplementBytesPerSecMetricName, ConsolidationSupplementRateMetricName, FailedIsrUpdatesPerSecMetricName, IsrExpandsPerSecMetricName, IsrShrinksPerSecMetricName, LeaderCountMetricName, OfflineReplicaCountMetricName, PartitionCountMetricName, PartitionsWithLateTransactionsCountMetricName, ProducerIdCountMetricName, ReassigningPartitionsMetricName, SealedPartitionsCountMetricName, DisklessSwitchedReplicasOutsideIsrCountMetricName, UnderMinIsrPartitionCountMetricName, UnderReplicatedPartitionsMetricName, createLogReadResult, isListOffsetsTimestampUnsupported}
+import kafka.server.ReplicaManager.{AtMinIsrPartitionCountMetricName, ConsolidationFetchBytesInPerSecMetricName, ConsolidationHighWatermarkLagFetchRateMetricName, ConsolidationHighWatermarkLagPartitionCountMetricName, ConsolidationLocalBytesPerSecMetricName, ConsolidationSupplementBytesPerSecMetricName, ConsolidationSupplementRateMetricName, FailedIsrUpdatesPerSecMetricName, IsrExpandsPerSecMetricName, IsrShrinksPerSecMetricName, LeaderCountMetricName, OfflineReplicaCountMetricName, PartitionCountMetricName, PartitionsWithLateTransactionsCountMetricName, ProducerIdCountMetricName, ReassigningPartitionsMetricName, SealedPartitionsCountMetricName, DisklessSwitchedReplicasOutsideIsrCountMetricName, UnderMinIsrPartitionCountMetricName, UnderReplicatedPartitionsMetricName, DisklessSwitchedPrefixLagMetricName, DisklessSwitchedPrefixMissingFetchRateMetricName, createLogReadResult, isListOffsetsTimestampUnsupported}
 import kafka.server.metadata.InklessMetadataView
 import kafka.server.share.DelayedShareFetch
 import kafka.utils._
@@ -121,6 +121,9 @@ object ReplicaManager {
   private val ConsolidationHighWatermarkLagFetchRateMetricName = "ConsolidationHighWatermarkLagFetchRate"
   private val ConsolidationHighWatermarkLagPartitionCountMetricName =
     "ConsolidationHighWatermarkLagPartitionCount"
+  private[server] val DisklessSwitchedPrefixLagMetricName = "DisklessSwitchedPrefixLag"
+  private val DisklessSwitchedPrefixMissingFetchRateMetricName =
+    "DisklessSwitchedPrefixMissingFetchRate"
 
   private[server] val GaugeMetricNames = Set(
     LeaderCountMetricName,
@@ -133,6 +136,7 @@ object ReplicaManager {
     SealedPartitionsCountMetricName,
     DisklessSwitchedReplicasOutsideIsrCountMetricName,
     ConsolidationHighWatermarkLagPartitionCountMetricName,
+    DisklessSwitchedPrefixLagMetricName,
     PartitionsWithLateTransactionsCountMetricName,
     ProducerIdCountMetricName
   )
@@ -145,7 +149,8 @@ object ReplicaManager {
     ConsolidationSupplementRateMetricName,
     ConsolidationSupplementBytesPerSecMetricName,
     ConsolidationLocalBytesPerSecMetricName,
-    ConsolidationHighWatermarkLagFetchRateMetricName
+    ConsolidationHighWatermarkLagFetchRateMetricName,
+    DisklessSwitchedPrefixMissingFetchRateMetricName
   )
 
   private[server] val MetricNames = GaugeMetricNames.union(MeterMetricNames)
@@ -402,6 +407,7 @@ class ReplicaManager(val config: KafkaConfig,
     () => disklessSwitchedReplicasOutsideIsrCount)
   metricsGroup.newGauge(ConsolidationHighWatermarkLagPartitionCountMetricName,
     () => consolidationHighWatermarkLagPartitionCount)
+  metricsGroup.newGauge(DisklessSwitchedPrefixLagMetricName, () => disklessSwitchedPrefixLag)
   metricsGroup.newGauge(PartitionsWithLateTransactionsCountMetricName, () => lateTransactionsCount)
   metricsGroup.newGauge(ProducerIdCountMetricName, () => producerIdCount)
 
@@ -420,6 +426,17 @@ class ReplicaManager(val config: KafkaConfig,
       partition.log.exists(log => log.highWatermark < log.logEndOffset)
   }
 
+  /**
+   * Records below the classic-to-diskless seal that this broker's replicas have not replicated.
+   * Zero means every replica here holds its prefix; a value that stops falling is a replica that has
+   * stopped catching up. A partition rebuilding from the remote tier and one whose prefix is gone look
+   * the same: telling them apart needs the tier's coverage of [0, seal).
+   */
+  private[server] def disklessSwitchedPrefixLag: Long = onlinePartitionsIterator.map { partition =>
+    val seal = _inklessMetadataView.getClassicToDisklessStartOffset(partition.topicPartition)
+    if (seal < 0L) 0L else partition.log.map(log => Math.max(0L, seal - log.logEndOffset)).getOrElse(0L)
+  }.sum
+
   private def lateTransactionsCount: Int = {
     val currentTimeMs = time.milliseconds()
     leaderPartitionsIterator.count(_.hasLateTransaction(currentTimeMs))
@@ -436,6 +453,8 @@ class ReplicaManager(val config: KafkaConfig,
   private val consolidationLocalBytesPerSec: Meter = metricsGroup.newMeter(ConsolidationLocalBytesPerSecMetricName, "bytes", TimeUnit.SECONDS)
   private val consolidationHighWatermarkLagFetchRate: Meter =
     metricsGroup.newMeter(ConsolidationHighWatermarkLagFetchRateMetricName, "fetches", TimeUnit.SECONDS)
+  private val disklessSwitchedPrefixMissingFetchRate: Meter =
+    metricsGroup.newMeter(DisklessSwitchedPrefixMissingFetchRateMetricName, "fetches", TimeUnit.SECONDS)
 
   /**
    * Returns true when this broker consolidates the topic: the feature is enabled here and the topic
@@ -2545,6 +2564,11 @@ class ReplicaManager(val config: KafkaConfig,
                 partitionLookupFailed = true
               } else if (fetchPartitionData.fetchOffset < readableFrontier) {
                 shouldReadFromUnifiedLog = true
+                // A floor put this read on the local path, but this replica has not replicated that
+                // far, so the read answers OFFSET_OUT_OF_RANGE and the consumer resets. Followers are
+                // excluded: a follower legitimately asks for its own LEO on a leader below the seal.
+                if (params.isFromConsumer && fetchPartitionData.fetchOffset >= logEndOffset)
+                  disklessSwitchedPrefixMissingFetchRate.mark()
                 // Track only a fetch that could actually receive a supplement. A follower or
                 // future replica never merges diskless records into a local-log read; a
                 // switch-pending partition has no committed seal, so the control plane holds

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -2526,14 +2526,16 @@ class ReplicaManager(val config: KafkaConfig,
               } else if (fetchPartitionData.fetchOffset < readableFrontier) {
                 shouldReadFromUnifiedLog = true
                 // Track only a fetch that could actually receive a supplement. A follower or
-                // future replica never merges diskless records into a local-log read; a fetch
-                // below localLogStartOffset routes to RemoteLogManager,
+                // future replica never merges diskless records into a local-log read; a
+                // switch-pending partition has no committed seal, so the control plane holds
+                // nothing for it; a fetch below localLogStartOffset routes to RemoteLogManager,
                 // which discards the supplement; and a read that cannot reach LEO is no proof of
                 // exhaustion, which the guard in buildConsolidationSupplementFetchInfos would then
                 // pass on an empty read. Store LEO, since firing from below it would ask object
                 // storage for classic offsets only the local log holds.
                 if (inklessSharedState.isDefined &&
                   params.isFromConsumer &&
+                  classicToDisklessStartOffset != PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING &&
                   fetchPartitionData.fetchOffset >= localLogStartOffset &&
                   localReadFrontier >= logEndOffset)
                   consolidatingLocalFetchSupplements += (tp -> logEndOffset)
@@ -2951,12 +2953,19 @@ class ReplicaManager(val config: KafkaConfig,
    * consumer reads must be allowed from its local log. ISR is deliberately not checked here because
    * born-diskless replicas are added to ISR before their local fetch state is ready.
    *
+   * Switch-pending (`-2`) partitions are excluded. Those serve every offset from the local log
+   * because diskless holds nothing until the seal commits, so a fetch above a lagging replica's log
+   * end offset has no diskless path to fall back on and would answer OFFSET_OUT_OF_RANGE for records
+   * the leader still holds. Keeping the leader-only requirement for the seal window makes the
+   * consumer retry until the switch completes instead.
    *
    * Managed replicas are not tested here: `KafkaConfig.validateValues` requires
    * `diskless.managed.replicas.enable` whenever consolidation is enabled.
    */
   private[server] def isManagedConsolidatingDisklessPartition(tp: TopicIdPartition): Boolean = {
-    consolidationActiveFor(tp.topic)
+    consolidationActiveFor(tp.topic) &&
+      _inklessMetadataView.getClassicToDisklessStartOffset(tp.topicPartition) !=
+        PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING
   }
 
   /**

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -417,8 +417,13 @@ class ReplicaManager(val config: KafkaConfig,
   private val consolidationSupplementBytesPerSec: Meter = metricsGroup.newMeter(ConsolidationSupplementBytesPerSecMetricName, "bytes", TimeUnit.SECONDS)
   private val consolidationLocalBytesPerSec: Meter = metricsGroup.newMeter(ConsolidationLocalBytesPerSecMetricName, "bytes", TimeUnit.SECONDS)
 
-  private def isConsolidatingPartition(partition: Partition): Boolean =
-    config.disklessRemoteStorageConsolidationEnabled && _inklessMetadataView.isConsolidatingDisklessTopic(partition.topic)
+  /**
+   * Returns true when this broker consolidates the topic: the feature is enabled here and the topic
+   * is diskless with remote storage. Says nothing about the switch phase, so a topic whose switch is
+   * still `CLASSIC_TO_DISKLESS_SWITCH_PENDING` already reads as consolidating.
+   */
+  private def consolidationActiveFor(topic: String): Boolean =
+    config.disklessRemoteStorageConsolidationEnabled && _inklessMetadataView.isConsolidatingDisklessTopic(topic)
 
   private[server] def disklessSwitchedReplicasOutsideIsrCount: Int = onlinePartitionsIterator.count { partition =>
     val topicPartition = partition.topicPartition
@@ -431,15 +436,15 @@ class ReplicaManager(val config: KafkaConfig,
   def recordConsolidationFetchBytesIn(bytes: Long): Unit = consolidationFetchBytesInPerSec.mark(bytes)
 
   def underReplicatedPartitionCount: Int = leaderPartitionsIterator.count { partition =>
-    partition.isUnderReplicated && !isConsolidatingPartition(partition)
+    partition.isUnderReplicated && !consolidationActiveFor(partition.topic)
   }
 
   def underMinIsrPartitionCount: Int = leaderPartitionsIterator.count { partition =>
-    partition.isUnderMinIsr && !isConsolidatingPartition(partition)
+    partition.isUnderMinIsr && !consolidationActiveFor(partition.topic)
   }
 
   def atMinIsrPartitionCount: Int = leaderPartitionsIterator.count { partition =>
-    partition.isAtMinIsr && !isConsolidatingPartition(partition)
+    partition.isAtMinIsr && !consolidationActiveFor(partition.topic)
   }
 
   def startHighWatermarkCheckPointThread(): Unit = {
@@ -2458,10 +2463,7 @@ class ReplicaManager(val config: KafkaConfig,
         val classicToDisklessStartOffset = _inklessMetadataView.getClassicToDisklessStartOffset(tp.topicPartition())
         // partitions with switching in progress should always serve from local log
         var shouldReadFromUnifiedLog = classicToDisklessStartOffset == PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING
-        val isConsolidatingPartition =
-          _inklessMetadataView.isConsolidatingDisklessTopic(tp.topic) &&
-            config.disklessRemoteStorageConsolidationEnabled
-        if (isConsolidatingPartition) {
+        if (consolidationActiveFor(tp.topic)) {
           getPartitionOrError(tp.topicPartition) match {
             case Right(partition) =>
               val logEndOffset = partition.log.map(_.logEndOffset).getOrElse(0L)
@@ -3760,7 +3762,7 @@ class ReplicaManager(val config: KafkaConfig,
                 stateChangeLogger.info(s"Stale high watermark detected: advanced high watermark to seal offset $seal for " +
                   s"switched leader partition $tp")
               } else if (log.logEndOffset < seal) {
-                if (isConsolidatingPartition(partition) && log.remoteLogEnabled()) {
+                if (consolidationActiveFor(partition.topic) && log.remoteLogEnabled()) {
                   // The leader's local classic prefix was lost (full local-storage wipe / DR).
                   // [0, seal) lives in the remote tier, so leave the partition online and let the
                   // ConsolidationReconciler arm consolidation at the current LEO: the first fetch
@@ -3840,8 +3842,7 @@ class ReplicaManager(val config: KafkaConfig,
   private def hasConsolidatedDisklessSuffixFromSeal(tp: TopicPartition,
                                                     log: UnifiedLog,
                                                     seal: Long): Boolean = {
-    if (!config.disklessRemoteStorageConsolidationEnabled ||
-        !_inklessMetadataView.isConsolidatingDisklessTopic(tp.topic)) {
+    if (!consolidationActiveFor(tp.topic)) {
       return false
     }
 
@@ -4019,9 +4020,7 @@ class ReplicaManager(val config: KafkaConfig,
     val consolidatingDisklessPartitionsToStartFetching = new mutable.HashMap[TopicPartition, Partition]
     localLeaders.foreachEntry { (tp, info) =>
       val isDiskless = _inklessMetadataView.isDisklessTopic(tp.topic())
-      val isConsolidatingDisklessTopic =
-        config.disklessRemoteStorageConsolidationEnabled &&
-          _inklessMetadataView.isConsolidatingDisklessTopic(tp.topic)
+      val isConsolidatingDisklessTopic = consolidationActiveFor(tp.topic)
       val existingPartition = onlinePartition(tp)
       // A pending classic-to-diskless switch must always seal+register below, even for a
       // consolidating topic (where isConsolidatingDisklessTopic is already true), or the
@@ -4154,9 +4153,7 @@ class ReplicaManager(val config: KafkaConfig,
     val partitionsToStopFetching = new mutable.HashMap[TopicPartition, Boolean]
     val followerTopicSet = new mutable.HashSet[String]
     localFollowers.foreachEntry { (tp, info) =>
-      val isConsolidatingDisklessTopic =
-        config.disklessRemoteStorageConsolidationEnabled &&
-          _inklessMetadataView.isConsolidatingDisklessTopic(tp.topic)
+      val isConsolidatingDisklessTopic = consolidationActiveFor(tp.topic)
       if (_inklessMetadataView.isDisklessTopic(tp.topic())) {
         // Clean up classic-to-diskless switch tracking since only the leader drives classic-to-diskless switch.
         initDisklessLogManager.foreach(_.removePartition(tp))

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -410,14 +410,13 @@ class ReplicaManager(val config: KafkaConfig,
   private def sealedPartitionsCount: Int = leaderPartitionsIterator.count(_.isSealed)
 
   /**
-   * Counts consolidating partitions holding data they cannot serve yet, that is a local high
-   * watermark below the local log end offset. Consumer reads of that range go to Inkless, which
-   * costs object-storage traffic, and below a classic-to-diskless seal Inkless has nothing to serve.
-   * Unlike ConsolidationHighWatermarkLagFetchRate this does not depend on consumer traffic, so a
-   * stalled replica stays visible after consumers have moved past its log end offset.
+   * Counts consolidating partitions whose local high watermark sits below their local log end
+   * offset, so a consumer read of that range goes to Inkless.
+   * Unlike ConsolidationHighWatermarkLagFetchRate this does not depend on consumer traffic,
+   * so a stalled replica stays visible after consumers have moved past its log end offset.
    */
   private[server] def consolidationHighWatermarkLagPartitionCount: Int = onlinePartitionsIterator.count { partition =>
-    consolidationActiveFor(partition.topic) &&
+    isManagedConsolidatingDisklessPartition(partition.topicPartition) &&
       partition.log.exists(log => log.highWatermark < log.logEndOffset)
   }
 
@@ -2981,9 +2980,9 @@ class ReplicaManager(val config: KafkaConfig,
    * Pending partitions are excluded because they have no diskless leg to fall back on, so a replica
    * read there can answer OFFSET_OUT_OF_RANGE for records the leader holds.
    */
-  private[server] def isManagedConsolidatingDisklessPartition(tp: TopicIdPartition): Boolean = {
+  private[server] def isManagedConsolidatingDisklessPartition(tp: TopicPartition): Boolean = {
     consolidationActiveFor(tp.topic) &&
-      _inklessMetadataView.getClassicToDisklessStartOffset(tp.topicPartition) !=
+      _inklessMetadataView.getClassicToDisklessStartOffset(tp) !=
         PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING
   }
 
@@ -2996,7 +2995,8 @@ class ReplicaManager(val config: KafkaConfig,
    */
   private[server] def allowsOlderConsumerReplicaRead(tp: TopicIdPartition, params: FetchParams): Boolean = {
     params.isFromConsumer && params.clientMetadata.isEmpty && !params.shareFetchRequest &&
-      (isPartitionSwitchedFromClassicToDiskless(tp) || isManagedConsolidatingDisklessPartition(tp))
+      (isPartitionSwitchedFromClassicToDiskless(tp) ||
+        isManagedConsolidatingDisklessPartition(tp.topicPartition))
   }
 
   /**

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -2466,7 +2466,34 @@ class ReplicaManager(val config: KafkaConfig,
         if (consolidationActiveFor(tp.topic)) {
           getPartitionOrError(tp.topicPartition) match {
             case Right(partition) =>
-              val logEndOffset = partition.log.map(_.logEndOffset).getOrElse(0L)
+              // Deref partition.log once: it is swapped on log recreation and dir change, so
+              // separate derefs can mix offsets from two different logs. The offsets below are still
+              // read one at a time, and the consolidation fetcher can append between them. Read the
+              // high watermark before LEO so that skew can only fail the supplement gate below, never
+              // pass it on a stale anchor.
+              val localLog = partition.log
+              val localHighWatermark = localLog.map(_.highWatermark).getOrElse(0L)
+              val logEndOffset = localLog.map(_.logEndOffset).getOrElse(0L)
+              val localLogStartOffset = localLog.map(_.localLogStartOffset).getOrElse(0L)
+              // Where the local read stops. Consumers are bounded by the high watermark because an
+              // AZ-local replica may have appended data which is not fetchable yet. Followers and
+              // future replicas are bounded by LEO, since LOG_END isolation permits them to
+              // replicate the uncommitted suffix. A read_committed consumer stops at the last stable
+              // offset instead, which this does not model: diskless carries no transactional data and
+              // the switch aborts undecided transactions, so no consolidating partition has an
+              // LSO below its high watermark. Derive the bound from params.isolation if that changes.
+              val localReadFrontier =
+                if (params.isFromConsumer) localHighWatermark else logEndOffset
+              // Two ranges must stay on the local read path even when they sit above the isolation
+              // frontier, because diskless cannot answer them: [logStartOffset, localLogStartOffset)
+              // lives only in the remote tier once ConsolidatedDisklessLogPruner has pruned the
+              // diskless batches, and [0, classicToDisklessStartOffset) is the classic prefix the
+              // control plane never held. Both switch sentinels are negative, so a partition that
+              // never switched keeps the frontier at the isolation bound. Without a local log there
+              // is nothing to read locally and diskless is authoritative for the whole range.
+              val readableFrontier =
+                if (localLog.isEmpty) 0L
+                else Math.max(Math.max(localReadFrontier, localLogStartOffset), classicToDisklessStartOffset)
               // A follower's local logStartOffset stays frozen at the switch. DeleteRecords and
               // retention advance only the real leader's log start and the control-plane cross-tier
               // earliest, never a follower's. With managed replicas the metadata transformer routes
@@ -2496,17 +2523,22 @@ class ReplicaManager(val config: KafkaConfig,
                   false
                 )
                 partitionLookupFailed = true
-              } else if (fetchPartitionData.fetchOffset < logEndOffset) {
-                // Local log has data for this offset range — serve from local, track for diskless supplement
+              } else if (fetchPartitionData.fetchOffset < readableFrontier) {
                 shouldReadFromUnifiedLog = true
-                // Skip supplement tracking when the fetch offset falls in the tiered-storage range
-                // (below localLogStartOffset). The read will route to RemoteLogManager and the
-                // supplement data would be discarded by processRemoteFetches anyway.
-                val localLogStartOffset = partition.log.map(_.localLogStartOffset).getOrElse(0L)
-                if (inklessSharedState.isDefined && fetchPartitionData.fetchOffset >= localLogStartOffset)
+                // Track only a fetch that could actually receive a supplement. A follower or
+                // future replica never merges diskless records into a local-log read; a fetch
+                // below localLogStartOffset routes to RemoteLogManager,
+                // which discards the supplement; and a read that cannot reach LEO is no proof of
+                // exhaustion, which the guard in buildConsolidationSupplementFetchInfos would then
+                // pass on an empty read. Store LEO, since firing from below it would ask object
+                // storage for classic offsets only the local log holds.
+                if (inklessSharedState.isDefined &&
+                  params.isFromConsumer &&
+                  fetchPartitionData.fetchOffset >= localLogStartOffset &&
+                  localReadFrontier >= logEndOffset)
                   consolidatingLocalFetchSupplements += (tp -> logEndOffset)
               }
-              // else: consumer is at or beyond consolidation frontier, diskless-only
+              // else: the fetch is at or beyond the frontier for its source, so diskless is authoritative
             case Left(error) =>
               warn(s"Error while fetching partition ${tp.topicPartition()} for consolidating diskless topic: $error. " +
                 s"Returning error for the fetch request since we cannot determine if the partition has switched to diskless or not.")
@@ -2914,6 +2946,20 @@ class ReplicaManager(val config: KafkaConfig,
   }
 
   /**
+   * Returns true for a managed consolidating diskless partition. The metadata transformer may
+   * advertise this broker as the AZ-local virtual leader even when it is not the partition leader, so
+   * consumer reads must be allowed from its local log. ISR is deliberately not checked here because
+   * born-diskless replicas are added to ISR before their local fetch state is ready.
+   *
+   *
+   * Managed replicas are not tested here: `KafkaConfig.validateValues` requires
+   * `diskless.managed.replicas.enable` whenever consolidation is enabled.
+   */
+  private[server] def isManagedConsolidatingDisklessPartition(tp: TopicIdPartition): Boolean = {
+    consolidationActiveFor(tp.topic)
+  }
+
+  /**
    * Read from multiple topic partitions at the given offset up to maxSize bytes
    */
   def readFromLog(
@@ -2980,17 +3026,17 @@ class ReplicaManager(val config: KafkaConfig,
             if (preferredReadReplica.isDefined) OptionalInt.of(preferredReadReplica.get) else OptionalInt.empty(),
             Errors.NONE)
         } else {
-          // For partitions that were switched from classic to diskless and still have classic
-          // local/remote data to read (classicToDisklessStartOffset >= 0), relax the leader-only
-          // requirement so any in-sync replica can serve the classic portion of the read. This is
-          // scoped to older consumer fetches that don't supply clientMetadata (pre-KIP-392 / no
-          // rackId), which would otherwise get NOT_LEADER_OR_FOLLOWER on a non-leader broker.
-          // Broker-to-broker follower replication and share fetches are intentionally excluded.
-          // The check is ordered so that the metadata lookup is only performed when the override
-          // could actually apply.
+          // The metadata transformer can advertise a managed diskless replica as the AZ-local
+          // virtual leader even when it is not the KRaft leader. Older consumers don't supply
+          // clientMetadata, so Kafka would otherwise enforce leader-only reads after consolidation
+          // makes the local log readable. Switched partitions need the same override for their
+          // classic prefix. Broker-to-broker follower replication and share fetches remain
+          // leader-only.
           val isOlderConsumer = params.isFromConsumer && params.clientMetadata.isEmpty
           val allowReplica = !params.fetchOnlyLeader() ||
-            (isOlderConsumer && isPartitionSwitchedFromClassicToDiskless(tp))
+            (isOlderConsumer &&
+              (isPartitionSwitchedFromClassicToDiskless(tp) ||
+                isManagedConsolidatingDisklessPartition(tp)))
           log = partition.localLogWithEpochOrThrow(fetchInfo.currentLeaderEpoch, !allowReplica)
 
           // Try the read first, this tells us whether we need all of adjustedFetchSize for this partition

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -2564,23 +2564,21 @@ class ReplicaManager(val config: KafkaConfig,
                 partitionLookupFailed = true
               } else if (fetchPartitionData.fetchOffset < readableFrontier) {
                 shouldReadFromUnifiedLog = true
-                // A floor put this read on the local path, but this replica has not replicated that
-                // far, so the read answers OFFSET_OUT_OF_RANGE and the consumer resets. Followers are
-                // excluded: a follower legitimately asks for its own LEO on a leader below the seal.
+                // Same population as isBelowSealAndAheadOfLocalLog: inside this branch only the seal
+                // can have raised the frontier. Keep the two in step. Marked here, not in the
+                // carve-out, since DelayedFetch re-reads on completion and would count twice.
+                // Followers ask for their own LEO on a leader below the seal, so they are excluded.
                 if (params.isFromConsumer && fetchPartitionData.fetchOffset >= logEndOffset)
                   disklessSwitchedPrefixMissingFetchRate.mark()
-                // Track only a fetch that could actually receive a supplement. A follower or
-                // future replica never merges diskless records into a local-log read; a
-                // switch-pending partition has no committed seal, so the control plane holds
-                // nothing for it; a fetch below localLogStartOffset routes to RemoteLogManager,
-                // which discards the supplement; and a read that cannot reach LEO is no proof of
-                // exhaustion, which the guard in buildConsolidationSupplementFetchInfos would then
-                // pass on an empty read. Store LEO, since firing from below it would ask object
-                // storage for classic offsets only the local log holds.
+                // Only a consumer read that starts inside the local log and reaches its end can take
+                // a supplement. Outside that window the anchor asks object storage for classic
+                // offsets, or an empty read passes the exhaustion guard in
+                // buildConsolidationSupplementFetchInfos. A pending switch has no committed seal.
                 if (inklessSharedState.isDefined &&
                   params.isFromConsumer &&
                   classicToDisklessStartOffset != PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING &&
                   fetchPartitionData.fetchOffset >= localLogStartOffset &&
+                  fetchPartitionData.fetchOffset < logEndOffset &&
                   localReadFrontier >= logEndOffset)
                   consolidatingLocalFetchSupplements += (tp -> logEndOffset)
               } else if (!shouldReadFromUnifiedLog && fetchPartitionData.fetchOffset < logEndOffset) {
@@ -3011,6 +3009,17 @@ class ReplicaManager(val config: KafkaConfig,
   }
 
   /**
+   * Returns true when this offset sits below the classic-to-diskless seal and beyond what this replica
+   * has replicated: the leader holds it and this replica will, so the fetch waits rather than being
+   * answered or refused. Used by both halves of that decision, the read and the purgatory.
+   */
+  private[server] def isBelowSealAndAheadOfLocalLog(tp: TopicPartition,
+                                                    fetchOffset: Long,
+                                                    localLogEndOffset: Long): Boolean =
+    fetchOffset >= localLogEndOffset &&
+      fetchOffset < _inklessMetadataView.getClassicToDisklessStartOffset(tp)
+
+  /**
    * Returns true when a fetch carrying no `clientMetadata` may read this partition from a replica
    * that is not the partition leader, because the metadata transformer advertised that replica.
    *
@@ -3229,6 +3238,21 @@ class ReplicaManager(val config: KafkaConfig,
           OptionalLong.of(log.lastStableOffset),
           Errors.NONE)
       }
+    } else if (params.isFromConsumer && log != null &&
+      isBelowSealAndAheadOfLocalLog(tp.topicPartition, offset, log.logEndOffset)) {
+      // The leader holds this offset and this replica will: the seal never exceeds the leader's log
+      // end offset. Out of range would reset the consumer over a range missing only here, so answer
+      // empty and let the fetch wait. DelayedFetch skips case F on the same condition.
+      new LogReadResult(
+        new FetchDataInfo(new LogOffsetMetadata(offset), MemoryRecords.EMPTY),
+        Optional.empty(),
+        log.highWatermark,
+        log.logStartOffset,
+        log.logEndOffset,
+        fetchInfo.logStartOffset,
+        fetchTimeMs,
+        OptionalLong.of(log.lastStableOffset),
+        Errors.NONE)
     } else {
       new LogReadResult(Errors.forException(exception))
     }

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -2988,22 +2988,11 @@ class ReplicaManager(val config: KafkaConfig,
   }
 
   /**
-   * Returns true when a consumer that supplies no `clientMetadata` may read this partition from a
-   * replica that is not the partition leader. Such consumers (pre-KIP-392, no rack) make
-   * `FetchParams.fetchOnlyLeader` true, while the metadata transformer advertises a hash-selected
-   * AZ-local replica as the leader of a diskless topic
-   * (`InklessTopicMetadataTransformer.selectLeaderForManagedReplicas`), so leader-only enforcement
-   * would answer NOT_LEADER_OR_FOLLOWER for the very broker the client was told to use. Switched
-   * partitions need the same override for their classic prefix.
+   * Returns true when a fetch carrying no `clientMetadata` may read this partition from a replica
+   * that is not the partition leader, because the metadata transformer advertised that replica.
    *
-   * Every path serving such a fetch must reach the same answer, `DelayedFetch` included: its
-   * offset-snapshot check also runs with `fetchOnlyLeader`, and a `NotLeaderOrFollowerException`
-   * there force-completes the parked request (case A) instead of waiting for the high watermark or
-   * `minBytes`.
-   *
-   * Share fetches are excluded on the flag rather than on convention: they set
-   * `CONSUMER_REPLICA_ID`, so `isFromConsumer` holds, and only `KafkaApis` always supplying
-   * `clientMetadata` keeps them leader-only today.
+   * `DelayedFetch` must reach the same answer: its offset snapshot also runs with `fetchOnlyLeader`,
+   * and refusing there force-completes the parked request instead of waiting.
    */
   private[server] def allowsOlderConsumerReplicaRead(tp: TopicIdPartition, params: FetchParams): Boolean = {
     params.isFromConsumer && params.clientMetadata.isEmpty && !params.shareFetchRequest &&

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -2969,6 +2969,29 @@ class ReplicaManager(val config: KafkaConfig,
   }
 
   /**
+   * Returns true when a consumer that supplies no `clientMetadata` may read this partition from a
+   * replica that is not the partition leader. Such consumers (pre-KIP-392, no rack) make
+   * `FetchParams.fetchOnlyLeader` true, while the metadata transformer advertises a hash-selected
+   * AZ-local replica as the leader of a diskless topic
+   * (`InklessTopicMetadataTransformer.selectLeaderForManagedReplicas`), so leader-only enforcement
+   * would answer NOT_LEADER_OR_FOLLOWER for the very broker the client was told to use. Switched
+   * partitions need the same override for their classic prefix.
+   *
+   * Every path serving such a fetch must reach the same answer, `DelayedFetch` included: its
+   * offset-snapshot check also runs with `fetchOnlyLeader`, and a `NotLeaderOrFollowerException`
+   * there force-completes the parked request (case A) instead of waiting for the high watermark or
+   * `minBytes`.
+   *
+   * Share fetches are excluded on the flag rather than on convention: they set
+   * `CONSUMER_REPLICA_ID`, so `isFromConsumer` holds, and only `KafkaApis` always supplying
+   * `clientMetadata` keeps them leader-only today.
+   */
+  private[server] def allowsOlderConsumerReplicaRead(tp: TopicIdPartition, params: FetchParams): Boolean = {
+    params.isFromConsumer && params.clientMetadata.isEmpty && !params.shareFetchRequest &&
+      (isPartitionSwitchedFromClassicToDiskless(tp) || isManagedConsolidatingDisklessPartition(tp))
+  }
+
+  /**
    * Read from multiple topic partitions at the given offset up to maxSize bytes
    */
   def readFromLog(
@@ -3035,17 +3058,7 @@ class ReplicaManager(val config: KafkaConfig,
             if (preferredReadReplica.isDefined) OptionalInt.of(preferredReadReplica.get) else OptionalInt.empty(),
             Errors.NONE)
         } else {
-          // The metadata transformer can advertise a managed diskless replica as the AZ-local
-          // virtual leader even when it is not the KRaft leader. Older consumers don't supply
-          // clientMetadata, so Kafka would otherwise enforce leader-only reads after consolidation
-          // makes the local log readable. Switched partitions need the same override for their
-          // classic prefix. Broker-to-broker follower replication and share fetches remain
-          // leader-only.
-          val isOlderConsumer = params.isFromConsumer && params.clientMetadata.isEmpty
-          val allowReplica = !params.fetchOnlyLeader() ||
-            (isOlderConsumer &&
-              (isPartitionSwitchedFromClassicToDiskless(tp) ||
-                isManagedConsolidatingDisklessPartition(tp)))
+          val allowReplica = !params.fetchOnlyLeader() || allowsOlderConsumerReplicaRead(tp, params)
           log = partition.localLogWithEpochOrThrow(fetchInfo.currentLeaderEpoch, !allowReplica)
 
           // Try the read first, this tells us whether we need all of adjustedFetchSize for this partition

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -2975,19 +2975,11 @@ class ReplicaManager(val config: KafkaConfig,
   }
 
   /**
-   * Returns true for a managed consolidating diskless partition. The metadata transformer may
-   * advertise this broker as the AZ-local virtual leader even when it is not the partition leader, so
-   * consumer reads must be allowed from its local log. ISR is deliberately not checked here because
-   * born-diskless replicas are added to ISR before their local fetch state is ready.
+   * Returns true for a consolidating partition whose switch is not still pending.
+   * ISR is not checked: born-diskless replicas join ISR before their local fetch state is ready.
    *
-   * Switch-pending (`-2`) partitions are excluded. Those serve every offset from the local log
-   * because diskless holds nothing until the seal commits, so a fetch above a lagging replica's log
-   * end offset has no diskless path to fall back on and would answer OFFSET_OUT_OF_RANGE for records
-   * the leader still holds. Keeping the leader-only requirement for the seal window makes the
-   * consumer retry until the switch completes instead.
-   *
-   * Managed replicas are not tested here: `KafkaConfig.validateValues` requires
-   * `diskless.managed.replicas.enable` whenever consolidation is enabled.
+   * Pending partitions are excluded because they have no diskless leg to fall back on, so a replica
+   * read there can answer OFFSET_OUT_OF_RANGE for records the leader holds.
    */
   private[server] def isManagedConsolidatingDisklessPartition(tp: TopicIdPartition): Boolean = {
     consolidationActiveFor(tp.topic) &&

--- a/core/src/test/java/kafka/server/InklessConsolidatedDisklessTopicsTest.java
+++ b/core/src/test/java/kafka/server/InklessConsolidatedDisklessTopicsTest.java
@@ -43,6 +43,7 @@ import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.errors.RecordTooLargeException;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
+import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.common.test.KafkaClusterTestKit;
@@ -111,6 +112,7 @@ import static org.apache.kafka.common.config.TopicConfig.REMOTE_LOG_STORAGE_ENAB
 import static org.apache.kafka.common.config.TopicConfig.SEGMENT_BYTES_CONFIG;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Testcontainers
 public class InklessConsolidatedDisklessTopicsTest {
@@ -627,6 +629,73 @@ public class InklessConsolidatedDisklessTopicsTest {
         final var unifiedLog = log.get();
         return new LocalLogState(unifiedLog.logStartOffset(), unifiedLog.localLogStartOffset(),
             unifiedLog.highWatermark(), unifiedLog.logEndOffset());
+    }
+
+    /**
+     * A consumer that negotiates Fetch below v11 must be able to read a consolidated diskless partition
+     * from a replica that is not the KRaft leader.
+     *
+     * <p>The broker attaches client metadata to a fetch only from v11 onward, and without it
+     * {@code FetchParams.fetchOnlyLeader} is true, so the local read is refused on a non-leader replica.
+     * AZ-aware metadata advertises exactly such a replica as the leader, so before this branch a
+     * pre-v11 consumer got NOT_LEADER_OR_FOLLOWER, refreshed metadata, was pointed back at the same
+     * replica, and never progressed - while reporting no error on either side.
+     *
+     * <p>No Kafka client can reproduce this any more: every current client negotiates v11 or later. The
+     * request is built by hand for that reason.
+     */
+    @Test
+    public void testPreKip392ConsumerReadsConsolidatedPartitionFromReplica() throws Exception {
+        numPartitions = 1;
+        topicName = "pre-kip-392-consolidated-read";
+        final TopicPartition tp = new TopicPartition(topicName, 0);
+        final int recordCount = 20;
+
+        final Map<String, Object> commonConfigs = new HashMap<>();
+        commonConfigs.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers());
+
+        try (Admin admin = AdminClient.create(commonConfigs)) {
+            final NewTopic topic = new NewTopic(topicName, numPartitions, (short) -1).configs(Map.of(
+                DISKLESS_ENABLE_CONFIG, "true",
+                REMOTE_LOG_STORAGE_ENABLE_CONFIG, "true",
+                CLEANUP_POLICY_CONFIG, CLEANUP_POLICY_DELETE,
+                SEGMENT_BYTES_CONFIG, "1048576"));
+            admin.createTopics(Collections.singletonList(topic)).all().get(30, TimeUnit.SECONDS);
+        }
+        produceRecords(commonConfigs, recordCount, largeValueRecordFactory());
+
+        // Consolidation has to have copied the range into the local log and committed it, or the fetch
+        // routes to Inkless and never reaches the leader-only check.
+        final AtomicReference<LocalLogState> stateRef = new AtomicReference<>();
+        TestUtils.waitForCondition(() -> {
+            for (int brokerId : new int[] {0, 1}) {
+                final LocalLogState state = localLogState(brokerId, tp);
+                if (state == null || state.highWatermark <= 0) {
+                    return false;
+                }
+            }
+            return true;
+        }, 120_000, () -> "Both replicas must consolidate and commit the range before the fetch; broker 0="
+            + localLogState(0, tp) + " broker 1=" + localLogState(1, tp));
+
+        final var kraftPartition = cluster.brokers().get(0).metadataCache()
+            .currentImage().topics().getTopic(topicName).partitions().get(0);
+        final int targetBrokerId = kraftPartition.leader == 0 ? 1 : 0;
+        stateRef.set(localLogState(targetBrokerId, tp));
+        log.info("KRaft leader is {}, fetching at Fetch v10 from replica {} with state {}",
+            kraftPartition.leader, targetBrokerId, stateRef.get());
+
+        // An offset the replica holds locally and has committed.
+        final long fetchOffset = stateRef.get().localLogStartOffset;
+        final PreKip392FetchClient.Reply reply = PreKip392FetchClient.fetch(
+            cluster.brokers().get(targetBrokerId), topicName, 0, fetchOffset, (short) 10);
+
+        assertEquals(Errors.NONE, reply.error(),
+            "A pre-v11 consumer must be allowed to read a consolidated partition from a non-leader "
+                + "replica; state=" + localLogState(targetBrokerId, tp));
+        assertTrue(reply.recordCount() > 0, "The reply must carry records, got " + reply);
+        assertEquals(fetchOffset, reply.firstOffset(),
+            "The reply must start at the requested offset, not skip ahead");
     }
 
     /**

--- a/core/src/test/java/kafka/server/InklessConsolidatedDisklessTopicsTest.java
+++ b/core/src/test/java/kafka/server/InklessConsolidatedDisklessTopicsTest.java
@@ -65,6 +65,7 @@ import org.slf4j.LoggerFactory;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.sql.Connection;
@@ -75,6 +76,7 @@ import java.sql.SQLException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -498,6 +500,133 @@ public class InklessConsolidatedDisklessTopicsTest {
         // The survivors [7, seal) on each partition are still readable and contiguous across the cut.
         final int survivorsPerPartition = (int) (sealPerPartition - 7);
         consumeAndVerify(commonConfigs, survivorsPerPartition * numPartitions);
+    }
+
+    /**
+     * Diskless never held {@code [0, classicToDisklessStartOffset)}, so a consumer asking for an offset
+     * below the seal must be answered from the classic log or the remote tier. A reply that starts at the
+     * seal instead has silently dropped the range the consumer asked for.
+     *
+     * <p>The read is served by a replica that lost its local data and rebuilt it, which is the reachable
+     * way a replica ends up below the seal: DR, a replaced log directory, or a reassignment target. The
+     * switch itself cannot produce that state, since it is refused while the partition is
+     * under-replicated.
+     *
+     * <p>Recovery of a small prefix outruns any attempt to route a consumer at the replica mid-catch-up,
+     * so this does not observe the high watermark sitting below the seal. The consumer-frontier floors
+     * that cover that window are unit-tested in {@code ReplicaManagerInklessTest}.
+     */
+    @Test
+    public void testWipedReplicaServesBelowSealReadAtRequestedOffset() throws Exception {
+        numPartitions = 1;
+        topicName = "below-seal-catching-up-replica";
+        final TopicPartition tp = new TopicPartition(topicName, 0);
+        final int prefixRecords = 60;
+        final long seal = prefixRecords;
+
+        final Map<String, Object> commonConfigs = new HashMap<>();
+        commonConfigs.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers());
+
+        try (Admin admin = AdminClient.create(commonConfigs)) {
+            createClassicTopic(admin);
+            produceRecords(commonConfigs, prefixRecords, largeValueRecordFactory());
+            switchTopicToConsolidatedDiskless(admin);
+
+            // describeTopics reports the transformer-selected leader for a diskless topic, so take
+            // leadership from the KRaft image.
+            final var kraftPartition = cluster.brokers().get(0).metadataCache()
+                .currentImage().topics().getTopic(topicName).partitions().get(0);
+            final int targetBrokerId = kraftPartition.leader == 0 ? 1 : 0;
+            log.info("KRaft leader is {}, wiping follower {}", kraftPartition.leader, targetBrokerId);
+
+            cluster.brokers().get(targetBrokerId).shutdown();
+            cluster.brokers().get(targetBrokerId).awaitShutdown();
+            wipeLocalPartitionData(targetBrokerId, tp);
+            cluster.brokers().get(targetBrokerId).startup();
+
+            // client.rack pins the read to the wiped replica: the transformer advertises the alive
+            // in-AZ replica as leader. auto.offset.reset=none keeps a broker-side out-of-range a test
+            // failure instead of a silent seek elsewhere.
+            final long belowSealOffset = seal - 5;
+            final Map<String, Object> pinnedConfigs = new HashMap<>(commonConfigs);
+            pinnedConfigs.put(ConsumerConfig.CLIENT_RACK_CONFIG, "az" + (targetBrokerId + 1));
+            pinnedConfigs.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+            pinnedConfigs.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+            pinnedConfigs.put(ConsumerConfig.GROUP_ID_CONFIG, "below-seal-group-" + UUID.randomUUID());
+            pinnedConfigs.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "none");
+
+            log.info("Local log state on the recovering replica {} before the read: {}",
+                targetBrokerId, localLogState(targetBrokerId, tp));
+
+            try (var consumer = new KafkaConsumer<String, String>(pinnedConfigs)) {
+                consumer.assign(Collections.singletonList(tp));
+                consumer.seek(tp, belowSealOffset);
+                final AtomicLong firstOffset = new AtomicLong(-1L);
+                TestUtils.waitForCondition(() -> {
+                    final var records = consumer.poll(Duration.ofMillis(500));
+                    if (records.isEmpty()) {
+                        return false;
+                    }
+                    firstOffset.set(records.iterator().next().offset());
+                    return true;
+                }, 120_000, () -> "A below-seal read was never served from the catching-up replica; state="
+                    + localLogState(targetBrokerId, tp));
+                assertEquals(belowSealOffset, firstOffset.get(),
+                    "The below-seal read must resume at the requested offset, not skip to the seal; state="
+                        + localLogState(targetBrokerId, tp));
+            }
+        }
+    }
+
+    /** Simulates the loss of a replica's local data: DR, a replaced log directory, or a fresh target. */
+    private void wipeLocalPartitionData(int brokerId, TopicPartition tp) throws Exception {
+        final String entryPrefix = tp.topic() + " " + tp.partition() + " ";
+        for (String logDir : cluster.brokers().get(brokerId).config().logDirs()) {
+            final Path partitionDir = Path.of(logDir, tp.topic() + "-" + tp.partition());
+            if (Files.isDirectory(partitionDir)) {
+                try (var paths = Files.walk(partitionDir)) {
+                    paths.sorted(Comparator.reverseOrder()).forEach(path -> {
+                        try {
+                            Files.delete(path);
+                        } catch (IOException e) {
+                            throw new RuntimeException(e);
+                        }
+                    });
+                }
+                log.info("Deleted local partition data at {}", partitionDir);
+            }
+            final Path checkpoint = Path.of(logDir, "replication-offset-checkpoint");
+            if (Files.exists(checkpoint)) {
+                final List<String> lines = Files.readAllLines(checkpoint);
+                final List<String> kept = new ArrayList<>();
+                int entries = 0;
+                for (int i = 0; i < lines.size(); i++) {
+                    if (i < 2) {
+                        kept.add(lines.get(i));
+                    } else if (!lines.get(i).startsWith(entryPrefix)) {
+                        kept.add(lines.get(i));
+                        entries++;
+                    }
+                }
+                if (kept.size() > 1) {
+                    kept.set(1, Integer.toString(entries));
+                }
+                Files.write(checkpoint, kept);
+            }
+        }
+    }
+
+    private record LocalLogState(long logStartOffset, long localLogStartOffset,
+                                 long highWatermark, long logEndOffset) { }
+
+    private LocalLogState localLogState(int brokerId, TopicPartition tp) {
+        final var log = cluster.brokers().get(brokerId).logManager().getLog(tp, false);
+        if (log.isEmpty()) {
+            return null;
+        }
+        final var unifiedLog = log.get();
+        return new LocalLogState(unifiedLog.logStartOffset(), unifiedLog.localLogStartOffset(),
+            unifiedLog.highWatermark(), unifiedLog.logEndOffset());
     }
 
     /**

--- a/core/src/test/java/kafka/server/PreKip392FetchClient.java
+++ b/core/src/test/java/kafka/server/PreKip392FetchClient.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.server;
+
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.message.FetchResponseData;
+import org.apache.kafka.common.network.ListenerName;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.record.internal.Record;
+import org.apache.kafka.common.requests.AbstractResponse;
+import org.apache.kafka.common.requests.FetchRequest;
+import org.apache.kafka.common.requests.FetchResponse;
+import org.apache.kafka.common.requests.RequestHeader;
+import org.apache.kafka.common.requests.ResponseHeader;
+import org.apache.kafka.common.test.api.TestKitDefaults;
+import org.apache.kafka.common.utils.Utils;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.net.Socket;
+import java.nio.ByteBuffer;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Sends a single Fetch request at a chosen API version straight to one broker's listener.
+ *
+ * <p>Exists to reach a code path no Kafka client can produce any more: the broker attaches client
+ * metadata to a fetch only from Fetch v11 (`KafkaApis`), and without it `FetchParams.fetchOnlyLeader`
+ * is true, so leader-only reads are enforced. Every current client negotiates v11 or later, which is
+ * why a pre-v11 request has to be built by hand.
+ *
+ * <p>The wire framing mirrors `BaseRequestTest` on the Scala side; this exists because the diskless
+ * cluster tests are Java on `KafkaClusterTestKit`, where that helper is not reachable.
+ */
+final class PreKip392FetchClient {
+
+    private PreKip392FetchClient() {
+    }
+
+    /** What the caller needs from the response, so callers do not depend on the protocol classes. */
+    record Reply(Errors error, int recordCount, long firstOffset, long highWatermark) {
+    }
+
+    /**
+     * Fetches one partition from one broker and returns the single partition response.
+     *
+     * @param apiVersion Fetch API version to negotiate; below 11 the broker sees no client metadata
+     */
+    static Reply fetch(BrokerServer broker,
+                       String topic,
+                       int partition,
+                       long fetchOffset,
+                       short apiVersion) throws IOException {
+        final int port = broker.boundPort(
+            ListenerName.normalised(TestKitDefaults.DEFAULT_BROKER_LISTENER_NAME));
+        final TopicPartition tp = new TopicPartition(topic, partition);
+        final Map<TopicPartition, FetchRequest.PartitionData> fetchData = new LinkedHashMap<>();
+        // Uuid.ZERO_UUID: below Fetch v13 the request carries topic names, and the broker backfills
+        // the topic id for diskless partitions.
+        fetchData.put(tp, new FetchRequest.PartitionData(
+            Uuid.ZERO_UUID, fetchOffset, 0L, 1024 * 1024, Optional.empty()));
+        final FetchRequest request = FetchRequest.Builder
+            .forConsumer(apiVersion, 1000, 1, fetchData)
+            .build(apiVersion);
+        final RequestHeader header = new RequestHeader(ApiKeys.FETCH, apiVersion, "pre-kip-392", 1);
+
+        final FetchResponse response;
+        try (Socket socket = new Socket("localhost", port)) {
+            final byte[] serialized = Utils.toArray(request.serializeWithHeader(header));
+            final DataOutputStream out = new DataOutputStream(socket.getOutputStream());
+            out.writeInt(serialized.length);
+            out.write(serialized);
+            out.flush();
+
+            final DataInputStream in = new DataInputStream(socket.getInputStream());
+            final byte[] responseBytes = new byte[in.readInt()];
+            in.readFully(responseBytes);
+            final ByteBuffer buffer = ByteBuffer.wrap(responseBytes);
+            ResponseHeader.parse(buffer, ApiKeys.FETCH.responseHeaderVersion(apiVersion));
+            response = (FetchResponse) AbstractResponse.parseResponse(
+                ApiKeys.FETCH, new ByteBufferAccessor(buffer), apiVersion);
+        }
+
+        final FetchResponseData.PartitionData partitionData =
+            response.responseData(Map.of(), apiVersion).get(tp);
+        if (partitionData == null) {
+            throw new IllegalStateException("No partition data for " + tp + " in the fetch response");
+        }
+        final Errors error = Errors.forCode(partitionData.errorCode());
+        int count = 0;
+        long firstOffset = -1L;
+        if (error == Errors.NONE) {
+            for (final Record record : FetchResponse.recordsOrFail(partitionData).records()) {
+                if (firstOffset < 0) {
+                    firstOffset = record.offset();
+                }
+                count++;
+            }
+        }
+        return new Reply(error, count, firstOffset, partitionData.highWatermark());
+    }
+}

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerInklessTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerInklessTest.scala
@@ -2427,6 +2427,78 @@ class ReplicaManagerInklessTest {
     }
   }
 
+  // A switch-pending partition has no committed seal, so the control plane holds no batches for it.
+  // Registering a supplement would spend a find_batches round trip that can only come back empty and
+  // would mark the supplement meters for a fetch that never had diskless data to merge.
+  @Test
+  def testFetchConsolidatingSwitchPendingRegistersNoSupplement(): Unit = {
+    var localFileRecords: FileRecords = null
+    val fetchHandlerCtor = mockFetchHandler(Map.empty)
+    val timer = new MockTimer(time)
+    val fetchPurgatory = new DelayedOperationPurgatory[DelayedFetch]("Fetch", timer, 0, false)
+    val replicaManager = spy(createReplicaManager(
+      List(disklessTopicPartition.topic()),
+      disklessManagedReplicasEnabled = true,
+      disklessRemoteStorageConsolidationEnabled = true,
+      consolidatingDisklessTopics = Set(disklessTopicPartition.topic()),
+      delayedFetchPurgatory = Some(fetchPurgatory),
+    ))
+    try {
+      when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
+        .thenReturn(PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING)
+      val mockPartition = mock(classOf[Partition])
+      val mockLog = mock(classOf[UnifiedLog])
+      when(mockLog.logEndOffset).thenReturn(100L)
+      when(mockLog.highWatermark).thenReturn(100L)
+      when(mockPartition.log).thenReturn(Some(mockLog))
+      val endOffsetMetadata = new LogOffsetMetadata(100L, 0L, 0)
+      when(mockPartition.fetchOffsetSnapshot(any(), any()))
+        .thenReturn(new LogOffsetSnapshot(0L, endOffsetMetadata, endOffsetMetadata, endOffsetMetadata))
+      doReturn(Right(mockPartition)).when(replicaManager)
+        .getPartitionOrError(ArgumentMatchers.eq(disklessTopicPartition.topicPartition()))
+      doReturn(mockPartition).when(replicaManager)
+        .getPartitionOrException(ArgumentMatchers.eq(disklessTopicPartition.topicPartition()))
+
+      // The local read reaches LEO, so only the pending state keeps the supplement from firing.
+      localFileRecords = memoryRecordsToFileRecords(RECORDS_AT_SEAL)
+      doReturn(Seq(disklessTopicPartition ->
+        new LogReadResult(
+          new FetchDataInfo(new LogOffsetMetadata(99L, 0L, 0), localFileRecords),
+          Optional.empty(), 100L, 0L, 100L, 0L, 0L, OptionalLong.empty(), Errors.NONE
+        ))
+      ).when(replicaManager).readFromLog(any(), any(), any(), any())
+
+      val maxWaitMs = 30000L
+      val fetchParams = new FetchParams(
+        FetchRequest.ORDINARY_CONSUMER_ID, -1L,
+        maxWaitMs,
+        RECORDS.sizeInBytes + 1024, // minBytes above the local read, so a supplement would fire
+        1024 * 1024,
+        FetchIsolation.HIGH_WATERMARK, Optional.empty()
+      )
+      val fetchInfos = Seq(
+        disklessTopicPartition -> new PartitionData(disklessTopicPartition.topicId(), 50L, 0L, 1024, Optional.empty())
+      )
+
+      @volatile var responseData: Map[TopicIdPartition, FetchPartitionData] = null
+      replicaManager.fetchMessages(
+        fetchParams,
+        fetchInfos,
+        QuotaFactory.UNBOUNDED_QUOTA,
+        response => responseData = response.toMap)
+
+      verify(fetchHandlerCtor.constructed().get(0), never()).handle(any(), any())
+      timer.advanceClock(maxWaitMs + 1)
+      waitForFetchResponse(responseData)
+      assertEquals(Errors.NONE, responseData(disklessTopicPartition).error)
+      verify(fetchHandlerCtor.constructed().get(0), never()).handle(any(), any())
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+      fetchHandlerCtor.close()
+      if (localFileRecords != null) localFileRecords.close()
+    }
+  }
+
   // When the supplement returns data with an error, those bytes must NOT count toward minBytes
   // satisfaction — the response must park in the purgatory, not respond prematurely.
   @Test
@@ -7912,6 +7984,25 @@ class ReplicaManagerInklessTest {
       disklessManagedReplicasEnabled = true,
       disklessRemoteStorageConsolidationEnabled = true)
     try {
+      assertFalse(replicaManager.isManagedConsolidatingDisklessPartition(disklessTopicPartition))
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  // During the seal window diskless holds nothing, so a non-leader replica has no fallback for an
+  // offset its local log has not replicated yet. Leader-only reads keep the consumer retrying
+  // instead of resetting on OFFSET_OUT_OF_RANGE.
+  @Test
+  def testIsManagedConsolidatingDisklessPartitionFalseWhileSwitchPending(): Unit = {
+    val replicaManager = spy(createReplicaManager(
+      List(disklessTopicPartition.topic()),
+      disklessManagedReplicasEnabled = true,
+      disklessRemoteStorageConsolidationEnabled = true,
+      consolidatingDisklessTopics = Set(disklessTopicPartition.topic())))
+    try {
+      when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
+        .thenReturn(PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING)
       assertFalse(replicaManager.isManagedConsolidatingDisklessPartition(disklessTopicPartition))
     } finally {
       replicaManager.shutdown(checkpointHW = false)

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerInklessTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerInklessTest.scala
@@ -8595,7 +8595,9 @@ class ReplicaManagerInklessTest {
   private val switchedTopicId = Uuid.fromString("YK2ed2GaTH2JpgzUaJ8tgg")
 
   private def setupReplicaManagerWithMockedPurgatories(
-    aliveBrokerIds: Seq[Int]
+    aliveBrokerIds: Seq[Int],
+    mockTimer: MockTimer = new MockTimer(time),
+    fetchPurgatory: Option[DelayedOperationPurgatory[DelayedFetch]] = None
   ): ReplicaManager = {
     val props = TestUtils.createBrokerConfig(0)
     val path1 = TestUtils.tempRelativeDir("data").getAbsolutePath
@@ -8619,9 +8621,10 @@ class ReplicaManagerInklessTest {
     when(metadataCache.getAliveBrokerEpoch(1)).thenReturn(util.Optional.of(0L))
     when(metadataCache.contains(new TopicPartition(switchedTopic, 0))).thenReturn(true)
 
-    val timer = new MockTimer(time)
+    val timer = mockTimer
     val mockProducePurgatory = new DelayedOperationPurgatory[DelayedProduce]("Produce", timer, 0, false)
-    val mockFetchPurgatory = new DelayedOperationPurgatory[DelayedFetch]("Fetch", timer, 0, false)
+    val mockFetchPurgatory = fetchPurgatory.getOrElse(
+      new DelayedOperationPurgatory[DelayedFetch]("Fetch", timer, 0, false))
     val mockDeleteRecordsPurgatory = new DelayedOperationPurgatory[DelayedDeleteRecords]("DeleteRecords", timer, 0, false)
     val mockDelayedRemoteFetchPurgatory = new DelayedOperationPurgatory[DelayedRemoteFetch]("DelayedRemoteFetch", timer, 0, false)
     val mockDelayedRemoteListOffsetsPurgatory = new DelayedOperationPurgatory[DelayedRemoteListOffsets]("RemoteListOffsets", timer, 0, false)
@@ -8718,6 +8721,76 @@ class ReplicaManagerInklessTest {
       val partitionData = new FetchRequest.PartitionData(Uuid.ZERO_UUID, 0L, 0L, 100, Optional.of(0))
       val fetchResult = fetchPartitionAsConsumer(replicaManager, tidp0, partitionData)
       assertEquals(Errors.NONE, fetchResult.assertFired.error)
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  // DelayedFetch.tryComplete takes the offset snapshot with params.fetchOnlyLeader, which is true for
+  // a consumer that sends no clientMetadata. On the non-leader replica the transformer advertises,
+  // that throws NotLeaderOrFollowerException and force-completes the request as case A, so the
+  // consumer gets an immediate empty response and re-polls instead of waiting out fetch.max.wait.ms.
+  @Test
+  def testParkedOlderClientFetchOnHybridDisklessPartitionWaitsOnNonLeaderReplica(): Unit = {
+    val timer = new MockTimer(time)
+    val fetchPurgatory = new DelayedOperationPurgatory[DelayedFetch]("Fetch", timer, 0, false)
+    val replicaManager = spy(setupReplicaManagerWithMockedPurgatories(
+      aliveBrokerIds = Seq(0, 1), mockTimer = timer, fetchPurgatory = Some(fetchPurgatory)))
+
+    try {
+      val tp0 = new TopicPartition(switchedTopic, 0)
+      val tidp0 = new TopicIdPartition(switchedTopicId, tp0)
+      val offsetCheckpoints = new LazyOffsetCheckpoints(replicaManager.highWatermarkCheckpoints.asJava)
+      replicaManager.createPartition(tp0).createLogIfNotExists(isNew = false, isFutureReplica = false, offsetCheckpoints, None)
+
+      val followerDelta = createFollowerDelta(switchedTopicId, tp0, 0, 1)
+      val followerImage = imageFromTopics(followerDelta.apply())
+      replicaManager.applyDelta(followerDelta, followerImage)
+
+      doReturn(true).when(replicaManager).isPartitionSwitchedFromClassicToDiskless(tidp0)
+
+      // minBytes above what the empty local log can serve, and a non-zero maxWait, so the request parks.
+      val result = new CallbackResult[FetchPartitionData]()
+      val params = new FetchParams(
+        FetchRequest.ORDINARY_CONSUMER_ID, 1, 1000L, 1024, 1024 * 1024,
+        FetchIsolation.HIGH_WATERMARK, Optional.empty())
+      val partitionData = new FetchRequest.PartitionData(Uuid.ZERO_UUID, 0L, 0L, 100, Optional.of(0))
+      replicaManager.fetchMessages(params, Seq(tidp0 -> partitionData), QuotaFactory.UNBOUNDED_QUOTA,
+        responseStatus => result.fire(responseStatus.head._2))
+
+      // Parked, not dropped: the request is in the purgatory and answers when its wait expires.
+      assertEquals(1, fetchPurgatory.watched(),
+        "A parked older-client fetch must be watched on a non-leader replica, not force-completed as case A")
+      assertFalse(result.hasFired)
+
+      timer.advanceClock(1001L)
+      assertEquals(Errors.NONE, result.assertFired.error)
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
+  def testShareFetchKeepsLeaderOnlyOnHybridDisklessPartition(): Unit = {
+    val replicaManager = spy(createReplicaManager(
+      List(disklessTopicPartition.topic()),
+      disklessManagedReplicasEnabled = true,
+      disklessRemoteStorageConsolidationEnabled = true,
+      consolidatingDisklessTopics = Set(disklessTopicPartition.topic())))
+    try {
+      when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
+        .thenReturn(PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET)
+      // Share fetch sets CONSUMER_REPLICA_ID, so only the shareFetchRequest flag separates it from an
+      // older consumer once clientMetadata is absent.
+      val shareParams = new FetchParams(
+        FetchRequest.ORDINARY_CONSUMER_ID, -1L, 0L, 1, 1024,
+        FetchIsolation.HIGH_WATERMARK, Optional.empty(), true)
+      val consumerParams = new FetchParams(
+        FetchRequest.ORDINARY_CONSUMER_ID, -1L, 0L, 1, 1024,
+        FetchIsolation.HIGH_WATERMARK, Optional.empty())
+
+      assertFalse(replicaManager.allowsOlderConsumerReplicaRead(disklessTopicPartition, shareParams))
+      assertTrue(replicaManager.allowsOlderConsumerReplicaRead(disklessTopicPartition, consumerParams))
     } finally {
       replicaManager.shutdown(checkpointHW = false)
     }

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerInklessTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerInklessTest.scala
@@ -36,7 +36,7 @@ import org.apache.kafka.common.config.TopicConfig
 import org.apache.kafka.common.{DirectoryId, IsolationLevel, Node, TopicIdPartition, TopicPartition, Uuid}
 import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.compress.Compression
-import org.apache.kafka.common.errors.UnknownTopicOrPartitionException
+import org.apache.kafka.common.errors.{NotLeaderOrFollowerException, UnknownTopicOrPartitionException}
 import org.apache.kafka.common.message.ListOffsetsRequestData.{ListOffsetsPartition, ListOffsetsTopic}
 import org.apache.kafka.common.message.ListOffsetsResponseData.{ListOffsetsPartitionResponse, ListOffsetsTopicResponse}
 import org.apache.kafka.common.message.DeleteRecordsResponseData
@@ -67,7 +67,7 @@ import org.apache.kafka.server.util.timer.MockTimer
 import org.apache.kafka.server.metrics.KafkaYammerMetrics
 import org.apache.kafka.storage.log.metrics.BrokerTopicStats
 import org.apache.kafka.storage.internals.checkpoint.LazyOffsetCheckpoints
-import org.apache.kafka.storage.internals.log.{AppendOrigin, AsyncOffsetReadFutureHolder, FetchDataInfo, LogConfig, LogDirFailureChannel, LogOffsetMetadata, LogOffsetSnapshot, LogReadResult, OffsetResultHolder, UnifiedLog}
+import org.apache.kafka.storage.internals.log.{AppendOrigin, AsyncOffsetReadFutureHolder, FetchDataInfo, LogConfig, LogDirFailureChannel, LogOffsetMetadata, LogOffsetSnapshot, LogReadInfo, LogReadResult, OffsetResultHolder, UnifiedLog}
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
 import org.junit.jupiter.params.ParameterizedTest
@@ -1786,14 +1786,21 @@ class ReplicaManagerInklessTest {
     }
   }
 
-  private def stubConsolidatingPartitionWithLocalLeo(replicaManager: ReplicaManager, localLeo: Long): Unit = {
-    stubConsolidatingPartitionWithLocalLeoFor(replicaManager, disklessTopicPartition, localLeo)
+  private def stubConsolidatingPartitionWithLocalLeo(replicaManager: ReplicaManager,
+                                                     localLeo: Long,
+                                                     localHighWatermark: Option[Long] = None): Unit = {
+    stubConsolidatingPartitionWithLocalLeoFor(
+      replicaManager, disklessTopicPartition, localLeo, localHighWatermark)
   }
 
-  private def stubConsolidatingPartitionWithLocalLeoFor(replicaManager: ReplicaManager, tp: TopicIdPartition, localLeo: Long): Unit = {
+  private def stubConsolidatingPartitionWithLocalLeoFor(replicaManager: ReplicaManager,
+                                                        tp: TopicIdPartition,
+                                                        localLeo: Long,
+                                                        localHighWatermark: Option[Long] = None): Unit = {
     val mockPartition = mock(classOf[Partition])
     val mockLog = mock(classOf[UnifiedLog])
     when(mockLog.logEndOffset).thenReturn(localLeo)
+    when(mockLog.highWatermark).thenReturn(localHighWatermark.getOrElse(localLeo))
     when(mockPartition.log).thenReturn(Some(mockLog))
     doReturn(Right(mockPartition)).when(replicaManager).getPartitionOrError(
       ArgumentMatchers.eq(tp.topicPartition()))
@@ -1801,14 +1808,16 @@ class ReplicaManagerInklessTest {
 
   // Like stubConsolidatingPartitionWithLocalLeoFor but also pins leadership (the read-path
   // cross-tier-earliest guard only fires for followers) and localLogStartOffset.
-  private def stubConsolidatingPartitionForFollowerReadGuard(replicaManager: ReplicaManager,
-                                                             tp: TopicIdPartition,
-                                                             localLeo: Long,
-                                                             isLeader: Boolean,
-                                                             localLogStartOffset: Long = 0L): Unit = {
+  private def stubConsolidatingPartitionWithLogStart(replicaManager: ReplicaManager,
+                                                     tp: TopicIdPartition,
+                                                     localLeo: Long,
+                                                     isLeader: Boolean,
+                                                     localLogStartOffset: Long = 0L,
+                                                     localHighWatermark: Option[Long] = None): Unit = {
     val mockPartition = mock(classOf[Partition])
     val mockLog = mock(classOf[UnifiedLog])
     when(mockLog.logEndOffset).thenReturn(localLeo)
+    when(mockLog.highWatermark).thenReturn(localHighWatermark.getOrElse(localLeo))
     when(mockLog.localLogStartOffset).thenReturn(localLogStartOffset)
     when(mockPartition.log).thenReturn(Some(mockLog))
     when(mockPartition.isLeader).thenReturn(isLeader)
@@ -1911,7 +1920,7 @@ class ReplicaManagerInklessTest {
     try {
       when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
         .thenReturn(100L)
-      stubConsolidatingPartitionForFollowerReadGuard(replicaManager, disklessTopicPartition, localLeo = 200L, isLeader = false)
+      stubConsolidatingPartitionWithLogStart(replicaManager, disklessTopicPartition, localLeo = 200L, isLeader = false)
 
       // Older consumer: replicaId = -1 and empty clientMetadata.
       val fetchParams = new FetchParams(
@@ -1957,7 +1966,7 @@ class ReplicaManagerInklessTest {
     try {
       when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
         .thenReturn(100L)
-      stubConsolidatingPartitionForFollowerReadGuard(replicaManager, disklessTopicPartition, localLeo = 200L, isLeader = false)
+      stubConsolidatingPartitionWithLogStart(replicaManager, disklessTopicPartition, localLeo = 200L, isLeader = false)
 
       doReturn(Seq(disklessTopicPartition ->
         new LogReadResult(
@@ -2012,7 +2021,7 @@ class ReplicaManagerInklessTest {
     try {
       when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
         .thenReturn(100L)
-      stubConsolidatingPartitionForFollowerReadGuard(replicaManager, disklessTopicPartition, localLeo = 200L, isLeader = true)
+      stubConsolidatingPartitionWithLogStart(replicaManager, disklessTopicPartition, localLeo = 200L, isLeader = true)
 
       doReturn(Seq(disklessTopicPartition ->
         new LogReadResult(
@@ -2065,7 +2074,7 @@ class ReplicaManagerInklessTest {
     try {
       when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
         .thenReturn(100L)
-      stubConsolidatingPartitionForFollowerReadGuard(replicaManager, disklessTopicPartition, localLeo = 200L, isLeader = false)
+      stubConsolidatingPartitionWithLogStart(replicaManager, disklessTopicPartition, localLeo = 200L, isLeader = false)
 
       // Modern consumer: non-empty clientMetadata (rackId present).
       val clientMetadata = new DefaultClientMetadata(
@@ -2117,7 +2126,7 @@ class ReplicaManagerInklessTest {
     try {
       when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
         .thenReturn(100L)
-      stubConsolidatingPartitionForFollowerReadGuard(replicaManager, disklessTopicPartition, localLeo = 200L, isLeader = false)
+      stubConsolidatingPartitionWithLogStart(replicaManager, disklessTopicPartition, localLeo = 200L, isLeader = false)
 
       doReturn(Seq(disklessTopicPartition ->
         new LogReadResult(
@@ -2183,6 +2192,7 @@ class ReplicaManagerInklessTest {
       val mockPartition = mock(classOf[Partition])
       val mockLog = mock(classOf[UnifiedLog])
       when(mockLog.logEndOffset).thenReturn(100L)
+      when(mockLog.highWatermark).thenReturn(100L)
       when(mockPartition.log).thenReturn(Some(mockLog))
       val endOffsetMetadata = new LogOffsetMetadata(100L, 0L, 0)
       when(mockPartition.fetchOffsetSnapshot(any(), any()))
@@ -2273,6 +2283,7 @@ class ReplicaManagerInklessTest {
       val mockPartition = mock(classOf[Partition])
       val mockLog = mock(classOf[UnifiedLog])
       when(mockLog.logEndOffset).thenReturn(100L)
+      when(mockLog.highWatermark).thenReturn(100L)
       when(mockPartition.log).thenReturn(Some(mockLog))
       val endOffsetMetadata = new LogOffsetMetadata(100L, 0L, 0)
       when(mockPartition.fetchOffsetSnapshot(any(), any()))
@@ -2449,6 +2460,7 @@ class ReplicaManagerInklessTest {
       val mockPartition = mock(classOf[Partition])
       val mockLog = mock(classOf[UnifiedLog])
       when(mockLog.logEndOffset).thenReturn(100L)
+      when(mockLog.highWatermark).thenReturn(100L)
       when(mockPartition.log).thenReturn(Some(mockLog))
       val endOffsetMetadata = new LogOffsetMetadata(100L, 0L, 0)
       when(mockPartition.fetchOffsetSnapshot(any(), any()))
@@ -2522,6 +2534,7 @@ class ReplicaManagerInklessTest {
       val mockPartition = mock(classOf[Partition])
       val mockLog = mock(classOf[UnifiedLog])
       when(mockLog.logEndOffset).thenReturn(100L)
+      when(mockLog.highWatermark).thenReturn(100L)
       when(mockPartition.log).thenReturn(Some(mockLog))
       val endOffsetMetadata = new LogOffsetMetadata(100L, 0L, 0)
       when(mockPartition.fetchOffsetSnapshot(any(), any()))
@@ -2648,6 +2661,7 @@ class ReplicaManagerInklessTest {
       val mockPartition = mock(classOf[Partition])
       val mockLog = mock(classOf[UnifiedLog])
       when(mockLog.logEndOffset).thenReturn(100L)
+      when(mockLog.highWatermark).thenReturn(100L)
       when(mockPartition.log).thenReturn(Some(mockLog))
       val endOffsetMetadata = new LogOffsetMetadata(100L, 0L, 0)
       when(mockPartition.fetchOffsetSnapshot(any(), any()))
@@ -2714,6 +2728,7 @@ class ReplicaManagerInklessTest {
       val mockPartition = mock(classOf[Partition])
       val mockLog = mock(classOf[UnifiedLog])
       when(mockLog.logEndOffset).thenReturn(500L)
+      when(mockLog.highWatermark).thenReturn(500L)
       when(mockLog.localLogStartOffset).thenReturn(200L)
       when(mockPartition.log).thenReturn(Some(mockLog))
       val endOffsetMetadata = new LogOffsetMetadata(500L, 0L, 0)
@@ -2832,6 +2847,7 @@ class ReplicaManagerInklessTest {
       val mockPartition = mock(classOf[Partition])
       val mockLog = mock(classOf[UnifiedLog])
       when(mockLog.logEndOffset).thenReturn(localLeo)
+      when(mockLog.highWatermark).thenReturn(localLeo)
       when(mockPartition.log).thenReturn(Some(mockLog))
       // endOffset on a NEWER segment than the fetch offset (480, baseOffset 0) so Case F fires.
       val endOffsetMetadata = new LogOffsetMetadata(localLeo, 500L, 0)
@@ -2949,6 +2965,7 @@ class ReplicaManagerInklessTest {
       val consolidatingPartition = mock(classOf[Partition])
       val consolidatingLog = mock(classOf[UnifiedLog])
       when(consolidatingLog.logEndOffset).thenReturn(100L)
+      when(consolidatingLog.highWatermark).thenReturn(100L)
       when(consolidatingPartition.log).thenReturn(Some(consolidatingLog))
       val consolidatingEndOffset = new LogOffsetMetadata(100L, 0L, 0)
       when(consolidatingPartition.fetchOffsetSnapshot(any(), any()))
@@ -3661,6 +3678,237 @@ class ReplicaManagerInklessTest {
       assertEquals(RECORDS, responseData(disklessTopicPartition).records)
       verify(replicaManager, never()).readFromLog(any(), any(), any(), any())
       verify(fetchHandlerCtor.constructed().get(0), times(1)).handle(any(), any())
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+      fetchHandlerCtor.close()
+    }
+  }
+
+  @Test
+  def testFetchConsolidatingDisklessBelowLocalLeoButAtHighWatermarkUsesDisklessPath(): Unit = {
+    val disklessResponse = Map(disklessTopicPartition ->
+      new FetchPartitionData(
+        Errors.NONE,
+        110L, 0L,
+        RECORDS,
+        Optional.empty(), OptionalLong.empty(), Optional.empty(), OptionalInt.empty(), false)
+    )
+    val fetchHandlerCtor = mockFetchHandler(disklessResponse)
+    val cp = mock(classOf[ControlPlane])
+    val replicaManager = spy(createReplicaManager(
+      List(disklessTopicPartition.topic()),
+      controlPlane = Some(cp),
+      disklessManagedReplicasEnabled = true,
+      disklessRemoteStorageConsolidationEnabled = true,
+      consolidatingDisklessTopics = Set(disklessTopicPartition.topic()),
+    ))
+    try {
+      when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
+        .thenReturn(PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET)
+      stubConsolidatingPartitionWithLocalLeo(
+        replicaManager, localLeo = 100L, localHighWatermark = Some(50L))
+
+      val fetchParams = new FetchParams(
+        -1, -1L,
+        0L, 1, 1024, FetchIsolation.HIGH_WATERMARK, Optional.empty()
+      )
+      val fetchInfos = Seq(
+        disklessTopicPartition ->
+          new PartitionData(disklessTopicPartition.topicId(), 50L, 0L, 1024, Optional.empty())
+      )
+
+      @volatile var responseData: Map[TopicIdPartition, FetchPartitionData] = null
+      replicaManager.fetchMessages(
+        fetchParams,
+        fetchInfos,
+        QuotaFactory.UNBOUNDED_QUOTA,
+        response => responseData = response.toMap)
+
+      waitForFetchResponse(responseData)
+      assertEquals(RECORDS, responseData(disklessTopicPartition).records)
+      verify(replicaManager, never()).readFromLog(any(), any(), any(), any())
+      verify(fetchHandlerCtor.constructed().get(0), times(1)).handle(any(), any())
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+      fetchHandlerCtor.close()
+    }
+  }
+
+  @Test
+  def testFetchConsolidatingFollowerBelowLeoAtHighWatermarkReadsFromUnifiedLog(): Unit = {
+    val fetchHandlerCtor = mockFetchHandler(Map.empty)
+    val replicaManager = spy(createReplicaManager(
+      List(disklessTopicPartition.topic()),
+      disklessManagedReplicasEnabled = true,
+      disklessRemoteStorageConsolidationEnabled = true,
+      consolidatingDisklessTopics = Set(disklessTopicPartition.topic()),
+    ))
+    try {
+      // Never switched, so the seal floor cannot decide the routing: only the follower's LEO
+      // frontier keeps this read on the local log.
+      when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
+        .thenReturn(PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET)
+      stubConsolidatingPartitionWithLocalLeo(
+        replicaManager, localLeo = 100L, localHighWatermark = Some(50L))
+      doReturn(Seq(disklessTopicPartition ->
+        new LogReadResult(
+          new FetchDataInfo(new LogOffsetMetadata(50L, 0L, 0), RECORDS),
+          Optional.empty(), 50L, 0L, 100L, 0L, 0L, OptionalLong.empty(), Errors.NONE
+        ))
+      ).when(replicaManager).readFromLog(any(), any(), any(), any())
+
+      val fetchParams = new FetchParams(
+        1, -1L,
+        0L, 1, 1024, FetchIsolation.LOG_END, Optional.empty()
+      )
+      val fetchInfos = Seq(
+        disklessTopicPartition ->
+          new PartitionData(disklessTopicPartition.topicId(), 50L, 0L, 1024, Optional.empty())
+      )
+
+      @volatile var responseData: Map[TopicIdPartition, FetchPartitionData] = null
+      val localBytesBefore = yammerMeterCount("ConsolidationLocalBytesPerSec")
+      replicaManager.fetchMessages(
+        fetchParams,
+        fetchInfos,
+        QuotaFactory.UNBOUNDED_QUOTA,
+        response => responseData = response.toMap)
+
+      waitForFetchResponse(responseData)
+      assertEquals(RECORDS, responseData(disklessTopicPartition).records)
+      verify(replicaManager, times(1)).readFromLog(any(), any(), any(), any())
+      verify(fetchHandlerCtor.constructed().get(0), never()).handle(any(), any())
+      // Replication traffic is not a consumer consolidation local read: a follower never receives a
+      // supplement, so its bytes must stay out of the consolidation meter.
+      assertEquals(localBytesBefore, yammerMeterCount("ConsolidationLocalBytesPerSec"),
+        "Follower replication bytes must not be recorded as consolidation local bytes")
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+      fetchHandlerCtor.close()
+    }
+  }
+
+  // The diskless pruner deletes batches up to highestOffsetInRemoteStorage, so
+  // [logStartOffset, localLogStartOffset) exists only in the remote tier. A high watermark
+  // restored below that range (missing or stale checkpoint) must not route those offsets to
+  // diskless, which answers OFFSET_OUT_OF_RANGE for them: the local read has to run so it can
+  // throw OffsetOutOfRangeException and reach RemoteLogManager.
+  @Test
+  def testFetchConsolidatingTieredRangeAboveHighWatermarkReadsFromUnifiedLog(): Unit = {
+    val fetchHandlerCtor = mockFetchHandler(Map.empty)
+    val replicaManager = spy(createReplicaManager(
+      List(disklessTopicPartition.topic()),
+      disklessManagedReplicasEnabled = true,
+      disklessRemoteStorageConsolidationEnabled = true,
+      consolidatingDisklessTopics = Set(disklessTopicPartition.topic()),
+    ))
+    try {
+      when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
+        .thenReturn(PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET)
+      stubConsolidatingPartitionWithLogStart(
+        replicaManager, disklessTopicPartition, localLeo = 500L, isLeader = true,
+        localLogStartOffset = 200L, localHighWatermark = Some(0L))
+      doReturn(Seq(disklessTopicPartition ->
+        new LogReadResult(
+          new FetchDataInfo(new LogOffsetMetadata(50L, 0L, 0), RECORDS),
+          Optional.empty(), 0L, 0L, 500L, 0L, 0L, OptionalLong.empty(), Errors.NONE
+        ))
+      ).when(replicaManager).readFromLog(any(), any(), any(), any())
+
+      val fetchParams = new FetchParams(
+        FetchRequest.ORDINARY_CONSUMER_ID, -1L,
+        0L, 1, 1024, FetchIsolation.HIGH_WATERMARK, Optional.empty()
+      )
+      val fetchInfos = Seq(
+        disklessTopicPartition ->
+          new PartitionData(disklessTopicPartition.topicId(), 50L, 0L, 1024, Optional.empty())
+      )
+
+      @volatile var responseData: Map[TopicIdPartition, FetchPartitionData] = null
+      replicaManager.fetchMessages(
+        fetchParams,
+        fetchInfos,
+        QuotaFactory.UNBOUNDED_QUOTA,
+        response => responseData = response.toMap)
+
+      waitForFetchResponse(responseData)
+      assertEquals(RECORDS, responseData(disklessTopicPartition).records)
+      verify(replicaManager, times(1)).readFromLog(any(), any(), any(), any())
+      verify(fetchHandlerCtor.constructed().get(0), never()).handle(any(), any())
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+      fetchHandlerCtor.close()
+    }
+  }
+
+  // Diskless never held [0, classicToDisklessStartOffset), so a consumer fetching the classic prefix
+  // of a switched partition must stay on the local read path even when this replica's high watermark
+  // has not caught up: routing it to diskless would answer OFFSET_OUT_OF_RANGE for records the log
+  // holds. The response is empty until the high watermark advances, and DelayedFetch returns it
+  // immediately (case F, fetch offset beyond the isolation bound), so the consumer re-fetches rather
+  // than waiting out fetch.max.wait.ms. The supplement must stay off: a read stopped at the high
+  // watermark is no proof that the local log is exhausted.
+  @Test
+  def testFetchConsolidatingBelowSealAboveHighWatermarkStaysLocalWithoutSupplement(): Unit = {
+    val fetchHandlerCtor = mockFetchHandler(Map.empty)
+    val timer = new MockTimer(time)
+    val fetchPurgatory = new DelayedOperationPurgatory[DelayedFetch]("Fetch", timer, 0, false)
+    val replicaManager = spy(createReplicaManager(
+      List(disklessTopicPartition.topic()),
+      disklessManagedReplicasEnabled = true,
+      disklessRemoteStorageConsolidationEnabled = true,
+      consolidatingDisklessTopics = Set(disklessTopicPartition.topic()),
+      delayedFetchPurgatory = Some(fetchPurgatory),
+    ))
+    try {
+      when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
+        .thenReturn(100L)
+      val mockPartition = mock(classOf[Partition])
+      val mockLog = mock(classOf[UnifiedLog])
+      when(mockLog.logEndOffset).thenReturn(100L)
+      when(mockLog.highWatermark).thenReturn(50L)
+      when(mockPartition.log).thenReturn(Some(mockLog))
+      when(mockPartition.isLeader).thenReturn(true)
+      val hwMetadata = new LogOffsetMetadata(50L, 0L, 0)
+      val endOffsetMetadata = new LogOffsetMetadata(100L, 0L, 0)
+      when(mockPartition.fetchOffsetSnapshot(any(), any()))
+        .thenReturn(new LogOffsetSnapshot(0L, endOffsetMetadata, hwMetadata, hwMetadata))
+      doReturn(Right(mockPartition)).when(replicaManager)
+        .getPartitionOrError(ArgumentMatchers.eq(disklessTopicPartition.topicPartition()))
+      doReturn(mockPartition).when(replicaManager)
+        .getPartitionOrException(ArgumentMatchers.eq(disklessTopicPartition.topicPartition()))
+
+      // A HIGH_WATERMARK read at an offset above the high watermark returns no records.
+      doReturn(Seq(disklessTopicPartition ->
+        new LogReadResult(
+          new FetchDataInfo(new LogOffsetMetadata(60L, 0L, 0), MemoryRecords.EMPTY),
+          Optional.empty(), 50L, 0L, 100L, 0L, 0L, OptionalLong.empty(), Errors.NONE
+        ))
+      ).when(replicaManager).readFromLog(any(), any(), any(), any())
+
+      val fetchParams = new FetchParams(
+        FetchRequest.ORDINARY_CONSUMER_ID, -1L,
+        30000L, 1024, 1024 * 1024, FetchIsolation.HIGH_WATERMARK, Optional.empty()
+      )
+      val fetchInfos = Seq(
+        disklessTopicPartition ->
+          new PartitionData(disklessTopicPartition.topicId(), 60L, 0L, 1024, Optional.empty())
+      )
+
+      @volatile var responseData: Map[TopicIdPartition, FetchPartitionData] = null
+      replicaManager.fetchMessages(
+        fetchParams,
+        fetchInfos,
+        QuotaFactory.UNBOUNDED_QUOTA,
+        response => responseData = response.toMap)
+
+      waitForFetchResponse(responseData)
+      assertEquals(Errors.NONE, responseData(disklessTopicPartition).error)
+      assertEquals(0, responseData(disklessTopicPartition).records.sizeInBytes,
+        "A below-seal read above the high watermark has nothing committed to return yet")
+      verify(replicaManager, atLeastOnce()).readFromLog(any(), any(), any(), any())
+      // Diskless holds nothing below the seal, so neither the read nor a supplement may go there.
+      verify(fetchHandlerCtor.constructed().get(0), never()).handle(any(), any())
     } finally {
       replicaManager.shutdown(checkpointHW = false)
       fetchHandlerCtor.close()
@@ -7638,6 +7886,108 @@ class ReplicaManagerInklessTest {
       when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(tp))
         .thenReturn(100L)
       assertTrue(replicaManager.isPartitionSwitchedFromClassicToDiskless(disklessTopicPartition))
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
+  def testIsManagedConsolidatingDisklessPartitionTrueForConsolidatingTopic(): Unit = {
+    val replicaManager = createReplicaManager(
+      List(disklessTopicPartition.topic()),
+      disklessManagedReplicasEnabled = true,
+      disklessRemoteStorageConsolidationEnabled = true,
+      consolidatingDisklessTopics = Set(disklessTopicPartition.topic()))
+    try {
+      assertTrue(replicaManager.isManagedConsolidatingDisklessPartition(disklessTopicPartition))
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
+  def testIsManagedConsolidatingDisklessPartitionFalseForNonConsolidatingTopic(): Unit = {
+    val replicaManager = createReplicaManager(
+      List(disklessTopicPartition.topic()),
+      disklessManagedReplicasEnabled = true,
+      disklessRemoteStorageConsolidationEnabled = true)
+    try {
+      assertFalse(replicaManager.isManagedConsolidatingDisklessPartition(disklessTopicPartition))
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  // Stubs a non-leader partition whose local log is only reachable with requireLeader = false, so a
+  // read that keeps the leader-only requirement surfaces as NOT_LEADER_OR_FOLLOWER.
+  private def stubNonLeaderPartitionForReplicaRead(replicaManager: ReplicaManager): Unit = {
+    val mockPartition = mock(classOf[Partition])
+    val mockLog = mock(classOf[UnifiedLog])
+    when(mockPartition.topicId).thenReturn(Some(disklessTopicPartition.topicId()))
+    when(mockPartition.isLeader).thenReturn(false)
+    when(mockPartition.localLogWithEpochOrThrow(any(), ArgumentMatchers.eq(true)))
+      .thenThrow(new NotLeaderOrFollowerException("Broker is not the leader for this partition"))
+    when(mockPartition.localLogWithEpochOrThrow(any(), ArgumentMatchers.eq(false)))
+      .thenReturn(mockLog)
+    when(mockPartition.fetchRecords(any(), any(), anyLong(), anyInt(), anyBoolean(), anyBoolean(), anyBoolean()))
+      .thenReturn(new LogReadInfo(
+        new FetchDataInfo(new LogOffsetMetadata(50L, 0L, 0), RECORDS),
+        Optional.empty(), 100L, 0L, 100L, 100L))
+    doReturn(mockPartition).when(replicaManager)
+      .getPartitionOrException(ArgumentMatchers.eq(disklessTopicPartition.topicPartition()))
+  }
+
+  private def readFromLogAsOlderConsumer(replicaManager: ReplicaManager): LogReadResult = {
+    val fetchParams = new FetchParams(
+      FetchRequest.ORDINARY_CONSUMER_ID, -1L,
+      0L, 1, 1024, FetchIsolation.HIGH_WATERMARK, Optional.empty()
+    )
+    val fetchInfos = Seq(
+      disklessTopicPartition ->
+        new PartitionData(disklessTopicPartition.topicId(), 50L, 0L, 1024, Optional.empty())
+    )
+    replicaManager.readFromLog(fetchParams, fetchInfos, QuotaFactory.UNBOUNDED_QUOTA, readFromPurgatory = false)
+      .head._2
+  }
+
+  // The behavior the predicate exists for: AZ routing points a pre-KIP-392 consumer (no
+  // clientMetadata, so no preferred-read-replica negotiation) at a replica that is not the
+  // partition leader, and the read must be authorized against that replica's local log.
+  @Test
+  def testReadFromLogAllowsReplicaConsumerReadOnManagedConsolidatingPartition(): Unit = {
+    val replicaManager = spy(createReplicaManager(
+      List(disklessTopicPartition.topic()),
+      disklessManagedReplicasEnabled = true,
+      disklessRemoteStorageConsolidationEnabled = true,
+      consolidatingDisklessTopics = Set(disklessTopicPartition.topic())))
+    try {
+      // Never switched, so only isManagedConsolidatingDisklessPartition can grant the override.
+      when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
+        .thenReturn(PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET)
+      stubNonLeaderPartitionForReplicaRead(replicaManager)
+
+      val result = readFromLogAsOlderConsumer(replicaManager)
+
+      assertEquals(Errors.NONE, result.error)
+      assertEquals(RECORDS, result.info.records)
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  @Test
+  def testReadFromLogKeepsLeaderOnlyWhenConsolidationDisabled(): Unit = {
+    val replicaManager = spy(createReplicaManager(
+      List(disklessTopicPartition.topic()),
+      disklessManagedReplicasEnabled = true,
+      disklessRemoteStorageConsolidationEnabled = false,
+      consolidatingDisklessTopics = Set(disklessTopicPartition.topic())))
+    try {
+      when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
+        .thenReturn(PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET)
+      stubNonLeaderPartitionForReplicaRead(replicaManager)
+
+      assertEquals(Errors.NOT_LEADER_OR_FOLLOWER, readFromLogAsOlderConsumer(replicaManager).error)
     } finally {
       replicaManager.shutdown(checkpointHW = false)
     }

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerInklessTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerInklessTest.scala
@@ -8033,7 +8033,7 @@ class ReplicaManagerInklessTest {
       disklessRemoteStorageConsolidationEnabled = true,
       consolidatingDisklessTopics = Set(disklessTopicPartition.topic()))
     try {
-      assertTrue(replicaManager.isManagedConsolidatingDisklessPartition(disklessTopicPartition))
+      assertTrue(replicaManager.isManagedConsolidatingDisklessPartition(disklessTopicPartition.topicPartition()))
     } finally {
       replicaManager.shutdown(checkpointHW = false)
     }
@@ -8046,7 +8046,7 @@ class ReplicaManagerInklessTest {
       disklessManagedReplicasEnabled = true,
       disklessRemoteStorageConsolidationEnabled = true)
     try {
-      assertFalse(replicaManager.isManagedConsolidatingDisklessPartition(disklessTopicPartition))
+      assertFalse(replicaManager.isManagedConsolidatingDisklessPartition(disklessTopicPartition.topicPartition()))
     } finally {
       replicaManager.shutdown(checkpointHW = false)
     }
@@ -8065,7 +8065,7 @@ class ReplicaManagerInklessTest {
     try {
       when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
         .thenReturn(PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING)
-      assertFalse(replicaManager.isManagedConsolidatingDisklessPartition(disklessTopicPartition))
+      assertFalse(replicaManager.isManagedConsolidatingDisklessPartition(disklessTopicPartition.topicPartition()))
     } finally {
       replicaManager.shutdown(checkpointHW = false)
     }
@@ -8166,6 +8166,16 @@ class ReplicaManagerInklessTest {
 
       assertEquals(1, replicaManager.consolidationHighWatermarkLagPartitionCount,
         "A consolidating partition holding data below its high watermark must be counted")
+
+      // A pending switch serves every offset locally and waits for its high watermark, so the same
+      // lag carries no object-storage cost and must not be counted.
+      when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(tp))
+        .thenReturn(PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING)
+      assertEquals(0, replicaManager.consolidationHighWatermarkLagPartitionCount,
+        "A switch-pending partition must not be counted")
+      when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(tp))
+        .thenReturn(PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET)
+      assertEquals(1, replicaManager.consolidationHighWatermarkLagPartitionCount)
 
       log.maybeUpdateHighWatermark(10L)
       assertEquals(0, replicaManager.consolidationHighWatermarkLagPartitionCount,

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerInklessTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerInklessTest.scala
@@ -3790,6 +3790,7 @@ class ReplicaManagerInklessTest {
       )
 
       @volatile var responseData: Map[TopicIdPartition, FetchPartitionData] = null
+      val hwLagFetchesBefore = yammerMeterCount("ConsolidationHighWatermarkLagFetchRate")
       replicaManager.fetchMessages(
         fetchParams,
         fetchInfos,
@@ -3800,6 +3801,10 @@ class ReplicaManagerInklessTest {
       assertEquals(RECORDS, responseData(disklessTopicPartition).records)
       verify(replicaManager, never()).readFromLog(any(), any(), any(), any())
       verify(fetchHandlerCtor.constructed().get(0), times(1)).handle(any(), any())
+      // The local log holds offset 50 (LEO is 100) but the high watermark does not, so this fetch is
+      // the window the meter exists to make visible.
+      assertEquals(hwLagFetchesBefore + 1L, yammerMeterCount("ConsolidationHighWatermarkLagFetchRate"),
+        "A consumer read routed to Inkless while the local log holds the offset must be recorded")
     } finally {
       replicaManager.shutdown(checkpointHW = false)
       fetchHandlerCtor.close()
@@ -3840,6 +3845,7 @@ class ReplicaManagerInklessTest {
 
       @volatile var responseData: Map[TopicIdPartition, FetchPartitionData] = null
       val localBytesBefore = yammerMeterCount("ConsolidationLocalBytesPerSec")
+      val hwLagFetchesBefore = yammerMeterCount("ConsolidationHighWatermarkLagFetchRate")
       replicaManager.fetchMessages(
         fetchParams,
         fetchInfos,
@@ -3854,6 +3860,8 @@ class ReplicaManagerInklessTest {
       // supplement, so its bytes must stay out of the consolidation meter.
       assertEquals(localBytesBefore, yammerMeterCount("ConsolidationLocalBytesPerSec"),
         "Follower replication bytes must not be recorded as consolidation local bytes")
+      assertEquals(hwLagFetchesBefore, yammerMeterCount("ConsolidationHighWatermarkLagFetchRate"),
+        "A follower reads to LEO, so it is never in the high-watermark-lag window")
     } finally {
       replicaManager.shutdown(checkpointHW = false)
       fetchHandlerCtor.close()
@@ -3968,6 +3976,7 @@ class ReplicaManagerInklessTest {
       )
 
       @volatile var responseData: Map[TopicIdPartition, FetchPartitionData] = null
+      val hwLagFetchesBefore = yammerMeterCount("ConsolidationHighWatermarkLagFetchRate")
       replicaManager.fetchMessages(
         fetchParams,
         fetchInfos,
@@ -3981,6 +3990,59 @@ class ReplicaManagerInklessTest {
       verify(replicaManager, atLeastOnce()).readFromLog(any(), any(), any(), any())
       // Diskless holds nothing below the seal, so neither the read nor a supplement may go there.
       verify(fetchHandlerCtor.constructed().get(0), never()).handle(any(), any())
+      assertEquals(hwLagFetchesBefore, yammerMeterCount("ConsolidationHighWatermarkLagFetchRate"),
+        "A fetch served from the local log must not count as routed to Inkless")
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+      fetchHandlerCtor.close()
+    }
+  }
+
+  // A switch-pending partition serves every offset from the local log, so a fetch above its high
+  // watermark is not routed to Inkless and must not be counted as if it were.
+  @Test
+  def testFetchConsolidatingSwitchPendingDoesNotCountAsHighWatermarkLagRouted(): Unit = {
+    val fetchHandlerCtor = mockFetchHandler(Map.empty)
+    val replicaManager = spy(createReplicaManager(
+      List(disklessTopicPartition.topic()),
+      disklessManagedReplicasEnabled = true,
+      disklessRemoteStorageConsolidationEnabled = true,
+      consolidatingDisklessTopics = Set(disklessTopicPartition.topic()),
+    ))
+    try {
+      when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
+        .thenReturn(PartitionRegistration.CLASSIC_TO_DISKLESS_SWITCH_PENDING)
+      stubConsolidatingPartitionWithLocalLeo(
+        replicaManager, localLeo = 100L, localHighWatermark = Some(50L))
+      doReturn(Seq(disklessTopicPartition ->
+        new LogReadResult(
+          new FetchDataInfo(new LogOffsetMetadata(60L, 0L, 0), MemoryRecords.EMPTY),
+          Optional.empty(), 50L, 0L, 100L, 0L, 0L, OptionalLong.empty(), Errors.NONE
+        ))
+      ).when(replicaManager).readFromLog(any(), any(), any(), any())
+
+      val fetchParams = new FetchParams(
+        FetchRequest.ORDINARY_CONSUMER_ID, -1L,
+        0L, 1, 1024, FetchIsolation.HIGH_WATERMARK, Optional.empty()
+      )
+      val fetchInfos = Seq(
+        disklessTopicPartition ->
+          new PartitionData(disklessTopicPartition.topicId(), 60L, 0L, 1024, Optional.empty())
+      )
+
+      @volatile var responseData: Map[TopicIdPartition, FetchPartitionData] = null
+      val hwLagFetchesBefore = yammerMeterCount("ConsolidationHighWatermarkLagFetchRate")
+      replicaManager.fetchMessages(
+        fetchParams,
+        fetchInfos,
+        QuotaFactory.UNBOUNDED_QUOTA,
+        response => responseData = response.toMap)
+
+      waitForFetchResponse(responseData)
+      verify(replicaManager, atLeastOnce()).readFromLog(any(), any(), any(), any())
+      verify(fetchHandlerCtor.constructed().get(0), never()).handle(any(), any())
+      assertEquals(hwLagFetchesBefore, yammerMeterCount("ConsolidationHighWatermarkLagFetchRate"),
+        "A switch-pending fetch is served locally, so it must not count as routed to Inkless")
     } finally {
       replicaManager.shutdown(checkpointHW = false)
       fetchHandlerCtor.close()
@@ -8079,6 +8141,35 @@ class ReplicaManagerInklessTest {
       stubNonLeaderPartitionForReplicaRead(replicaManager)
 
       assertEquals(Errors.NOT_LEADER_OR_FOLLOWER, readFromLogAsOlderConsumer(replicaManager).error)
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
+  // The gauge must see a stalled replica whether or not consumers are reading it, which is what the
+  // fetch-rate meter cannot do once consumers move past the frozen log end offset.
+  @Test
+  def testConsolidationHighWatermarkLagPartitionCountCountsUncommittedLocalData(): Unit = {
+    val topicName = disklessTopicPartition.topic()
+    val tp = disklessTopicPartition.topicPartition()
+    val replicaManager = spy(createReplicaManager(
+      List(topicName),
+      disklessManagedReplicasEnabled = true,
+      disklessRemoteStorageConsolidationEnabled = true,
+      consolidatingDisklessTopics = Set(topicName)))
+    try {
+      val log = replicaManager.logManager.getOrCreateLog(
+        tp, isNew = true, topicId = Optional.of(disklessTopicPartition.topicId()))
+      populateLocalLogAtLeoAndCheckpointedHwm(replicaManager, tp, log, leo = 10L, hw = 4L)
+      val partition = replicaManager.createPartition(tp)
+      partition.log = Some(log)
+
+      assertEquals(1, replicaManager.consolidationHighWatermarkLagPartitionCount,
+        "A consolidating partition holding data below its high watermark must be counted")
+
+      log.maybeUpdateHighWatermark(10L)
+      assertEquals(0, replicaManager.consolidationHighWatermarkLagPartitionCount,
+        "Once the high watermark reaches the log end offset the partition can serve what it holds")
     } finally {
       replicaManager.shutdown(checkpointHW = false)
     }

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerInklessTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerInklessTest.scala
@@ -8185,6 +8185,97 @@ class ReplicaManagerInklessTest {
     }
   }
 
+  // Viktor's review case on #774: seal 100, this replica at LEO 10, consumer at 55. The seal floor puts
+  // the read on the local path, which cannot serve 55, so the consumer resets. The meter is the only
+  // record that it happened.
+  @Test
+  def testFetchConsolidatingBelowSealAboveLeoRecordsMissingPrefix(): Unit = {
+    val fetchHandlerCtor = mockFetchHandler(Map.empty)
+    val replicaManager = spy(createReplicaManager(
+      List(disklessTopicPartition.topic()),
+      disklessManagedReplicasEnabled = true,
+      disklessRemoteStorageConsolidationEnabled = true,
+      consolidatingDisklessTopics = Set(disklessTopicPartition.topic()),
+    ))
+    try {
+      when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
+        .thenReturn(100L)
+      stubConsolidatingPartitionWithLocalLeo(replicaManager, localLeo = 10L)
+      doReturn(Seq(disklessTopicPartition ->
+        new LogReadResult(
+          new FetchDataInfo(new LogOffsetMetadata(55L, 0L, 0), MemoryRecords.EMPTY),
+          Optional.empty(), 10L, 0L, 10L, 0L, 0L, OptionalLong.empty(), Errors.OFFSET_OUT_OF_RANGE
+        ))
+      ).when(replicaManager).readFromLog(any(), any(), any(), any())
+
+      val fetchParams = new FetchParams(
+        FetchRequest.ORDINARY_CONSUMER_ID, -1L,
+        0L, 1, 1024, FetchIsolation.HIGH_WATERMARK, Optional.empty()
+      )
+      val fetchInfos = Seq(
+        disklessTopicPartition ->
+          new PartitionData(disklessTopicPartition.topicId(), 55L, 0L, 1024, Optional.empty())
+      )
+
+      @volatile var responseData: Map[TopicIdPartition, FetchPartitionData] = null
+      val missingBefore = yammerMeterCount("DisklessSwitchedPrefixMissingFetchRate")
+      replicaManager.fetchMessages(
+        fetchParams,
+        fetchInfos,
+        QuotaFactory.UNBOUNDED_QUOTA,
+        response => responseData = response.toMap)
+
+      waitForFetchResponse(responseData)
+      verify(replicaManager, atLeastOnce()).readFromLog(any(), any(), any(), any())
+      verify(fetchHandlerCtor.constructed().get(0), never()).handle(any(), any())
+      assertEquals(missingBefore + 1L, yammerMeterCount("DisklessSwitchedPrefixMissingFetchRate"),
+        "A below-seal read this replica cannot serve must be recorded")
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+      fetchHandlerCtor.close()
+    }
+  }
+
+  @Test
+  def testDisklessSwitchedPrefixLagMeasuresWhatTheReplicaHasNotReplicated(): Unit = {
+    val tp = disklessTopicPartition.topicPartition()
+    val replicaManager = spy(createReplicaManager(
+      List(disklessTopicPartition.topic()),
+      disklessManagedReplicasEnabled = true,
+      disklessRemoteStorageConsolidationEnabled = true,
+      consolidatingDisklessTopics = Set(disklessTopicPartition.topic())))
+    try {
+      val log = replicaManager.logManager.getOrCreateLog(
+        tp, isNew = true, topicId = Optional.of(disklessTopicPartition.topicId()))
+      populateLocalLogAtLeoAndCheckpointedHwm(replicaManager, tp, log, leo = 5L, hw = 5L)
+      val partition = replicaManager.createPartition(tp)
+      partition.log = Some(log)
+
+      when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(tp)).thenReturn(10L)
+      assertEquals(5L, replicaManager.disklessSwitchedPrefixLag,
+        "The lag is the records below the seal this replica has not replicated")
+
+      when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(tp)).thenReturn(7L)
+      assertEquals(2L, replicaManager.disklessSwitchedPrefixLag,
+        "It falls as the replica catches up, which is what shows progress")
+
+      when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(tp)).thenReturn(5L)
+      assertEquals(0L, replicaManager.disklessSwitchedPrefixLag,
+        "A replica that reached the seal holds the whole prefix")
+
+      // A consolidated suffix puts LEO past the seal; the lag must not go negative.
+      when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(tp)).thenReturn(3L)
+      assertEquals(0L, replicaManager.disklessSwitchedPrefixLag)
+
+      when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(tp))
+        .thenReturn(PartitionRegistration.NO_CLASSIC_TO_DISKLESS_START_OFFSET)
+      assertEquals(0L, replicaManager.disklessSwitchedPrefixLag,
+        "A partition that never switched has no classic prefix to miss")
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+    }
+  }
+
   @Test
   def testApplyDeltaSkipsPartitionForDisklessTopicWithoutLocalLog(): Unit = {
     val topicName = "fully-diskless-topic"

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerInklessTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerInklessTest.scala
@@ -36,7 +36,7 @@ import org.apache.kafka.common.config.TopicConfig
 import org.apache.kafka.common.{DirectoryId, IsolationLevel, Node, TopicIdPartition, TopicPartition, Uuid}
 import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.compress.Compression
-import org.apache.kafka.common.errors.{NotLeaderOrFollowerException, UnknownTopicOrPartitionException}
+import org.apache.kafka.common.errors.{NotLeaderOrFollowerException, OffsetOutOfRangeException, UnknownTopicOrPartitionException}
 import org.apache.kafka.common.message.ListOffsetsRequestData.{ListOffsetsPartition, ListOffsetsTopic}
 import org.apache.kafka.common.message.ListOffsetsResponseData.{ListOffsetsPartitionResponse, ListOffsetsTopicResponse}
 import org.apache.kafka.common.message.DeleteRecordsResponseData
@@ -8230,6 +8230,80 @@ class ReplicaManagerInklessTest {
       verify(fetchHandlerCtor.constructed().get(0), never()).handle(any(), any())
       assertEquals(missingBefore + 1L, yammerMeterCount("DisklessSwitchedPrefixMissingFetchRate"),
         "A below-seal read this replica cannot serve must be recorded")
+    } finally {
+      replicaManager.shutdown(checkpointHW = false)
+      fetchHandlerCtor.close()
+    }
+  }
+
+  // A below-seal offset this replica has not replicated yet is valid on the leader, so answering
+  // OFFSET_OUT_OF_RANGE would reset the consumer over a range that is only missing here. The fetch
+  // must wait for this replica instead: empty, and parked rather than answered at once.
+  @Test
+  def testFetchConsolidatingBelowSealAboveLeoWaitsInsteadOfResetting(): Unit = {
+    val fetchHandlerCtor = mockFetchHandler(Map.empty)
+    val timer = new MockTimer(time)
+    val fetchPurgatory = new DelayedOperationPurgatory[DelayedFetch]("Fetch", timer, 0, false)
+    val replicaManager = spy(createReplicaManager(
+      List(disklessTopicPartition.topic()),
+      disklessManagedReplicasEnabled = true,
+      disklessRemoteStorageConsolidationEnabled = true,
+      consolidatingDisklessTopics = Set(disklessTopicPartition.topic()),
+      delayedFetchPurgatory = Some(fetchPurgatory),
+    ))
+    try {
+      when(replicaManager.inklessMetadataView().getClassicToDisklessStartOffset(disklessTopicPartition.topicPartition()))
+        .thenReturn(100L)
+      // The real read path runs here: a fetch at 55 against a log that ends at 10 throws
+      // OffsetOutOfRangeException, and the carve-out turns it into an empty successful read.
+      val mockPartition = mock(classOf[Partition])
+      val mockLog = mock(classOf[UnifiedLog])
+      when(mockLog.logEndOffset).thenReturn(10L)
+      when(mockLog.highWatermark).thenReturn(10L)
+      when(mockLog.logStartOffset).thenReturn(0L)
+      when(mockLog.lastStableOffset).thenReturn(10L)
+      when(mockLog.remoteLogEnabled()).thenReturn(false)
+      when(mockPartition.log).thenReturn(Some(mockLog))
+      when(mockPartition.topicId).thenReturn(Some(disklessTopicPartition.topicId()))
+      when(mockPartition.isLeader).thenReturn(true)
+      when(mockPartition.localLogWithEpochOrThrow(any(), anyBoolean())).thenReturn(mockLog)
+      when(mockPartition.fetchRecords(any(), any(), anyLong(), anyInt(), anyBoolean(), anyBoolean(), anyBoolean()))
+        .thenThrow(new OffsetOutOfRangeException("Received request for offset 55 but we only have up to 10"))
+      val endOffsetMetadata = new LogOffsetMetadata(10L, 0L, 0)
+      when(mockPartition.fetchOffsetSnapshot(any(), any()))
+        .thenReturn(new LogOffsetSnapshot(0L, endOffsetMetadata, endOffsetMetadata, endOffsetMetadata))
+      doReturn(Right(mockPartition)).when(replicaManager)
+        .getPartitionOrError(ArgumentMatchers.eq(disklessTopicPartition.topicPartition()))
+      doReturn(mockPartition).when(replicaManager)
+        .getPartitionOrException(ArgumentMatchers.eq(disklessTopicPartition.topicPartition()))
+
+      val maxWaitMs = 30000L
+      val fetchParams = new FetchParams(
+        FetchRequest.ORDINARY_CONSUMER_ID, -1L,
+        maxWaitMs, 1024, 1024 * 1024, FetchIsolation.HIGH_WATERMARK, Optional.empty()
+      )
+      val fetchInfos = Seq(
+        disklessTopicPartition ->
+          new PartitionData(disklessTopicPartition.topicId(), 55L, 0L, 1024, Optional.empty())
+      )
+
+      @volatile var responseData: Map[TopicIdPartition, FetchPartitionData] = null
+      replicaManager.fetchMessages(
+        fetchParams,
+        fetchInfos,
+        QuotaFactory.UNBOUNDED_QUOTA,
+        response => responseData = response.toMap)
+
+      assertEquals(1, fetchPurgatory.watched(),
+        "The fetch must wait for this replica to catch up, not be answered at once")
+      assertNull(responseData)
+
+      timer.advanceClock(maxWaitMs + 1)
+      waitForFetchResponse(responseData)
+      assertEquals(Errors.NONE, responseData(disklessTopicPartition).error,
+        "A below-seal offset missing only on this replica must not reset the consumer")
+      assertEquals(0, responseData(disklessTopicPartition).records.sizeInBytes)
+      verify(fetchHandlerCtor.constructed().get(0), never()).handle(any(), any())
     } finally {
       replicaManager.shutdown(checkpointHW = false)
       fetchHandlerCtor.close()


### PR DESCRIPTION
A consumer in the same availability zone (AZ) can land on a consolidating replica that has the requested records on disk but has not committed them yet. The local log then returns an empty response, so the consumer looks caught up. This change serves those reads from object storage until the replica's high watermark moves past the fetch offset.

The routing decision used the log end offset, which is not a bound the local read can honor: a consumer read stops at the high watermark. Every fetch for an offset between the two was sent to the local log, which had nothing to return. Followers still read through the log end offset, so they keep copying uncommitted records and the high watermark can still advance.

## How it reached consumers

What the consumer saw next depended on the Fetch API version it speaks, because that is what decides whether the broker will serve it from a replica at all.

A client on Fetch v11 or later gets client metadata attached to its request (`KafkaApis` populates it for v11+, with or without `client.rack`), so leader-only enforcement is off and the read is allowed on the replica. It came back empty, and the consumer made progress again once the high watermark advanced: slow and silent, but self-correcting.

A client on an older Fetch version sends no client metadata, which makes the broker enforce leader-only reads. The existing override for that case covered only topics switched from classic, so on a born-diskless consolidating topic the read was refused with `NOT_LEADER_OR_FOLLOWER`. The client refreshed metadata, the transformer pointed it back at the same replica, and the partition stopped progressing while reporting no error to either side. That is the shape KC-461 was reported as: a partition that reads as empty while its data is committed and durable.

Neither condition appears in our test setups. They use the Java client, so client metadata is always present, and single-replica topics make the advertised replica the leader, so leader-only enforcement never engages. Reproducing the refusal needs a client that negotiates Fetch below v11 against a topic with more than one replica.

## Commits

This pull request is nine commits. See the commit messages for the reasoning behind each step:

- `refactor(inkless:consume): one helper for the consolidating-topic check`: six inline spellings, one of them with the operands the other way round, become one topic-scoped helper. No behavior change.
- `fix(inkless:consume): wait for local HW on AZ replicas`: serve consumer fetches from object storage when the replica has not committed the offset. Followers keep reading the local log.
- `fix(inkless:consume): keep the seal window leader-only`: while a switch is pending there is no diskless leg to fall back on, so a replica read can answer out-of-range for records the leader holds, and a supplement can only come back empty.
- `fix(inkless:consume): keep parked fetches waiting on AZ replicas`: a waiting fetch on that replica is no longer completed as "this broker is not the leader".
- `test(inkless:consume): cover below-seal reads on a recovered replica`: a replica that lost its local data still returns records from before the switch.
- `feat(inkless:consume): surface local HW lag on consolidating replicas`: a gauge for partitions in that state and a meter for the consumer fetches that land in it.
- `test(inkless:consume): cover a pre-v11 consumer read from a replica`: the reported failure, reproduced against a running cluster.
- `feat(inkless:consume): report replicas missing the classic prefix`: a lag gauge for what a replica has not replicated from before the switch offset, and a meter for the reads it cannot serve.
- `fix(inkless:consume): wait out a below-seal offset this replica lacks`: those reads wait for the replica instead of resetting the consumer.

## Operator impact

While a replica's high watermark lags its log end offset, consumer reads go to object storage. `ConsolidationLocalBytesPerSec`, `ConsolidationSupplementRate`, and `ConsolidationSupplementBytesPerSec` fall. Diskless fetch volume and object-storage GET cost rise.

Two new metrics report that state:

- `ConsolidationHighWatermarkLagPartitionCount`: partitions on this broker whose local high watermark sits below their local log end offset. Alert on this. It holds whether or not anyone is reading.
- `ConsolidationHighWatermarkLagFetchRate`: consumer fetches that land in the window, one mark per affected partition. Use it to size the impact.
- `DisklessSwitchedPrefixLag`: records from before the switch offset that this broker's replicas have not replicated. Zero means every replica here holds them. A value that falls is a replica catching up; one that stops falling is a replica that has stopped.
- `DisklessSwitchedPrefixMissingFetchRate`: consumer reads that hit that range. They wait for the replica now rather than resetting, so this is the only signal that they are waiting.

A small value on either is normal on a busy topic, because the high watermark trails an append briefly. Followers never increment the meter, and neither do fetches while a switch is pending, which are served locally.

Neither replaces `ConsolidationLocalLag`. That measures how far behind consolidation is in copying diskless data into the local log. It can read zero while the high watermark sits below the local log end offset.

Follower copies of records from before the switch no longer count toward `ConsolidationLocalBytesPerSec`. Re-baseline dashboards you key on that meter.

No config changes. Two new metrics.

## Test plan

`ReplicaManagerInklessTest` adds cases on `fetchMessages` and the delayed-fetch path. Each case fails if you remove the production check it covers:

- A consumer asking for an offset the replica has written but not committed is served from object storage, and `ConsolidationHighWatermarkLagFetchRate` advances by one.
- The gauge counts a partition in that state against a real log (log end 10, checkpointed high watermark 4), and stops counting it once the high watermark advances.
- A follower asking for those same offsets is served from the local log, and the meter does not move. Nor does it move for a fetch while the switch is pending, which is served locally too.
- A fetch for records that live only in remote storage stays on the local path.
- A fetch for records from before the topic switched stays on the local path and does not merge object-storage data. Above the replica's high watermark that reply is empty and returns at once, so the consumer re-fetches until the high watermark advances.
- A consumer whose request carries no client metadata may read from a non-leader replica of a consolidating topic.
- A share fetch, and a fetch while the switch is still pending, still require the partition leader.
- A fetch on that non-leader replica reaches the fetch purgatory instead of being completed as "this broker is not the leader".
- A read for records from before the switch that this replica has not replicated waits in the purgatory and returns empty, rather than out of range. It fails if any of the three sites disagree: an error from the read, an immediate empty response from the purgatory, or a supplement issued below the switch offset.
- The lag is what a replica has not replicated from before the switch offset: it falls as the replica catches up, is zero once it arrives, and does not go negative when a consolidated suffix puts the log end offset past that point.

`InklessConsolidatedDisklessTopicsTest.testPreKip392ConsumerReadsConsolidatedPartitionFromReplica` reproduces the reported failure against a running cluster. It produces to a born-consolidated topic, waits for both replicas to consolidate and commit the range, then fetches at Fetch v10 from the replica that is not the KRaft leader. Without the change it fails with `NOT_LEADER_OR_FOLLOWER`. No current client sends a request that old, so `PreKip392FetchClient` builds one and sends it to a single broker's listener. Fetch v10 also predates topic ids, so this covers the topic-id backfill too; the assertions keep the two apart, `NOT_LEADER_OR_FOLLOWER` for the replica read and `UNKNOWN_TOPIC_ID` for the backfill.

`InklessConsolidatedDisklessTopicsTest.testWipedReplicaServesBelowSealReadAtRequestedOffset` wipes a follower's log directory, restarts the broker, and reads an offset from before the switch on that replica. The first record in the reply is the requested offset, not the switch offset. A route that answered from object storage and dropped the range in between fails this test.

`DelayedFetchTest` and `ReplicaManagerTest` cover the unchanged classic snapshot path through the shared helper.
