### PR TITLE
feat(inkless:storage): default S3 API call timeouts to 2s and 1s

### DIFF
--- a/docs/inkless/configs.rst
+++ b/docs/inkless/configs.rst
@@ -692,16 +692,16 @@ Under ``inkless.storage.``
   AWS S3 API call attempt (single retry) timeout in milliseconds
 
   * Type: long
-  * Default: null
-  * Valid Values: null or [1,...,9223372036854775807]
+  * Default: 1000
+  * Valid Values: [1,...]
   * Importance: low
 
 ``s3.api.call.timeout``
   AWS S3 API call timeout in milliseconds, including all retries
 
   * Type: long
-  * Default: null
-  * Valid Values: null or [1,...,9223372036854775807]
+  * Default: 2000
+  * Valid Values: [1,...]
   * Importance: low
 
 ``s3.endpoint.url``

--- a/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/s3/S3StorageConfig.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/storage_backend/s3/S3StorageConfig.java
@@ -28,7 +28,6 @@ import java.time.Duration;
 import java.util.Map;
 
 import io.aiven.inkless.common.config.validators.NonEmptyPassword;
-import io.aiven.inkless.common.config.validators.Null;
 import io.aiven.inkless.common.config.validators.Subclass;
 import io.aiven.inkless.common.config.validators.ValidUrl;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
@@ -58,9 +57,11 @@ public class S3StorageConfig extends AbstractConfig {
     private static final String S3_API_CALL_TIMEOUT_CONFIG = "s3.api.call.timeout";
     private static final String S3_API_CALL_TIMEOUT_DOC = "AWS S3 API call timeout in milliseconds, "
         + "including all retries";
+    private static final long S3_API_CALL_TIMEOUT_DEFAULT = 2_000;
     private static final String S3_API_CALL_ATTEMPT_TIMEOUT_CONFIG = "s3.api.call.attempt.timeout";
     private static final String S3_API_CALL_ATTEMPT_TIMEOUT_DOC = "AWS S3 API call attempt "
         + "(single retry) timeout in milliseconds";
+    private static final long S3_API_CALL_ATTEMPT_TIMEOUT_DEFAULT = 1_000;
     public static final String AWS_CREDENTIALS_PROVIDER_CLASS_CONFIG = "aws.credentials.provider.class";
     private static final String AWS_CREDENTIALS_PROVIDER_CLASS_DOC = "AWS credentials provider. "
         + "If not set, AWS SDK uses the default "
@@ -132,15 +133,15 @@ public class S3StorageConfig extends AbstractConfig {
             .define(
                 S3_API_CALL_TIMEOUT_CONFIG,
                 ConfigDef.Type.LONG,
-                null,
-                Null.or(ConfigDef.Range.between(1, Long.MAX_VALUE)),
+                S3_API_CALL_TIMEOUT_DEFAULT,
+                atLeast(1),
                 ConfigDef.Importance.LOW,
                 S3_API_CALL_TIMEOUT_DOC)
             .define(
                 S3_API_CALL_ATTEMPT_TIMEOUT_CONFIG,
                 ConfigDef.Type.LONG,
-                null,
-                Null.or(ConfigDef.Range.between(1, Long.MAX_VALUE)),
+                S3_API_CALL_ATTEMPT_TIMEOUT_DEFAULT,
+                atLeast(1),
                 ConfigDef.Importance.LOW,
                 S3_API_CALL_ATTEMPT_TIMEOUT_DOC)
             .define(

--- a/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/s3/S3ClientBuilderTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/s3/S3ClientBuilderTest.java
@@ -55,8 +55,9 @@ class S3ClientBuilderTest {
         assertThat(clientConfiguration.endpointOverride()).isNotPresent();
         assertThat(clientConfiguration.overrideConfiguration().metricPublishers())
             .allSatisfy(metricPublisher -> assertThat(metricPublisher).isInstanceOf(MetricCollector.class));
-        assertThat(clientConfiguration.overrideConfiguration().apiCallTimeout()).isEmpty();
-        assertThat(clientConfiguration.overrideConfiguration().apiCallAttemptTimeout()).isEmpty();
+        assertThat(clientConfiguration.overrideConfiguration().apiCallTimeout()).hasValue(Duration.ofMillis(2000));
+        assertThat(clientConfiguration.overrideConfiguration().apiCallAttemptTimeout())
+            .hasValue(Duration.ofMillis(1000));
 
         final AttributeMap resolvedOptions = getInternalHttpClientResolvedOptions(s3Client);
         assertThat(resolvedOptions.get(SdkHttpConfigurationOption.TRUST_ALL_CERTIFICATES)).isFalse();
@@ -78,8 +79,9 @@ class S3ClientBuilderTest {
         assertThat(clientConfiguration.endpointOverride()).hasValue(URI.create("http://minio"));
         assertThat(clientConfiguration.overrideConfiguration().metricPublishers())
             .allSatisfy(metricPublisher -> assertThat(metricPublisher).isInstanceOf(MetricCollector.class));
-        assertThat(clientConfiguration.overrideConfiguration().apiCallTimeout()).isEmpty();
-        assertThat(clientConfiguration.overrideConfiguration().apiCallAttemptTimeout()).isEmpty();
+        assertThat(clientConfiguration.overrideConfiguration().apiCallTimeout()).hasValue(Duration.ofMillis(2000));
+        assertThat(clientConfiguration.overrideConfiguration().apiCallAttemptTimeout())
+            .hasValue(Duration.ofMillis(1000));
         assertThat(clientConfiguration.credentialsProvider()).isInstanceOf(DefaultCredentialsProvider.class);
         assertThat(clientConfiguration.overrideConfiguration().metricPublishers()).hasSize(1);
         assertThat(clientConfiguration.overrideConfiguration().metricPublishers()).element(0)
@@ -107,8 +109,9 @@ class S3ClientBuilderTest {
         final var clientConfiguration = s3Client.serviceClientConfiguration();
         assertThat(clientConfiguration.region()).isEqualTo(TEST_REGION);
         assertThat(clientConfiguration.endpointOverride()).hasValue(URI.create("http://minio"));
-        assertThat(clientConfiguration.overrideConfiguration().apiCallTimeout()).isEmpty();
-        assertThat(clientConfiguration.overrideConfiguration().apiCallAttemptTimeout()).isEmpty();
+        assertThat(clientConfiguration.overrideConfiguration().apiCallTimeout()).hasValue(Duration.ofMillis(2000));
+        assertThat(clientConfiguration.overrideConfiguration().apiCallAttemptTimeout())
+            .hasValue(Duration.ofMillis(1000));
         assertThat(clientConfiguration.credentialsProvider()).isInstanceOf(customCredentialsProvider);
         assertThat(clientConfiguration.overrideConfiguration().metricPublishers()).hasSize(1);
         assertThat(clientConfiguration.overrideConfiguration().metricPublishers()).element(0)
@@ -141,8 +144,9 @@ class S3ClientBuilderTest {
         assertThat(clientConfiguration.endpointOverride()).hasValue(URI.create("http://minio"));
         assertThat(clientConfiguration.overrideConfiguration().metricPublishers())
             .allSatisfy(metricPublisher -> assertThat(metricPublisher).isInstanceOf(MetricCollector.class));
-        assertThat(clientConfiguration.overrideConfiguration().apiCallTimeout()).isEmpty();
-        assertThat(clientConfiguration.overrideConfiguration().apiCallAttemptTimeout()).isEmpty();
+        assertThat(clientConfiguration.overrideConfiguration().apiCallTimeout()).hasValue(Duration.ofMillis(2000));
+        assertThat(clientConfiguration.overrideConfiguration().apiCallAttemptTimeout())
+            .hasValue(Duration.ofMillis(1000));
 
         final AttributeMap resolvedOptions = getInternalHttpClientResolvedOptions(s3Client);
         assertThat(resolvedOptions.get(SdkHttpConfigurationOption.TRUST_ALL_CERTIFICATES)).isTrue();

--- a/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/s3/S3StorageConfigTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/s3/S3StorageConfigTest.java
@@ -62,8 +62,8 @@ class S3StorageConfigTest {
         assertThat(config.checksumCheckEnabled()).isFalse();
         assertThat(config.region()).isEqualTo(TEST_REGION);
         assertThat(config.s3ServiceEndpoint()).isNull();
-        assertThat(config.apiCallTimeout()).isNull();
-        assertThat(config.apiCallAttemptTimeout()).isNull();
+        assertThat(config.apiCallTimeout()).isEqualTo(Duration.ofMillis(2000));
+        assertThat(config.apiCallAttemptTimeout()).isEqualTo(Duration.ofMillis(1000));
     }
 
     // - Credential provider scenarios
@@ -85,8 +85,8 @@ class S3StorageConfigTest {
         assertThat(config.httpMaxConnections()).isEqualTo(150);
         assertThat(config.region()).isEqualTo(TEST_REGION);
         assertThat(config.s3ServiceEndpoint()).extracting(URI::getHost).isEqualTo("minio");
-        assertThat(config.apiCallTimeout()).isNull();
-        assertThat(config.apiCallAttemptTimeout()).isNull();
+        assertThat(config.apiCallTimeout()).isEqualTo(Duration.ofMillis(2000));
+        assertThat(config.apiCallAttemptTimeout()).isEqualTo(Duration.ofMillis(1000));
     }
 
     //   - With provider
@@ -110,8 +110,8 @@ class S3StorageConfigTest {
         assertThat(config.credentialsProvider()).isInstanceOf(customCredentialsProvider);
         assertThat(config.region()).isEqualTo(TEST_REGION);
         assertThat(config.s3ServiceEndpoint()).extracting(URI::getHost).isEqualTo("minio");
-        assertThat(config.apiCallTimeout()).isNull();
-        assertThat(config.apiCallAttemptTimeout()).isNull();
+        assertThat(config.apiCallTimeout()).isEqualTo(Duration.ofMillis(2000));
+        assertThat(config.apiCallAttemptTimeout()).isEqualTo(Duration.ofMillis(1000));
     }
 
     //   - With static credentials
@@ -148,8 +148,8 @@ class S3StorageConfigTest {
         assertThat(awsCredentials.secretAccessKey()).isEqualTo(password);
         assertThat(config.region()).isEqualTo(TEST_REGION);
         assertThat(config.s3ServiceEndpoint()).extracting(URI::getHost).isEqualTo("minio");
-        assertThat(config.apiCallTimeout()).isNull();
-        assertThat(config.apiCallAttemptTimeout()).isNull();
+        assertThat(config.apiCallTimeout()).isEqualTo(Duration.ofMillis(2000));
+        assertThat(config.apiCallAttemptTimeout()).isEqualTo(Duration.ofMillis(1000));
     }
 
     @Test

--- a/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/s3/integration/S3ErrorMetricsTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/storage_backend/s3/integration/S3ErrorMetricsTest.java
@@ -83,6 +83,7 @@ class S3ErrorMetricsTest {
             "s3.region", Region.US_EAST_1.id(),
             "s3.endpoint.url", wmRuntimeInfo.getHttpBaseUrl(),
             "s3.path.style.access.enabled", "true",
+            "s3.api.call.timeout", 10_000,
             "aws.credentials.provider.class", AnonymousCredentialsProvider.class.getName()
         );
         storage.configure(configs);


### PR DESCRIPTION
## Summary
- Default `inkless.storage.s3.api.call.timeout` to `2000` ms (full call, including retries) and `inkless.storage.s3.api.call.attempt.timeout` to `1000` ms (single attempt).
- Previously these configs defaulted to `null`, so the AWS SDK applied its own (much longer) timeouts. The new defaults fail hung S3 calls sooner and align with the GCS connect and read timeout defaults.

## Test plan
- [x] `./gradlew :storage:inkless:test --tests io.aiven.inkless.storage_backend.s3.S3StorageConfigTest --tests io.aiven.inkless.storage_backend.s3.S3ClientBuilderTest`


Made with [Cursor](https://cursor.com)