### PR TITLE
fix(inkless:gcs): count batch object deletions in metrics [KC-483]

### DIFF
--- a/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/gcs/GcsStorage.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/gcs/GcsStorage.java
@@ -59,6 +59,7 @@ public class GcsStorage extends StorageBackend {
     private String bucketName;
     private ReloadableCredentialsProvider credentialsProvider;
     private StorageOptions.Builder storageOptionsBuilder;
+    private final MetricCollector metricCollector;
 
     // needed for reflection based instantiation
     public GcsStorage() {
@@ -67,11 +68,11 @@ public class GcsStorage extends StorageBackend {
 
     public GcsStorage(final Metrics metrics) {
         super(metrics);
+        this.metricCollector = new MetricCollector(metrics);
     }
 
     @Override
     public void configure(final Map<String, ?> configs) {
-        final MetricCollector metricCollector = new MetricCollector(metrics);
         final GcsStorageConfig config = new GcsStorageConfig(configs);
         this.bucketName = config.bucketName();
 
@@ -136,6 +137,7 @@ public class GcsStorage extends StorageBackend {
             // all-or-nothing: on success every key is gone (idempotent), and on failure we delete
             // nothing and let the FileCleaner cycle retry the whole set.
             storage.delete(ids);
+            metricCollector.recordBatchDeleteObjects(keys.size());
             return Set.copyOf(keys);
         } catch (final BaseServiceException e) {
             throw new StorageBackendException("Failed to delete " + keys.size() + " keys", e);

--- a/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/gcs/MetricCollector.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/gcs/MetricCollector.java
@@ -21,7 +21,7 @@ package io.aiven.inkless.storage_backend.gcs;
 import org.apache.kafka.common.MetricNameTemplate;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.Sensor;
-import org.apache.kafka.common.metrics.stats.CumulativeCount;
+import org.apache.kafka.common.metrics.stats.CumulativeSum;
 import org.apache.kafka.common.metrics.stats.Rate;
 
 import com.google.api.client.http.*;
@@ -116,8 +116,15 @@ public class MetricCollector {
     ) {
         final Sensor sensor = metrics.sensor(name);
         sensor.add(metrics.metricInstance(rateMetricName), new Rate());
-        sensor.add(metrics.metricInstance(totalMetricName), new CumulativeCount());
+        sensor.add(metrics.metricInstance(totalMetricName), new CumulativeSum());
         return sensor;
+    }
+
+    void recordBatchDeleteObjects(final int objectCount) {
+        // The response interceptor sees only the outer batch request, whose path doesn't identify its operations.
+        if (objectCount > 0) {
+            deleteObjectRequests.record(objectCount);
+        }
     }
 
     private final MetricResponseInterceptor metricResponseInterceptor = new MetricResponseInterceptor();

--- a/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/gcs/integration/GcsStorageMetricsTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/gcs/integration/GcsStorageMetricsTest.java
@@ -38,6 +38,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import java.io.ByteArrayInputStream;
 import java.nio.channels.ReadableByteChannel;
 import java.util.Map;
+import java.util.Set;
 
 import io.aiven.inkless.common.ByteRange;
 import io.aiven.inkless.common.ObjectKey;
@@ -102,6 +103,15 @@ public class GcsStorageMetricsTest {
         }
         storage.delete(key);
 
+        final Set<ObjectKey> batchDeleteKeys = Set.of(
+            new TestObjectKey("batch-delete-1"),
+            new TestObjectKey("batch-delete-2")
+        );
+        for (final ObjectKey batchDeleteKey : batchDeleteKeys) {
+            storage.upload(batchDeleteKey, new ByteArrayInputStream(data), data.length);
+        }
+        storage.delete(batchDeleteKeys);
+
         assertThat(getMetric("object-metadata-get-rate").metricValue())
             .asInstanceOf(DOUBLE)
             .isGreaterThan(0.0);
@@ -118,7 +128,7 @@ public class GcsStorageMetricsTest {
             .asInstanceOf(DOUBLE)
             .isGreaterThan(0.0);
         assertThat(getMetric("object-delete-total").metricValue())
-            .isEqualTo(1.0);
+            .isEqualTo(3.0);
     }
 
     private KafkaMetric getMetric(String metricName) {


### PR DESCRIPTION
Record each operation in a GCS batch delete so retention-driven cleanup is visible through the existing delete rate and total metrics.