### PR TITLE
fix(inkless:ci): update Inkless CI workflow and JUnit catalog parsing

### DIFF
--- a/.github/scripts/junit.py
+++ b/.github/scripts/junit.py
@@ -92,7 +92,11 @@ def clean_test_name(test_name: str) -> str:
     cleaned = test_name.strip("\"").rstrip("()")
     m = method_matcher.match(cleaned)
     if m is None:
-        raise ValueError(f"Could not parse test name '{test_name}'. Expected a valid Java method name.")
+        # Custom @ParameterizedTest display names (for example "{0}") aren't
+        # required to look like a Java method name at all, so fall back to
+        # using the cleaned display name as-is instead of failing the whole
+        # catalog export.
+        return cleaned
     else:
         return m.group(1)
 

--- a/.github/workflows/inkless.yml
+++ b/.github/workflows/inkless.yml
@@ -101,13 +101,13 @@ jobs:
           compression-level: 9
           if-no-files-found: ignore
       - name: Annotate checkstyle errors
-        # Avoid duplicate annotations, only run on java 21
+        # Avoid duplicate annotations, only run on java 25
         if: failure()
         run: python .github/scripts/checkstyle.py
         env:
           GITHUB_WORKSPACE: ${{ github.workspace }}
       # - name: Annotate Rat errors
-      #   # Avoid duplicate annotations, only run on java 21
+      #   # Avoid duplicate annotations, only run on java 25
       #   if: failure()
       #   run: python .github/scripts/rat.py
       #   env:
@@ -283,14 +283,6 @@ jobs:
           GRADLE_TEST_EXIT_CODE: ${{ steps.junit-test.outputs.exitcode }}
         run: |
           python .github/scripts/junit.py --path build/junit-xml >> $GITHUB_STEP_SUMMARY
-      - name: Archive Test Catalog
-        if: ${{ always() && matrix.java == '21' }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: test-catalog
-          path: test-catalog
-          compression-level: 9
-          if-no-files-found: ignore
       - name: Archive Build Scan
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/inkless.yml
+++ b/.github/workflows/inkless.yml
@@ -282,7 +282,12 @@ jobs:
           THREAD_DUMP_URL: ${{ steps.thread-dump-upload-artifact.outputs.artifact-url }}
           GRADLE_TEST_EXIT_CODE: ${{ steps.junit-test.outputs.exitcode }}
         run: |
-          python .github/scripts/junit.py --path build/junit-xml >> $GITHUB_STEP_SUMMARY
+          # Export the catalog here so parameterized display names are checked on
+          # PRs. Kafka CI's Collate Test Catalog job is the only other caller of
+          # --export-test-catalog, and it does not run on PRs targeting main.
+          python .github/scripts/junit.py \
+           --path build/junit-xml \
+           --export-test-catalog ./test-catalog >> $GITHUB_STEP_SUMMARY
       - name: Archive Build Scan
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/inkless.yml
+++ b/.github/workflows/inkless.yml
@@ -28,16 +28,15 @@ jobs:
           github.event.pull_request.draft
         run: echo "is-draft=true" >> "$GITHUB_OUTPUT"
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
+      - name: Setup Python
+        uses: ./.github/actions/setup-python
 
       # Generate JOOQ classes with JDK 25 to include @SuppressWarnings("this-escape") annotations
       - name: Setup JDK 25 for JOOQ generation
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 25
@@ -119,7 +118,7 @@ jobs:
     name: Inkless version tag resolution
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
       - name: Setup Gradle
@@ -142,13 +141,11 @@ jobs:
     name: JUnit tests Java ${{ matrix.java }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-      - run: pip install -r .github/scripts/requirements.txt
+      - name: Setup Python
+        uses: ./.github/actions/setup-python
       - name: Setup Gradle
         uses: ./.github/actions/setup-gradle
         with:


### PR DESCRIPTION
Collate Test Catalog on main crashed after #772: `clean_test_name()` required every JUnit display name to look like a Java method name, and `@ParameterizedTest(name = "{0}")` names such as ObjectFetcherTest's `1 byte` are not. Inkless CI never hit that path — it parsed reports without `--export-test-catalog` — and its workflow pins had drifted from `build.yml`. See the commit messages for the reasoning behind each step.

## Commits

- `chore(inkless:ci): bump Inkless CI action pins to match upstream`
- `chore(inkless:ci): drop the dead Java 21 catalog archive`
- `fix(inkless:ci): tolerate non-identifier parameterized test names in junit.py`

## Testing

Inkless CI now exports the catalog while parsing JUnit XML, so a display name like `1 byte` fails on the PR instead of only on main Kafka collation.