### PR TITLE
fix(inkless:storage): report an oversized fetch as a storage failure [KC-481]

### DIFF
--- a/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/common/SizedReadableByteChannel.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/common/SizedReadableByteChannel.java
@@ -23,6 +23,8 @@ import java.nio.channels.ClosedChannelException;
 import java.nio.channels.ReadableByteChannel;
 import java.util.Objects;
 
+import io.aiven.inkless.common.ObjectKey;
+
 /**
  * A channel that knows how many bytes it delivers before EOF.
  *
@@ -91,6 +93,20 @@ public interface SizedReadableByteChannel extends ReadableByteChannel {
                 open = false;
             }
         };
+    }
+
+    /**
+     * Narrows a backend's own {@code long} length to the {@code int} this contract requires.
+     *
+     * @throws StorageBackendException if it does not fit, rather than the unchecked
+     *         {@code ArithmeticException} {@code Math.toIntExact} would raise
+     */
+    static int exactLength(final ObjectKey key, final long contentLength) throws StorageBackendException {
+        if (contentLength < 0 || contentLength > Integer.MAX_VALUE) {
+            throw new StorageBackendException("Failed to fetch " + key + ": content length "
+                + contentLength + " is outside the 0.." + Integer.MAX_VALUE + " bytes a single fetch can hold");
+        }
+        return (int) contentLength;
     }
 
     /**

--- a/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/gcs/GcsStorage.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/gcs/GcsStorage.java
@@ -163,7 +163,7 @@ public class GcsStorage extends StorageBackend {
                 reader.limit(range.endOffset() + 1);
                 reader.seek(range.offset());
             }
-            return SizedReadableByteChannel.of(reader, Math.toIntExact(contentLength));
+            return SizedReadableByteChannel.of(reader, SizedReadableByteChannel.exactLength(key, contentLength));
         } catch (final IOException e) {
             throw new StorageBackendException("Failed to fetch " + key, e);
         } catch (final BaseServiceException e) {

--- a/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/common/SizedReadableByteChannelExactLengthTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/common/SizedReadableByteChannelExactLengthTest.java
@@ -1,0 +1,53 @@
+/*
+ * Inkless
+ * Copyright (C) 2024 - 2026 Aiven OY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.aiven.inkless.storage_backend.common;
+
+import org.junit.jupiter.api.Test;
+
+import io.aiven.inkless.common.ObjectKey;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class SizedReadableByteChannelExactLengthTest {
+
+    private static final ObjectKey KEY = ObjectKey.creator("prefix/", false).from("prefix/obj");
+
+    @Test
+    void returnsTheLengthWhenItFitsInAnInt() throws Exception {
+        assertThat(SizedReadableByteChannel.exactLength(KEY, 0L)).isZero();
+        assertThat(SizedReadableByteChannel.exactLength(KEY, 42L)).isEqualTo(42);
+        assertThat(SizedReadableByteChannel.exactLength(KEY, Integer.MAX_VALUE))
+            .isEqualTo(Integer.MAX_VALUE);
+    }
+
+    @Test
+    void rejectsALengthAnIntCannotHoldNamingTheObjectAndTheLength() {
+        assertThatThrownBy(() -> SizedReadableByteChannel.exactLength(KEY, Integer.MAX_VALUE + 1L))
+            .isInstanceOf(StorageBackendException.class)
+            .hasMessageContaining("prefix/obj")
+            .hasMessageContaining(String.valueOf(Integer.MAX_VALUE + 1L));
+    }
+
+    @Test
+    void rejectsANegativeLength() {
+        assertThatThrownBy(() -> SizedReadableByteChannel.exactLength(KEY, -1L))
+            .isInstanceOf(StorageBackendException.class)
+            .hasMessageContaining("prefix/obj");
+    }
+}


### PR DESCRIPTION
GcsStorage narrowed its long content length with Math.toIntExact, which raises an unchecked ArithmeticException reading "integer overflow". It escapes the StorageBackendException that fetch declares, and names neither the object nor the length.

The int is a property of the SizedReadableByteChannel contract, not of GCS: the payload lands in a single ByteBuffer and a byte[] on the extent. exactLength owns that rule so no backend narrows on its own, and the message carries the key and the length.

InMemoryStorage keeps its own narrowing: it bounds the length by an in-heap byte[], so it cannot exceed the int range by construction.

Unreachable at default caps, since object and range sizes stay well below 2 GiB. Both caps are operator-settable and nothing validates them against this ceiling, so the failure should be diagnosable if anyone raises them.

Testing

SizedReadableByteChannelExactLengthTest covers the boundary: 0, a normal length and Integer.MAX_VALUE pass through; MAX_VALUE + 1 and a negative raise StorageBackendException naming the object and the length.
