### PR TITLE
feat(inkless:storage): bound and shorten the GCS upload path

### DIFF
--- a/docs/inkless/configs.rst
+++ b/docs/inkless/configs.rst
@@ -567,12 +567,28 @@ Under ``inkless.storage.``
   * Valid Values: non-empty string
   * Importance: medium
 
+``gcs.connect.timeout``
+  GCS connection establishment timeout in milliseconds.
+
+  * Type: long
+  * Default: 2000
+  * Valid Values: [1,...,2147483647]
+  * Importance: low
+
 ``gcs.endpoint.url``
   Custom GCS endpoint URL. To be used with custom GCS-compatible backends.
 
   * Type: string
   * Default: null
   * Valid Values: Valid URL as defined in rfc2396
+  * Importance: low
+
+``gcs.read.timeout``
+  GCS response read timeout in milliseconds. Bounds each socket read of a response, not the whole request: connection setup is bounded by gcs.connect.timeout, request-body writes are not covered, and a response that arrives in several reads can take longer. A timed out read is retried by the GCS client for a read operation, but not for an upload, whose attempts are bounded by inkless.produce.max.upload.attempts.
+
+  * Type: long
+  * Default: 1000
+  * Valid Values: [1,...,2147483647]
   * Importance: low
 
 

--- a/docs/inkless/configs.rst
+++ b/docs/inkless/configs.rst
@@ -584,7 +584,7 @@ Under ``inkless.storage.``
   * Importance: low
 
 ``gcs.read.timeout``
-  GCS response read timeout in milliseconds. Bounds each socket read of a response, not the whole request: connection setup is bounded by gcs.connect.timeout, request-body writes are not covered, and a response that arrives in several reads can take longer. A timed out read is retried by the GCS client for a read operation, but not for an upload, whose attempts are bounded by inkless.produce.max.upload.attempts.
+  GCS response read timeout in milliseconds. Bounds each socket read of a response, not the whole request: connection setup is bounded by gcs.connect.timeout, request-body writes are not covered, and a response that arrives in several reads can take longer. Whether a timed out read ends the operation depends on how the GCS client classifies the request. A read and a resumable upload's chunk write are idempotent, so the client retries them under its own retry budget and this value bounds an attempt rather than the operation. A single-request upload and a resumable session initiate are not retried, so for those it bounds the attempt that inkless.produce.max.upload.attempts then counts.
 
   * Type: long
   * Default: 1000

--- a/docs/inkless/metrics.rst
+++ b/docs/inkless/metrics.rst
@@ -112,6 +112,8 @@ object-get-rate                   Rate of get object operations
 object-get-total                  Total number of get object operations                              
 object-metadata-get-rate          Rate of get object metadata operations                             
 object-metadata-get-total         Total number of get object metadata operations                     
+object-upload-rate                Rate of single request object upload operations                    
+object-upload-total               Total number of single request object upload operations            
 resumable-chunk-upload-rate       Rate of upload chunk operations as part of resumable upload        
 resumable-chunk-upload-total      Total number of upload chunk operations as part of resumable upload
 resumable-upload-initiate-rate    Rate of initiate resumable upload operations                       

--- a/docs/inkless/metrics.rst
+++ b/docs/inkless/metrics.rst
@@ -103,22 +103,28 @@ GcsStorage metrics
 io.aiven.inkless.storage:type=gcs-client-metrics
 ------------------------------------------------
 
-================================  ===================================================================
-Attribute name                    Description                                                        
-================================  ===================================================================
-object-delete-rate                Rate of delete object operations                                   
-object-delete-total               Total number of delete object operations                           
-object-get-rate                   Rate of get object operations                                      
-object-get-total                  Total number of get object operations                              
-object-metadata-get-rate          Rate of get object metadata operations                             
-object-metadata-get-total         Total number of get object metadata operations                     
-object-upload-rate                Rate of single request object upload operations                    
-object-upload-total               Total number of single request object upload operations            
-resumable-chunk-upload-rate       Rate of upload chunk operations as part of resumable upload        
-resumable-chunk-upload-total      Total number of upload chunk operations as part of resumable upload
-resumable-upload-initiate-rate    Rate of initiate resumable upload operations                       
-resumable-upload-initiate-total   Total number of initiate resumable upload operations               
-================================  ===================================================================
+================================  ========================================================================================
+Attribute name                    Description                                                                             
+================================  ========================================================================================
+object-delete-rate                Rate of delete object operations                                                        
+object-delete-total               Total number of delete object operations                                                
+object-get-rate                   Rate of get object operations                                                           
+object-get-total                  Total number of get object operations                                                   
+object-metadata-get-rate          Rate of get object metadata operations                                                  
+object-metadata-get-total         Total number of get object metadata operations                                          
+object-upload-rate                Rate of single request object upload operations                                         
+object-upload-total               Total number of single request object upload operations                                 
+other-errors-rate                 Rate of other errors (non-2xx responses other than throttling and server errors)        
+other-errors-total                Total number of other errors (non-2xx responses other than throttling and server errors)
+resumable-chunk-upload-rate       Rate of upload chunk operations as part of resumable upload                             
+resumable-chunk-upload-total      Total number of upload chunk operations as part of resumable upload                     
+resumable-upload-initiate-rate    Rate of initiate resumable upload operations                                            
+resumable-upload-initiate-total   Total number of initiate resumable upload operations                                    
+server-errors-rate                Rate of server errors (other 5xx responses)                                             
+server-errors-total               Total number of server errors (other 5xx responses)                                     
+throttling-errors-rate            Rate of throttling errors (429 and 503 responses)                                       
+throttling-errors-total           Total number of throttling errors (429 and 503 responses)                               
+================================  ========================================================================================
 
 
 InklessFetch metrics

--- a/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/gcs/GcsStorage.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/gcs/GcsStorage.java
@@ -30,9 +30,16 @@ import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 import com.groupcdg.pitest.annotations.CoverageIgnore;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.SocketTimeoutException;
 import java.nio.channels.ReadableByteChannel;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -45,9 +52,18 @@ import io.aiven.inkless.storage_backend.common.KeyNotFoundException;
 import io.aiven.inkless.storage_backend.common.SizedReadableByteChannel;
 import io.aiven.inkless.storage_backend.common.StorageBackend;
 import io.aiven.inkless.storage_backend.common.StorageBackendException;
+import io.aiven.inkless.storage_backend.common.StorageBackendTimeoutException;
 
 @CoverageIgnore  // tested on integration level
 public class GcsStorage extends StorageBackend {
+    private static final Logger LOGGER = LoggerFactory.getLogger(GcsStorage.class);
+
+    // The client splits a delete into HTTP batches of at most 100 sub-requests, and the server has to
+    // process every sub-request before it answers, so the response wait grows with the batch. Half the
+    // client's maximum keeps that wait clear of gcs.read.timeout; a default cleaner cycle of 20000
+    // files then costs 400 round trips, well inside file.cleaner.interval.ms.
+    private static final int MAX_DELETE_BATCH_SIZE = 50;
+
     private volatile Storage storage;
     private String bucketName;
     private ReloadableCredentialsProvider credentialsProvider;
@@ -70,6 +86,8 @@ public class GcsStorage extends StorageBackend {
         this.bucketName = config.bucketName();
 
         final HttpTransportOptions.Builder httpTransportOptionsBuilder = HttpTransportOptions.newBuilder();
+        httpTransportOptionsBuilder.setConnectTimeout((int) config.connectTimeout().toMillis());
+        httpTransportOptionsBuilder.setReadTimeout((int) config.readTimeout().toMillis());
 
         // Create reloadable credentials provider
         this.credentialsProvider = config.reloadableCredentials();
@@ -104,8 +122,24 @@ public class GcsStorage extends StorageBackend {
                         "Object " + key + " created with incorrect length " + transferred + " instead of " + length);
             }
         } catch (final IOException | BaseServiceException e) {
+            if (isTimeout(e)) {
+                throw new StorageBackendTimeoutException("Timed out to upload " + key, e);
+            }
             throw new StorageBackendException("Failed to upload " + key, e);
         }
+    }
+
+    // The GCS client wraps the originating SocketTimeoutException in a BaseServiceException, so the
+    // whole cause chain is inspected.
+    private static boolean isTimeout(final Throwable e) {
+        Throwable cause = e;
+        while (cause != null) {
+            if (cause instanceof SocketTimeoutException) {
+                return true;
+            }
+            cause = cause.getCause() == cause ? null : cause.getCause();
+        }
+        return false;
     }
 
     @Override
@@ -113,28 +147,44 @@ public class GcsStorage extends StorageBackend {
         try {
             storage.delete(this.bucketName, key.value());
         } catch (final BaseServiceException e) {
+            if (isTimeout(e)) {
+                throw new StorageBackendTimeoutException("Timed out to delete " + key, e);
+            }
             throw new StorageBackendException("Failed to delete " + key, e);
         }
     }
 
     @Override
     public Set<ObjectKey> delete(final Set<ObjectKey> keys) throws StorageBackendException {
-        try {
-            final Set<BlobId> ids = keys.stream()
-                    .map(k -> BlobId.of(this.bucketName,k.value()))
-                    .collect(Collectors.toSet());
+        final List<ObjectKey> objectKeys = new ArrayList<>(keys);
+        final Set<ObjectKey> deleted = new HashSet<>();
 
-            // storage.delete returns a List<Boolean> of deleted-vs-already-absent, but a genuine
-            // failure surfaces as a thrown BaseServiceException rather than a per-blob flag, so we
-            // cannot extract a confirmed-deleted subset the way the S3 backend does. This stays
-            // all-or-nothing: on success every key is gone (idempotent), and on failure we delete
-            // nothing and let the FileCleaner cycle retry the whole set.
-            storage.delete(ids);
-            metricCollector.recordBatchDeleteObjects(keys.size());
-            return Set.copyOf(keys);
-        } catch (final BaseServiceException e) {
-            throw new StorageBackendException("Failed to delete " + keys.size() + " keys", e);
+        for (int i = 0; i < objectKeys.size(); i += MAX_DELETE_BATCH_SIZE) {
+            final List<ObjectKey> batch = objectKeys.subList(
+                i,
+                Math.min(i + MAX_DELETE_BATCH_SIZE, objectKeys.size())
+            );
+            final Set<BlobId> ids = batch.stream()
+                    .map(k -> BlobId.of(this.bucketName, k.value()))
+                    .collect(Collectors.toSet());
+            try {
+                // storage.delete returns a List<Boolean> of deleted-vs-already-absent, but a genuine
+                // failure surfaces as a thrown BaseServiceException rather than a per-blob flag, so a
+                // batch stays all-or-nothing: on success every key in it is gone (idempotent), and on
+                // failure none of it is confirmed.
+                storage.delete(ids);
+            } catch (final BaseServiceException e) {
+                // Deletion is idempotent, so stopping here is safe: the keys left unconfirmed stay
+                // marked for deletion and the next FileCleaner cycle retries them.
+                LOGGER.warn("Batch delete failed after {} of {} keys, stopping the pass",
+                    deleted.size(), objectKeys.size(), e);
+                break;
+            }
+            deleted.addAll(batch);
+            metricCollector.recordBatchDeleteObjects(batch.size());
         }
+
+        return deleted;
     }
 
     @Override
@@ -165,6 +215,9 @@ public class GcsStorage extends StorageBackend {
             }
             return SizedReadableByteChannel.of(reader, SizedReadableByteChannel.exactLength(key, contentLength));
         } catch (final IOException e) {
+            if (isTimeout(e)) {
+                throw new StorageBackendTimeoutException("Timed out to fetch " + key, e);
+            }
             throw new StorageBackendException("Failed to fetch " + key, e);
         } catch (final BaseServiceException e) {
             if (e.getCode() == 404) {
@@ -173,6 +226,11 @@ public class GcsStorage extends StorageBackend {
             } else if (e.getCode() == 416) {
                 // https://cloud.google.com/storage/docs/json_api/v1/status-codes#416_Requested_Range_Not_Satisfiable
                 throw new InvalidRangeException("Failed to fetch " + key + ": Invalid range " + range, e);
+            } else if (isTimeout(e)) {
+                // Reaches only the metadata request. The body is streamed from the channel this
+                // method returns, so a stall mid-download surfaces to the caller as a plain
+                // IOException; ReadableByteChannel.read cannot throw StorageBackendException.
+                throw new StorageBackendTimeoutException("Timed out to fetch " + key, e);
             } else {
                 throw new StorageBackendException("Failed to fetch " + key, e);
             }

--- a/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/gcs/GcsStorage.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/gcs/GcsStorage.java
@@ -64,6 +64,13 @@ public class GcsStorage extends StorageBackend {
     // files then costs 400 round trips, well inside file.cleaner.interval.ms.
     private static final int MAX_DELETE_BATCH_SIZE = 50;
 
+    // A single-request upload saves the round trip a resumable session spends on initiate, but it
+    // buffers the object into one array and cannot stream, so its cost per megabyte is higher. The
+    // measured break-even is near 2 MiB and this sits deliberately below it rather than at it, so
+    // the win holds even if the crossing point shifts. Raising it without re-measuring makes large
+    // uploads slower, not faster.
+    private static final int DIRECT_UPLOAD_MAX_SIZE = 1024 * 1024;
+
     private volatile Storage storage;
     private String bucketName;
     private ReloadableCredentialsProvider credentialsProvider;
@@ -115,11 +122,21 @@ public class GcsStorage extends StorageBackend {
         }
         try {
             final BlobInfo blobInfo = BlobInfo.newBuilder(this.bucketName, key.value()).build();
-            Blob blob = storage.createFrom(blobInfo, inputStream);
+            final Blob blob;
+            if (length <= DIRECT_UPLOAD_MAX_SIZE) {
+                blob = storage.create(blobInfo, inputStream.readNBytes((int) length));
+            } else {
+                blob = storage.createFrom(blobInfo, inputStream);
+            }
             long transferred = blob.getSize();
             if (transferred != length) {
                 throw new StorageBackendException(
                         "Object " + key + " created with incorrect length " + transferred + " instead of " + length);
+            }
+            int remaining = inputStream.read(new byte[]{1});
+            if (remaining != -1) {
+                throw new StorageBackendException(
+                        "Object " + key + " created with incorrect length, input stream has remaining content");
             }
         } catch (final IOException | BaseServiceException e) {
             if (isTimeout(e)) {

--- a/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/gcs/GcsStorage.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/gcs/GcsStorage.java
@@ -27,6 +27,8 @@ import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageBatch;
+import com.google.cloud.storage.StorageBatchResult;
 import com.google.cloud.storage.StorageOptions;
 import com.groupcdg.pitest.annotations.CoverageIgnore;
 
@@ -39,11 +41,12 @@ import java.net.SocketTimeoutException;
 import java.nio.channels.ReadableByteChannel;
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.stream.Collectors;
+import java.util.TreeMap;
 
 import io.aiven.inkless.common.ByteRange;
 import io.aiven.inkless.common.ObjectKey;
@@ -63,6 +66,9 @@ public class GcsStorage extends StorageBackend {
     // client's maximum keeps that wait clear of gcs.read.timeout; a default cleaner cycle of 20000
     // files then costs 400 round trips, well inside file.cleaner.interval.ms.
     private static final int MAX_DELETE_BATCH_SIZE = 50;
+
+    // https://cloud.google.com/storage/docs/retry-strategy#client-libraries
+    private static final Set<Integer> THROTTLE_RESPONSE_CODES = Set.of(429, 503);
 
     // A single-request upload saves the round trip a resumable session spends on initiate, but it
     // buffers the object into one array and cannot stream, so its cost per megabyte is higher. The
@@ -175,30 +181,56 @@ public class GcsStorage extends StorageBackend {
     public Set<ObjectKey> delete(final Set<ObjectKey> keys) throws StorageBackendException {
         final List<ObjectKey> objectKeys = new ArrayList<>(keys);
         final Set<ObjectKey> deleted = new HashSet<>();
+        // Count the failures by response code instead of logging one line per key: a pass that fails
+        // for every key repeats on every FileCleaner cycle, so per-key lines grow with the worklist.
+        final Map<Integer, Integer> failuresByCode = new TreeMap<>();
 
         for (int i = 0; i < objectKeys.size(); i += MAX_DELETE_BATCH_SIZE) {
             final List<ObjectKey> batch = objectKeys.subList(
                 i,
                 Math.min(i + MAX_DELETE_BATCH_SIZE, objectKeys.size())
             );
-            final Set<BlobId> ids = batch.stream()
-                    .map(k -> BlobId.of(this.bucketName, k.value()))
-                    .collect(Collectors.toSet());
+            // Storage.delete(Iterable) collapses a failed sub-request into the same false its callback
+            // uses for an absent blob, which loses the distinction this method has to return. Driving
+            // the batch keeps it: a result carries true or false, and a failure throws.
+            final StorageBatch storageBatch = storage.batch();
+            final Map<ObjectKey, StorageBatchResult<Boolean>> results = new LinkedHashMap<>();
+            for (final ObjectKey key : batch) {
+                results.put(key, storageBatch.delete(BlobId.of(this.bucketName, key.value())));
+            }
             try {
-                // storage.delete returns a List<Boolean> of deleted-vs-already-absent, but a genuine
-                // failure surfaces as a thrown BaseServiceException rather than a per-blob flag, so a
-                // batch stays all-or-nothing: on success every key in it is gone (idempotent), and on
-                // failure none of it is confirmed.
-                storage.delete(ids);
+                storageBatch.submit();
             } catch (final BaseServiceException e) {
-                // Deletion is idempotent, so stopping here is safe: the keys left unconfirmed stay
-                // marked for deletion and the next FileCleaner cycle retries them.
-                LOGGER.warn("Batch delete failed after {} of {} keys, stopping the pass",
+                // The request itself failed, so no sub-request was applied. Deletion is idempotent, so
+                // stopping here is safe: the keys left unconfirmed stay marked for deletion and the
+                // next FileCleaner cycle retries them.
+                LOGGER.warn("Batch delete request failed after {} of {} keys, stopping the pass",
                     deleted.size(), objectKeys.size(), e);
                 break;
             }
-            deleted.addAll(batch);
-            metricCollector.recordBatchDeleteObjects(batch.size());
+            int confirmed = 0;
+            for (final var result : results.entrySet()) {
+                try {
+                    // Called to throw on a failed sub-request. The result is ignored: deleted (true) and
+                    // already absent (false) both leave the key gone.
+                    result.getValue().get();
+                    deleted.add(result.getKey());
+                    confirmed++;
+                } catch (final BaseServiceException e) {
+                    failuresByCode.merge(e.getCode(), 1, Integer::sum);
+                }
+            }
+            metricCollector.recordBatchDeleteObjects(confirmed);
+        }
+
+        if (!failuresByCode.isEmpty()) {
+            // Throttling is backpressure the next FileCleaner cycle retries; any other code needs an
+            // operator, so it must not sit at INFO while the worklist stops draining.
+            if (THROTTLE_RESPONSE_CODES.containsAll(failuresByCode.keySet())) {
+                LOGGER.info("Delete failures by response code {}", failuresByCode);
+            } else {
+                LOGGER.warn("Delete failures by response code {}", failuresByCode);
+            }
         }
 
         return deleted;

--- a/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/gcs/GcsStorage.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/gcs/GcsStorage.java
@@ -204,6 +204,7 @@ public class GcsStorage extends StorageBackend {
                 // The request itself failed, so no sub-request was applied. Deletion is idempotent, so
                 // stopping here is safe: the keys left unconfirmed stay marked for deletion and the
                 // next FileCleaner cycle retries them.
+                metricCollector.recordBatchRequestFailure(e);
                 LOGGER.warn("Batch delete request failed after {} of {} keys, stopping the pass",
                     deleted.size(), objectKeys.size(), e);
                 break;

--- a/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/gcs/GcsStorageConfig.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/gcs/GcsStorageConfig.java
@@ -24,6 +24,7 @@ import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.types.Password;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Map;
 
 import io.aiven.inkless.common.config.validators.NonEmptyPassword;
@@ -36,6 +37,19 @@ public class GcsStorageConfig extends AbstractConfig {
     static final String GCS_ENDPOINT_URL_CONFIG = "gcs.endpoint.url";
     private static final String GCS_ENDPOINT_URL_DOC = "Custom GCS endpoint URL. "
         + "To be used with custom GCS-compatible backends.";
+
+    static final String GCS_CONNECT_TIMEOUT_CONFIG = "gcs.connect.timeout";
+    private static final String GCS_CONNECT_TIMEOUT_DOC = "GCS connection establishment timeout in milliseconds.";
+    private static final long GCS_CONNECT_TIMEOUT_DEFAULT = 2_000;
+
+    static final String GCS_READ_TIMEOUT_CONFIG = "gcs.read.timeout";
+    private static final String GCS_READ_TIMEOUT_DOC = "GCS response read timeout in milliseconds. "
+        + "Bounds each socket read of a response, not the whole request: connection setup is bounded "
+        + "by gcs.connect.timeout, request-body writes are not covered, and a response that arrives "
+        + "in several reads can take longer. A timed out read is retried by the GCS client for a read "
+        + "operation, but not for an upload, whose attempts are bounded by "
+        + "inkless.produce.max.upload.attempts.";
+    private static final long GCS_READ_TIMEOUT_DEFAULT = 1_000;
 
     static final String GCP_CREDENTIALS_JSON_CONFIG = "gcs.credentials.json";
     static final String GCP_CREDENTIALS_PATH_CONFIG = "gcs.credentials.path";
@@ -69,6 +83,20 @@ public class GcsStorageConfig extends AbstractConfig {
                 new ValidUrl(),
                 ConfigDef.Importance.LOW,
                 GCS_ENDPOINT_URL_DOC)
+            .define(
+                GCS_CONNECT_TIMEOUT_CONFIG,
+                ConfigDef.Type.LONG,
+                GCS_CONNECT_TIMEOUT_DEFAULT,
+                ConfigDef.Range.between(1, Integer.MAX_VALUE),
+                ConfigDef.Importance.LOW,
+                GCS_CONNECT_TIMEOUT_DOC)
+            .define(
+                GCS_READ_TIMEOUT_CONFIG,
+                ConfigDef.Type.LONG,
+                GCS_READ_TIMEOUT_DEFAULT,
+                ConfigDef.Range.between(1, Integer.MAX_VALUE),
+                ConfigDef.Importance.LOW,
+                GCS_READ_TIMEOUT_DOC)
             .define(
                 GCP_CREDENTIALS_JSON_CONFIG,
                 ConfigDef.Type.PASSWORD,
@@ -118,6 +146,18 @@ public class GcsStorageConfig extends AbstractConfig {
 
     String endpointUrl() {
         return getString(GCS_ENDPOINT_URL_CONFIG);
+    }
+
+    Duration connectTimeout() {
+        return getDuration(GCS_CONNECT_TIMEOUT_CONFIG);
+    }
+
+    Duration readTimeout() {
+        return getDuration(GCS_READ_TIMEOUT_CONFIG);
+    }
+
+    private Duration getDuration(final String key) {
+        return Duration.ofMillis(getLong(key));
     }
 
     /**

--- a/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/gcs/GcsStorageConfig.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/gcs/GcsStorageConfig.java
@@ -46,9 +46,12 @@ public class GcsStorageConfig extends AbstractConfig {
     private static final String GCS_READ_TIMEOUT_DOC = "GCS response read timeout in milliseconds. "
         + "Bounds each socket read of a response, not the whole request: connection setup is bounded "
         + "by gcs.connect.timeout, request-body writes are not covered, and a response that arrives "
-        + "in several reads can take longer. A timed out read is retried by the GCS client for a read "
-        + "operation, but not for an upload, whose attempts are bounded by "
-        + "inkless.produce.max.upload.attempts.";
+        + "in several reads can take longer. Whether a timed out read ends the operation depends on "
+        + "how the GCS client classifies the request. A read and a resumable upload's chunk write are "
+        + "idempotent, so the client retries them under its own retry budget and this value bounds an "
+        + "attempt rather than the operation. A single-request upload and a resumable session initiate "
+        + "are not retried, so for those it bounds the attempt that "
+        + "inkless.produce.max.upload.attempts then counts.";
     private static final long GCS_READ_TIMEOUT_DEFAULT = 1_000;
 
     static final String GCP_CREDENTIALS_JSON_CONFIG = "gcs.credentials.json";

--- a/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/gcs/MetricCollector.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/gcs/MetricCollector.java
@@ -40,6 +40,9 @@ import static io.aiven.inkless.storage_backend.gcs.MetricRegistry.OBJECT_GET_TOT
 import static io.aiven.inkless.storage_backend.gcs.MetricRegistry.OBJECT_METADATA_GET;
 import static io.aiven.inkless.storage_backend.gcs.MetricRegistry.OBJECT_METADATA_GET_RATE_METRIC_NAME;
 import static io.aiven.inkless.storage_backend.gcs.MetricRegistry.OBJECT_METADATA_GET_TOTAL_METRIC_NAME;
+import static io.aiven.inkless.storage_backend.gcs.MetricRegistry.OBJECT_UPLOAD;
+import static io.aiven.inkless.storage_backend.gcs.MetricRegistry.OBJECT_UPLOAD_RATE_METRIC_NAME;
+import static io.aiven.inkless.storage_backend.gcs.MetricRegistry.OBJECT_UPLOAD_TOTAL_METRIC_NAME;
 import static io.aiven.inkless.storage_backend.gcs.MetricRegistry.RESUMABLE_CHUNK_UPLOAD;
 import static io.aiven.inkless.storage_backend.gcs.MetricRegistry.RESUMABLE_CHUNK_UPLOAD_RATE_METRIC_NAME;
 import static io.aiven.inkless.storage_backend.gcs.MetricRegistry.RESUMABLE_CHUNK_UPLOAD_TOTAL_METRIC_NAME;
@@ -76,6 +79,7 @@ public class MetricCollector {
     private final Metrics metrics;
     private final Sensor getObjectMetadataRequests;
     private final Sensor deleteObjectRequests;
+    private final Sensor uploadObjectRequests;
     private final Sensor resumableUploadInitiateRequests;
     private final Sensor resumableChunkUploadRequests;
     private final Sensor getObjectRequests;
@@ -96,6 +100,11 @@ public class MetricCollector {
             OBJECT_DELETE,
             OBJECT_DELETE_RATE_METRIC_NAME,
             OBJECT_DELETE_TOTAL_METRIC_NAME
+        );
+        uploadObjectRequests = createSensor(
+            OBJECT_UPLOAD,
+            OBJECT_UPLOAD_RATE_METRIC_NAME,
+            OBJECT_UPLOAD_TOTAL_METRIC_NAME
         );
         resumableUploadInitiateRequests = createSensor(
             RESUMABLE_UPLOAD_INITIATE,
@@ -150,11 +159,15 @@ public class MetricCollector {
                 }
             } else if (OBJECT_UPLOAD_PATH_PATTERN.matcher(url.getRawPath()).matches()) {
                 // Object upload operations.
-                if (request.getRequestMethod().equals(HttpMethods.POST)
-                    && url.getFirst("uploadType").equals("resumable")) {
-                    resumableUploadInitiateRequests.record();
+                final boolean resumable = "resumable".equals(url.getFirst("uploadType"));
+                if (request.getRequestMethod().equals(HttpMethods.POST)) {
+                    if (resumable) {
+                        resumableUploadInitiateRequests.record();
+                    } else {
+                        uploadObjectRequests.record();
+                    }
                 } else if (request.getRequestMethod().equals(HttpMethods.PUT)
-                    && url.getFirst("uploadType").equals("resumable")
+                    && resumable
                     && url.containsKey("upload_id")) {
                     resumableChunkUploadRequests.record();
                 }

--- a/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/gcs/MetricCollector.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/gcs/MetricCollector.java
@@ -24,7 +24,13 @@ import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.metrics.stats.CumulativeSum;
 import org.apache.kafka.common.metrics.stats.Rate;
 
-import com.google.api.client.http.*;
+import com.google.api.client.http.GenericUrl;
+import com.google.api.client.http.HttpMethods;
+import com.google.api.client.http.HttpRequest;
+import com.google.api.client.http.HttpRequestInitializer;
+import com.google.api.client.http.HttpResponse;
+import com.google.api.client.http.HttpResponseInterceptor;
+import com.google.cloud.BaseServiceException;
 import com.google.cloud.ServiceOptions;
 import com.google.cloud.http.HttpTransportOptions;
 import com.groupcdg.pitest.annotations.CoverageIgnore;
@@ -43,12 +49,21 @@ import static io.aiven.inkless.storage_backend.gcs.MetricRegistry.OBJECT_METADAT
 import static io.aiven.inkless.storage_backend.gcs.MetricRegistry.OBJECT_UPLOAD;
 import static io.aiven.inkless.storage_backend.gcs.MetricRegistry.OBJECT_UPLOAD_RATE_METRIC_NAME;
 import static io.aiven.inkless.storage_backend.gcs.MetricRegistry.OBJECT_UPLOAD_TOTAL_METRIC_NAME;
+import static io.aiven.inkless.storage_backend.gcs.MetricRegistry.OTHER_ERRORS;
+import static io.aiven.inkless.storage_backend.gcs.MetricRegistry.OTHER_ERRORS_RATE_METRIC_NAME;
+import static io.aiven.inkless.storage_backend.gcs.MetricRegistry.OTHER_ERRORS_TOTAL_METRIC_NAME;
 import static io.aiven.inkless.storage_backend.gcs.MetricRegistry.RESUMABLE_CHUNK_UPLOAD;
 import static io.aiven.inkless.storage_backend.gcs.MetricRegistry.RESUMABLE_CHUNK_UPLOAD_RATE_METRIC_NAME;
 import static io.aiven.inkless.storage_backend.gcs.MetricRegistry.RESUMABLE_CHUNK_UPLOAD_TOTAL_METRIC_NAME;
 import static io.aiven.inkless.storage_backend.gcs.MetricRegistry.RESUMABLE_UPLOAD_INITIATE;
 import static io.aiven.inkless.storage_backend.gcs.MetricRegistry.RESUMABLE_UPLOAD_INITIATE_RATE_METRIC_NAME;
 import static io.aiven.inkless.storage_backend.gcs.MetricRegistry.RESUMABLE_UPLOAD_INITIATE_TOTAL_METRIC_NAME;
+import static io.aiven.inkless.storage_backend.gcs.MetricRegistry.SERVER_ERRORS;
+import static io.aiven.inkless.storage_backend.gcs.MetricRegistry.SERVER_ERRORS_RATE_METRIC_NAME;
+import static io.aiven.inkless.storage_backend.gcs.MetricRegistry.SERVER_ERRORS_TOTAL_METRIC_NAME;
+import static io.aiven.inkless.storage_backend.gcs.MetricRegistry.THROTTLING_ERRORS;
+import static io.aiven.inkless.storage_backend.gcs.MetricRegistry.THROTTLING_ERRORS_RATE_METRIC_NAME;
+import static io.aiven.inkless.storage_backend.gcs.MetricRegistry.THROTTLING_ERRORS_TOTAL_METRIC_NAME;
 
 @CoverageIgnore  // tested on integration level
 public class MetricCollector {
@@ -83,6 +98,9 @@ public class MetricCollector {
     private final Sensor resumableUploadInitiateRequests;
     private final Sensor resumableChunkUploadRequests;
     private final Sensor getObjectRequests;
+    private final Sensor throttlingErrors;
+    private final Sensor serverErrors;
+    private final Sensor otherErrors;
 
     public MetricCollector(final Metrics metrics) {
         this.metrics = metrics;
@@ -116,6 +134,21 @@ public class MetricCollector {
             RESUMABLE_CHUNK_UPLOAD_RATE_METRIC_NAME,
             RESUMABLE_CHUNK_UPLOAD_TOTAL_METRIC_NAME
         );
+        throttlingErrors = createSensor(
+            THROTTLING_ERRORS,
+            THROTTLING_ERRORS_RATE_METRIC_NAME,
+            THROTTLING_ERRORS_TOTAL_METRIC_NAME
+        );
+        serverErrors = createSensor(
+            SERVER_ERRORS,
+            SERVER_ERRORS_RATE_METRIC_NAME,
+            SERVER_ERRORS_TOTAL_METRIC_NAME
+        );
+        otherErrors = createSensor(
+            OTHER_ERRORS,
+            OTHER_ERRORS_RATE_METRIC_NAME,
+            OTHER_ERRORS_TOTAL_METRIC_NAME
+        );
     }
 
     private Sensor createSensor(
@@ -129,10 +162,29 @@ public class MetricCollector {
         return sensor;
     }
 
+    // The client builds the batch request without the request initializer, so the response interceptor
+    // never sees it; its caller reports both its operations and its failure.
     void recordBatchDeleteObjects(final int objectCount) {
-        // The response interceptor sees only the outer batch request, whose path doesn't identify its operations.
         if (objectCount > 0) {
             deleteObjectRequests.record(objectCount);
+        }
+    }
+
+    void recordBatchRequestFailure(final BaseServiceException error) {
+        if (error.getCode() != BaseServiceException.UNKNOWN_CODE) {
+            recordResponseStatus(error.getCode());
+        }
+    }
+
+    private void recordResponseStatus(final int statusCode) {
+        // 503 counts as throttling, as it does for S3's SlowDown: GCS returns it under load and asks
+        // the client to back off rather than reporting a fault.
+        if (statusCode == 429 || statusCode == 503) {
+            throttlingErrors.record();
+        } else if (statusCode >= 500) {
+            serverErrors.record();
+        } else if (statusCode >= 400) {
+            otherErrors.record();
         }
     }
 
@@ -142,6 +194,8 @@ public class MetricCollector {
 
         @Override
         public void interceptResponse(final HttpResponse response) {
+            recordResponseStatus(response.getStatusCode());
+
             final HttpRequest request = response.getRequest();
             final GenericUrl url = request.getUrl();
 

--- a/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/gcs/MetricRegistry.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/gcs/MetricRegistry.java
@@ -39,6 +39,10 @@ public class MetricRegistry {
     static final String OBJECT_DELETE_RATE = OBJECT_DELETE + "-rate";
     static final String OBJECT_DELETE_TOTAL = OBJECT_DELETE + "-total";
     static final String OBJECT_DELETE_DOC = "delete object operations";
+    static final String OBJECT_UPLOAD = "object-upload";
+    static final String OBJECT_UPLOAD_RATE = OBJECT_UPLOAD + "-rate";
+    static final String OBJECT_UPLOAD_TOTAL = OBJECT_UPLOAD + "-total";
+    static final String OBJECT_UPLOAD_DOC = "single request object upload operations";
     static final String RESUMABLE_UPLOAD_INITIATE = "resumable-upload-initiate";
     static final String RESUMABLE_UPLOAD_INITIATE_RATE = RESUMABLE_UPLOAD_INITIATE + "-rate";
     static final String RESUMABLE_UPLOAD_INITIATE_TOTAL = RESUMABLE_UPLOAD_INITIATE + "-total";
@@ -81,6 +85,16 @@ public class MetricRegistry {
         METRIC_GROUP,
         TOTAL_DOC_PREFIX + OBJECT_DELETE_DOC
     );
+    static final MetricNameTemplate OBJECT_UPLOAD_RATE_METRIC_NAME = new MetricNameTemplate(
+        OBJECT_UPLOAD_RATE,
+        METRIC_GROUP,
+        RATE_DOC_PREFIX + OBJECT_UPLOAD_DOC
+    );
+    static final MetricNameTemplate OBJECT_UPLOAD_TOTAL_METRIC_NAME = new MetricNameTemplate(
+        OBJECT_UPLOAD_TOTAL,
+        METRIC_GROUP,
+        TOTAL_DOC_PREFIX + OBJECT_UPLOAD_DOC
+    );
     static final MetricNameTemplate RESUMABLE_UPLOAD_INITIATE_RATE_METRIC_NAME = new MetricNameTemplate(
         RESUMABLE_UPLOAD_INITIATE_RATE,
         METRIC_GROUP,
@@ -110,6 +124,8 @@ public class MetricRegistry {
             OBJECT_GET_TOTAL_METRIC_NAME,
             OBJECT_DELETE_RATE_METRIC_NAME,
             OBJECT_DELETE_TOTAL_METRIC_NAME,
+            OBJECT_UPLOAD_RATE_METRIC_NAME,
+            OBJECT_UPLOAD_TOTAL_METRIC_NAME,
             RESUMABLE_UPLOAD_INITIATE_RATE_METRIC_NAME,
             RESUMABLE_UPLOAD_INITIATE_TOTAL_METRIC_NAME,
             RESUMABLE_CHUNK_UPLOAD_RATE_METRIC_NAME,

--- a/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/gcs/MetricRegistry.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/gcs/MetricRegistry.java
@@ -52,6 +52,23 @@ public class MetricRegistry {
     static final String RESUMABLE_CHUNK_UPLOAD_TOTAL = RESUMABLE_CHUNK_UPLOAD + "-total";
     static final String RESUMABLE_CHUNK_UPLOAD_DOC = "upload chunk operations as part of resumable upload";
 
+    // Error sensors count per request attempt, so a failure the client retries is counted once per
+    // attempt. The names match the S3 backend's so dashboards can be shared across backends. A request
+    // that fails without a response is not counted: the client offers no once-per-attempt hook that
+    // carries the exception.
+    static final String THROTTLING_ERRORS = "throttling-errors";
+    static final String THROTTLING_ERRORS_RATE = THROTTLING_ERRORS + "-rate";
+    static final String THROTTLING_ERRORS_TOTAL = THROTTLING_ERRORS + "-total";
+    static final String THROTTLING_ERRORS_DOC = "throttling errors (429 and 503 responses)";
+    static final String SERVER_ERRORS = "server-errors";
+    static final String SERVER_ERRORS_RATE = SERVER_ERRORS + "-rate";
+    static final String SERVER_ERRORS_TOTAL = SERVER_ERRORS + "-total";
+    static final String SERVER_ERRORS_DOC = "server errors (other 5xx responses)";
+    static final String OTHER_ERRORS = "other-errors";
+    static final String OTHER_ERRORS_RATE = OTHER_ERRORS + "-rate";
+    static final String OTHER_ERRORS_TOTAL = OTHER_ERRORS + "-total";
+    static final String OTHER_ERRORS_DOC = "other errors (non-2xx responses other than throttling and server errors)";
+
     private static final String RATE_DOC_PREFIX = "Rate of ";
     private static final String TOTAL_DOC_PREFIX = "Total number of ";
 
@@ -115,6 +132,36 @@ public class MetricRegistry {
         METRIC_GROUP,
         TOTAL_DOC_PREFIX + RESUMABLE_CHUNK_UPLOAD_DOC
     );
+    static final MetricNameTemplate THROTTLING_ERRORS_RATE_METRIC_NAME = new MetricNameTemplate(
+        THROTTLING_ERRORS_RATE,
+        METRIC_GROUP,
+        RATE_DOC_PREFIX + THROTTLING_ERRORS_DOC
+    );
+    static final MetricNameTemplate THROTTLING_ERRORS_TOTAL_METRIC_NAME = new MetricNameTemplate(
+        THROTTLING_ERRORS_TOTAL,
+        METRIC_GROUP,
+        TOTAL_DOC_PREFIX + THROTTLING_ERRORS_DOC
+    );
+    static final MetricNameTemplate SERVER_ERRORS_RATE_METRIC_NAME = new MetricNameTemplate(
+        SERVER_ERRORS_RATE,
+        METRIC_GROUP,
+        RATE_DOC_PREFIX + SERVER_ERRORS_DOC
+    );
+    static final MetricNameTemplate SERVER_ERRORS_TOTAL_METRIC_NAME = new MetricNameTemplate(
+        SERVER_ERRORS_TOTAL,
+        METRIC_GROUP,
+        TOTAL_DOC_PREFIX + SERVER_ERRORS_DOC
+    );
+    static final MetricNameTemplate OTHER_ERRORS_RATE_METRIC_NAME = new MetricNameTemplate(
+        OTHER_ERRORS_RATE,
+        METRIC_GROUP,
+        RATE_DOC_PREFIX + OTHER_ERRORS_DOC
+    );
+    static final MetricNameTemplate OTHER_ERRORS_TOTAL_METRIC_NAME = new MetricNameTemplate(
+        OTHER_ERRORS_TOTAL,
+        METRIC_GROUP,
+        TOTAL_DOC_PREFIX + OTHER_ERRORS_DOC
+    );
 
     public static List<MetricNameTemplate> all() {
         return List.of(
@@ -129,7 +176,13 @@ public class MetricRegistry {
             RESUMABLE_UPLOAD_INITIATE_RATE_METRIC_NAME,
             RESUMABLE_UPLOAD_INITIATE_TOTAL_METRIC_NAME,
             RESUMABLE_CHUNK_UPLOAD_RATE_METRIC_NAME,
-            RESUMABLE_CHUNK_UPLOAD_TOTAL_METRIC_NAME
+            RESUMABLE_CHUNK_UPLOAD_TOTAL_METRIC_NAME,
+            THROTTLING_ERRORS_RATE_METRIC_NAME,
+            THROTTLING_ERRORS_TOTAL_METRIC_NAME,
+            SERVER_ERRORS_RATE_METRIC_NAME,
+            SERVER_ERRORS_TOTAL_METRIC_NAME,
+            OTHER_ERRORS_RATE_METRIC_NAME,
+            OTHER_ERRORS_TOTAL_METRIC_NAME
         );
     }
 }

--- a/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/gcs/GcsStorageConfigTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/gcs/GcsStorageConfigTest.java
@@ -31,6 +31,7 @@ import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -49,6 +50,8 @@ class GcsStorageConfigTest {
         final GcsStorageConfig config = new GcsStorageConfig(configs);
         assertThat(config.bucketName()).isEqualTo(bucketName);
         assertThat(config.endpointUrl()).isNull();
+        assertThat(config.connectTimeout()).isEqualTo(Duration.ofSeconds(2));
+        assertThat(config.readTimeout()).isEqualTo(Duration.ofSeconds(1));
 
         final GoogleCredentials mockCredentials = GoogleCredentials.newBuilder().build();
         try (final MockedStatic<GoogleCredentials> googleCredentialsMockedStatic =
@@ -56,6 +59,28 @@ class GcsStorageConfigTest {
             googleCredentialsMockedStatic.when(GoogleCredentials::getApplicationDefault).thenReturn(mockCredentials);
             assertThat(config.reloadableCredentials().getCredentials()).isSameAs(mockCredentials);
         }
+    }
+
+    @Test
+    void timeouts() {
+        final GcsStorageConfig config = new GcsStorageConfig(Map.of(
+            "gcs.bucket.name", "b1",
+            "gcs.credentials.default", "true",
+            "gcs.connect.timeout", 500L,
+            "gcs.read.timeout", 2000L));
+        assertThat(config.connectTimeout()).isEqualTo(Duration.ofMillis(500));
+        assertThat(config.readTimeout()).isEqualTo(Duration.ofMillis(2000));
+    }
+
+    @Test
+    void invalidReadTimeout() {
+        assertThatThrownBy(() -> new GcsStorageConfig(
+            Map.of(
+                "gcs.bucket.name", "bucket",
+                "gcs.read.timeout", 0L)
+        ))
+            .isInstanceOf(ConfigException.class)
+            .hasMessage("Invalid value 0 for configuration gcs.read.timeout: Value must be at least 1");
     }
 
     @Test

--- a/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/gcs/integration/GcsErrorHandlingTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/gcs/integration/GcsErrorHandlingTest.java
@@ -1,0 +1,74 @@
+/*
+ * Inkless
+ * Copyright (C) 2024 - 2026 Aiven OY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.aiven.inkless.storage_backend.gcs.integration;
+
+import org.apache.kafka.common.metrics.Metrics;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.net.SocketTimeoutException;
+import java.util.Map;
+
+import io.aiven.inkless.storage_backend.common.StorageBackendTimeoutException;
+import io.aiven.inkless.storage_backend.common.fixtures.TestObjectKey;
+import io.aiven.inkless.storage_backend.gcs.GcsStorage;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.any;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Tag("integration")
+@WireMockTest
+class GcsErrorHandlingTest {
+    private static final String BUCKET_NAME = "test-bucket";
+    private final GcsStorage storage = new GcsStorage(new Metrics());
+
+    @AfterEach
+    void tearDown() throws Exception {
+        storage.close();
+    }
+
+    @Test
+    void uploadReadTimeout(final WireMockRuntimeInfo wmRuntimeInfo) {
+        configure(wmRuntimeInfo);
+        stubFor(any(anyUrl()).willReturn(aResponse().withFixedDelay(100)));
+
+        final byte[] data = "content".getBytes();
+        assertThatThrownBy(() -> storage.upload(new TestObjectKey("key"), new ByteArrayInputStream(data), data.length))
+            .isExactlyInstanceOf(StorageBackendTimeoutException.class)
+            .hasMessage("Timed out to upload key")
+            // The client wraps the socket timeout, so this pins the cause-chain walk in isTimeout.
+            .hasRootCauseInstanceOf(SocketTimeoutException.class);
+    }
+
+    private void configure(final WireMockRuntimeInfo wmRuntimeInfo) {
+        storage.configure(Map.of(
+            "gcs.bucket.name", BUCKET_NAME,
+            "gcs.endpoint.url", wmRuntimeInfo.getHttpBaseUrl(),
+            "gcs.credentials.default", "false",
+            "gcs.read.timeout", 1L));
+    }
+}

--- a/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/gcs/integration/GcsErrorHandlingTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/gcs/integration/GcsErrorHandlingTest.java
@@ -32,6 +32,8 @@ import java.util.Map;
 import java.util.Set;
 
 import io.aiven.inkless.common.ObjectKey;
+import io.aiven.inkless.storage_backend.common.KeyNotFoundException;
+import io.aiven.inkless.storage_backend.common.StorageBackendException;
 import io.aiven.inkless.storage_backend.common.StorageBackendTimeoutException;
 import io.aiven.inkless.storage_backend.common.fixtures.TestObjectKey;
 import io.aiven.inkless.storage_backend.gcs.GcsStorage;
@@ -50,11 +52,14 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 class GcsErrorHandlingTest {
     private static final String BUCKET_NAME = "test-bucket";
     private static final String BATCH_BOUNDARY = "batch_boundary";
-    private final GcsStorage storage = new GcsStorage(new Metrics());
+    private static final byte[] DATA = "content".getBytes();
+    private final Metrics metrics = new Metrics();
+    private final GcsStorage storage = new GcsStorage(metrics);
 
     @AfterEach
     void tearDown() throws Exception {
         storage.close();
+        metrics.close();
     }
 
     @Test
@@ -62,12 +67,49 @@ class GcsErrorHandlingTest {
         configure(wmRuntimeInfo, 1L);
         stubFor(any(anyUrl()).willReturn(aResponse().withFixedDelay(100)));
 
-        final byte[] data = "content".getBytes();
-        assertThatThrownBy(() -> storage.upload(new TestObjectKey("key"), new ByteArrayInputStream(data), data.length))
+        assertThatThrownBy(() -> upload())
             .isExactlyInstanceOf(StorageBackendTimeoutException.class)
             .hasMessage("Timed out to upload key")
             // The client wraps the socket timeout, so this pins the cause-chain walk in isTimeout.
             .hasRootCauseInstanceOf(SocketTimeoutException.class);
+    }
+
+    @Test
+    void uploadThrottled(final WireMockRuntimeInfo wmRuntimeInfo) {
+        configure(wmRuntimeInfo, 10_000L);
+        stubFor(any(anyUrl()).willReturn(aResponse().withStatus(429)));
+
+        assertThatThrownBy(() -> upload()).isExactlyInstanceOf(StorageBackendException.class);
+        assertThat(errorTotal("throttling-errors")).isEqualTo(1.0);
+    }
+
+    @Test
+    void uploadServerError(final WireMockRuntimeInfo wmRuntimeInfo) {
+        configure(wmRuntimeInfo, 10_000L);
+        stubFor(any(anyUrl()).willReturn(aResponse().withStatus(500)));
+
+        assertThatThrownBy(() -> upload()).isExactlyInstanceOf(StorageBackendException.class);
+        assertThat(errorTotal("server-errors")).isEqualTo(1.0);
+    }
+
+    @Test
+    void fetchMissingKeyCountsAsOtherError(final WireMockRuntimeInfo wmRuntimeInfo) {
+        configure(wmRuntimeInfo, 10_000L);
+        stubFor(any(anyUrl()).willReturn(aResponse().withStatus(404)));
+
+        assertThatThrownBy(() -> storage.fetch(new TestObjectKey("key"), null))
+            .isInstanceOf(KeyNotFoundException.class);
+        assertThat(errorTotal("other-errors")).isEqualTo(1.0);
+    }
+
+    @Test
+    void batchDeleteRequestFailureIsCounted(final WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        configure(wmRuntimeInfo, 10_000L);
+        stubFor(post(urlPathEqualTo("/batch/storage/v1")).willReturn(aResponse().withStatus(503)));
+
+        // The batch request bypasses the client's retry loop, so this pins the caller-side count.
+        assertThat(storage.delete(Set.of(new TestObjectKey("key1"), new TestObjectKey("key2")))).isEmpty();
+        assertThat(errorTotal("throttling-errors")).isEqualTo(1.0);
     }
 
     @Test
@@ -120,6 +162,14 @@ class GcsErrorHandlingTest {
             + "Content-Type: application/json; charset=UTF-8\r\n"
             + "\r\n"
             + "{\"error\":{\"code\":" + code + ",\"message\":\"failed\"}}\r\n";
+    }
+
+    private void upload() throws Exception {
+        storage.upload(new TestObjectKey("key"), new ByteArrayInputStream(DATA), DATA.length);
+    }
+
+    private double errorTotal(final String sensor) {
+        return (double) metrics.metric(metrics.metricName(sensor + "-total", "gcs-client-metrics")).metricValue();
     }
 
     private void configure(final WireMockRuntimeInfo wmRuntimeInfo, final long readTimeoutMs) {

--- a/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/gcs/integration/GcsErrorHandlingTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/gcs/integration/GcsErrorHandlingTest.java
@@ -29,7 +29,9 @@ import org.junit.jupiter.api.Test;
 import java.io.ByteArrayInputStream;
 import java.net.SocketTimeoutException;
 import java.util.Map;
+import java.util.Set;
 
+import io.aiven.inkless.common.ObjectKey;
 import io.aiven.inkless.storage_backend.common.StorageBackendTimeoutException;
 import io.aiven.inkless.storage_backend.common.fixtures.TestObjectKey;
 import io.aiven.inkless.storage_backend.gcs.GcsStorage;
@@ -37,13 +39,17 @@ import io.aiven.inkless.storage_backend.gcs.GcsStorage;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.any;
 import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @Tag("integration")
 @WireMockTest
 class GcsErrorHandlingTest {
     private static final String BUCKET_NAME = "test-bucket";
+    private static final String BATCH_BOUNDARY = "batch_boundary";
     private final GcsStorage storage = new GcsStorage(new Metrics());
 
     @AfterEach
@@ -53,7 +59,7 @@ class GcsErrorHandlingTest {
 
     @Test
     void uploadReadTimeout(final WireMockRuntimeInfo wmRuntimeInfo) {
-        configure(wmRuntimeInfo);
+        configure(wmRuntimeInfo, 1L);
         stubFor(any(anyUrl()).willReturn(aResponse().withFixedDelay(100)));
 
         final byte[] data = "content".getBytes();
@@ -64,11 +70,63 @@ class GcsErrorHandlingTest {
             .hasRootCauseInstanceOf(SocketTimeoutException.class);
     }
 
-    private void configure(final WireMockRuntimeInfo wmRuntimeInfo) {
+    @Test
+    void batchDeleteConfirmsOnlyDeletedKeys(final WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        configure(wmRuntimeInfo, 10_000L);
+        stubBatchResponse(deletedSubResponse(), failedSubResponse(403), failedSubResponse(403));
+
+        final Set<ObjectKey> keys = Set.of(
+            new TestObjectKey("key1"), new TestObjectKey("key2"), new TestObjectKey("key3"));
+        // One of the three is confirmed, and which one depends on the order the keys are batched in.
+        // Size is what matters: a pass that confirmed all three would dereference two live files, and
+        // an unmatched stub would confirm none.
+        assertThat(storage.delete(keys)).hasSize(1).isSubsetOf(keys);
+    }
+
+    @Test
+    void batchDeleteConfirmsAbsentKeys(final WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        configure(wmRuntimeInfo, 10_000L);
+        stubBatchResponse(failedSubResponse(404), failedSubResponse(404));
+
+        // A 404 leaves nothing to delete, so both keys are confirmed and stop being retried.
+        final Set<ObjectKey> keys = Set.of(new TestObjectKey("key1"), new TestObjectKey("key2"));
+        assertThat(storage.delete(keys)).isEqualTo(keys);
+    }
+
+    /**
+     * Stubs the batch endpoint with one sub-response per part, matched to the sub-requests by position.
+     */
+    private static void stubBatchResponse(final String... parts) {
+        final StringBuilder body = new StringBuilder();
+        for (final String part : parts) {
+            body.append("--").append(BATCH_BOUNDARY).append("\r\n")
+                .append("Content-Type: application/http\r\n")
+                .append("\r\n")
+                .append(part);
+        }
+        body.append("--").append(BATCH_BOUNDARY).append("--\r\n");
+
+        stubFor(post(urlPathEqualTo("/batch/storage/v1")).willReturn(aResponse()
+            .withHeader("Content-Type", "multipart/mixed; boundary=" + BATCH_BOUNDARY)
+            .withBody(body.toString())));
+    }
+
+    private static String deletedSubResponse() {
+        return "HTTP/1.1 204 No Content\r\n\r\n";
+    }
+
+    private static String failedSubResponse(final int code) {
+        return "HTTP/1.1 " + code + " \r\n"
+            + "Content-Type: application/json; charset=UTF-8\r\n"
+            + "\r\n"
+            + "{\"error\":{\"code\":" + code + ",\"message\":\"failed\"}}\r\n";
+    }
+
+    private void configure(final WireMockRuntimeInfo wmRuntimeInfo, final long readTimeoutMs) {
         storage.configure(Map.of(
             "gcs.bucket.name", BUCKET_NAME,
             "gcs.endpoint.url", wmRuntimeInfo.getHttpBaseUrl(),
             "gcs.credentials.default", "false",
-            "gcs.read.timeout", 1L));
+            "gcs.read.timeout", readTimeoutMs));
     }
 }

--- a/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/gcs/integration/GcsStorageMetricsTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/gcs/integration/GcsStorageMetricsTest.java
@@ -54,7 +54,10 @@ import static org.assertj.core.api.InstanceOfAssertFactories.DOUBLE;
 @Testcontainers
 public class GcsStorageMetricsTest {
     private static final String GCS_CLIENT_METRICS = "gcs-client-metrics";
-    private static final int RESUMABLE_UPLOAD_CHUNK_SIZE = 256 * 1024;
+    // Below the backend's direct-upload threshold, so these uploads take the single-request path.
+    private static final int DIRECT_UPLOAD_SIZE = 256 * 1024;
+    // Above it, so the upload falls back to a resumable session.
+    private static final int RESUMABLE_UPLOAD_SIZE = 1024 * 1024 + 1;
 
     @Container
     static final FakeGcsServerContainer GCS_SERVER = new FakeGcsServerContainer();
@@ -82,7 +85,6 @@ public class GcsStorageMetricsTest {
         final Map<String, Object> configs = Map.of(
             "gcs.bucket.name", bucketName,
             "gcs.endpoint.url", GCS_SERVER.url(),
-            "gcs.resumable.upload.chunk.size", Integer.toString(RESUMABLE_UPLOAD_CHUNK_SIZE),
             "gcs.credentials.default", "false"
         );
         storage.configure(configs);
@@ -90,7 +92,7 @@ public class GcsStorageMetricsTest {
 
     @Test
     void metricsShouldBeReported() throws Exception {
-        final byte[] data = new byte[RESUMABLE_UPLOAD_CHUNK_SIZE + 1];
+        final byte[] data = new byte[DIRECT_UPLOAD_SIZE];
 
         final ObjectKey key = new TestObjectKey("x");
 
@@ -129,6 +131,31 @@ public class GcsStorageMetricsTest {
             .isGreaterThan(0.0);
         assertThat(getMetric("object-delete-total").metricValue())
             .isEqualTo(3.0);
+
+        // All three uploads are under the direct-upload threshold, so they are counted here and the
+        // resumable counters stay at zero.
+        assertThat(getMetric("object-upload-rate").metricValue())
+            .asInstanceOf(DOUBLE)
+            .isGreaterThan(0.0);
+        assertThat(getMetric("object-upload-total").metricValue())
+            .isEqualTo(3.0);
+        assertThat(getMetric("resumable-upload-initiate-total").metricValue())
+            .isEqualTo(0.0);
+        assertThat(getMetric("resumable-chunk-upload-total").metricValue())
+            .isEqualTo(0.0);
+    }
+
+    @Test
+    void uploadAboveThresholdIsCountedAsResumable() throws Exception {
+        storage.upload(new TestObjectKey("big"), new ByteArrayInputStream(new byte[RESUMABLE_UPLOAD_SIZE]), RESUMABLE_UPLOAD_SIZE);
+
+        assertThat(getMetric("resumable-upload-initiate-total").metricValue())
+            .isEqualTo(1.0);
+        assertThat(getMetric("resumable-chunk-upload-total").metricValue())
+            .asInstanceOf(DOUBLE)
+            .isGreaterThan(0.0);
+        assertThat(getMetric("object-upload-total").metricValue())
+            .isEqualTo(0.0);
     }
 
     private KafkaMetric getMetric(String metricName) {

--- a/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/gcs/integration/GcsStorageTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/gcs/integration/GcsStorageTest.java
@@ -77,6 +77,21 @@ class GcsStorageTest extends BaseStorageTest {
     }
 
     @Test
+    @Override
+    protected void testUploadOversizeStream() throws Exception {
+        try (StorageBackend storage = storage()) {
+            final byte[] content = "content".getBytes();
+            final long expectedLength = content.length - 1;
+
+            // The direct upload path reads the declared length, so the surplus is reported by the
+            // trailing-byte probe instead of by the size check.
+            assertThatThrownBy(() -> storage.upload(TOPIC_PARTITION_SEGMENT_KEY, new ByteArrayInputStream(content), expectedLength))
+                    .isInstanceOf(StorageBackendException.class)
+                    .hasMessage("Object key created with incorrect length, input stream has remaining content");
+        }
+    }
+
+    @Test
     void deletesSpanningMultipleBatches() throws Exception {
         // More than one batch, with a partial last one, so the chunking loop's bounds and the
         // accumulation of confirmed keys across batches are both exercised.

--- a/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/gcs/integration/GcsStorageTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/gcs/integration/GcsStorageTest.java
@@ -27,17 +27,30 @@ import com.google.cloud.storage.StorageOptions;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
+import java.io.ByteArrayInputStream;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
+import io.aiven.inkless.common.ByteRange;
+import io.aiven.inkless.common.ObjectKey;
+import io.aiven.inkless.storage_backend.common.KeyNotFoundException;
 import io.aiven.inkless.storage_backend.common.StorageBackend;
+import io.aiven.inkless.storage_backend.common.StorageBackendException;
 import io.aiven.inkless.storage_backend.common.fixtures.BaseStorageTest;
+import io.aiven.inkless.storage_backend.common.fixtures.TestObjectKey;
 import io.aiven.inkless.storage_backend.common.fixtures.TestUtils;
 import io.aiven.inkless.storage_backend.gcs.GcsStorage;
 import io.aiven.testcontainers.fakegcsserver.FakeGcsServerContainer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @Testcontainers
 class GcsStorageTest extends BaseStorageTest {
@@ -61,6 +74,28 @@ class GcsStorageTest extends BaseStorageTest {
     void setUp(final TestInfo testInfo) {
         bucketName = TestUtils.testNameToBucketName(testInfo);
         storage.create(BucketInfo.newBuilder(bucketName).build());
+    }
+
+    @Test
+    void deletesSpanningMultipleBatches() throws Exception {
+        // More than one batch, with a partial last one, so the chunking loop's bounds and the
+        // accumulation of confirmed keys across batches are both exercised.
+        try (StorageBackend storage = storage()) {
+            final Set<ObjectKey> keys = IntStream.range(0, 101)
+                .mapToObj(i -> (ObjectKey) new TestObjectKey("batched-" + i))
+                .collect(Collectors.toSet());
+            final byte[] data = "test".getBytes();
+            for (final ObjectKey key : keys) {
+                storage.upload(key, new ByteArrayInputStream(data), data.length);
+            }
+
+            assertThat(storage.delete(keys)).containsExactlyInAnyOrderElementsOf(keys);
+
+            for (final ObjectKey key : keys) {
+                assertThatThrownBy(() -> storage.fetch(key, ByteRange.maxRange()))
+                    .isInstanceOf(KeyNotFoundException.class);
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
GCS requests were bounded only by the google-cloud client defaults (20s connect, 20s read), neither of which was configurable, and every upload opened a resumable session and paid two round trips. Both costs land on the produce path: a stalled or slow upload holds an uploader thread, shows up as `FileUploadTime`, and cascades into produce latency through `FileCommitWaitTime`. This makes the timeouts configurable, bounds each response read by default, and drops one round trip for small objects. See the commit messages for the reasoning behind each step.

## Commits

- `feat(inkless:storage): bound each GCS request attempt by default` - adds `gcs.connect.timeout` and `gcs.read.timeout`, defaulting to 2s and 1s; maps a timed out request to `StorageBackendTimeoutException`; and reshapes the batch delete so it chunks its work, reports per-key failures, and no longer confirms a key the server refused to delete.
- `feat(inkless:storage): upload GCS objects in a single request` - uses `storage.create` for objects up to 1 MiB, keeps the resumable path above that, and adds an `object-upload` counter so per-request upload activity stays visible.
- `feat(inkless:storage): count GCS error responses by type` - adds `throttling-errors`, `server-errors`, and `other-errors` under the S3 backend's names, counted per request attempt from the response interceptor.

## Config changes

- `gcs.connect.timeout` (new): connection establishment timeout in milliseconds. Default 2000.
- `gcs.read.timeout` (new): response read timeout in milliseconds. Default 1000.

Both mirror the existing `s3.api.call.timeout` and `s3.api.call.attempt.timeout` knobs, except that these carry real defaults rather than deferring to the client's. An operator who wants the old behavior sets the client's values explicitly (20000 each); there is no null or sentinel, because a plain number already expresses it.

Three properties of these bounds are worth knowing before tuning them:

- **The read value bounds each socket read, not a whole request.** Connection setup falls under `gcs.connect.timeout`, request-body writes are not covered, and a response arriving in several reads can exceed it.
- **Whether it bounds the operation depends on the client's idempotency classification.** A single-request upload and a resumable session initiate are non-idempotent, and the client's non-idempotent handler retries nothing, so their ceiling is ours to set: an object at or below 1 MiB ends its attempt on the first stalled read, making the upload budget `produce.max.upload.attempts` stalled reads, about 3s. A read and a resumable upload's chunk write are idempotent and run up to 6 client attempts under a 50s total timeout, so above 1 MiB an upload attempt is bounded by that budget rather than by this value, and lowering the read timeout changes how many attempts fit in the 50s rather than shortening it. Removing the client's retry on the produce path is left as a follow-up.
- **Both values apply to every GCS role.** `SharedState` builds four independent backends (fetch, lagging fetch, produce, background) from the same `inkless.storage.*` config. Connect keeps the wider bound on purpose: it applies only on a connection-pool miss, so a generous ceiling costs nothing in steady state and leaves headroom for the connection churn that accompanies a slowdown, while the read bound applies to every stalled request and is the one worth keeping tight.

A timed out request surfaces as `StorageBackendTimeoutException` from `upload`, single-key `delete`, and a fetch's metadata request. A fetch's body is streamed from the channel `fetch` returns, so a stall mid-download reaches the caller as a plain `IOException` instead -- `ReadableByteChannel.read` cannot throw `StorageBackendException`. `S3Storage` classifies its whole fetch only because it materializes the response into a buffer. The batch delete stops the pass rather than classifying, as S3 does. When an upload exhausts its attempts the file fails, and every produce request in it gets `KAFKA_STORAGE_ERROR`. That is a `RefreshRetriableException` at the client, so producers retry after a metadata refresh rather than losing data.

## Metric changes

- `object-upload-rate` / `object-upload-total` (new): single-request object uploads. `resumable-upload-initiate` and `resumable-chunk-upload` stop advancing for objects at or below the threshold, so dashboards that track upload activity through those two need this one added.
- `throttling-errors`, `server-errors`, `other-errors` (new, each `-rate` / `-total`): error responses per request attempt, under the S3 backend's names so one dashboard serves both. 429 and 503 are throttling, as `SlowDown` is on S3; other 5xx are server errors; other non-2xx, including the 404 for a missing key, are other errors. A request that fails without a response (a configured timeout, a connection reset) is not counted; see the follow-ups.

## Operator impact

Objects up to 1 MiB now issue one request instead of two. With `produce.buffer.max.bytes` at 8 MiB, that is the small-file end of the distribution: a broker rotating full buffers under load keeps streaming, while a low-throughput topic flushing a few kilobytes every `produce.commit.interval.ms` saves a round trip, which is where the fixed cost dominates. The threshold sits below the measured break-even near 2 MiB, above which a single request costs more per megabyte than the round trip it saves.

A GCS request that stalls beyond the new timeouts fails its attempt rather than holding a connection for 20s. For an object at or below 1 MiB, where nothing is retried inside the client, three upload attempts now complete in about 3s instead of a minute. Above the threshold the client's own 50s retry budget dominates and the read timeout does not shorten the upload, so expect `FileUploadTime` maxima to drop at the small end of the distribution and stay where they are at the large end.

A stalled object download is a second place the client's budget wins. `ApiaryUnbufferedReadableByteChannel.read` reopens the stream on a retryable failure and each reopen starts a fresh budget, so a shorter read timeout makes it reopen more often against a backend that is already slow rather than giving up sooner. Bounding a stalled fetch needs a deadline above the channel; see the follow-ups.

Batch deletes change shape rather than budget. The client splits a delete into HTTP batches of at most 100 sub-requests and answers only after processing all of them, so the response wait scales with the batch, and a batch delete is not retried by the client. `GcsStorage.delete(Set)` now deletes in chunks of half that maximum and returns the keys confirmed so far, so a slow batch costs one chunk instead of a whole cleaner pass. A default cycle of 20000 files becomes 400 round trips, well inside `file.cleaner.interval.ms`. `FileCleaner` already treats deletion as partial, so this matches the contract it expects and the S3 backend's shape.

The same rewrite fixes a confirmation bug the previous shape had. `Storage.delete(Iterable)` reports a failed sub-request as the same `false` its callback uses for an absent blob, and the old code ignored the result and confirmed every key in the batch, so a 403 or 5xx on one key still dereferenced its file in the control plane and left a permanent orphan. Driving `Storage.batch()` directly keeps the three outcomes apart: deleted and already-absent are confirmed, a failure is not, and failures are now logged by response code the way the S3 backend logs them. `object-delete` counts confirmed deletions rather than attempted ones, so it can read lower than before on a bucket that is refusing deletes.

## Testing

`GcsStorageConfigTest` covers the new defaults, that both values parse into `Duration` objects, and that a non-positive value is rejected. `GcsStorageMetricsTest` asserts the upload counters on both sides of the 1 MiB threshold. `GcsStorageTest` covers a delete spanning several batches, which the shared suite's ten-key case does not reach, and overrides `testUploadOversizeStream`, since a stream longer than its declared length is now reported by the trailing-byte probe rather than by the size check, matching the S3 backend.

`GcsErrorHandlingTest` uses WireMock for the failures fake-gcs-server cannot produce. A delayed response pins the timeout classification: an upload surfaces `StorageBackendTimeoutException` with `SocketTimeoutException` as its root cause, which exercises the cause-chain walk every classification site depends on. A hand-built multipart batch response pins the delete confirmation on both sides: with one deleted sub-response and two refused, only one key comes back confirmed, and with every sub-response a 404, both keys do. Each error sensor is asserted at exactly one count end to end: a 429 and a 500 on upload, a 404 on fetch, and a 503 on the batch endpoint, which the interceptor never sees and the caller reports.

## Follow-ups

- `configured-timeout-errors` and `io-errors` are still missing on GCS, so nothing reports how often these timeouts fire per attempt. The AWS SDK publishes those itself; the GCS client has no once-per-attempt hook that carries the exception (the response interceptor never runs on an `IOException`, `HttpIOExceptionHandler` receives no exception, `NetHttpTransport` is final, and gax consults the retry strategy up to three times per attempt). Settling where that hook lives is its own change, and it is what would let these defaults be validated in production rather than inferred from `FileUploadTime`.
- A stalled GCS object download is neither classified nor bounded. The body is streamed after `fetch` returns, so a stall reaches the caller as a plain `IOException`, and the client's read channel reopens the stream on each retryable failure with a fresh retry budget, so no number of read timeouts ends the fetch. Both need a wall-clock deadline above the channel, around `ObjectFetcher.readToByteBuffer`, which can throw `StorageBackendException`. Shared across backends, so it belongs in its own change.
- Above 1 MiB an upload is retried twice over: by the client's idempotent handler on the resumable PUT and by `FileUploadJob` on top, while a fetch has only the client's retry. The fix is no client retry on the produce backend and the default on the fetch backend, which needs per-role storage config, since `SharedState` builds all four backends from the same `inkless.storage.*` map. `produce.upload.backoff.ms` (10ms, unjittered) has to be re-sized in the same change: it is masked by the client's backoff today and becomes the only wait between attempts once that is gone. Both should follow the error counters, because removing the client's retry trades a slow success for a fast `KAFKA_STORAGE_ERROR`, and how often a stalled PUT recovers on a retry is the number that decides whether that trade is worth making.
