### PR TITLE
fix(inkless:gcs): narrow fetch length before opening the reader

### DIFF
--- a/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/gcs/GcsStorage.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/gcs/GcsStorage.java
@@ -153,6 +153,7 @@ public class GcsStorage extends StorageBackend {
             final long contentLength = range == null
                 ? blob.getSize()
                 : Math.min(range.size(), blob.getSize() - range.offset());
+            final int length = SizedReadableByteChannel.exactLength(key, contentLength);
 
             final ReadChannel reader = blob.reader();
             // A chunk size of 0 makes the client read straight into the destination buffer.
@@ -163,7 +164,7 @@ public class GcsStorage extends StorageBackend {
                 reader.limit(range.endOffset() + 1);
                 reader.seek(range.offset());
             }
-            return SizedReadableByteChannel.of(reader, SizedReadableByteChannel.exactLength(key, contentLength));
+            return SizedReadableByteChannel.of(reader, length);
         } catch (final IOException e) {
             throw new StorageBackendException("Failed to fetch " + key, e);
         } catch (final BaseServiceException e) {


### PR DESCRIPTION
`exactLength` throws before the caller owns the channel. If it runs after `blob.reader()`, that channel is never returned and never closed. Narrow first so an oversized fetch does not open a reader.