### PR TITLE
fix(inkless:consume): stop a slow ListOffsets from wedging the broker [KC-537]

### DIFF
--- a/docs/inkless/configs.rst
+++ b/docs/inkless/configs.rst
@@ -219,6 +219,14 @@ Under ``inkless.``
   * Valid Values: [1,...]
   * Importance: low
 
+``fetch.offset.thread.pool.size``
+  Thread pool size to concurrently resolve ListOffsets requests against the batch coordinator. The queue capacity is thread.pool.size * 100; a ListOffsets request that arrives when the queue is full fails immediately instead of waiting.
+
+  * Type: int
+  * Default: 8
+  * Valid Values: [1,...]
+  * Importance: low
+
 ``file.cleaner.interval.ms``
   The interval with which to clean up files marked for deletion. Together with file.cleaner.max.files.per.cycle, this interval sets the rate at which files marked for deletion drain.
 

--- a/docs/inkless/metrics.rst
+++ b/docs/inkless/metrics.rst
@@ -183,13 +183,14 @@ InklessFetchOffset metrics
 io.aiven.inkless.consume:type=InklessFetchOffsetMetrics
 -------------------------------------------------------
 
-=====================  ==================================================================
-Attribute name         Description                                                       
-=====================  ==================================================================
-FetchOffsetErrorRate   Rate of failed fetch offset requests per second                   
-FetchOffsetRate        Rate of fetch offset requests processed per second                
-FetchOffsetTotalTime   Total time spent processing a fetch offset request in milliseconds
-=====================  ==================================================================
+========================  ================================================================================================================================================================
+Attribute name            Description                                                                                                                                                     
+========================  ================================================================================================================================================================
+FetchOffsetErrorRate      Rate of failed fetch offset requests per second                                                                                                                 
+FetchOffsetRate           Rate of fetch offset requests processed per second                                                                                                              
+FetchOffsetRejectedRate   Rate of fetch offset requests rejected per second because the fetch offset thread pool queue is full. Rejected requests are also counted in FetchOffsetErrorRate
+FetchOffsetTotalTime      Total time spent processing a fetch offset request in milliseconds                                                                                              
+========================  ================================================================================================================================================================
 
 
 Writer metrics

--- a/storage/inkless/src/main/java/io/aiven/inkless/config/InklessConfig.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/config/InklessConfig.java
@@ -201,6 +201,12 @@ public class InklessConfig extends AbstractConfig {
         + "from becoming a bottleneck in mixed hot/cold workloads.";
     private static final int FETCH_METADATA_THREAD_POOL_SIZE_DEFAULT = 8;
 
+    public static final String FETCH_OFFSET_THREAD_POOL_SIZE_CONFIG = "fetch.offset.thread.pool.size";
+    public static final String FETCH_OFFSET_THREAD_POOL_SIZE_DOC = "Thread pool size to concurrently resolve ListOffsets requests "
+        + "against the batch coordinator. The queue capacity is thread.pool.size * 100; a ListOffsets request that "
+        + "arrives when the queue is full fails immediately instead of waiting.";
+    private static final int FETCH_OFFSET_THREAD_POOL_SIZE_DEFAULT = 8;
+
     public static final String FETCH_LAGGING_CONSUMER_THREAD_POOL_SIZE_CONFIG = "fetch.lagging.consumer.thread.pool.size";
     public static final String FETCH_LAGGING_CONSUMER_THREAD_POOL_SIZE_DOC = "Thread pool size for lagging consumer fetch requests (consumers reading old data). "
         + "Set to 0 to disable the lagging consumer feature (all requests will use the recent data path). "
@@ -498,6 +504,14 @@ public class InklessConfig extends AbstractConfig {
             ConfigDef.Range.atLeast(1),
             ConfigDef.Importance.LOW,
             FETCH_METADATA_THREAD_POOL_SIZE_DOC
+        );
+        configDef.define(
+            FETCH_OFFSET_THREAD_POOL_SIZE_CONFIG,
+            ConfigDef.Type.INT,
+            FETCH_OFFSET_THREAD_POOL_SIZE_DEFAULT,
+            ConfigDef.Range.atLeast(1),
+            ConfigDef.Importance.LOW,
+            FETCH_OFFSET_THREAD_POOL_SIZE_DOC
         );
         configDef.define(
             FETCH_LAGGING_CONSUMER_THREAD_POOL_SIZE_CONFIG,
@@ -829,6 +843,10 @@ public class InklessConfig extends AbstractConfig {
 
     public int fetchMetadataThreadPoolSize() {
         return getInt(FETCH_METADATA_THREAD_POOL_SIZE_CONFIG);
+    }
+
+    public int fetchOffsetThreadPoolSize() {
+        return getInt(FETCH_OFFSET_THREAD_POOL_SIZE_CONFIG);
     }
 
     public int fetchLaggingConsumerThreadPoolSize() {

--- a/storage/inkless/src/main/java/io/aiven/inkless/consume/FetchOffsetHandler.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/consume/FetchOffsetHandler.java
@@ -41,11 +41,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 import io.aiven.inkless.TimeUtils;
@@ -53,6 +55,7 @@ import io.aiven.inkless.cache.CrossTierLogStartCache;
 import io.aiven.inkless.common.InklessThreadFactory;
 import io.aiven.inkless.common.SharedState;
 import io.aiven.inkless.common.TopicIdEnricher;
+import io.aiven.inkless.common.metrics.ThreadPoolMonitor;
 import io.aiven.inkless.control_plane.ControlPlane;
 import io.aiven.inkless.control_plane.ListOffsetsRequest;
 import io.aiven.inkless.control_plane.ListOffsetsResponse;
@@ -61,15 +64,19 @@ import io.aiven.inkless.control_plane.MetadataView;
 import static org.apache.kafka.common.requests.ListOffsetsRequest.EARLIEST_TIMESTAMP;
 
 public class FetchOffsetHandler implements Closeable {
+    private static final String THREAD_NAME_PREFIX = "inkless-fetch-offset-metadata";
+    private static final int QUEUE_CAPACITY_PER_THREAD = 100;
+
     private final SharedState state;
     private final ExecutorService executor;
     private final Time time;
     private final InklessFetchOffsetMetrics metrics;
+    private final ThreadPoolMonitor threadPoolMonitor;
 
     public FetchOffsetHandler(SharedState state) {
         this(
             state,
-            Executors.newCachedThreadPool(new InklessThreadFactory("inkless-fetch-offset-metadata", false)),
+            createExecutor(state.config().fetchOffsetThreadPoolSize()),
             state.time(),
             new InklessFetchOffsetMetrics(state.time())
         );
@@ -86,6 +93,22 @@ public class FetchOffsetHandler implements Closeable {
         this.executor = executor;
         this.time = time;
         this.metrics = metrics;
+        this.threadPoolMonitor = executor instanceof ThreadPoolExecutor
+            ? new ThreadPoolMonitor(THREAD_NAME_PREFIX, executor)
+            : null;
+    }
+
+    private static ExecutorService createExecutor(final int poolSize) {
+        return new ThreadPoolExecutor(
+            poolSize,
+            poolSize,
+            0L,
+            TimeUnit.MILLISECONDS,
+            new ArrayBlockingQueue<>(poolSize * QUEUE_CAPACITY_PER_THREAD),
+            new InklessThreadFactory(THREAD_NAME_PREFIX, false),
+            // Reject instead of CallerRunsPolicy: the caller is a request handler thread.
+            new ThreadPoolExecutor.AbortPolicy()
+        );
     }
 
     public Job createJob() {
@@ -95,6 +118,9 @@ public class FetchOffsetHandler implements Closeable {
     @Override
     public void close() throws IOException {
         ThreadUtils.shutdownExecutorServiceQuietly(executor, 5, TimeUnit.SECONDS);
+        if (threadPoolMonitor != null) {
+            threadPoolMonitor.close();
+        }
         metrics.close();
     }
 
@@ -161,16 +187,17 @@ public class FetchOffsetHandler implements Closeable {
                 // Complete all pending futures with the error rather than throwing an unchecked
                 // exception that propagates to the request handler, which may log the full request
                 // context (all topic names) producing an oversized log entry.
-                final var exception = new RuntimeException("Topic ID not found: " + e.topicName, e);
-                for (final var future : futures.values()) {
-                    future.complete(new OffsetResultHolder.FileRecordsOrError(
-                        Optional.of(exception),
-                        Optional.empty()
-                    ));
-                }
+                failAll(new RuntimeException("Topic ID not found: " + e.topicName, e));
                 return;
             }
-            final Future<?> submitted = executor.submit(() -> queryControlPlane(requestsEnriched));
+            final Future<?> submitted;
+            try {
+                submitted = executor.submit(() -> queryControlPlane(requestsEnriched));
+            } catch (final RejectedExecutionException e) {
+                metrics.fetchOffsetRejected();
+                failAll(e);
+                return;
+            }
             cancelHandler.handle((_ignored, e) -> {
                 if (e instanceof CancellationException) {
                     if (submitted.cancel(true)) {
@@ -211,14 +238,7 @@ public class FetchOffsetHandler implements Closeable {
                 controlPlaneResponses = controlPlane.listOffsets(controlPlaneRequests);
             } catch (final Exception exception) {
                 // Handle global errors (e.g. control plane not available).
-                for (final var future : futures.values()) {
-                    if (!future.isDone()) {
-                        future.complete(new OffsetResultHolder.FileRecordsOrError(
-                            Optional.of(exception),
-                            Optional.empty()
-                        ));
-                    }
-                }
+                failAll(exception);
                 metrics.fetchOffsetFailed();
                 return;
             }
@@ -243,6 +263,17 @@ public class FetchOffsetHandler implements Closeable {
                 }
             }
             metrics.fetchOffsetCompleted(startTime);
+        }
+
+        private void failAll(final Exception exception) {
+            for (final var future : futures.values()) {
+                if (!future.isDone()) {
+                    future.complete(new OffsetResultHolder.FileRecordsOrError(
+                        Optional.of(exception),
+                        Optional.empty()
+                    ));
+                }
+            }
         }
 
         private boolean isCrossTierEarliest(final TopicIdPartition topicIdPartition, final long timestamp) {

--- a/storage/inkless/src/main/java/io/aiven/inkless/consume/InklessFetchOffsetMetrics.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/consume/InklessFetchOffsetMetrics.java
@@ -43,6 +43,9 @@ public class InklessFetchOffsetMetrics {
     private static final String FETCH_OFFSET_RATE_DOC = "Rate of fetch offset requests processed per second";
     private static final String FETCH_OFFSET_ERROR_RATE = "FetchOffsetErrorRate";
     private static final String FETCH_OFFSET_ERROR_RATE_DOC = "Rate of failed fetch offset requests per second";
+    private static final String FETCH_OFFSET_REJECTED_RATE = "FetchOffsetRejectedRate";
+    private static final String FETCH_OFFSET_REJECTED_RATE_DOC = "Rate of fetch offset requests rejected per second because the "
+        + "fetch offset thread pool queue is full. Rejected requests are also counted in FetchOffsetErrorRate";
 
     /**
      * This method returns a list of all the metric name templates for the InklessFetchOffsetMetrics class.
@@ -52,7 +55,8 @@ public class InklessFetchOffsetMetrics {
         return List.of(
             new MetricNameTemplate(FETCH_OFFSET_TOTAL_TIME, GROUP, FETCH_OFFSET_TOTAL_TIME_DOC),
             new MetricNameTemplate(FETCH_OFFSET_RATE, GROUP, FETCH_OFFSET_RATE_DOC),
-            new MetricNameTemplate(FETCH_OFFSET_ERROR_RATE, GROUP, FETCH_OFFSET_ERROR_RATE_DOC)
+            new MetricNameTemplate(FETCH_OFFSET_ERROR_RATE, GROUP, FETCH_OFFSET_ERROR_RATE_DOC),
+            new MetricNameTemplate(FETCH_OFFSET_REJECTED_RATE, GROUP, FETCH_OFFSET_REJECTED_RATE_DOC)
         );
     }
 
@@ -64,12 +68,14 @@ public class InklessFetchOffsetMetrics {
     private final Histogram fetchOffsetTimeHistogram;
     private final Meter fetchOffsetRate;
     private final Meter fetchOffsetErrorRate;
+    private final Meter fetchOffsetRejectedRate;
 
     public InklessFetchOffsetMetrics(Time time) {
         this.time = Objects.requireNonNull(time, "time cannot be null");
         fetchOffsetTimeHistogram = metricsGroup.newHistogram(FETCH_OFFSET_TOTAL_TIME, true, Map.of());
         fetchOffsetRate = metricsGroup.newMeter(FETCH_OFFSET_RATE, "fetches", java.util.concurrent.TimeUnit.SECONDS, Map.of());
         fetchOffsetErrorRate = metricsGroup.newMeter(FETCH_OFFSET_ERROR_RATE, "errors", java.util.concurrent.TimeUnit.SECONDS, Map.of());
+        fetchOffsetRejectedRate = metricsGroup.newMeter(FETCH_OFFSET_REJECTED_RATE, "rejections", java.util.concurrent.TimeUnit.SECONDS, Map.of());
     }
 
     public void fetchOffsetCompleted(final Instant startTime) {
@@ -81,9 +87,15 @@ public class InklessFetchOffsetMetrics {
         fetchOffsetErrorRate.mark();
     }
 
+    public void fetchOffsetRejected() {
+        fetchOffsetRejectedRate.mark();
+        fetchOffsetErrorRate.mark();
+    }
+
     public void close() {
         metricsGroup.removeMetric(FETCH_OFFSET_RATE);
         metricsGroup.removeMetric(FETCH_OFFSET_ERROR_RATE);
+        metricsGroup.removeMetric(FETCH_OFFSET_REJECTED_RATE);
         metricsGroup.removeMetric(FETCH_OFFSET_TOTAL_TIME);
     }
 }

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/AbstractControlPlane.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/AbstractControlPlane.java
@@ -109,7 +109,7 @@ public abstract class AbstractControlPlane implements ControlPlane {
     );
 
     @Override
-    public synchronized List<ListOffsetsResponse> listOffsets(final List<ListOffsetsRequest> listOffsetsRequests) {
+    public List<ListOffsetsResponse> listOffsets(final List<ListOffsetsRequest> listOffsetsRequests) {
         final SplitMapper<ListOffsetsRequest, ListOffsetsResponse> splitMapper = new SplitMapper<>(
                 listOffsetsRequests, findBatchRequest -> true
         );

--- a/storage/inkless/src/main/java/io/aiven/inkless/control_plane/InMemoryControlPlane.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/control_plane/InMemoryControlPlane.java
@@ -643,7 +643,7 @@ public class InMemoryControlPlane extends AbstractControlPlane {
                 .iterator();
     }
 
-    private ListOffsetsResponse listOffset(ListOffsetsRequest request) {
+    private synchronized ListOffsetsResponse listOffset(ListOffsetsRequest request) {
         final LogInfo logInfo = liveLog(request.topicIdPartition());
 
         if (logInfo == null) {

--- a/storage/inkless/src/main/java/io/aiven/inkless/delete/DeleteRecordsInterceptor.java
+++ b/storage/inkless/src/main/java/io/aiven/inkless/delete/DeleteRecordsInterceptor.java
@@ -31,8 +31,10 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -41,6 +43,7 @@ import io.aiven.inkless.common.InklessThreadFactory;
 import io.aiven.inkless.common.SharedState;
 import io.aiven.inkless.common.TopicIdEnricher;
 import io.aiven.inkless.common.TopicTypeCounter;
+import io.aiven.inkless.common.metrics.ThreadPoolMonitor;
 import io.aiven.inkless.control_plane.ControlPlane;
 import io.aiven.inkless.control_plane.DeleteRecordsRequest;
 import io.aiven.inkless.control_plane.DeleteRecordsResponse;
@@ -50,17 +53,31 @@ import static org.apache.kafka.common.requests.DeleteRecordsResponse.INVALID_LOW
 
 public class DeleteRecordsInterceptor implements Closeable {
     private static final Logger LOGGER = LoggerFactory.getLogger(DeleteRecordsInterceptor.class);
+    private static final String THREAD_NAME_PREFIX = "inkless-delete-records";
+    // DeleteRecords is an admin operation with a low arrival rate; no config for the pool size.
+    private static final int THREAD_POOL_SIZE = 2;
+    private static final int QUEUE_CAPACITY = 200;
 
     private final ControlPlane controlPlane;
     private final MetadataView metadataView;
     private final ExecutorService executorService;
     private final TopicTypeCounter topicTypeCounter;
+    private final ThreadPoolMonitor threadPoolMonitor;
 
     public DeleteRecordsInterceptor(final SharedState state) {
         this(
-            state.controlPlane(), 
-            state.metadata(), 
-            Executors.newCachedThreadPool(new InklessThreadFactory("inkless-delete-records", false))
+            state.controlPlane(),
+            state.metadata(),
+            new ThreadPoolExecutor(
+                THREAD_POOL_SIZE,
+                THREAD_POOL_SIZE,
+                0L,
+                TimeUnit.MILLISECONDS,
+                new ArrayBlockingQueue<>(QUEUE_CAPACITY),
+                new InklessThreadFactory(THREAD_NAME_PREFIX, false),
+                // Reject instead of CallerRunsPolicy: the caller is a request handler thread.
+                new ThreadPoolExecutor.AbortPolicy()
+            )
         );
     }
 
@@ -74,6 +91,9 @@ public class DeleteRecordsInterceptor implements Closeable {
         this.executorService = executorService;
         this.metadataView = metadataView;
         this.topicTypeCounter = new TopicTypeCounter(metadataView);
+        this.threadPoolMonitor = executorService instanceof ThreadPoolExecutor
+            ? new ThreadPoolMonitor(THREAD_NAME_PREFIX, executorService)
+            : null;
     }
 
     /**
@@ -107,29 +127,38 @@ public class DeleteRecordsInterceptor implements Closeable {
         }
 
         // TODO use purgatory
-        executorService.execute(() -> {
-            try {
-                final List<DeleteRecordsRequest> requests = offsetPerPartitionEnriched.entrySet().stream()
-                    .map(kv -> new DeleteRecordsRequest(kv.getKey(), kv.getValue()))
-                    .toList();
-                final List<DeleteRecordsResponse> responses = controlPlane.deleteRecords(requests);
-                final Map<TopicPartition, DeleteRecordsResponseData.DeleteRecordsPartitionResult> result = new HashMap<>();
-                for (int i = 0; i < responses.size(); i++) {
-                    final DeleteRecordsRequest request = requests.get(i);
-                    final DeleteRecordsResponse response = responses.get(i);
-                    final var value = new DeleteRecordsResponseData.DeleteRecordsPartitionResult()
-                        .setPartitionIndex(request.topicIdPartition().partition())
-                        .setErrorCode(response.errors().code())
-                        .setLowWatermark(response.lowWatermark());
-                    result.put(request.topicIdPartition().topicPartition(), value);
-                }
-                responseCallback.accept(result);
-            } catch (final Exception e) {
-                LOGGER.error("Unknown exception", e);
-                respondAllWithError(offsetPerPartition, responseCallback, Errors.UNKNOWN_SERVER_ERROR);
-            }
-        });
+        try {
+            executorService.execute(() -> deleteRecords(offsetPerPartition, offsetPerPartitionEnriched, responseCallback));
+        } catch (final RejectedExecutionException e) {
+            LOGGER.warn("DeleteRecords rejected: thread pool queue is full");
+            respondAllWithError(offsetPerPartition, responseCallback, Errors.UNKNOWN_SERVER_ERROR);
+        }
         return true;
+    }
+
+    private void deleteRecords(final Map<TopicPartition, Long> offsetPerPartition,
+                               final Map<TopicIdPartition, Long> offsetPerPartitionEnriched,
+                               final Consumer<Map<TopicPartition, DeleteRecordsResponseData.DeleteRecordsPartitionResult>> responseCallback) {
+        try {
+            final List<DeleteRecordsRequest> requests = offsetPerPartitionEnriched.entrySet().stream()
+                .map(kv -> new DeleteRecordsRequest(kv.getKey(), kv.getValue()))
+                .toList();
+            final List<DeleteRecordsResponse> responses = controlPlane.deleteRecords(requests);
+            final Map<TopicPartition, DeleteRecordsResponseData.DeleteRecordsPartitionResult> result = new HashMap<>();
+            for (int i = 0; i < responses.size(); i++) {
+                final DeleteRecordsRequest request = requests.get(i);
+                final DeleteRecordsResponse response = responses.get(i);
+                final var value = new DeleteRecordsResponseData.DeleteRecordsPartitionResult()
+                    .setPartitionIndex(request.topicIdPartition().partition())
+                    .setErrorCode(response.errors().code())
+                    .setLowWatermark(response.lowWatermark());
+                result.put(request.topicIdPartition().topicPartition(), value);
+            }
+            responseCallback.accept(result);
+        } catch (final Exception e) {
+            LOGGER.error("Unknown exception", e);
+            respondAllWithError(offsetPerPartition, responseCallback, Errors.UNKNOWN_SERVER_ERROR);
+        }
     }
 
     private void respondAllWithError(final Map<TopicPartition, Long> offsetPerPartition,
@@ -149,5 +178,8 @@ public class DeleteRecordsInterceptor implements Closeable {
     @Override
     public void close() throws IOException {
         ThreadUtils.shutdownExecutorServiceQuietly(executorService, 5, TimeUnit.SECONDS);
+        if (threadPoolMonitor != null) {
+            threadPoolMonitor.close();
+        }
     }
 }

--- a/storage/inkless/src/test/java/io/aiven/inkless/config/InklessConfigTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/config/InklessConfigTest.java
@@ -60,6 +60,7 @@ class InklessConfigTest {
         configs.put("inkless.produce.upload.thread.pool.size", "16");
         configs.put("inkless.fetch.data.thread.pool.size", "12");
         configs.put("inkless.fetch.metadata.thread.pool.size", "14");
+        configs.put("inkless.fetch.offset.thread.pool.size", "6");
         configs.put("inkless.retention.enforcement.max.batches.per.request", "50");
         configs.put("inkless.consolidation.cleanup.interval.ms", "60000");
         final InklessConfig config = new InklessConfig(new AbstractConfig(new ConfigDef(), configs));
@@ -83,6 +84,7 @@ class InklessConfigTest {
         assertThat(config.produceUploadThreadPoolSize()).isEqualTo(16);
         assertThat(config.fetchDataThreadPoolSize()).isEqualTo(12);
         assertThat(config.fetchMetadataThreadPoolSize()).isEqualTo(14);
+        assertThat(config.fetchOffsetThreadPoolSize()).isEqualTo(6);
         assertThat(config.maxBatchesPerEnforcementRequest()).isEqualTo(50);
         assertThat(config.consolidationCleanupInterval()).isEqualTo(Duration.ofMillis(60000));
     }
@@ -116,6 +118,7 @@ class InklessConfigTest {
         assertThat(config.produceUploadThreadPoolSize()).isEqualTo(8);
         assertThat(config.fetchDataThreadPoolSize()).isEqualTo(32);
         assertThat(config.fetchMetadataThreadPoolSize()).isEqualTo(8);
+        assertThat(config.fetchOffsetThreadPoolSize()).isEqualTo(8);
         assertThat(config.maxBatchesPerEnforcementRequest()).isEqualTo(2000);
         assertThat(config.retentionEnforcementInterval()).isEqualTo(Duration.ofMinutes(1));
         assertThat(config.consolidationCleanupInterval()).isEqualTo(Duration.ofMinutes(5));

--- a/storage/inkless/src/test/java/io/aiven/inkless/consume/FetchOffsetHandlerTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/consume/FetchOffsetHandlerTest.java
@@ -43,6 +43,7 @@ import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import io.aiven.inkless.cache.CrossTierLogStartCache;
@@ -59,6 +60,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -322,6 +324,26 @@ class FetchOffsetHandlerTest {
             assertThat(future.get().exception()).isNotEmpty();
             assertThat(future.get().exception().get()).isInstanceOf(RuntimeException.class);
             assertThat(future.get().exception().get()).message().contains("Topic ID not found");
+            assertThat(future.get().timestampAndOffset()).isEmpty();
+        }
+    }
+
+    @Test
+    void rejectedSubmissionFailsAllFutures() throws ExecutionException, InterruptedException {
+        when(metadataView.getTopicId(TOPIC_0)).thenReturn(TOPIC_ID_0);
+        when(metadataView.getTopicId(TOPIC_1)).thenReturn(TOPIC_ID_1);
+        doThrow(new RejectedExecutionException("queue full")).when(executor).submit((Runnable) any());
+
+        final FetchOffsetHandler.Job job = new FetchOffsetHandler.Job(metadataView, controlPlane, crossTierLogStartCache, executor, time, metrics);
+        final var future1 = job.add(T0P0, new ListOffsetsRequestData.ListOffsetsPartition().setPartitionIndex(0).setTimestamp(-1));
+        final var future2 = job.add(T1P1, new ListOffsetsRequestData.ListOffsetsPartition().setPartitionIndex(1).setTimestamp(-3));
+
+        job.start();
+
+        verify(controlPlane, never()).listOffsets(any());
+        for (final var future : List.of(future1, future2)) {
+            assertThat(future.isDone()).isTrue();
+            assertThat(future.get().exception()).containsInstanceOf(RejectedExecutionException.class);
             assertThat(future.get().timestampAndOffset()).isEmpty();
         }
     }

--- a/storage/inkless/src/test/java/io/aiven/inkless/control_plane/AbstractControlPlaneListOffsetsConcurrencyTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/control_plane/AbstractControlPlaneListOffsetsConcurrencyTest.java
@@ -1,0 +1,85 @@
+/*
+ * Inkless
+ * Copyright (C) 2026 Aiven OY
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.aiven.inkless.control_plane;
+
+import org.apache.kafka.common.TopicIdPartition;
+import org.apache.kafka.common.Uuid;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.kafka.common.requests.ListOffsetsRequest.LATEST_TIMESTAMP;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.withSettings;
+
+/**
+ * Pins that {@link AbstractControlPlane#listOffsets} does not serialize callers.
+ * A slow implementation must only block its own request, not every ListOffsets on the broker.
+ */
+class AbstractControlPlaneListOffsetsConcurrencyTest {
+    private static final TopicIdPartition PARTITION = new TopicIdPartition(Uuid.randomUuid(), 0, "topic");
+
+    @Test
+    void concurrentCallersAreNotSerialized() throws Exception {
+        final int callers = 2;
+        final CountDownLatch entered = new CountDownLatch(callers);
+        final CountDownLatch release = new CountDownLatch(1);
+
+        final AbstractControlPlane controlPlane = mock(AbstractControlPlane.class,
+            withSettings().defaultAnswer(CALLS_REAL_METHODS));
+        doAnswer(invocation -> {
+            entered.countDown();
+            release.await();
+            return List.of(ListOffsetsResponse.success(PARTITION, -1, 0)).iterator();
+        }).when(controlPlane).listOffsetsForExistingPartitions(any());
+
+        final ExecutorService executor = Executors.newFixedThreadPool(callers);
+        try {
+            final List<Future<List<ListOffsetsResponse>>> results = List.of(
+                executor.submit(() -> controlPlane.listOffsets(requests())),
+                executor.submit(() -> controlPlane.listOffsets(requests()))
+            );
+
+            assertThat(entered.await(5, TimeUnit.SECONDS))
+                .as("both callers should be inside listOffsetsForExistingPartitions at the same time")
+                .isTrue();
+
+            release.countDown();
+            for (final var result : results) {
+                assertThat(result.get(5, TimeUnit.SECONDS)).hasSize(1);
+            }
+        } finally {
+            release.countDown();
+            executor.shutdownNow();
+        }
+    }
+
+    private static List<ListOffsetsRequest> requests() {
+        return List.of(new ListOffsetsRequest(PARTITION, LATEST_TIMESTAMP));
+    }
+}

--- a/storage/inkless/src/test/java/io/aiven/inkless/delete/DeleteRecordsInterceptorTest.java
+++ b/storage/inkless/src/test/java/io/aiven/inkless/delete/DeleteRecordsInterceptorTest.java
@@ -36,6 +36,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
@@ -51,6 +52,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -252,6 +254,32 @@ class DeleteRecordsInterceptorTest {
             new TopicPartition("diskless2", 2),
             new DeleteRecordsResponseData.DeleteRecordsPartitionResult()
                 .setPartitionIndex(2)
+                .setErrorCode(Errors.UNKNOWN_SERVER_ERROR.code())
+                .setLowWatermark(INVALID_LOW_WATERMARK)
+        ));
+        interceptor.close();
+    }
+
+    @Test
+    public void rejectedSubmissionRespondsWithError() throws Exception {
+        final Uuid topicId = new Uuid(1, 2);
+        when(metadataView.isDisklessTopic(eq("diskless"))).thenReturn(true);
+        when(metadataView.getTopicId(eq("diskless"))).thenReturn(topicId);
+        doThrow(new RejectedExecutionException("queue full")).when(executorService).execute(any());
+
+        final DeleteRecordsInterceptor interceptor = new DeleteRecordsInterceptor(
+            controlPlane, metadataView, executorService);
+
+        final TopicPartition topicPartition = new TopicPartition("diskless", 1);
+        final boolean result = interceptor.intercept(Map.of(topicPartition, 4567L), responseCallback);
+        assertThat(result).isTrue();
+        verify(controlPlane, never()).deleteRecords(anyList());
+
+        verify(responseCallback).accept(resultCaptor.capture());
+        assertThat(resultCaptor.getValue()).isEqualTo(Map.of(
+            topicPartition,
+            new DeleteRecordsResponseData.DeleteRecordsPartitionResult()
+                .setPartitionIndex(1)
                 .setErrorCode(Errors.UNKNOWN_SERVER_ERROR.code())
                 .setLowWatermark(INVALID_LOW_WATERMARK)
         ));


### PR DESCRIPTION
A single slow `list_offsets_v1` call stalled every ListOffsets on the broker and leaked one thread per arriving request, for a day, on a control plane whose query had been pushed to `statement_timeout`. Two broker-side properties composed: `AbstractControlPlane.listOffsets` was `synchronized`, so every call waited on the slowest one, and `FetchOffsetHandler` used a cached thread pool, so every waiting request became a parked OS thread. Neither makes the query fast; together they turn a slow query into a wedge that outlives its trigger. Each commit removes one property and stands on its own. See the commit messages for the reasoning behind each step.

## Commits

- `fix(inkless:control_plane): don't serialize listOffsets across callers`: moves the lock from the abstract base into `InMemoryControlPlane`, the only implementation that needed it.
- `fix(inkless:consume): bound the fetch offset and delete records pools`: fixed pools with a bounded queue; a full queue rejects and the request gets an error response instead of a parked thread.

## Config

- New `fetch.offset.thread.pool.size` (default 8). Queue capacity is 100 per thread; a ListOffsets that arrives when the queue is full fails immediately.

## Metrics

- New `FetchOffsetRejectedRate` under `InklessFetchOffsetMetrics`. Rejections are also counted in `FetchOffsetErrorRate`.
- `ThreadPoolMonitor` groups `inkless-fetch-offset-metadata` and `inkless-delete-records` now report pool size, active threads, and queue depth.

## Testing

- `AbstractControlPlaneListOffsetsConcurrencyTest`: two callers block inside `listOffsetsForExistingPartitions` at the same time. Fails on the old `synchronized` method.
- `FetchOffsetHandlerTest.rejectedSubmissionFailsAllFutures` and `DeleteRecordsInterceptorTest.rejectedSubmissionRespondsWithError`: a rejected submission completes every partition with an error instead of escaping to the request handler.

## Follow-ups

- The diskless DeleteRecords leg does not apply the request's `timeout.ms` (the `TODO use purgatory` in `DeleteRecordsInterceptor`). The bounded pool caps admitted work; purgatory would cap how long a request waits. Separate change.
- `Reader.createBoundedThreadPool` has the same pool shape inline. Left as is until there is a reason to standardize the reject policy and queue depth.

## Related

The control-plane query fix (V29 index and V30 lookup rewrite) is #799. Neither depends on the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
