### PR TITLE
fix(inkless:delete): do not sleep inside the topic purger tick [KC-349]

### DIFF
--- a/core/src/test/java/kafka/server/InklessDisklessTopicDeleteTest.java
+++ b/core/src/test/java/kafka/server/InklessDisklessTopicDeleteTest.java
@@ -32,6 +32,7 @@ import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.common.test.KafkaClusterTestKit;
 import org.apache.kafka.common.test.TestKitNodes;
+import org.apache.kafka.common.utils.LogCaptureAppender;
 import org.apache.kafka.coordinator.group.GroupCoordinatorConfig;
 import org.apache.kafka.server.config.ServerConfigs;
 import org.apache.kafka.test.TestUtils;
@@ -50,10 +51,8 @@ import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
@@ -64,6 +63,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import io.aiven.inkless.config.InklessConfig;
 import io.aiven.inkless.control_plane.postgres.PostgresControlPlane;
 import io.aiven.inkless.control_plane.postgres.PostgresControlPlaneConfig;
+import io.aiven.inkless.delete.TopicPurger;
 import io.aiven.inkless.storage_backend.s3.S3Storage;
 import io.aiven.inkless.storage_backend.s3.S3StorageConfig;
 import io.aiven.inkless.test_utils.InklessPostgreSQLContainer;
@@ -137,7 +137,7 @@ public class InklessDisklessTopicDeleteTest {
             .setConfigProp(InklessConfig.PREFIX + InklessConfig.PRODUCE_BUFFER_MAX_BYTES_CONFIG, Integer.toString(PRODUCE_BUFFER_MAX_BYTES))
             // Drain and object delete must finish inside the wait windows below. The batch-coordinate
             // cache TTL must stay at most half of file.cleaner.retention.period.ms. Cap the purger so
-            // the test can observe leftover batches between cycles.
+            // a single cycle cannot finish the drain.
             .setConfigProp(InklessConfig.PREFIX + InklessConfig.TOPIC_PURGER_INTERVAL_MS_CONFIG, "1000")
             .setConfigProp(InklessConfig.PREFIX + InklessConfig.TOPIC_PURGER_MAX_BATCHES_PER_CYCLE_CONFIG, Integer.toString(MAX_BATCHES_PER_CYCLE))
             .setConfigProp(InklessConfig.PREFIX + InklessConfig.FILE_CLEANER_INTERVAL_MS_CONFIG, "1000")
@@ -185,20 +185,23 @@ public class InklessDisklessTopicDeleteTest {
             assertEquals(NUM_PARTITIONS, beforeDelete.logCount(), "Every partition must have a log row");
             assertEquals(0, beforeDelete.deletedLogCount(), "Live logs must not be stamped deleted");
 
-            admin.deleteTopics(Collections.singletonList(TOPIC_NAME)).all().get(30, TimeUnit.SECONDS);
+            try (LogCaptureAppender appender = LogCaptureAppender.createAndRegister(TopicPurger.class)) {
+                admin.deleteTopics(Collections.singletonList(TOPIC_NAME)).all().get(30, TimeUnit.SECONDS);
 
-            final ControlPlaneSnapshot afterDelete = readControlPlaneSnapshot(topicId);
-            log.info("Control plane snapshot immediately after delete: {}", afterDelete);
-            if (afterDelete.logCount() > 0) {
-                assertEquals(afterDelete.logCount(), afterDelete.deletedLogCount(),
-                    "DELETE_TOPICS must stamp logs.deleted_at rather than drop the rows");
+                final ControlPlaneSnapshot afterDelete = readControlPlaneSnapshot(topicId);
+                log.info("Control plane snapshot immediately after delete: {}", afterDelete);
+                if (afterDelete.logCount() > 0) {
+                    assertEquals(afterDelete.logCount(), afterDelete.deletedLogCount(),
+                        "DELETE_TOPICS must stamp logs.deleted_at rather than drop the rows");
+                }
+                assertTrue(afterDelete.batchCount() >= MIN_BATCHES_FOR_MULTI_CYCLE,
+                    "DELETE_TOPICS must return before TopicPurger drains the batches, got "
+                        + afterDelete.batchCount());
+
+                waitUntilPurged(topicId);
+                assertSaturatedAcrossMultipleCycles(appender, afterDelete.batchCount());
             }
-            assertTrue(afterDelete.batchCount() >= MIN_BATCHES_FOR_MULTI_CYCLE,
-                "DELETE_TOPICS must return before TopicPurger drains the batches, got "
-                    + afterDelete.batchCount());
-
             waitUntilTopicGone(admin);
-            waitUntilPurgedAcrossMultipleCycles(topicId, afterDelete.batchCount());
         }
 
         try (S3Client s3 = s3Container.getS3Client()) {
@@ -275,40 +278,32 @@ public class InklessDisklessTopicDeleteTest {
         }, 60_000, () -> "Topic must disappear from Kafka metadata after DELETE_TOPICS");
     }
 
-    /**
-     * Polls until the control-plane rows are gone and requires a leftover batch count in between.
-     * With {@code topic.purger.max.batches.per.cycle} capped, one cycle cannot finish the drain.
-     */
-    private void waitUntilPurgedAcrossMultipleCycles(Uuid topicId, long batchesAtDelete) throws InterruptedException {
-        final List<Long> observedBatchCounts = new ArrayList<>();
-        observedBatchCounts.add(batchesAtDelete);
+    private void waitUntilPurged(Uuid topicId) throws InterruptedException {
         final AtomicReference<ControlPlaneSnapshot> last = new AtomicReference<>();
-        boolean sawPartialDrain = false;
-        final long deadline = System.currentTimeMillis() + 90_000;
-
-        while (System.currentTimeMillis() < deadline) {
+        TestUtils.waitForCondition(() -> {
             ControlPlaneSnapshot snapshot = readControlPlaneSnapshot(topicId);
-            last.set(snapshot);
-            long batches = snapshot.batchCount();
-            if (observedBatchCounts.get(observedBatchCounts.size() - 1) != batches) {
-                observedBatchCounts.add(batches);
+            ControlPlaneSnapshot previous = last.getAndSet(snapshot);
+            if (previous == null || !previous.equals(snapshot)) {
                 log.info("TopicPurger progress: {}", snapshot);
             }
-            if (batches > 0 && batches < batchesAtDelete) {
-                sawPartialDrain = true;
-            }
-            if (snapshot.isFullyPurged()) {
-                break;
-            }
-            Thread.sleep(100);
-        }
+            return snapshot.isFullyPurged();
+        }, 90_000, () -> "TopicPurger must drop logs, batches, and producer_state; last seen: " + last.get());
+    }
 
-        assertTrue(last.get() != null && last.get().isFullyPurged(),
-            "TopicPurger must drop logs, batches, and producer_state; last seen: " + last.get()
-                + "; batch counts: " + observedBatchCounts);
-        assertTrue(sawPartialDrain,
-            "TopicPurger must drain batches across multiple cycles (max "
-                + MAX_BATCHES_PER_CYCLE + " per cycle); observed batch counts: " + observedBatchCounts);
+    /**
+     * One cycle cannot finish the drain: each broker deletes at most
+     * {@code topic.purger.max.batches.per.cycle} batches. Count saturated cycles from TopicPurger
+     * logs instead of a {@code COUNT(*)} poll, which can miss leftovers between 1s ticks.
+     */
+    private static void assertSaturatedAcrossMultipleCycles(LogCaptureAppender appender, long batchesAtDelete) {
+        long saturated = appender.getMessages().stream()
+            .filter(message -> message.contains("per-cycle cap reached"))
+            .count();
+        assertTrue(saturated >= batchesAtDelete - NUM_BROKERS,
+            "TopicPurger must hit the per-cycle cap across multiple cycles (max "
+                + MAX_BATCHES_PER_CYCLE + " per cycle); saturated=" + saturated
+                + " batchesAtDelete=" + batchesAtDelete
+                + " messages=" + appender.getMessages());
     }
 
     private record ControlPlaneSnapshot(

--- a/storage/inkless/src/main/java/io/aiven/inkless/delete/TopicPurger.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/delete/TopicPurger.java
@@ -27,7 +27,6 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Supplier;
 
 import io.aiven.inkless.TimeUtils;
 import io.aiven.inkless.common.SharedState;
@@ -42,8 +41,11 @@ public class TopicPurger implements Runnable, Closeable {
     final int maxBatchesPerCycle;
     final TopicPurgerMetrics metrics;
     private final ExponentialBackoff errorBackoff = new ExponentialBackoff(100, 2, 60 * 1000, 0.2);
-    private final Supplier<Long> noWorkBackoffSupplier;
     private final AtomicInteger attempts = new AtomicInteger();
+    // KafkaScheduler uses scheduleAtFixedRate. Sleeping inside run() queues missed ticks, and
+    // the next work cycle bursts past topic.purger.max.batches.per.cycle / interval. Skip the
+    // tick until this time instead.
+    private volatile long nextEligibleMs;
 
     public TopicPurger(SharedState sharedState) {
         this(
@@ -61,14 +63,13 @@ public class TopicPurger implements Runnable, Closeable {
         this.controlPlane = controlPlane;
         this.maxBatchesPerCycle = maxBatchesPerCycle;
         this.metrics = new TopicPurgerMetrics(time);
-
-        final int noWorkBackoffDuration = 10 * 1000;
-        final var noWorkBackoff = new ExponentialBackoff(noWorkBackoffDuration, 1, noWorkBackoffDuration * 2, 0.2);
-        noWorkBackoffSupplier = () -> noWorkBackoff.backoff(1);
     }
 
     @Override
     public void run() {
+        if (time.milliseconds() < nextEligibleMs) {
+            return;
+        }
         try {
             metrics.recordTopicPurgerStart();
             final PurgeDeletedLogsResponse result = TimeUtils.measureDurationMs(time,
@@ -77,9 +78,7 @@ public class TopicPurger implements Runnable, Closeable {
 
             metrics.recordTopicPurgerWorkRemain(result.moreRemain());
             if (result.isEmpty()) {
-                final long sleepMillis = noWorkBackoffSupplier.get();
-                LOGGER.info("No purge work this cycle, sleeping for {}", Duration.ofMillis(sleepMillis));
-                time.sleep(sleepMillis);
+                LOGGER.debug("No purge work this cycle");
             } else {
                 final boolean saturated = result.capReached();
                 if (saturated) {
@@ -95,12 +94,13 @@ public class TopicPurger implements Runnable, Closeable {
             }
 
             attempts.set(0);
+            nextEligibleMs = 0L;
             metrics.recordTopicPurgerCycleSucceeded();
         } catch (final Exception e) {
             metrics.recordTopicPurgerError();
             final long backoff = errorBackoff.backoff(attempts.incrementAndGet());
-            LOGGER.error("Error while purging deleted logs, waiting for {}", Duration.ofMillis(backoff), e);
-            time.sleep(backoff);
+            nextEligibleMs = time.milliseconds() + backoff;
+            LOGGER.error("Error while purging deleted logs, retrying after {}", Duration.ofMillis(backoff), e);
         }
     }
 

--- a/storage/inkless/src/test/java/io/aiven/inkless/delete/TopicPurgerMockedTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/delete/TopicPurgerMockedTest.java
@@ -31,7 +31,6 @@ import io.aiven.inkless.control_plane.ControlPlane;
 import io.aiven.inkless.control_plane.PurgeDeletedLogsResponse;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -54,6 +53,7 @@ class TopicPurgerMockedTest {
 
         assertEquals(-1, purger.metrics.lastSuccessfulPurgeTimeMs.get());
 
+        final long beforeMs = time.milliseconds();
         purger.run();
 
         verify(controlPlane, times(1)).purgeDeletedLogs(eq(MAX_BATCHES_PER_CYCLE));
@@ -61,10 +61,11 @@ class TopicPurgerMockedTest {
         assertEquals(time.milliseconds(), purger.metrics.lastSuccessfulPurgeTimeMs.get());
         assertEquals(0, purger.metrics.topicPurgerCycleSaturated.intValue());
         assertEquals(0, purger.metrics.topicPurgerWorkRemain.get());
+        assertEquals(beforeMs, time.milliseconds());
     }
 
     @Test
-    void noWorkIsIdleEvenWhenMoreRemain() {
+    void noWorkDoesNotSleepWhenMoreRemain() {
         final var purger = new TopicPurger(time, controlPlane, MAX_BATCHES_PER_CYCLE);
         // Another broker holds the deleted rows (SKIP LOCKED miss): moreRemain is cluster-wide.
         when(controlPlane.purgeDeletedLogs(MAX_BATCHES_PER_CYCLE))
@@ -73,7 +74,7 @@ class TopicPurgerMockedTest {
         final long beforeMs = time.milliseconds();
         purger.run();
 
-        assertTrue(time.milliseconds() > beforeMs);
+        assertEquals(beforeMs, time.milliseconds());
         assertEquals(0, purger.metrics.topicPurgerCycleSaturated.intValue());
         assertEquals(1, purger.metrics.topicPurgerWorkRemain.get());
         assertEquals(time.milliseconds(), purger.metrics.lastSuccessfulPurgeTimeMs.get());
@@ -118,7 +119,7 @@ class TopicPurgerMockedTest {
     }
 
     @Test
-    void doesNotTrackFailedCycleAsSuccessful() {
+    void errorBackoffSkipsTicksUntilEligible() {
         final var purger = new TopicPurger(time, controlPlane, MAX_BATCHES_PER_CYCLE);
         when(controlPlane.purgeDeletedLogs(MAX_BATCHES_PER_CYCLE))
             .thenThrow(new RuntimeException("purge failed"))
@@ -126,8 +127,16 @@ class TopicPurgerMockedTest {
 
         purger.run();
         assertEquals(-1, purger.metrics.lastSuccessfulPurgeTimeMs.get());
+        verify(controlPlane, times(1)).purgeDeletedLogs(eq(MAX_BATCHES_PER_CYCLE));
 
         purger.run();
+        assertEquals(-1, purger.metrics.lastSuccessfulPurgeTimeMs.get());
+        verify(controlPlane, times(1)).purgeDeletedLogs(eq(MAX_BATCHES_PER_CYCLE));
+
+        // First error backoff is 100 * 2^1 * [0.8, 1.2] ms. Jump past the max.
+        time.sleep(1_000);
+        purger.run();
         assertEquals(time.milliseconds(), purger.metrics.lastSuccessfulPurgeTimeMs.get());
+        verify(controlPlane, times(2)).purgeDeletedLogs(eq(MAX_BATCHES_PER_CYCLE));
     }
 }


### PR DESCRIPTION
KafkaScheduler uses scheduleAtFixedRate. An idle or error sleep inside run() queues missed ticks and the next work cycle bursts past max.batches.per.cycle / interval. Empty cycles return immediately. Errors set nextEligibleMs and later ticks skip until that time.

InklessDisklessTopicDeleteTest asserts the per-cycle cap from TopicPurger logs instead of a COUNT(*) poll.
