### PR TITLE
fix(inkless:ci): copy integrationTest JUnit XML into build/junit-xml

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -613,8 +613,6 @@ subprojects {
   // were not run, but instead were restored via FROM-CACHE. See KAFKA-17479 for more details.
   def copyTestXml = tasks.register('copyTestXml') {
     onlyIf("Environment GITHUB_ACTIONS is set") { isGithubActions }
-    onlyIf("Project '${project.name}:test' has sources") { ! test.state.noSource }
-    onlyIf("Task '${project.name}:test' did work") { test.state.didWork }
 
     ext {
       output = project.findProperty("kafka.test.xml.output.dir")
@@ -627,11 +625,23 @@ subprojects {
     doLast {
       def moduleDirPath = projectToJUnitXmlPath(project)
       def dest = rootProject.layout.buildDirectory.dir("junit-xml/${moduleDirPath}/${output}").get().asFile
-      println "Copy JUnit XML for ${project.name} to $dest"
-      ant.copy(todir: "$dest") {
-	ant.fileset(dir: "${test.reports.junitXml.entryPoint}") {
-	  ant.include(name: "**/*.xml")
-	}
+      // Copy every Test task that actually ran, not only `test`. Inkless CI's
+      // integrationTest failures otherwise never land in build/junit-xml, so
+      // junit.py reports 0 results. Skip FROM-CACHE/no-source tasks (KAFKA-17479).
+      tasks.withType(Test).each { testTask ->
+        if (testTask.state.noSource || !testTask.state.didWork) {
+          return
+        }
+        def xmlDir = testTask.reports.junitXml.entryPoint
+        if (!xmlDir.exists()) {
+          return
+        }
+        println "Copy JUnit XML for ${project.name}:${testTask.name} to $dest"
+        ant.copy(todir: "$dest") {
+          ant.fileset(dir: "${xmlDir}") {
+            ant.include(name: "**/*.xml")
+          }
+        }
       }
     }
   }
@@ -715,6 +725,8 @@ subprojects {
         maxFailures = userMaxTestRetryFailures
       }
     }
+
+    finalizedBy("copyTestXml")
   }
 
   task unitTest(type: Test, dependsOn: compileJava) {


### PR DESCRIPTION
copyTestXml only ran after the unit test task, so Inkless CI's integrationTest failures never reached junit.py (Found 0 JUnit results). Copy XML from every Test task that did work, and finalize integrationTest the same way.

Tested on failing integration test and now it reports failing test: 

```
Run # Export the catalog here so parameterized display names are checked on
Found 7 JUnit results
Read env GITHUB_WORKSPACE: /home/runner/work/inkless/inkless
Parsing 7 JUnit Report Files
Generating Test Catalog Files
Finished processing 7 reports
Read env GRADLE_TEST_EXIT_CODE: 1
Read env JUNIT_REPORT_URL: https://github.com/aiven/inkless/actions/runs/34324570056/artifacts/10093806833
Read env THREAD_DUMP_URL: 
Could not find env RUN_FLAKY
Found 1 test failures:
FAILED ❌ S3ErrorMetricsTest > "testS3ServerExceptions(int, String, WireMockRuntimeInfo).statusCode=429, metricName=throttling-errors"
Gradle task had a failure exit code. Failing this script.
35 tests cases run in 24s.

34 PASSED ✅, 1 FAILED ❌, 0 FLAKY ⚠️ , 0 SKIPPED 🙈, 0 QUARANTINED 😷, and 0 errors.
Error: Process completed with exit code 1.
```

compared to https://github.com/aiven/inkless/actions/runs/34228704621/job/102074449310?pr=791
