### PR TITLE
fix(inkless:release): exclude sync-tooling commits from the branch-consistency gate

### DIFF
--- a/inkless-sync/branch-consistency.sh
+++ b/inkless-sync/branch-consistency.sh
@@ -116,8 +116,9 @@ is_excluded_commit() {
         return 0
     fi
 
-    # Exclude sync-specific commits (main-trunk sync related)
-    if [[ "$commit_msg" =~ ^(sync\(|fix\(sync\)|docs\(sync\)|refactor\(sync\)) ]]; then
+    # Exclude sync fix-ups and sync-tooling commits. Release branches never read
+    # inkless-sync/: the sync guides copy main's copy into the worktree.
+    if [[ "$commit_msg" =~ ^(sync\(|[a-z]+\((sync|inkless-sync|inkless:sync|inkless:release-sync)\)) ]]; then
         return 0
     fi
 


### PR DESCRIPTION
branch-consistency.sh --check is the release gate: the release workflow runs it per active branch and refuses to tag while any actionable main commit is missing. The check matches by PR number and only excluded titles starting with sync(, fix(sync), docs(sync), or refactor(sync).

Sync-tooling PRs use the scopes inkless-sync, inkless:sync, and inkless:release-sync, so they did not match and the gate counted them as missing on every release branch. They only touch inkless-sync/, which no release branch reads: the sync guides copy main's inkless-sync/ into the sync worktree. Since 0.47 that covered #768, #770, #776, and #780 on inkless-4.1 and inkless-4.2, and #780 on inkless-4.3.

Match any conventional-commit type with those scopes, in addition to the existing sync( prefix. inkless:ci and inkless:release commits keep counting: they change workflows, build files, and docs that release branches do carry.
