### PR TITLE
test(inkless:consolidation): tolerate re-delivery in the consume check

### DIFF
--- a/core/src/test/java/kafka/server/InklessConsolidatedDisklessTopicsTest.java
+++ b/core/src/test/java/kafka/server/InklessConsolidatedDisklessTopicsTest.java
@@ -81,7 +81,9 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.NavigableSet;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -1171,26 +1173,27 @@ public class InklessConsolidatedDisklessTopicsTest {
 
         try (var consumer = new KafkaConsumer<String, String>(consumerConfigs)) {
             consumer.subscribe(Collections.singletonList(topicName));
-            var offsetsByPartition = new HashMap<TopicPartition, List<Long>>();
-            var consumedCount = new AtomicLong(0);
+            // Collect distinct offsets. A subscribed consumer can legally be re-delivered records it
+            // has already seen: a rebalance before the first auto-commit resets the partition to the
+            // earliest offset, so the stream restarts at 0. Counting raw deliveries would then both
+            // satisfy the wait early and make a contiguity check over delivery order fail.
+            var offsetsByPartition = new HashMap<TopicPartition, NavigableSet<Long>>();
             TestUtils.waitForCondition(() -> {
                 var records = consumer.poll(Duration.ofMillis(1000));
-                records.forEach(r -> {
-                    var tp = new TopicPartition(r.topic(), r.partition());
-                    offsetsByPartition.computeIfAbsent(tp, __ -> new ArrayList<>()).add(r.offset());
-                });
-                consumedCount.addAndGet(records.count());
-                return consumedCount.get() >= expectedTotalRecords;
+                records.forEach(r -> offsetsByPartition
+                    .computeIfAbsent(new TopicPartition(r.topic(), r.partition()), __ -> new TreeSet<>())
+                    .add(r.offset()));
+                return distinctOffsetCount(offsetsByPartition) >= expectedTotalRecords;
             }, 60_000, "Not all records have been consumed");
-            // Monotonicity + no gaps per partition
-            offsetsByPartition.forEach((tp, offsets) -> {
-                for (int i = 1; i < offsets.size(); i++) {
-                    long prev = offsets.get(i - 1);
-                    long cur = offsets.get(i);
-                    assertEquals(prev + 1, cur, "Offset gap or reordering for " + tp);
-                }
-            });
+            // No gaps per partition: the distinct offsets form one unbroken run.
+            offsetsByPartition.forEach((tp, offsets) ->
+                assertEquals(offsets.last() - offsets.first() + 1, offsets.size(),
+                    "Offset gap for " + tp + " over " + offsets.first() + ".." + offsets.last()));
         }
+    }
+
+    private static int distinctOffsetCount(Map<TopicPartition, NavigableSet<Long>> offsetsByPartition) {
+        return offsetsByPartition.values().stream().mapToInt(Set::size).sum();
     }
 
     private static int countObjectsWithPrefix(S3Client s3, String bucket, String prefix) {


### PR DESCRIPTION
`consumeAndVerify` asserted that each delivered offset was exactly one past the previous one, walking raw delivery order, and counted raw deliveries to decide when to stop polling. Both assume every record arrives once.

Nothing guarantees that. The helper subscribes with a fresh group id and auto.offset.reset=earliest, so the consumer is group-managed: a rebalance before the first auto-commit lands (auto-commit is on by default, every five seconds) resets the partition and the stream restarts at its earliest offset. That is legal at-least-once delivery, and it breaks the helper twice over. Duplicates count toward the wait, so polling can stop before every distinct record has arrived, and the walk over delivery order then sees the offset go backwards.

CI caught it as `"Offset gap or reordering ... expected: <6> but was: <0>"` after a partition had delivered 0..5 and started again from 0. Four tests call the helper, across seven call sites, so any of them can fail this way.

Collect distinct offsets per partition in a sorted set, wait on the distinct count, and assert the distinct offsets form one unbroken run. A replay now adds nothing to the set and changes no outcome.

The check still means what it did: it fails when a partition is genuinely missing an offset, including a gap that a replay would otherwise pad over.

**Testing**

`InklessConsolidatedDisklessTopicsTest` passes across two runs of the full class. The contiguity logic was checked against the delivery sequence from the CI failure (0..5 then 0..5 again, which the previous check rejected and this one accepts), a clean run, a run with one offset missing, and a run with both a replay and a missing offset. The last two still fail.
