### PR TITLE
fix(inkless:storage): count retried GCS error responses

### DIFF
--- a/docs/inkless/metrics.rst
+++ b/docs/inkless/metrics.rst
@@ -103,28 +103,28 @@ GcsStorage metrics
 io.aiven.inkless.storage:type=gcs-client-metrics
 ------------------------------------------------
 
-================================  ===================================================================
-Attribute name                    Description                                                        
-================================  ===================================================================
-object-delete-rate                Rate of delete object operations                                   
-object-delete-total               Total number of delete object operations                           
-object-get-rate                   Rate of get object operations                                      
-object-get-total                  Total number of get object operations                              
-object-metadata-get-rate          Rate of get object metadata operations                             
-object-metadata-get-total         Total number of get object metadata operations                     
-object-upload-rate                Rate of single request object upload operations                    
-object-upload-total               Total number of single request object upload operations            
-other-errors-rate                 Rate of other errors (4xx responses other than 429)                
-other-errors-total                Total number of other errors (4xx responses other than 429)        
-resumable-chunk-upload-rate       Rate of upload chunk operations as part of resumable upload        
-resumable-chunk-upload-total      Total number of upload chunk operations as part of resumable upload
-resumable-upload-initiate-rate    Rate of initiate resumable upload operations                       
-resumable-upload-initiate-total   Total number of initiate resumable upload operations               
-server-errors-rate                Rate of server errors (other 5xx responses)                        
-server-errors-total               Total number of server errors (other 5xx responses)                
-throttling-errors-rate            Rate of throttling errors (429 and 503 responses)                  
-throttling-errors-total           Total number of throttling errors (429 and 503 responses)          
-================================  ===================================================================
+================================  ====================================================================================
+Attribute name                    Description                                                                         
+================================  ====================================================================================
+object-delete-rate                Rate of delete object operations                                                    
+object-delete-total               Total number of delete object operations                                            
+object-get-rate                   Rate of get object operations                                                       
+object-get-total                  Total number of get object operations                                               
+object-metadata-get-rate          Rate of get object metadata operations                                              
+object-metadata-get-total         Total number of get object metadata operations                                      
+object-upload-rate                Rate of single request object upload operations                                     
+object-upload-total               Total number of single request object upload operations                             
+other-errors-rate                 Rate of other errors (non-429 4xx responses, excluding absent batch deletes)        
+other-errors-total                Total number of other errors (non-429 4xx responses, excluding absent batch deletes)
+resumable-chunk-upload-rate       Rate of upload chunk operations as part of resumable upload                         
+resumable-chunk-upload-total      Total number of upload chunk operations as part of resumable upload                 
+resumable-upload-initiate-rate    Rate of initiate resumable upload operations                                        
+resumable-upload-initiate-total   Total number of initiate resumable upload operations                                
+server-errors-rate                Rate of server errors (other 5xx responses)                                         
+server-errors-total               Total number of server errors (other 5xx responses)                                 
+throttling-errors-rate            Rate of throttling errors (429 and 503 responses)                                   
+throttling-errors-total           Total number of throttling errors (429 and 503 responses)                           
+================================  ====================================================================================
 
 
 InklessFetch metrics

--- a/docs/inkless/metrics.rst
+++ b/docs/inkless/metrics.rst
@@ -103,28 +103,28 @@ GcsStorage metrics
 io.aiven.inkless.storage:type=gcs-client-metrics
 ------------------------------------------------
 
-================================  ========================================================================================
-Attribute name                    Description                                                                             
-================================  ========================================================================================
-object-delete-rate                Rate of delete object operations                                                        
-object-delete-total               Total number of delete object operations                                                
-object-get-rate                   Rate of get object operations                                                           
-object-get-total                  Total number of get object operations                                                   
-object-metadata-get-rate          Rate of get object metadata operations                                                  
-object-metadata-get-total         Total number of get object metadata operations                                          
-object-upload-rate                Rate of single request object upload operations                                         
-object-upload-total               Total number of single request object upload operations                                 
-other-errors-rate                 Rate of other errors (non-2xx responses other than throttling and server errors)        
-other-errors-total                Total number of other errors (non-2xx responses other than throttling and server errors)
-resumable-chunk-upload-rate       Rate of upload chunk operations as part of resumable upload                             
-resumable-chunk-upload-total      Total number of upload chunk operations as part of resumable upload                     
-resumable-upload-initiate-rate    Rate of initiate resumable upload operations                                            
-resumable-upload-initiate-total   Total number of initiate resumable upload operations                                    
-server-errors-rate                Rate of server errors (other 5xx responses)                                             
-server-errors-total               Total number of server errors (other 5xx responses)                                     
-throttling-errors-rate            Rate of throttling errors (429 and 503 responses)                                       
-throttling-errors-total           Total number of throttling errors (429 and 503 responses)                               
-================================  ========================================================================================
+================================  ===================================================================
+Attribute name                    Description                                                        
+================================  ===================================================================
+object-delete-rate                Rate of delete object operations                                   
+object-delete-total               Total number of delete object operations                           
+object-get-rate                   Rate of get object operations                                      
+object-get-total                  Total number of get object operations                              
+object-metadata-get-rate          Rate of get object metadata operations                             
+object-metadata-get-total         Total number of get object metadata operations                     
+object-upload-rate                Rate of single request object upload operations                    
+object-upload-total               Total number of single request object upload operations            
+other-errors-rate                 Rate of other errors (4xx responses other than 429)                
+other-errors-total                Total number of other errors (4xx responses other than 429)        
+resumable-chunk-upload-rate       Rate of upload chunk operations as part of resumable upload        
+resumable-chunk-upload-total      Total number of upload chunk operations as part of resumable upload
+resumable-upload-initiate-rate    Rate of initiate resumable upload operations                       
+resumable-upload-initiate-total   Total number of initiate resumable upload operations               
+server-errors-rate                Rate of server errors (other 5xx responses)                        
+server-errors-total               Total number of server errors (other 5xx responses)                
+throttling-errors-rate            Rate of throttling errors (429 and 503 responses)                  
+throttling-errors-total           Total number of throttling errors (429 and 503 responses)          
+================================  ===================================================================
 
 
 InklessFetch metrics

--- a/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/gcs/GcsStorage.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/gcs/GcsStorage.java
@@ -209,19 +209,17 @@ public class GcsStorage extends StorageBackend {
                     deleted.size(), objectKeys.size(), e);
                 break;
             }
-            int confirmed = 0;
             for (final var result : results.entrySet()) {
                 try {
                     // Called to throw on a failed sub-request. The result is ignored: deleted (true) and
                     // already absent (false) both leave the key gone.
                     result.getValue().get();
                     deleted.add(result.getKey());
-                    confirmed++;
                 } catch (final BaseServiceException e) {
                     failuresByCode.merge(e.getCode(), 1, Integer::sum);
                 }
             }
-            metricCollector.recordBatchDeleteObjects(confirmed);
+            metricCollector.recordBatchDeleteObjects(results.size());
         }
 
         if (!failuresByCode.isEmpty()) {

--- a/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/gcs/MetricCollector.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/gcs/MetricCollector.java
@@ -30,11 +30,13 @@ import com.google.api.client.http.HttpRequest;
 import com.google.api.client.http.HttpRequestInitializer;
 import com.google.api.client.http.HttpResponse;
 import com.google.api.client.http.HttpResponseInterceptor;
+import com.google.api.client.http.HttpUnsuccessfulResponseHandler;
 import com.google.cloud.BaseServiceException;
 import com.google.cloud.ServiceOptions;
 import com.google.cloud.http.HttpTransportOptions;
 import com.groupcdg.pitest.annotations.CoverageIgnore;
 
+import java.io.IOException;
 import java.util.regex.Pattern;
 
 import static io.aiven.inkless.storage_backend.gcs.MetricRegistry.OBJECT_DELETE;
@@ -162,8 +164,8 @@ public class MetricCollector {
         return sensor;
     }
 
-    // The client builds the batch request without the request initializer, so the response interceptor
-    // never sees it; its caller reports both its operations and its failure.
+    // The client builds the batch request without the request initializer, so the metric handlers
+    // never see it; its caller reports both its operations and its failure.
     void recordBatchDeleteObjects(final int objectCount) {
         if (objectCount > 0) {
             deleteObjectRequests.record(objectCount);
@@ -190,12 +192,37 @@ public class MetricCollector {
 
     private final MetricResponseInterceptor metricResponseInterceptor = new MetricResponseInterceptor();
 
+    private class MetricUnsuccessfulResponseHandler implements HttpUnsuccessfulResponseHandler {
+        private final HttpUnsuccessfulResponseHandler delegate;
+
+        private MetricUnsuccessfulResponseHandler(final HttpUnsuccessfulResponseHandler delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public boolean handleResponse(
+            final HttpRequest request,
+            final HttpResponse response,
+            final boolean supportsRetry
+        ) throws IOException {
+            recordResponseStatus(response.getStatusCode());
+            if (delegate == null) {
+                return false;
+            }
+            try {
+                return delegate.handleResponse(request, response, supportsRetry);
+            } finally {
+                // The credentials handler reinstalls itself after refreshing a token. Restore this
+                // wrapper so a later failed response from the same request is also counted.
+                request.setUnsuccessfulResponseHandler(this);
+            }
+        }
+    }
+
     private class MetricResponseInterceptor implements HttpResponseInterceptor {
 
         @Override
         public void interceptResponse(final HttpResponse response) {
-            recordResponseStatus(response.getStatusCode());
-
             final HttpRequest request = response.getRequest();
             final GenericUrl url = request.getUrl();
 
@@ -236,6 +263,8 @@ public class MetricCollector {
                 final var superInitializer = super.getHttpRequestInitializer(serviceOptions);
                 return request -> {
                     superInitializer.initialize(request);
+                    request.setUnsuccessfulResponseHandler(
+                        new MetricUnsuccessfulResponseHandler(request.getUnsuccessfulResponseHandler()));
                     request.setResponseInterceptor(metricResponseInterceptor);
                 };
             }

--- a/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/gcs/MetricCollector.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/gcs/MetricCollector.java
@@ -164,8 +164,10 @@ public class MetricCollector {
         return sensor;
     }
 
-    // The client builds the batch request without the request initializer, so the metric handlers
-    // never see it; its caller reports both its operations and its failure.
+    // The client builds the outer batch request without the request initializer, so the metric
+    // handlers don't see its response or successful sub-responses. The unsuccessful-response
+    // handler does see failed sub-responses; the caller reports submitted operations and outer
+    // request failures.
     void recordBatchDeleteObjects(final int objectCount) {
         if (objectCount > 0) {
             deleteObjectRequests.record(objectCount);
@@ -190,6 +192,15 @@ public class MetricCollector {
         }
     }
 
+    private static boolean isAbsentBatchDelete(final HttpRequest request, final HttpResponse response) {
+        // BatchUnparsedResponse attaches a synthetic request to each sub-response and passes the
+        // original request separately. GCS treats a missing object as a successful idempotent delete,
+        // so this case shouldn't count as a provider error.
+        return response.getStatusCode() == 404
+            && HttpMethods.DELETE.equals(request.getRequestMethod())
+            && response.getRequest() != request;
+    }
+
     private final MetricResponseInterceptor metricResponseInterceptor = new MetricResponseInterceptor();
 
     private class MetricUnsuccessfulResponseHandler implements HttpUnsuccessfulResponseHandler {
@@ -205,7 +216,9 @@ public class MetricCollector {
             final HttpResponse response,
             final boolean supportsRetry
         ) throws IOException {
-            recordResponseStatus(response.getStatusCode());
+            if (!isAbsentBatchDelete(request, response)) {
+                recordResponseStatus(response.getStatusCode());
+            }
             if (delegate == null) {
                 return false;
             }

--- a/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/gcs/MetricRegistry.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/gcs/MetricRegistry.java
@@ -67,7 +67,7 @@ public class MetricRegistry {
     static final String OTHER_ERRORS = "other-errors";
     static final String OTHER_ERRORS_RATE = OTHER_ERRORS + "-rate";
     static final String OTHER_ERRORS_TOTAL = OTHER_ERRORS + "-total";
-    static final String OTHER_ERRORS_DOC = "other errors (non-2xx responses other than throttling and server errors)";
+    static final String OTHER_ERRORS_DOC = "other errors (4xx responses other than 429)";
 
     private static final String RATE_DOC_PREFIX = "Rate of ";
     private static final String TOTAL_DOC_PREFIX = "Total number of ";

--- a/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/gcs/MetricRegistry.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/gcs/MetricRegistry.java
@@ -67,7 +67,7 @@ public class MetricRegistry {
     static final String OTHER_ERRORS = "other-errors";
     static final String OTHER_ERRORS_RATE = OTHER_ERRORS + "-rate";
     static final String OTHER_ERRORS_TOTAL = OTHER_ERRORS + "-total";
-    static final String OTHER_ERRORS_DOC = "other errors (4xx responses other than 429)";
+    static final String OTHER_ERRORS_DOC = "other errors (non-429 4xx responses, excluding absent batch deletes)";
 
     private static final String RATE_DOC_PREFIX = "Rate of ";
     private static final String TOTAL_DOC_PREFIX = "Total number of ";

--- a/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/gcs/MetricCollectorTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/gcs/MetricCollectorTest.java
@@ -1,0 +1,89 @@
+/*
+ * Inkless
+ * Copyright (C) 2026 Aiven OY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package io.aiven.inkless.storage_backend.gcs;
+
+import org.apache.kafka.common.metrics.Metrics;
+
+import com.google.api.client.http.HttpHeaders;
+import com.google.api.client.http.HttpRequest;
+import com.google.api.client.http.HttpResponse;
+import com.google.api.client.http.HttpUnsuccessfulResponseHandler;
+import com.google.auth.Credentials;
+import com.google.cloud.http.HttpTransportOptions;
+import com.google.cloud.storage.StorageOptions;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class MetricCollectorTest {
+    private final Metrics metrics = new Metrics();
+
+    @AfterEach
+    void tearDown() {
+        metrics.close();
+    }
+
+    @Test
+    void countsResponsesRetriedByCredentialsHandler() throws IOException {
+        final Credentials credentials = mock(Credentials.class);
+        when(credentials.getUniverseDomain()).thenReturn(Credentials.GOOGLE_DEFAULT_UNIVERSE);
+
+        final AtomicReference<HttpUnsuccessfulResponseHandler> unsuccessfulHandler = new AtomicReference<>();
+        final HttpRequest request = mock(HttpRequest.class);
+        when(request.getHeaders()).thenReturn(new HttpHeaders());
+        when(request.setUnsuccessfulResponseHandler(any())).thenAnswer(invocation -> {
+            unsuccessfulHandler.set(invocation.getArgument(0));
+            return request;
+        });
+        when(request.getUnsuccessfulResponseHandler()).thenAnswer(ignored -> unsuccessfulHandler.get());
+
+        final MetricCollector collector = new MetricCollector(metrics);
+        final HttpTransportOptions transportOptions =
+            collector.httpTransportOptions(HttpTransportOptions.newBuilder());
+        final StorageOptions storageOptions = StorageOptions.newBuilder()
+            .setProjectId("test-project")
+            .setCredentials(credentials)
+            .build();
+        transportOptions.getHttpRequestInitializer(storageOptions).initialize(request);
+
+        final HttpResponse unauthorized = mock(HttpResponse.class);
+        when(unauthorized.getHeaders()).thenReturn(new HttpHeaders());
+        when(unauthorized.getStatusCode()).thenReturn(401);
+
+        assertThat(unsuccessfulHandler.get().handleResponse(request, unauthorized, true)).isTrue();
+        assertThat(unsuccessfulHandler.get().handleResponse(request, unauthorized, true)).isTrue();
+
+        assertThat(errorTotal("other-errors")).isEqualTo(2.0);
+        verify(credentials, times(2)).refresh();
+    }
+
+    private double errorTotal(final String sensor) {
+        return (double) metrics.metric(metrics.metricName(sensor + "-total", "gcs-client-metrics")).metricValue();
+    }
+}

--- a/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/gcs/integration/GcsErrorHandlingTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/gcs/integration/GcsErrorHandlingTest.java
@@ -80,7 +80,7 @@ class GcsErrorHandlingTest {
         stubFor(any(anyUrl()).willReturn(aResponse().withStatus(429)));
 
         assertThatThrownBy(() -> upload()).isExactlyInstanceOf(StorageBackendException.class);
-        assertThat(errorTotal("throttling-errors")).isEqualTo(1.0);
+        assertThat(metricTotal("throttling-errors")).isEqualTo(1.0);
     }
 
     @Test
@@ -89,7 +89,7 @@ class GcsErrorHandlingTest {
         stubFor(any(anyUrl()).willReturn(aResponse().withStatus(500)));
 
         assertThatThrownBy(() -> upload()).isExactlyInstanceOf(StorageBackendException.class);
-        assertThat(errorTotal("server-errors")).isEqualTo(1.0);
+        assertThat(metricTotal("server-errors")).isEqualTo(1.0);
     }
 
     @Test
@@ -99,7 +99,7 @@ class GcsErrorHandlingTest {
 
         assertThatThrownBy(() -> storage.fetch(new TestObjectKey("key"), null))
             .isInstanceOf(KeyNotFoundException.class);
-        assertThat(errorTotal("other-errors")).isEqualTo(1.0);
+        assertThat(metricTotal("other-errors")).isEqualTo(1.0);
     }
 
     @Test
@@ -109,7 +109,7 @@ class GcsErrorHandlingTest {
 
         // The batch request bypasses the client's retry loop, so this pins the caller-side count.
         assertThat(storage.delete(Set.of(new TestObjectKey("key1"), new TestObjectKey("key2")))).isEmpty();
-        assertThat(errorTotal("throttling-errors")).isEqualTo(1.0);
+        assertThat(metricTotal("throttling-errors")).isEqualTo(1.0);
     }
 
     @Test
@@ -123,6 +123,8 @@ class GcsErrorHandlingTest {
         // Size is what matters: a pass that confirmed all three would dereference two live files, and
         // an unmatched stub would confirm none.
         assertThat(storage.delete(keys)).hasSize(1).isSubsetOf(keys);
+        assertThat(metricTotal("other-errors")).isEqualTo(2.0);
+        assertThat(metricTotal("object-delete")).isEqualTo(3.0);
     }
 
     @Test
@@ -133,6 +135,8 @@ class GcsErrorHandlingTest {
         // A 404 leaves nothing to delete, so both keys are confirmed and stop being retried.
         final Set<ObjectKey> keys = Set.of(new TestObjectKey("key1"), new TestObjectKey("key2"));
         assertThat(storage.delete(keys)).isEqualTo(keys);
+        assertThat(metricTotal("other-errors")).isZero();
+        assertThat(metricTotal("object-delete")).isEqualTo(2.0);
     }
 
     /**
@@ -168,7 +172,7 @@ class GcsErrorHandlingTest {
         storage.upload(new TestObjectKey("key"), new ByteArrayInputStream(DATA), DATA.length);
     }
 
-    private double errorTotal(final String sensor) {
+    private double metricTotal(final String sensor) {
         return (double) metrics.metric(metrics.metricName(sensor + "-total", "gcs-client-metrics")).metricValue();
     }
 


### PR DESCRIPTION
## Background

[PR #783](https://github.com/aiven/inkless/pull/783) added GCS error counters through an `HttpResponseInterceptor`. The Google HTTP client invokes that interceptor only after `HttpRequest.execute()` finishes its internal retry loop. When GCS returns `401`, `HttpCredentialsAdapter` can refresh the token and retry the same request before the interceptor runs, so a successful refresh hides the failed response and repeated authorization failures are undercounted.

The credentials handler also reinstalls itself after a refresh. Wrapping it without restoring the metrics wrapper would therefore count only the first `401` from a request.

Batch requests add a second distinction. The outer POST bypasses the request initializer, but each failed multipart sub-response invokes the unsuccessful-response handler. A `404` delete means the object is already absent, and `StorageBatch` treats that outcome as a confirmed idempotent delete, so counting it as a provider error creates noise during cleaner retries. GCS still bills and rate-limits every submitted delete sub-request, including refused requests, so the operation counter must include all of them.

## Changes

- Record error statuses through an `HttpUnsuccessfulResponseHandler`, which runs before the client decides whether to retry each response.
- Delegate to the existing credentials handler and restore the metrics wrapper after it refreshes a token.
- Keep the response interceptor for operation counters, which should run once after the internal retry loop.
- Exclude an already-absent batch delete from `other-errors`, while continuing to count refused and throttled sub-requests.
- Count every returned batch delete sub-request as an `object-delete` operation; confirmed deletions remain available through cleaner metrics.
- Describe `other-errors` as non-`429` 4xx responses, excluding absent batch deletes. Protocol responses such as `308 Resume Incomplete` also remain excluded.

## Testing

- `./gradlew :storage:inkless:test --tests io.aiven.inkless.storage_backend.gcs.MetricCollectorTest --tests io.aiven.inkless.storage_backend.gcs.integration.GcsErrorHandlingTest --tests io.aiven.inkless.storage_backend.gcs.integration.GcsStorageMetricsTest`
- `./gradlew :storage:inkless:genInklessMetricsDoc`