### PR TITLE
docs(inkless:sync): align sync guides with PEP 440 version-consistency fixes

### DIFF
--- a/inkless-sync/CONFLICT-RESOLUTION-STRATEGY.md
+++ b/inkless-sync/CONFLICT-RESOLUTION-STRATEGY.md
@@ -26,6 +26,8 @@ Files that are 100% inkless-specific and don't exist in upstream:
 | `build.gradle` | Keep inkless module config (`:storage:inkless`), accept upstream plugin versions |
 | `gradle/dependencies.gradle` | Add inkless dependencies (assertj, testcontainers) to upstream |
 | `settings.gradle` | Verify `storage:inkless` module is included |
+| `tests/kafkatest/__init__.py` | `__version__` must be PEP 440 (https://peps.python.org/pep-0440/) compliant: use `{version}+inkless` (the `+inkless` local version label), never a bare `.inkless`/`-inkless` suffix |
+| `tests/kafkatest/version.py`, `committer-tools/kafka-merge-pr.py`, `streams/quickstart/*.pom` | Must match `gradle.properties` exactly (for example `4.3.0-inkless-SNAPSHOT`); the `:verifyVersionConsistency` Gradle task enforces this |
 
 **Resolution**: Manual review required - merge both sets of changes.
 

--- a/inkless-sync/CONFLICT-RESOLUTION-STRATEGY.md
+++ b/inkless-sync/CONFLICT-RESOLUTION-STRATEGY.md
@@ -26,7 +26,7 @@ Files that are 100% inkless-specific and don't exist in upstream:
 | `build.gradle` | Keep inkless module config (`:storage:inkless`), accept upstream plugin versions |
 | `gradle/dependencies.gradle` | Add inkless dependencies (assertj, testcontainers) to upstream |
 | `settings.gradle` | Verify `storage:inkless` module is included |
-| `tests/kafkatest/__init__.py` | `__version__` must be PEP 440 (https://peps.python.org/pep-0440/) compliant: use `{version}+inkless` (the `+inkless` local version label), never a bare `.inkless`/`-inkless` suffix |
+| `tests/kafkatest/__init__.py` | `__version__` must be PEP 440 (https://peps.python.org/pep-0440/) compliant: use `{X.Y.Z}.dev0+inkless` for `-SNAPSHOT`, otherwise `{X.Y.Z}+inkless`; never a bare `.inkless`/`-inkless` suffix |
 | `tests/kafkatest/version.py`, `committer-tools/kafka-merge-pr.py`, `streams/quickstart/*.pom` | Must match `gradle.properties` exactly (for example `4.3.0-inkless-SNAPSHOT`); the `:verifyVersionConsistency` Gradle task enforces this |
 
 **Resolution**: Manual review required - merge both sets of changes.

--- a/inkless-sync/MAIN-SYNC-ACTION-PLAN.md
+++ b/inkless-sync/MAIN-SYNC-ACTION-PLAN.md
@@ -65,6 +65,13 @@ For each config file (gradle.properties, build.gradle, etc.):
 2. Merge manually: upstream changes + inkless config
 3. Test with `./gradlew tasks` to verify Gradle works
 
+Also check the auxiliary version files that `:verifyVersionConsistency` enforces
+against `gradle.properties`: `tests/kafkatest/__init__.py` (must use the PEP 440
+`+inkless` local version label, not a bare `.inkless`/`-inkless` suffix),
+`tests/kafkatest/version.py`, `committer-tools/kafka-merge-pr.py`, and the
+`streams/quickstart/*.pom` files (must match `gradle.properties` exactly). Run
+`./gradlew verifyVersionConsistency` to confirm.
+
 #### Step 5: Resolve Core Files (30-60 min)
 For each core file with inkless modifications:
 

--- a/inkless-sync/MAIN-SYNC-ACTION-PLAN.md
+++ b/inkless-sync/MAIN-SYNC-ACTION-PLAN.md
@@ -66,8 +66,7 @@ For each config file (gradle.properties, build.gradle, etc.):
 3. Test with `./gradlew tasks` to verify Gradle works
 
 Also check the auxiliary version files that `:verifyVersionConsistency` enforces
-against `gradle.properties`: `tests/kafkatest/__init__.py` (must use the PEP 440
-`+inkless` local version label, not a bare `.inkless`/`-inkless` suffix),
+against `gradle.properties`: `tests/kafkatest/__init__.py` (PEP 440; use `{X.Y.Z}.dev0+inkless` for `-SNAPSHOT`, otherwise `{X.Y.Z}+inkless`; never `.inkless`/`-inkless`),
 `tests/kafkatest/version.py`, `committer-tools/kafka-merge-pr.py`, and the
 `streams/quickstart/*.pom` files (must match `gradle.properties` exactly). Run
 `./gradlew verifyVersionConsistency` to confirm.

--- a/inkless-sync/MAIN-SYNC-PROMPT.md
+++ b/inkless-sync/MAIN-SYNC-PROMPT.md
@@ -91,6 +91,15 @@ For each config file (gradle.properties, build.gradle, gradle/dependencies.gradl
    - Keeps inkless module configuration
    - Accepts upstream dependency/plugin versions
 
+Also check auxiliary version files enforced by `:verifyVersionConsistency`:
+- `tests/kafkatest/__init__.py`: `__version__` must stay PEP 440 compliant, using
+  `{version}+inkless` (the `+inkless` local version label), never a bare
+  `.inkless`/`-inkless` suffix.
+- `tests/kafkatest/version.py`, `committer-tools/kafka-merge-pr.py`, and
+  `streams/quickstart/*.pom`: must match `gradle.properties` exactly.
+
+Run `./gradlew verifyVersionConsistency` to confirm before moving on.
+
 Wait for approval before applying changes.
 ```
 

--- a/inkless-sync/MAIN-SYNC-PROMPT.md
+++ b/inkless-sync/MAIN-SYNC-PROMPT.md
@@ -92,9 +92,7 @@ For each config file (gradle.properties, build.gradle, gradle/dependencies.gradl
    - Accepts upstream dependency/plugin versions
 
 Also check auxiliary version files enforced by `:verifyVersionConsistency`:
-- `tests/kafkatest/__init__.py`: `__version__` must stay PEP 440 compliant, using
-  `{version}+inkless` (the `+inkless` local version label), never a bare
-  `.inkless`/`-inkless` suffix.
+- `tests/kafkatest/__init__.py`: `__version__` must stay PEP 440 compliant. Use `{X.Y.Z}.dev0+inkless` when `gradle.properties` ends with `-SNAPSHOT`, otherwise use `{X.Y.Z}+inkless`; never a bare `.inkless`/`-inkless` suffix.
 - `tests/kafkatest/version.py`, `committer-tools/kafka-merge-pr.py`, and
   `streams/quickstart/*.pom`: must match `gradle.properties` exactly.
 

--- a/inkless-sync/MAIN-SYNC-SESSION-TEMPLATE.md
+++ b/inkless-sync/MAIN-SYNC-SESSION-TEMPLATE.md
@@ -46,10 +46,10 @@ git diff --name-only --diff-filter=U
 | | gradle.properties | | |
 | | build.gradle | | |
 | | gradle/dependencies.gradle | | |
-| | tests/kafkatest/__init__.py | PEP 440 local version label: `{version}+inkless` | |
+| | tests/kafkatest/__init__.py | PEP 440: `{X.Y.Z}.dev0+inkless` for `-SNAPSHOT`, otherwise `{X.Y.Z}+inkless` | |
 | | tests/kafkatest/version.py | Must match `gradle.properties` exactly | |
 | | committer-tools/kafka-merge-pr.py | Must match `gradle.properties` exactly | |
-| | streams/quickstart/*.pom | Must match `gradle.properties` exactly | |
+| | streams/quickstart/**/pom.xml | Must match `gradle.properties` exactly | |
 
 ### Core Files with Inkless Modifications
 | # | File | Inkless Additions Needed | Status |

--- a/inkless-sync/MAIN-SYNC-SESSION-TEMPLATE.md
+++ b/inkless-sync/MAIN-SYNC-SESSION-TEMPLATE.md
@@ -46,6 +46,10 @@ git diff --name-only --diff-filter=U
 | | gradle.properties | | |
 | | build.gradle | | |
 | | gradle/dependencies.gradle | | |
+| | tests/kafkatest/__init__.py | PEP 440 local version label: `{version}+inkless` | |
+| | tests/kafkatest/version.py | Must match `gradle.properties` exactly | |
+| | committer-tools/kafka-merge-pr.py | Must match `gradle.properties` exactly | |
+| | streams/quickstart/*.pom | Must match `gradle.properties` exactly | |
 
 ### Core Files with Inkless Modifications
 | # | File | Inkless Additions Needed | Status |
@@ -111,6 +115,7 @@ make test
   - [ ] `storage/inkless/src/main/java/io/aiven/inkless/InklessWriter.java`
   - [ ] `docs/inkless/README.md`
 - [ ] Version preserved in `gradle.properties`
+- [ ] `./gradlew verifyVersionConsistency` passes
 
 ### Comparison with Previous Sync
 ```bash

--- a/inkless-sync/RELEASE-SYNC-ACTION-PLAN.md
+++ b/inkless-sync/RELEASE-SYNC-ACTION-PLAN.md
@@ -92,7 +92,7 @@ gh pr create --base inkless-4.0 --title "Sync inkless-4.0 to upstream 4.0.1"
 
 ### Version Files
 
-These files need the `-inkless` suffix pattern:
+These files need the `inkless` suffix pattern:
 
 #### gradle.properties
 ```properties
@@ -100,9 +100,8 @@ version=4.0.1-inkless
 ```
 
 #### tests/kafkatest/__init__.py
-This value must stay PEP 440 (https://peps.python.org/pep-0440/) compliant: `setuptools`
-parses it with `packaging.version.Version`, which rejects a bare `-inkless`/`.inkless`
-suffix. Use `+inkless` as a local version label instead.
+This value must stay PEP 440 (https://peps.python.org/pep-0440/) compliant:
+Use `+inkless` as a local version label instead.
 ```python
 __version__ = '4.0.1+inkless'
 ```
@@ -202,7 +201,7 @@ git push -u origin inkless-4.0-sync-4.0.1
 
 Most common scenario:
 
-1. Resolve version files with `-inkless` pattern
+1. Resolve version files with `inkless` pattern
 2. Commit merge
 3. Verify build
 

--- a/inkless-sync/RELEASE-SYNC-ACTION-PLAN.md
+++ b/inkless-sync/RELEASE-SYNC-ACTION-PLAN.md
@@ -100,13 +100,18 @@ version=4.0.1-inkless
 ```
 
 #### tests/kafkatest/__init__.py
+This value must stay PEP 440 (https://peps.python.org/pep-0440/) compliant: `setuptools`
+parses it with `packaging.version.Version`, which rejects a bare `-inkless`/`.inkless`
+suffix. Use `+inkless` as a local version label instead.
 ```python
-__version__ = '4.0.1.inkless'
+__version__ = '4.0.1+inkless'
 ```
 
 #### tests/kafkatest/version.py
+Must match `gradle.properties` exactly (verified by the `:verifyVersionConsistency`
+Gradle task); don't add an extra `-SNAPSHOT` suffix on top of `-inkless`.
 ```python
-DEV_VERSION = KafkaVersion("4.0.1-inkless-SNAPSHOT")
+DEV_VERSION = KafkaVersion("4.0.1-inkless")
 ```
 
 #### docs/js/templateData.js
@@ -124,16 +129,17 @@ var context={
 DEFAULT_FIX_VERSION = "4.0.1-inkless"
 ```
 
-### POM Files (Keep Upstream Version)
+### POM files (use the `-inkless` version)
 
-These files use standard Apache Kafka versioning for Maven Central compatibility:
+These files must match `gradle.properties` exactly; the `:verifyVersionConsistency`
+Gradle task enforces this:
 
 - `streams/quickstart/pom.xml`
 - `streams/quickstart/java/pom.xml`
 - `streams/quickstart/java/src/main/resources/archetype-resources/pom.xml`
 
 ```xml
-<version>4.0.1</version>  <!-- NOT 4.0.1-inkless -->
+<version>4.0.1-inkless</version>
 ```
 
 ### Dependencies (gradle/dependencies.gradle)

--- a/inkless-sync/RELEASE-SYNC-GUIDE.md
+++ b/inkless-sync/RELEASE-SYNC-GUIDE.md
@@ -142,12 +142,12 @@ Common conflict areas when syncing release branches:
 | File | Reason | Resolution |
 |------|--------|------------|
 | `gradle.properties` | Version changes | Use `{version}-inkless` pattern |
-| `tests/kafkatest/__init__.py` | Version changes | Use `{version}.inkless` pattern |
-| `tests/kafkatest/version.py` | DEV_VERSION | Use `{version}-inkless-SNAPSHOT` |
+| `tests/kafkatest/__init__.py` | Version changes | Use `{version}+inkless` (PEP 440 local version label) |
+| `tests/kafkatest/version.py` | DEV_VERSION | Use `{version}-inkless` (matches `gradle.properties` exactly) |
 | `docs/js/templateData.js` | Version strings | Use inkless version pattern |
 | `committer-tools/kafka-merge-pr.py` | DEFAULT_FIX_VERSION | Use inkless version |
 | `gradle/dependencies.gradle` | Dependency changes | Add new upstream deps, verify inkless deps are used |
-| `streams/quickstart/*.pom` | Maven versions | Keep upstream version (no -inkless) |
+| `streams/quickstart/*.pom` | Maven versions | Use `{version}-inkless` (matches `gradle.properties` exactly) |
 | `*.scala` / `*.java` | Import organization | Accept upstream, remove duplicates |
 | `.gitignore` | Inkless-specific entries | Keep both inkless and upstream |
 
@@ -162,10 +162,15 @@ version=4.0.1-inkless
 
 ```python
 # tests/kafkatest/__init__.py
-__version__ = '4.0.1.inkless'
+# This value must stay PEP 440 (https://peps.python.org/pep-0440/) compliant:
+# setuptools parses it with packaging.version.Version, which rejects a bare
+# "-inkless" or ".inkless" suffix. Use "+inkless" as a local version label.
+__version__ = '4.0.1+inkless'
 
 # tests/kafkatest/version.py
-DEV_VERSION = KafkaVersion("4.0.1-inkless-SNAPSHOT")
+# Must match gradle.properties exactly (verified by the ':verifyVersionConsistency'
+# Gradle task); don't add an extra "-SNAPSHOT" suffix on top of "-inkless".
+DEV_VERSION = KafkaVersion("4.0.1-inkless")
 ```
 
 ```javascript
@@ -178,11 +183,12 @@ var context={
 };
 ```
 
-#### POM Files (keep upstream version)
+#### POM files (use the `-inkless` version)
 
-The `streams/quickstart` POMs use standard Apache versioning for Maven Central compatibility:
+The `streams/quickstart` POMs must match `gradle.properties` exactly; the
+`:verifyVersionConsistency` Gradle task enforces this:
 ```xml
-<version>4.0.1</version>  <!-- NOT 4.0.1-inkless -->
+<version>4.0.1-inkless</version>
 ```
 
 #### Dependencies (merge and verify)

--- a/inkless-sync/RELEASE-SYNC-GUIDE.md
+++ b/inkless-sync/RELEASE-SYNC-GUIDE.md
@@ -153,7 +153,7 @@ Common conflict areas when syncing release branches:
 
 ### Conflict Resolution Patterns
 
-#### Version Files (use `-inkless` suffix)
+#### Version Files (use `inkless` suffix)
 
 ```properties
 # gradle.properties
@@ -163,8 +163,7 @@ version=4.0.1-inkless
 ```python
 # tests/kafkatest/__init__.py
 # This value must stay PEP 440 (https://peps.python.org/pep-0440/) compliant:
-# setuptools parses it with packaging.version.Version, which rejects a bare
-# "-inkless" or ".inkless" suffix. Use "+inkless" as a local version label.
+# Use "+inkless" as a local version label.
 __version__ = '4.0.1+inkless'
 
 # tests/kafkatest/version.py

--- a/inkless-sync/RELEASE-SYNC-GUIDE.md
+++ b/inkless-sync/RELEASE-SYNC-GUIDE.md
@@ -147,7 +147,7 @@ Common conflict areas when syncing release branches:
 | `docs/js/templateData.js` | Version strings | Use inkless version pattern |
 | `committer-tools/kafka-merge-pr.py` | DEFAULT_FIX_VERSION | Use inkless version |
 | `gradle/dependencies.gradle` | Dependency changes | Add new upstream deps, verify inkless deps are used |
-| `streams/quickstart/*.pom` | Maven versions | Use `{version}-inkless` (matches `gradle.properties` exactly) |
+| `streams/quickstart/**/pom.xml` | Maven versions | Use `{version}-inkless` (matches `gradle.properties` exactly) |
 | `*.scala` / `*.java` | Import organization | Accept upstream, remove duplicates |
 | `.gitignore` | Inkless-specific entries | Keep both inkless and upstream |
 

--- a/inkless-sync/RELEASE-SYNC-PROMPT.md
+++ b/inkless-sync/RELEASE-SYNC-PROMPT.md
@@ -45,7 +45,7 @@ I need to sync the inkless release branch with an upstream Apache Kafka release.
 6. **Resolve conflicts**: When conflicts occur, resolve them following these patterns:
    - **Version files**: Use `{upstream_version}-inkless` pattern (e.g., `4.0.1-inkless`)
    - **gradle/dependencies.gradle**: Add upstream new deps, verify inkless deps are actually used
-   - **streams/quickstart POMs**: Keep upstream version (no -inkless suffix)
+   - **streams/quickstart POMs**: Keep upstream version (no `inkless` suffix)
    - **Test files**: Accept upstream changes, keep inkless-specific code
    - **.gitignore**: Keep both inkless and upstream entries
 
@@ -77,9 +77,9 @@ Please help me execute this release sync process.
 
 ### Version Files
 
-Files that need `-inkless` suffix:
+Files that need `inkless` suffix:
 - `gradle.properties` → `version=4.0.1-inkless`
-- `tests/kafkatest/__init__.py` → `__version__ = '4.0.1+inkless'` (PEP 440 local version label; a bare `.inkless`/`-inkless` suffix fails `packaging.version.Version` parsing in CI)
+- `tests/kafkatest/__init__.py` → `__version__ = '4.0.1+inkless'` (PEP 440 local version label)
 - `tests/kafkatest/version.py` → `DEV_VERSION = KafkaVersion("4.0.1-inkless")` (must match `gradle.properties` exactly; verified by the `:verifyVersionConsistency` Gradle task)
 - `docs/js/templateData.js` → `"fullDotVersion": "4.0.1-inkless"`
 - `committer-tools/kafka-merge-pr.py` → `DEFAULT_FIX_VERSION = "4.0.1-inkless"`

--- a/inkless-sync/RELEASE-SYNC-PROMPT.md
+++ b/inkless-sync/RELEASE-SYNC-PROMPT.md
@@ -79,14 +79,14 @@ Please help me execute this release sync process.
 
 Files that need `-inkless` suffix:
 - `gradle.properties` → `version=4.0.1-inkless`
-- `tests/kafkatest/__init__.py` → `__version__ = '4.0.1.inkless'`
-- `tests/kafkatest/version.py` → `DEV_VERSION = KafkaVersion("4.0.1-inkless-SNAPSHOT")`
+- `tests/kafkatest/__init__.py` → `__version__ = '4.0.1+inkless'` (PEP 440 local version label; a bare `.inkless`/`-inkless` suffix fails `packaging.version.Version` parsing in CI)
+- `tests/kafkatest/version.py` → `DEV_VERSION = KafkaVersion("4.0.1-inkless")` (must match `gradle.properties` exactly; verified by the `:verifyVersionConsistency` Gradle task)
 - `docs/js/templateData.js` → `"fullDotVersion": "4.0.1-inkless"`
 - `committer-tools/kafka-merge-pr.py` → `DEFAULT_FIX_VERSION = "4.0.1-inkless"`
 
-### POM Files (Keep Upstream Version)
+### POM files (use the `-inkless` version)
 
-These files use standard Apache Kafka versioning:
+These files must match `gradle.properties` exactly (`:verifyVersionConsistency` enforces this):
 - `streams/quickstart/pom.xml`
 - `streams/quickstart/java/pom.xml`
 - `streams/quickstart/java/src/main/resources/archetype-resources/pom.xml`

--- a/inkless-sync/RELEASE-SYNC-SESSION-TEMPLATE.md
+++ b/inkless-sync/RELEASE-SYNC-SESSION-TEMPLATE.md
@@ -47,8 +47,8 @@ git merge [TAG]
 | # | File | Resolution | Status |
 |---|------|------------|--------|
 | 1 | gradle.properties | `version=[TAG]-inkless` | |
-| 2 | tests/kafkatest/__init__.py | `__version__ = '[TAG].inkless'` | |
-| 3 | tests/kafkatest/version.py | `DEV_VERSION = KafkaVersion("[TAG]-inkless-SNAPSHOT")` | |
+| 2 | tests/kafkatest/__init__.py | `__version__ = '[TAG]+inkless'` (PEP 440 local version label; a bare `.inkless`/`-inkless` suffix fails `packaging.version.Version` parsing in CI) | |
+| 3 | tests/kafkatest/version.py | `DEV_VERSION = KafkaVersion("[TAG]-inkless")` (must match `gradle.properties` exactly; verified by the `:verifyVersionConsistency` Gradle task) | |
 | 4 | docs/js/templateData.js | Update version strings | |
 | 5 | committer-tools/kafka-merge-pr.py | `DEFAULT_FIX_VERSION = "[TAG]-inkless"` | |
 
@@ -57,10 +57,10 @@ git merge [TAG]
 |---|------|------------------|--------|
 | | gradle/dependencies.gradle | | |
 
-### POM Files (Keep Upstream Version)
+### POM Files (use the `-inkless` version)
 | # | File | Notes | Status |
 |---|------|-------|--------|
-| | streams/quickstart/pom.xml | No -inkless suffix | |
+| | streams/quickstart/pom.xml | Must match `gradle.properties` exactly (`[TAG]-inkless`); verified by `:verifyVersionConsistency` | |
 | | streams/quickstart/java/pom.xml | | |
 
 ### Test Files


### PR DESCRIPTION
The 4.3.1 release sync (inkless-4.3-sync-4.3.1) and an earlier main (trunk) sync both hit CI failures from the same root cause: upstream's verifyVersionConsistency and pip-install dry-run checks require tests/kafkatest/__init__.py, tests/kafkatest/version.py, committer-tools/kafka-merge-pr.py, and the streams/quickstart POMs to carry the inkless-suffixed version, and __init__.py's __version__ must additionally stay PEP 440 compliant (packaging.version.Version rejects a bare ".inkless"/"-inkless" suffix; use the "+inkless" local version label instead).

None of the sync docs described this pattern correctly or completely: RELEASE-SYNC-GUIDE.md and RELEASE-SYNC-SESSION-TEMPLATE.md still had the old, invalid ".inkless"/"-inkless-SNAPSHOT"/plain-POM guidance; RELEASE-SYNC-ACTION-PLAN.md and RELEASE-SYNC-PROMPT.md repeated the same stale patterns; and the main-sync docs (MAIN-SYNC-ACTION-PLAN.md, MAIN-SYNC-PROMPT.md, MAIN-SYNC-SESSION-TEMPLATE.md, CONFLICT-RESOLUTION-STRATEGY.md) didn't mention these auxiliary version files at all, despite hitting the same failure during a main sync.

Update every affected doc with the correct PEP 440 pattern and the "must match gradle.properties exactly" rule, and add a verifyVersionConsistency checklist item to the main-sync session template, so future syncs of either kind don't repeat these CI failures.