### PR TITLE
docs(inkless): drop cleanup.policy=delete from the unsupported list

### DIFF
--- a/docs/inkless/FEATURES.md
+++ b/docs/inkless/FEATURES.md
@@ -20,8 +20,7 @@ Currently Diskless topics support:
 * Managed replicas with user-defined replication factor (see [Managed Replicas](#managed-replicas))
 
 The following are notable unsupported features:
-* cleanup.policy=delete
-* cleanup.policy=compact
+* `cleanup.policy=compact`
 * Transactional Produce, `AddPartitionsToTxn`, and `WriteTxnMarkers` targeting Diskless topics
 * read_committed consumers reading Diskless topics
 * Producing to both inkless and traditional topics simultaneously


### PR DESCRIPTION
The unsupported-features list named both cleanup.policy=delete and cleanup.policy=compact. Only compact is unsupported; delete is the policy diskless topics use.
